### PR TITLE
fix: allow dragging multiple songs to playlists

### DIFF
--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -122,6 +122,15 @@ export const SongDatagridRow = ({
   )
   const { selectedIds = [], data: listData = {} } = useListContext()
 
+  const dragSongIds = useMemo(() => {
+    const rawIds = selectedIds.includes(record?.id)
+      ? selectedIds.map(
+          (id) => listData[id]?.mediaFileId ?? listData[id]?.id,
+        )
+      : [record?.mediaFileId ?? record?.id]
+    return Array.from(new Set(rawIds.filter(Boolean)))
+  }, [record, selectedIds, listData])
+
   const [, dragDiscRef] = useDrag(
     () => ({
       type: DraggableTypes.DISC,
@@ -141,14 +150,10 @@ export const SongDatagridRow = ({
   const [, dragSongRef] = useDrag(
     () => ({
       type: DraggableTypes.SONG,
-      item: {
-        ids: selectedIds.includes(record?.id)
-          ? selectedIds.map((id) => listData[id]?.mediaFileId || listData[id]?.id)
-          : [record?.mediaFileId || record?.id],
-      },
+      item: { ids: dragSongIds },
       options: { dropEffect: 'copy' },
     }),
-    [record, selectedIds, listData],
+    [dragSongIds],
   )
 
   if (!record || !record.title) {

--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -5,6 +5,7 @@ import {
   PureDatagridBody,
   PureDatagridRow,
   useTranslate,
+  useListContext,
 } from 'react-admin'
 import {
   TableCell,
@@ -119,6 +120,7 @@ export const SongDatagridRow = ({
   const fields = React.Children.toArray(children).filter((c) =>
     isValidElement(c),
   )
+  const { selectedIds = [], data: listData = {} } = useListContext()
 
   const [, dragDiscRef] = useDrag(
     () => ({
@@ -139,10 +141,14 @@ export const SongDatagridRow = ({
   const [, dragSongRef] = useDrag(
     () => ({
       type: DraggableTypes.SONG,
-      item: { ids: [record?.mediaFileId || record?.id] },
+      item: {
+        ids: selectedIds.includes(record?.id)
+          ? selectedIds.map((id) => listData[id]?.mediaFileId || listData[id]?.id)
+          : [record?.mediaFileId || record?.id],
+      },
       options: { dropEffect: 'copy' },
     }),
-    [record],
+    [record, selectedIds, listData],
   )
 
   if (!record || !record.title) {


### PR DESCRIPTION
## Summary
- enable dragging all selected songs when dropping onto playlists

## Testing
- `go test ./...` *(fails: apeproperties.h: No such file or directory)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf40dd28c4833087eb69a8aaed2e76