### PR TITLE
Add GCP sync trigger to activity panel

### DIFF
--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -266,7 +266,7 @@ func (n *Router) addConfigRoute(r chi.Router) {
 }
 
 func (n *Router) addSyncRoute(r chi.Router) {
-	r.Get("/sync/*", func(w http.ResponseWriter, r *http.Request) {
+	r.Get("/sync", func(w http.ResponseWriter, r *http.Request) {
 		resp, err := http.Get("http://localhost:3003")
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -616,6 +616,7 @@
     "totalScanned": "Total Folders Scanned",
     "quickScan": "Quick Scan",
     "fullScan": "Full Scan",
+    "sync": "Sync",
     "serverUptime": "Server Uptime",
     "serverDown": "OFFLINE",
     "scanType": "Type",

--- a/ui/src/layout/ActivityPanel.jsx
+++ b/ui/src/layout/ActivityPanel.jsx
@@ -15,10 +15,11 @@ import {
   Typography,
 } from '@material-ui/core'
 import { FiActivity } from 'react-icons/fi'
-import { BiError } from 'react-icons/bi'
+import { BiError, BiLink } from 'react-icons/bi'
 import { VscSync } from 'react-icons/vsc'
 import { GiMagnifyingGlass } from 'react-icons/gi'
 import subsonic from '../subsonic'
+import { httpClient } from '../dataProvider'
 import { useInitialScanStatus } from './useInitialScanStatus'
 import { useInterval } from '../common'
 import { useScanElapsedTime } from './useScanElapsedTime'
@@ -96,6 +97,14 @@ const ActivityPanel = () => {
 
   const handleMenuClose = () => setAnchorEl(null)
   const triggerScan = (full) => () => subsonic.startScan({ fullScan: full })
+  const triggerSync = () =>
+    httpClient('/api/sync')
+      .then(({ json }) => {
+        if (json?.message) {
+          notify(json.message, 'info')
+        }
+      })
+      .catch(() => notify('Sync failed', 'warning'))
 
   useEffect(() => {
     if (serverStart.version && serverStart.version !== config.version) {
@@ -208,6 +217,11 @@ const ActivityPanel = () => {
                 disabled={scanStatus.scanning}
               >
                 <VscSync />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title={translate('activity.sync')}>
+              <IconButton onClick={triggerSync} disabled={scanStatus.scanning}>
+                <BiLink />
               </IconButton>
             </Tooltip>
             <Tooltip title={translate('activity.fullScan')}>


### PR DESCRIPTION
## Summary
- add `/api/sync` endpoint to call local GCP sync service
- expose sync action in Activity panel UI
- add English translation entry for new sync button

## Testing
- `npm test`
- `go test ./server/...`
- `make test-i18n` *(fails: ./.github/workflows/validate-translations.sh: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68be593060148330bd5f407524694806