### PR TITLE
Hide radio/share menus and show playlist folder name

### DIFF
--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -134,7 +134,9 @@ const updateUser = async (params) => {
 const emitFoldersChanged = (detail) => {
   try {
     window.dispatchEvent(new CustomEvent('folder:changed', { detail }))
-  } catch {}
+  } catch {
+    /* empty */
+  }
 }
 
 const wrapperDataProvider = {

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -51,7 +51,9 @@ const Menu = ({ dense = false }) => {
   const translate = useTranslate()
   const queue = useSelector((state) => state.player?.queue)
   const classes = useStyles({ addPadding: queue.length > 0 })
-  const resources = useSelector(getResources)
+  const resources = useSelector(getResources).filter(
+    (r) => r.name !== 'radio' && r.name !== 'share',
+  )
 
   // TODO State is not persisted in mobile when you close the sidebar menu. Move to redux?
   const [state, setState] = useState({

--- a/ui/src/playlist_folder/PlaylistFolderShow.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderShow.jsx
@@ -12,6 +12,7 @@ import {
   useNotify,
   useRecordContext,
   usePermissions,
+  Title as RaTitle,
 } from 'react-admin'
 import { useMediaQuery } from '@material-ui/core'
 import Switch from '@material-ui/core/Switch'
@@ -21,6 +22,7 @@ import {
   isWritable,
   useSelectedFields,
   useResourceRefresh,
+  Title,
 } from '../common'
 import PlaylistListActions from './PlaylistListActions'
 import EmptyPlaylist from './EmptyPlaylist'
@@ -123,27 +125,30 @@ const FolderChildrenList = (props) => {
   const parentId = record?.id ?? ''
 
   return (
-    <List
-      {...props}
-      resource="folder"
-      exporter={false}
-      filters={<PlaylistFolderFilter />}
-      actions={<PlaylistListActions />}
-      bulkActionButtons={!isXsmall && <PlaylistFolderBulkActions />}
-      empty={<EmptyPlaylist />}
-      perPage={isXsmall ? 50 : 25}
-      filter={{ parent_id: parentId }}
-      filterDefaultValues={{ parent_id: parentId }}
-    >
-      <PlaylistFolderDataGrid rowClick={rowClick}>
-        <TypeIconField label={false} />
-        <TextField source="name" />
-        {columns}
-        <Writable>
-          <TypeAwareEditButton />
-        </Writable>
-      </PlaylistFolderDataGrid>
-    </List>
+    <>
+      {record && <RaTitle title={<Title subTitle={record.name} />} />}
+      <List
+        {...props}
+        resource="folder"
+        exporter={false}
+        filters={<PlaylistFolderFilter />}
+        actions={<PlaylistListActions />}
+        bulkActionButtons={!isXsmall && <PlaylistFolderBulkActions />}
+        empty={<EmptyPlaylist />}
+        perPage={isXsmall ? 50 : 25}
+        filter={{ parent_id: parentId }}
+        filterDefaultValues={{ parent_id: parentId }}
+      >
+        <PlaylistFolderDataGrid rowClick={rowClick}>
+          <TypeIconField label={false} />
+          <TextField source="name" />
+          {columns}
+          <Writable>
+            <TypeAwareEditButton />
+          </Writable>
+        </PlaylistFolderDataGrid>
+      </List>
+    </>
   )
 }
 

--- a/ui/src/playlist_folder/PlaylistFolderShow.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderShow.jsx
@@ -12,7 +12,6 @@ import {
   useNotify,
   useRecordContext,
   usePermissions,
-  Title as RaTitle,
 } from 'react-admin'
 import { useMediaQuery } from '@material-ui/core'
 import Switch from '@material-ui/core/Switch'
@@ -125,30 +124,28 @@ const FolderChildrenList = (props) => {
   const parentId = record?.id ?? ''
 
   return (
-    <>
-      {record && <RaTitle title={<Title subTitle={record.name} />} />}
-      <List
-        {...props}
-        resource="folder"
-        exporter={false}
-        filters={<PlaylistFolderFilter />}
-        actions={<PlaylistListActions />}
-        bulkActionButtons={!isXsmall && <PlaylistFolderBulkActions />}
-        empty={<EmptyPlaylist />}
-        perPage={isXsmall ? 50 : 25}
-        filter={{ parent_id: parentId }}
-        filterDefaultValues={{ parent_id: parentId }}
-      >
-        <PlaylistFolderDataGrid rowClick={rowClick}>
-          <TypeIconField label={false} />
-          <TextField source="name" />
-          {columns}
-          <Writable>
-            <TypeAwareEditButton />
-          </Writable>
-        </PlaylistFolderDataGrid>
-      </List>
-    </>
+    <List
+      {...props}
+      resource="folder"
+      exporter={false}
+      title={<Title subTitle={record?.name} />}
+      filters={<PlaylistFolderFilter />}
+      actions={<PlaylistListActions />}
+      bulkActionButtons={!isXsmall && <PlaylistFolderBulkActions />}
+      empty={<EmptyPlaylist />}
+      perPage={isXsmall ? 50 : 25}
+      filter={{ parent_id: parentId }}
+      filterDefaultValues={{ parent_id: parentId }}
+    >
+      <PlaylistFolderDataGrid rowClick={rowClick}>
+        <TypeIconField label={false} />
+        <TextField source="name" />
+        {columns}
+        <Writable>
+          <TypeAwareEditButton />
+        </Writable>
+      </PlaylistFolderDataGrid>
+    </List>
   )
 }
 

--- a/ui/src/themes/index.js
+++ b/ui/src/themes/index.js
@@ -11,6 +11,7 @@ import NordTheme from './nord'
 import GruvboxDarkTheme from './gruvboxDark'
 import CatppuccinMacchiatoTheme from './catppuccinMacchiato'
 import NuclearTheme from './nuclear'
+import ItachiTheme from './itachi'
 
 export default {
   // Classic default themes
@@ -23,6 +24,7 @@ export default {
   ExtraDarkTheme,
   GreenTheme,
   GruvboxDarkTheme,
+  ItachiTheme,
   LigeraTheme,
   MonokaiTheme,
   NordTheme,

--- a/ui/src/themes/itachi.css.js
+++ b/ui/src/themes/itachi.css.js
@@ -1,0 +1,35 @@
+const stylesheet = `
+.react-jinke-music-player-main svg:active, .react-jinke-music-player-main svg:hover {
+    color: #e53935
+}
+
+.react-jinke-music-player-main .music-player-panel .panel-content .rc-slider-handle, .react-jinke-music-player-main .music-player-panel .panel-content .rc-slider-track {
+    background-color: #e53935
+}
+
+.react-jinke-music-player-main ::-webkit-scrollbar-thumb {
+    background-color: #e53935;
+}
+
+.react-jinke-music-player-main .music-player-panel .panel-content .rc-slider-handle:active {
+    box-shadow: 0 0 2px #e53935
+}
+
+.react-jinke-music-player-main .audio-item.playing svg {
+    color: #e53935
+}
+
+.react-jinke-music-player-main .audio-item.playing .player-singer {
+    color: #e53935 !important
+}
+
+.audio-lists-panel-content .audio-item.playing, .audio-lists-panel-content .audio-item.playing svg {
+    color: #e53935
+}
+
+.audio-lists-panel-content .audio-item:active .group:not([class=".player-delete"]) svg, .audio-lists-panel-content .audio-item:hover .group:not([class=".player-delete"]) svg {
+    color: #e53935
+}
+`
+
+export default stylesheet

--- a/ui/src/themes/itachi.js
+++ b/ui/src/themes/itachi.js
@@ -1,0 +1,37 @@
+import red from '@material-ui/core/colors/red'
+import stylesheet from './itachi.css.js'
+
+export default {
+  themeName: 'Itachi',
+  palette: {
+    background: {
+      paper: '#0d0d0d',
+      default: '#0d0d0d',
+    },
+    primary: {
+      main: '#e53935',
+      contrastText: '#f5f5f5',
+    },
+    secondary: red,
+    type: 'dark',
+  },
+  overrides: {
+    MuiFormGroup: {
+      root: {
+        color: 'white',
+      },
+    },
+    NDLogin: {
+      systemNameLink: {
+        color: '#e53935',
+      },
+      welcome: {
+        color: '#eee',
+      },
+    },
+  },
+  player: {
+    theme: 'dark',
+    stylesheet,
+  },
+}


### PR DESCRIPTION
## Summary
- remove radio and share from sidebar menu
- display playlist folder name in title when viewing folders
- fix empty catch block to satisfy lint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b327263bf083309e9767aa1d89f010