### PR TITLE
Sync playlist files with UI changes

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -65,6 +65,7 @@ type configOptions struct {
 	MPVCmdTemplate                  string
 	CoverArtPriority                string
 	CoverJpegQuality                int
+	AlbumArtPlaceholder             string
 	ArtistArtPriority               string
 	LyricsPriority                  string
 	EnableGravatar                  bool
@@ -511,6 +512,7 @@ func setViperDefaults() {
 	viper.SetDefault("mpvcmdtemplate", "mpv --audio-device=%d --no-audio-display %f --input-ipc-server=%s")
 	viper.SetDefault("coverartpriority", "cover.*, folder.*, front.*, embedded, external")
 	viper.SetDefault("coverjpegquality", 75)
+	viper.SetDefault("albumartplaceholder", "")
 	viper.SetDefault("artistartpriority", "artist.*, album/artist.*, external")
 	viper.SetDefault("lyricspriority", ".lrc,.txt,embedded")
 	viper.SetDefault("enablegravatar", false)

--- a/core/artwork/artwork.go
+++ b/core/artwork/artwork.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	_ "image/gif"
 	"io"
+	"os"
 	"time"
 
+	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/core/external"
 	"github.com/navidrome/navidrome/core/ffmpeg"
@@ -49,6 +51,11 @@ func (a *artwork) GetOrPlaceholder(ctx context.Context, id string, size int, squ
 	if errors.Is(err, ErrUnavailable) {
 		if artID.Kind == model.KindArtistArtwork {
 			reader, _ = resources.FS().Open(consts.PlaceholderArtistArt)
+		} else if conf.Server.AlbumArtPlaceholder != "" {
+			reader, err = os.Open(conf.Server.AlbumArtPlaceholder)
+			if err != nil {
+				reader, _ = resources.FS().Open(consts.PlaceholderAlbumArt)
+			}
 		} else {
 			reader, _ = resources.FS().Open(consts.PlaceholderAlbumArt)
 		}

--- a/core/artwork/sources.go
+++ b/core/artwork/sources.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/dhowden/tag"
+	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/core/external"
 	"github.com/navidrome/navidrome/core/ffmpeg"
@@ -153,6 +154,12 @@ func fromAlbum(ctx context.Context, a *artwork, id model.ArtworkID) sourceFunc {
 
 func fromAlbumPlaceholder() sourceFunc {
 	return func() (io.ReadCloser, string, error) {
+		if conf.Server.AlbumArtPlaceholder != "" {
+			r, err := os.Open(conf.Server.AlbumArtPlaceholder)
+			if err == nil {
+				return r, conf.Server.AlbumArtPlaceholder, nil
+			}
+		}
 		r, _ := resources.FS().Open(consts.PlaceholderAlbumArt)
 		return r, consts.PlaceholderAlbumArt, nil
 	}

--- a/core/playlists.go
+++ b/core/playlists.go
@@ -421,9 +421,9 @@ func (s *playlists) Update(ctx context.Context, playlistID string,
 
 		if pls.Sync {
 			ext := filepath.Ext(oldPath)
-			if ext == "" {
-				ext = ".m3u8"
-			}
+                        if ext == "" {
+                                ext = ".m3u"
+                        }
 			newPath, err := s.buildPlaylistPath(ctx, tx, pls.FolderID, pls.Name, ext)
 			if err != nil {
 				return err

--- a/core/playlists.go
+++ b/core/playlists.go
@@ -421,9 +421,9 @@ func (s *playlists) Update(ctx context.Context, playlistID string,
 
 		if pls.Sync {
 			ext := filepath.Ext(oldPath)
-                        if ext == "" {
-                                ext = ".m3u"
-                        }
+			if ext == "" {
+				ext = ".m3u"
+			}
 			newPath, err := s.buildPlaylistPath(ctx, tx, pls.FolderID, pls.Name, ext)
 			if err != nil {
 				return err
@@ -476,6 +476,9 @@ func (s *playlists) SetFolder(ctx context.Context, playlistID string, folderID *
 			return nil
 		}
 		ext := filepath.Ext(oldPath)
+		if ext == "" {
+			ext = ".m3u"
+		}
 		newPath, err := s.buildPlaylistPath(ctx, tx, folderID, pls.Name, ext)
 		if err != nil {
 			return err
@@ -488,8 +491,13 @@ func (s *playlists) SetFolder(ctx context.Context, playlistID string, folderID *
 		if err := os.MkdirAll(filepath.Dir(newPath), 0o755); err != nil {
 			return err
 		}
-		if err := os.Rename(oldPath, newPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return err
+		if err := os.Rename(oldPath, newPath); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+			if writeErr := s.writePlaylistFile(newPath, pls); writeErr != nil {
+				return writeErr
+			}
 		}
 		return nil
 	})

--- a/core/playlists.go
+++ b/core/playlists.go
@@ -421,6 +421,9 @@ func (s *playlists) Update(ctx context.Context, playlistID string,
 
 		if pls.Sync {
 			ext := filepath.Ext(oldPath)
+			if ext == "" {
+				ext = ".m3u8"
+			}
 			newPath, err := s.buildPlaylistPath(ctx, tx, pls.FolderID, pls.Name, ext)
 			if err != nil {
 				return err
@@ -442,7 +445,7 @@ func (s *playlists) Update(ctx context.Context, playlistID string,
 			if err := os.MkdirAll(filepath.Dir(pls.Path), 0o755); err != nil {
 				return err
 			}
-			if oldPath != pls.Path {
+			if oldPath != "" && oldPath != pls.Path {
 				if err := os.Rename(oldPath, pls.Path); err != nil && !errors.Is(err, os.ErrNotExist) {
 					return err
 				}

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -112,7 +112,7 @@ func (n *Router) addPlaylistRoute(r chi.Router) {
 		r.Get("/", rest.GetAll(constructor))
 		r.Post("/", func(w http.ResponseWriter, r *http.Request) {
 			if r.Header.Get("Content-type") == "application/json" {
-				rest.Post(constructor)(w, r)
+				createPlaylist(n.ds, n.playlists)(w, r)
 				return
 			}
 			createPlaylistFromM3U(n.playlists)(w, r)
@@ -178,10 +178,10 @@ func (n *Router) addPlaylistTrackRoute(r chi.Router) {
 		})
 		r.With(server.URLParamsMiddleware).Route("/", func(r chi.Router) {
 			r.Delete("/", func(w http.ResponseWriter, r *http.Request) {
-				deleteFromPlaylist(n.ds)(w, r)
+				deleteFromPlaylist(n.ds, n.playlists)(w, r)
 			})
 			r.Post("/", func(w http.ResponseWriter, r *http.Request) {
-				addToPlaylist(n.ds)(w, r)
+				addToPlaylist(n.ds, n.playlists)(w, r)
 			})
 		})
 		r.Route("/{id}", func(r chi.Router) {
@@ -190,10 +190,10 @@ func (n *Router) addPlaylistTrackRoute(r chi.Router) {
 				getPlaylistTrack(n.ds)(w, r)
 			})
 			r.Put("/", func(w http.ResponseWriter, r *http.Request) {
-				reorderItem(n.ds)(w, r)
+				reorderItem(n.ds, n.playlists)(w, r)
 			})
 			r.Delete("/", func(w http.ResponseWriter, r *http.Request) {
-				deleteFromPlaylist(n.ds)(w, r)
+				deleteFromPlaylist(n.ds, n.playlists)(w, r)
 			})
 		})
 	})

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -126,16 +126,21 @@ func (n *Router) addPlaylistRoute(r chi.Router) {
 
 			r.Patch("/folder", func(w http.ResponseWriter, r *http.Request) {
 				id := chi.URLParam(r, "id")
-				type reqBody struct{ FolderID *string `json:"folderId"` }
+				type reqBody struct {
+					FolderID *string `json:"folderId"`
+				}
 				var body reqBody
 				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-					http.Error(w, err.Error(), http.StatusBadRequest); return
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
 				}
 				if body.FolderID != nil && *body.FolderID == "" {
-					http.Error(w, "folderId cannot be empty; use null for unassigned", http.StatusBadRequest); return
+					http.Error(w, "folderId cannot be empty; use null for unassigned", http.StatusBadRequest)
+					return
 				}
-				if err := n.ds.Playlist(r.Context()).UpdatePlaylistFolder(id, body.FolderID); err != nil {
-					http.Error(w, err.Error(), statusFor(err)); return
+				if err := n.playlists.SetFolder(r.Context(), id, body.FolderID); err != nil {
+					http.Error(w, err.Error(), statusFor(err))
+					return
 				}
 				w.WriteHeader(http.StatusNoContent)
 			})
@@ -162,7 +167,7 @@ func (n *Router) addPlaylistFolderRoute(r chi.Router) {
 			r.Patch("/parent", MoveFolder(n.ds))
 		})
 
-		r.Patch("/move", BulkMove(n.ds))
+		r.Patch("/move", BulkMove(n.ds, n.playlists))
 	})
 }
 

--- a/server/nativeapi/playlist_folder.go
+++ b/server/nativeapi/playlist_folder.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/Masterminds/squirrel"
 	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/core"
 	"github.com/navidrome/navidrome/model"
 )
 
@@ -19,12 +20,14 @@ func ListFoldersAndPlaylists(ds model.DataStore) http.HandlerFunc {
 
 		folders, err := ds.PlaylistFolder(ctx).GetAllByParent(opts.FolderOpts)
 		if err != nil {
-			http.Error(w, err.Error(), statusFor(err)); return
+			http.Error(w, err.Error(), statusFor(err))
+			return
 		}
 
 		playlists, err := ds.Playlist(ctx).GetAllByPlaylistFolder(opts.PlaylistOpts)
 		if err != nil {
-			http.Error(w, err.Error(), statusFor(err)); return
+			http.Error(w, err.Error(), statusFor(err))
+			return
 		}
 
 		commons := make(model.PlaylistAndFolderCommons, 0, len(folders)+len(playlists))
@@ -53,8 +56,12 @@ func ListFoldersAndPlaylists(ds model.DataStore) http.HandlerFunc {
 
 		total := len(commons)
 		start, end := opts.Offset, opts.Offset+opts.Max
-		if start > total { start = total }
-		if end > total { end = total }
+		if start > total {
+			start = total
+		}
+		if end > total {
+			end = total
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("X-Total-Count", fmt.Sprintf("%d", total))
@@ -64,25 +71,30 @@ func ListFoldersAndPlaylists(ds model.DataStore) http.HandlerFunc {
 }
 
 func MoveFolder(ds model.DataStore) http.HandlerFunc {
-	type reqBody struct{ ParentID *string `json:"parentId"` }
+	type reqBody struct {
+		ParentID *string `json:"parentId"`
+	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
 		var body reqBody
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest); return
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
 		}
 		if body.ParentID != nil && *body.ParentID == "" {
-			http.Error(w, "parentId cannot be empty; use null for root", http.StatusBadRequest); return
+			http.Error(w, "parentId cannot be empty; use null for root", http.StatusBadRequest)
+			return
 		}
 		if err := ds.PlaylistFolder(r.Context()).UpdateParent(id, body.ParentID); err != nil {
-			http.Error(w, err.Error(), statusFor(err)); return
+			http.Error(w, err.Error(), statusFor(err))
+			return
 		}
 		w.WriteHeader(http.StatusNoContent)
 	}
 }
 
-func BulkMove(ds model.DataStore) http.HandlerFunc {
+func BulkMove(ds model.DataStore, pls core.Playlists) http.HandlerFunc {
 	type movePayload struct {
 		Ids      []string `json:"ids"`
 		Types    []string `json:"types"`    // "folder" | "playlist"
@@ -92,13 +104,16 @@ func BulkMove(ds model.DataStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var payload movePayload
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest); return
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
 		}
 		if len(payload.Ids) != len(payload.Types) {
-			http.Error(w, "ids and types length mismatch", http.StatusBadRequest); return
+			http.Error(w, "ids and types length mismatch", http.StatusBadRequest)
+			return
 		}
 		if payload.FolderID != nil && *payload.FolderID == "" {
-			http.Error(w, "folderId cannot be empty; use null for root/unassigned", http.StatusBadRequest); return
+			http.Error(w, "folderId cannot be empty; use null for root/unassigned", http.StatusBadRequest)
+			return
 		}
 
 		ctx := r.Context()
@@ -106,24 +121,26 @@ func BulkMove(ds model.DataStore) http.HandlerFunc {
 		for i, id := range payload.Ids {
 			switch payload.Types[i] {
 			case "playlist":
-				if err := ds.Playlist(ctx).UpdatePlaylistFolder(id, payload.FolderID); err != nil {
-					http.Error(w, err.Error(), statusFor(err)); return
+				if err := pls.SetFolder(ctx, id, payload.FolderID); err != nil {
+					http.Error(w, err.Error(), statusFor(err))
+					return
 				}
 				updated++
 			case "folder":
 				if err := ds.PlaylistFolder(ctx).UpdateParent(id, payload.FolderID); err != nil {
-					http.Error(w, err.Error(), statusFor(err)); return
+					http.Error(w, err.Error(), statusFor(err))
+					return
 				}
 				updated++
 			default:
-				http.Error(w, "invalid type "+payload.Types[i], http.StatusBadRequest); return
+				http.Error(w, "invalid type "+payload.Types[i], http.StatusBadRequest)
+				return
 			}
 		}
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(fmt.Sprintf(`{"updated":%d}`, updated)))
 	}
 }
-
 
 type DualQueryOptions struct {
 	FolderOpts   model.QueryOptions
@@ -133,50 +150,52 @@ type DualQueryOptions struct {
 }
 
 func parseQueryOptions(r *http.Request) DualQueryOptions {
-    q := r.URL.Query()
+	q := r.URL.Query()
 
-    base := model.QueryOptions{Order: "ASC", Filters: And{}}
-    out := DualQueryOptions{Offset: 0, Max: 100}
+	base := model.QueryOptions{Order: "ASC", Filters: And{}}
+	out := DualQueryOptions{Offset: 0, Max: 100}
 
-    if sortField := q.Get("_sort"); sortField != "" {
-        base.Sort = sortField
-    }
-    if order := q.Get("_order"); order != "" {
-        base.Order = strings.ToUpper(order)
-    }
-    if start, err := strconv.Atoi(q.Get("_start")); err == nil {
-        out.Offset = start
-    }
-    if end, err := strconv.Atoi(q.Get("_end")); err == nil && end > out.Offset {
-        out.Max = end - out.Offset
-    }
+	if sortField := q.Get("_sort"); sortField != "" {
+		base.Sort = sortField
+	}
+	if order := q.Get("_order"); order != "" {
+		base.Order = strings.ToUpper(order)
+	}
+	if start, err := strconv.Atoi(q.Get("_start")); err == nil {
+		out.Offset = start
+	}
+	if end, err := strconv.Atoi(q.Get("_end")); err == nil && end > out.Offset {
+		out.Max = end - out.Offset
+	}
 
-    folderOpts, playlistOpts := base, base
+	folderOpts, playlistOpts := base, base
 
-    if search := strings.TrimSpace(q.Get("q")); search != "" {
-        folderOpts.Filters = append(folderOpts.Filters.(And), playlistFolderFilter("q", search))
-        playlistOpts.Filters = append(playlistOpts.Filters.(And), playlistFilter("q", search))
-    }
+	if search := strings.TrimSpace(q.Get("q")); search != "" {
+		folderOpts.Filters = append(folderOpts.Filters.(And), playlistFolderFilter("q", search))
+		playlistOpts.Filters = append(playlistOpts.Filters.(And), playlistFilter("q", search))
+	}
 
-    if raw, present := q["parent_id"]; present {
-        v := ""
-        if len(raw) > 0 { v = raw[0] }
-        if v == "" || strings.EqualFold(v, "null") {
-            folderOpts.Filters   = append(folderOpts.Filters.(And), Eq{"parent_id":  nil})
-            playlistOpts.Filters = append(playlistOpts.Filters.(And), Eq{"folder_id": nil})
-        } else {
-            folderOpts.Filters   = append(folderOpts.Filters.(And), Eq{"parent_id":  v})
-            playlistOpts.Filters = append(playlistOpts.Filters.(And), Eq{"folder_id": v})
-        }
-    }
+	if raw, present := q["parent_id"]; present {
+		v := ""
+		if len(raw) > 0 {
+			v = raw[0]
+		}
+		if v == "" || strings.EqualFold(v, "null") {
+			folderOpts.Filters = append(folderOpts.Filters.(And), Eq{"parent_id": nil})
+			playlistOpts.Filters = append(playlistOpts.Filters.(And), Eq{"folder_id": nil})
+		} else {
+			folderOpts.Filters = append(folderOpts.Filters.(And), Eq{"parent_id": v})
+			playlistOpts.Filters = append(playlistOpts.Filters.(And), Eq{"folder_id": v})
+		}
+	}
 
-    if owner := strings.TrimSpace(q.Get("owner_id")); owner != "" {
-        folderOpts.Filters   = append(folderOpts.Filters.(And), Eq{"owner_id": owner})
-        playlistOpts.Filters = append(playlistOpts.Filters.(And), Eq{"owner_id": owner})
-    }
+	if owner := strings.TrimSpace(q.Get("owner_id")); owner != "" {
+		folderOpts.Filters = append(folderOpts.Filters.(And), Eq{"owner_id": owner})
+		playlistOpts.Filters = append(playlistOpts.Filters.(And), Eq{"owner_id": owner})
+	}
 
-    out.FolderOpts, out.PlaylistOpts = folderOpts, playlistOpts
-    return out
+	out.FolderOpts, out.PlaylistOpts = folderOpts, playlistOpts
+	return out
 }
 
 func playlistFilter(_ string, value interface{}) Sqlizer {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -490,6 +490,7 @@
     "transcodingEnabled": "Navidrome is currently running with %{config}, making it possible to run system commands from the transcoding settings using the web interface. We recommend to disable it for security reasons and only enable it when configuring Transcoding options.",
     "songsAddedToPlaylist": "Added 1 song to playlist |||| Added %{smart_count} songs to playlist",
     "movedSuccess": "Moved successfully",
+    "folderExists": "Folder already exists",
     "noSimilarSongsFound": "No similar songs found",
     "noTopSongsFound": "No top songs found",
     "noPlaylistsAvailable": "None available",

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -79,6 +79,9 @@ const useStyles = makeStyles(
     ratingField: {
       visibility: 'hidden',
     },
+    draggable: {
+      cursor: 'move',
+    },
   }),
   { name: 'RaList' },
 )
@@ -221,6 +224,7 @@ const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
             readOnly={readOnly}
             onDragEnd={handleDragEnd}
             nodeSelector={'tr'}
+            handleSelector={'.draggable'}
           >
             <SongDatagrid
               rowClick={(id) => dispatch(playTracks(data, ids, id))}

--- a/ui/src/playlist_folder/PlaylistFolderCreate.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderCreate.jsx
@@ -31,8 +31,16 @@ const PlaylistFolderCreate = (props) => {
     refresh()
   }
 
+  const onFailure = (error) => {
+    if (error?.status === 409) {
+      notify('message.folderExists', 'warning')
+    } else {
+      notify('ra.page.error', 'warning')
+    }
+  }
+
   return (
-    <Create title={<Title subTitle={title} />} {...props} onSuccess={onSuccess}>
+    <Create title={<Title subTitle={title} />} {...props} onSuccess={onSuccess} onFailure={onFailure}>
       <SimpleForm redirect="list" variant="outlined">
         <TextInput source="name" validate={required()} />
         <BooleanInput source="public" initialValue />

--- a/ui/src/playlist_folder/PlaylistFolderDataGrid.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderDataGrid.jsx
@@ -55,9 +55,19 @@ const PlaylistFolderRow = ({ record, children, className, rowClick, ...rest }) =
   const handleDrop = useCallback(
     async (item) => {
       try {
-        if (!item || item.id === record.id) return
+        if (!item) return
         const currentSourceId = sourceIdRef.current ?? ''
         const isTargetFolder = record.type === 'folder'
+        const isTargetPlaylist = record.type === 'playlist'
+
+        if (isTargetPlaylist && item.type !== 'playlist' && item.type !== 'folder') {
+          const res = await dataProvider.addToPlaylist(record.id, item)
+          notify('message.songsAddedToPlaylist', 'info', { smart_count: res?.data?.added })
+          refresh()
+          return
+        }
+
+        if (item.id === record.id) return
 
         if (item.type === 'playlist') {
           const targetFolderId = isTargetFolder ? record.id : null
@@ -86,7 +96,7 @@ const PlaylistFolderRow = ({ record, children, className, rowClick, ...rest }) =
   const { dragDropRef, isDragging } = useDragAndDrop(
     record.type === 'playlist' ? DraggableTypes.PLAYLIST : DraggableTypes.FOLDER,
     { id: record.id, type: record.type },
-    record.type === 'playlist' ? [] : [DraggableTypes.PLAYLIST, DraggableTypes.FOLDER],
+    record.type === 'playlist' ? DraggableTypes.ALL : [DraggableTypes.PLAYLIST, DraggableTypes.FOLDER],
     handleDrop
   )
 


### PR DESCRIPTION
## Summary
- update playlists to rewrite and move playlist files when tracks or names change
- move playlist files when playlists are assigned to new folders
- route playlist folder moves through playlist sync logic

## Testing
- `go test ./...` *(fails: Package 'taglib' not found; multiple model tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68b235f3bd708330a76e71e363d9a943