### PR TITLE
feat: rebrand UI to MusicMatters

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -20,7 +20,7 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="./manifest.webmanifest" />
-    <meta property="og:site_name" content="Navidrome">
+    <meta property="og:site_name" content="MusicMatters">
     <meta property="og:url" content="{{ .ShareURL }}">
     <meta property="og:title" content="{{ .ShareDescription }}">
     <meta property="og:image" content="{{ .ShareImageURL }}">

--- a/ui/public/offline.html
+++ b/ui/public/offline.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<head><title>Navidrome</title></head>
+<head><title>MusicMatters</title></head>
 <body style="margin:0">
 <p id="errorMessageDescription" style="text-align:center;font-size:21px;font-family:arial;margin-top:28px">
 It looks like we are having trouble connecting.

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -212,7 +212,7 @@ const Player = () => {
       }
       if (info.duration) {
         const song = info.song
-        document.title = `${song.title} - ${song.artist} - Navidrome`
+        document.title = `${song.title} - ${song.artist} - MusicMatters`
         if (!info.isRadio) {
           const pos = startTime === null ? null : Math.floor(info.currentTime)
           subsonic.nowPlaying(info.trackId, pos)
@@ -278,7 +278,7 @@ const Player = () => {
   }, [dispatch])
 
   if (!visible) {
-    document.title = 'Navidrome'
+    document.title = 'MusicMatters'
   }
 
   const handlers = useMemo(

--- a/ui/src/dialogs/AboutDialog.jsx
+++ b/ui/src/dialogs/AboutDialog.jsx
@@ -69,13 +69,13 @@ const useStyles = makeStyles((theme) => ({
 }))
 
 const links = {
-  homepage: 'navidrome.org',
-  reddit: 'reddit.com/r/Navidrome',
-  twitter: 'twitter.com/navidrome',
+  homepage: 'musicmatters.org',
+  reddit: 'reddit.com/r/MusicMatters',
+  twitter: 'twitter.com/MusicMatters',
   discord: 'discord.gg/xh7j7yF',
-  source: 'github.com/navidrome/navidrome',
-  bugReports: 'github.com/navidrome/navidrome/issues/new/choose',
-  featureRequests: 'github.com/navidrome/navidrome/discussions/new',
+  source: 'github.com/MusicMatters/MusicMatters',
+  bugReports: 'github.com/MusicMatters/MusicMatters/issues/new/choose',
+  featureRequests: 'github.com/MusicMatters/MusicMatters/discussions/new',
 }
 
 const LinkToVersion = ({ version }) => {
@@ -87,10 +87,10 @@ const LinkToVersion = ({ version }) => {
   const commitID = parts[1].replace(/[()]/g, '')
   const isSnapshot = version.includes('SNAPSHOT')
   const url = isSnapshot
-    ? `https://github.com/navidrome/navidrome/compare/v${
+    ? `https://github.com/MusicMatters/MusicMatters/compare/v${
         parts[0].split('-')[0]
       }...${commitID}`
-    : `https://github.com/navidrome/navidrome/releases/tag/v${parts[0]}`
+    : `https://github.com/MusicMatters/MusicMatters/releases/tag/v${parts[0]}`
   return (
     <>
       <Link href={url} target="_blank" rel="noopener noreferrer">
@@ -444,7 +444,7 @@ const AboutDialog = ({ open, onClose }) => {
       className={classes.expandableDialog}
     >
       <DialogTitle id="about-dialog-title" onClose={onClose}>
-        Navidrome Music Server
+        MusicMatters Music Server
       </DialogTitle>
       <DialogContent dividers>
         <TabContent

--- a/ui/src/dialogs/AboutDialog.test.jsx
+++ b/ui/src/dialogs/AboutDialog.test.jsx
@@ -33,7 +33,7 @@ describe('<LinkToVersion />', () => {
 
     const link = screen.queryByRole('link')
     expect(link.href).toBe(
-      'https://github.com/navidrome/navidrome/releases/tag/v0.40.0',
+      'https://github.com/MusicMatters/MusicMatters/releases/tag/v0.40.0',
     )
     expect(link.textContent).toBe('0.40.0')
 
@@ -47,7 +47,7 @@ describe('<LinkToVersion />', () => {
 
     const link = screen.queryByRole('link')
     expect(link.href).toBe(
-      'https://github.com/navidrome/navidrome/compare/v0.40.0...300a0292',
+      'https://github.com/MusicMatters/MusicMatters/compare/v0.40.0...300a0292',
     )
     expect(link.textContent).toBe('0.40.0-SNAPSHOT')
 

--- a/ui/src/dialogs/aboutUtils.js
+++ b/ui/src/dialogs/aboutUtils.js
@@ -209,7 +209,7 @@ export const buildTomlSections = (configs) => {
  * @returns {string} - The TOML-formatted configuration
  */
 export const configToToml = (configData, translate = (key) => key) => {
-  let tomlContent = `# Navidrome Configuration\n# Generated on ${new Date().toISOString()}\n\n`
+  let tomlContent = `# MusicMatters Configuration\n# Generated on ${new Date().toISOString()}\n\n`
 
   // Handle both old array format (configData.config is array) and new nested format (configData.config is object)
   let configs

--- a/ui/src/dialogs/aboutUtils.test.js
+++ b/ui/src/dialogs/aboutUtils.test.js
@@ -155,7 +155,7 @@ describe('configToToml', () => {
 
     const result = configToToml(configData, mockTranslate)
 
-    expect(result).toContain('# Navidrome Configuration')
+    expect(result).toContain('# MusicMatters Configuration')
     expect(result).toContain('# Generated on')
     expect(result).toContain('TestKey = "testValue"')
   })
@@ -273,7 +273,7 @@ describe('configToToml', () => {
 
     const result = configToToml(configData, mockTranslate)
 
-    expect(result).toContain('# Navidrome Configuration')
+    expect(result).toContain('# MusicMatters Configuration')
     expect(result).not.toContain('Development Flags')
   })
 
@@ -282,7 +282,7 @@ describe('configToToml', () => {
 
     const result = configToToml(configData, mockTranslate)
 
-    expect(result).toContain('# Navidrome Configuration')
+    expect(result).toContain('# MusicMatters Configuration')
     expect(result).not.toContain('Development Flags')
   })
 

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -344,7 +344,7 @@
   },
   "ra": {
     "auth": {
-      "welcome1": "Thanks for installing Navidrome!",
+      "welcome1": "Thanks for installing MusicMatters!",
       "welcome2": "To start, create an admin user",
       "confirmPassword": "Confirm Password",
       "buttonCreateAdmin": "Create Admin",
@@ -355,7 +355,7 @@
       "sign_in": "Sign in",
       "sign_in_error": "Authentication failed, please retry",
       "logout": "Logout",
-      "insightsCollectionNote": "Navidrome collects anonymous usage data to\nhelp improve the project. Click [here] to learn\nmore and to opt-out if you want"
+      "insightsCollectionNote": "MusicMatters collects anonymous usage data to\nhelp improve the project. Click [here] to learn\nmore and to opt-out if you want"
     },
     "validation": {
       "invalidChars": "Please only use letters and numbers",
@@ -491,7 +491,7 @@
   "message": {
     "note": "NOTE",
     "transcodingDisabled": "Changing the transcoding configuration through the web interface is disabled for security reasons. If you would like to change (edit or add) transcoding options, restart the server with the %{config} configuration option.",
-    "transcodingEnabled": "Navidrome is currently running with %{config}, making it possible to run system commands from the transcoding settings using the web interface. We recommend to disable it for security reasons and only enable it when configuring Transcoding options.",
+    "transcodingEnabled": "MusicMatters is currently running with %{config}, making it possible to run system commands from the transcoding settings using the web interface. We recommend to disable it for security reasons and only enable it when configuring Transcoding options.",
     "songsAddedToPlaylist": "Added 1 song to playlist |||| Added %{smart_count} songs to playlist",
     "movedSuccess": "Moved successfully",
     "folderExists": "Folder already exists",
@@ -505,7 +505,7 @@
     "remove_all_missing_title": "Remove all missing files",
     "remove_all_missing_content": "Are you sure you want to remove all missing files from the database? This will permanently remove any references to them, including their play counts and ratings.",
     "notifications_blocked": "You have blocked Notifications for this site in your browser's settings",
-    "notifications_not_available": "This browser does not support desktop notifications or you are not accessing Navidrome over https",
+    "notifications_not_available": "This browser does not support desktop notifications or you are not accessing MusicMatters over https",
     "lastfmLinkSuccess": "Last.fm successfully linked and scrobbling enabled",
     "lastfmLinkFailure": "Last.fm could not be linked",
     "lastfmUnlinkSuccess": "Last.fm unlinked and scrobbling disabled",
@@ -633,7 +633,7 @@
     "minutesAgo": "%{smart_count} minute ago |||| %{smart_count} minutes ago"
   },
   "help": {
-    "title": "Navidrome Hotkeys",
+    "title": "MusicMatters Hotkeys",
     "hotkeys": {
       "show_help": "Show This Help",
       "toggle_menu": "Toggle Menu Side Bar",

--- a/ui/src/subsonic/index.js
+++ b/ui/src/subsonic/index.js
@@ -15,7 +15,7 @@ const url = (command, id, options) => {
   params.append('s', salt)
   params.append('f', 'json')
   params.append('v', '1.8.0')
-  params.append('c', 'NavidromeUI')
+  params.append('c', 'MusicMattersUI')
   id && params.append('id', id)
   if (options) {
     if (options.ts) {

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -49,10 +49,10 @@ export default defineConfig({
 // PWA manifest
 function manifest() {
   return {
-    name: 'Navidrome',
-    short_name: 'Navidrome',
+    name: 'MusicMatters',
+    short_name: 'MusicMatters',
     description:
-      'Navidrome, an open source web-based music collection server and streamer',
+      'MusicMatters, an open source web-based music collection server and streamer',
     categories: ['music', 'entertainment'],
     display: 'standalone',
     start_url: './',


### PR DESCRIPTION
## Summary
- replace Navidrome branding with MusicMatters across web UI
- update configuration export and tests

## Testing
- `npm test`
- `go test ./...` *(fails: Package 'taglib' not found and build assets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf33893f8c8330848584ac252d6e6a