### PR TITLE
feat: add playlist publish to sync folder

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -52,6 +52,7 @@ type configOptions struct {
 	AutoImportPlaylists             bool
 	DefaultPlaylistPublicVisibility bool
 	PlaylistsPath                   string
+	SyncFolder                      string
 	SmartPlaylistRefreshDelay       time.Duration
 	AutoTranscodeDownload           bool
 	DefaultDownsamplingFormat       string

--- a/core/playlists_test.go
+++ b/core/playlists_test.go
@@ -106,6 +106,20 @@ var _ = Describe("Playlists", func() {
 				Expect(pls.Tracks).To(HaveLen(1))
 				Expect(pls.Tracks[0].Path).To(Equal("Discovery-Specialty/Specialty/Asian/Jun Hyung Yong, 10cm - Sudden Shower.mp3"))
 			})
+
+			Describe("writePlaylistFile", func() {
+				It("writes file to sync folder when configured", func() {
+					DeferCleanup(configtest.SetupConfig())
+					playlistsDir := GinkgoT().TempDir()
+					syncDir := GinkgoT().TempDir()
+					conf.Server.PlaylistsPath = playlistsDir
+					conf.Server.SyncFolder = syncDir
+					ps := &playlists{}
+					pls := &model.Playlist{Name: "test", Path: filepath.Join(playlistsDir, "test.m3u")}
+					Expect(ps.writePlaylistFile(pls.Path, pls)).To(Succeed())
+					Expect(filepath.Join(syncDir, "test.m3u")).To(BeAnExistingFile())
+				})
+			})
 		})
 
 		Describe("NSP", func() {

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -443,6 +443,7 @@ The scanner's behavior can be customized through several configuration settings 
 | Setting                     | Description                                              | Default |
 |-----------------------------|----------------------------------------------------------|---------|
 | `PlaylistsPath`             | Path(s) to search for playlists (supports glob patterns) | ""      |
+| `SyncFolder`                | Directory to store published playlist files              | ""      |
 | `AutoImportPlaylists`       | Whether to import playlists during scanning              | true    |
 
 ### Performance Options

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -126,6 +126,8 @@ func (n *Router) addPlaylistRoute(r chi.Router) {
 			r.Put("/", rest.Put(constructor))
 			r.Delete("/", rest.Delete(constructor))
 
+			r.Post("/publish", publishPlaylist(n.ds, n.playlists))
+
 			r.Patch("/folder", func(w http.ResponseWriter, r *http.Request) {
 				id := chi.URLParam(r, "id")
 				type reqBody struct {

--- a/server/nativeapi/playlists.go
+++ b/server/nativeapi/playlists.go
@@ -147,6 +147,17 @@ func handleExportPlaylist(ds model.DataStore) http.HandlerFunc {
 	}
 }
 
+func publishPlaylist(ds model.DataStore, playlists core.Playlists) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		if err := syncPlaylist(playlists, ds, r.Context(), id); err != nil {
+			http.Error(w, err.Error(), statusFor(err))
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
 func deleteFromPlaylist(ds model.DataStore, playlists core.Playlists) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		p := req.Params(r)

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -221,6 +221,9 @@
         "pressEnterToCreate": "Press Enter to create new playlist",
         "removeFromSelection": "Remove from selection"
       },
+      "notifications": {
+        "published": "%{smart_count} song from %{name} published to Sync folder |||| %{smart_count} songs from %{name} published to Sync folder"
+      },
       "message": {
         "duplicate_song": "Add duplicated songs",
         "song_exist": "There are duplicates being added to the playlist. Would you like to add the duplicates or skip them?",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -213,6 +213,7 @@
         "selectPlaylist": "Select a playlist:",
         "addNewPlaylist": "Create \"%{name}\"",
         "export": "Export",
+        "publish": "Publish",
         "saveQueue": "Save Queue to Playlist",
         "makePublic": "Make Public",
         "makePrivate": "Make Private",

--- a/ui/src/playlist/PlaylistActions.jsx
+++ b/ui/src/playlist/PlaylistActions.jsx
@@ -117,7 +117,12 @@ const PlaylistActions = ({ className, ids, data, record, ...rest }) => {
       httpClient(`${REST_URL}/playlist/${record.id}/publish`, {
         method: 'POST',
       })
-        .then(() => notify('ra.notification.updated', 'info'))
+        .then(() =>
+          notify('resources.playlist.notifications.published', 'info', {
+            smart_count: record.songCount,
+            name: record.name,
+          }),
+        )
         .catch(() => notify('ra.page.error', 'warning')),
     [record, notify],
   )

--- a/ui/src/playlist/PlaylistActions.jsx
+++ b/ui/src/playlist/PlaylistActions.jsx
@@ -15,6 +15,7 @@ import CloudDownloadOutlinedIcon from '@material-ui/icons/CloudDownloadOutlined'
 import { RiPlayListAddFill, RiPlayList2Fill } from 'react-icons/ri'
 import QueueMusicIcon from '@material-ui/icons/QueueMusic'
 import ShareIcon from '@material-ui/icons/Share'
+import PublishIcon from '@material-ui/icons/Publish'
 import { httpClient } from '../dataProvider'
 import {
   playNext,
@@ -111,6 +112,16 @@ const PlaylistActions = ({ className, ids, data, record, ...rest }) => {
     [record],
   )
 
+  const handlePublish = React.useCallback(
+    () =>
+      httpClient(`${REST_URL}/playlist/${record.id}/publish`, {
+        method: 'POST',
+      })
+        .then(() => notify('ra.notification.updated', 'info'))
+        .catch(() => notify('ra.page.error', 'warning')),
+    [record, notify],
+  )
+
   return (
     <TopToolbar className={className} {...sanitizeListRestProps(rest)}>
       <div className={classes.toolbar}>
@@ -160,6 +171,12 @@ const PlaylistActions = ({ className, ids, data, record, ...rest }) => {
             label={translate('resources.playlist.actions.export')}
           >
             <QueueMusicIcon />
+          </Button>
+          <Button
+            onClick={handlePublish}
+            label={translate('resources.playlist.actions.publish')}
+          >
+            <PublishIcon />
           </Button>
         </div>
         <div>{isNotSmall && <ToggleFieldsMenu resource="playlistTrack" />}</div>


### PR DESCRIPTION
## Summary
- add SyncFolder env option to store published playlists
- copy exported playlists to sync folder when publishing
- expose publish playlist API and UI button

## Testing
- `npm test`
- `go test ./...` *(fails: Package 'taglib' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be66f5bec08330afec0210f63b1cf9