### PR TITLE
Improve MusicMatters theme palette

### DIFF
--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -134,7 +134,9 @@ const updateUser = async (params) => {
 const emitFoldersChanged = (detail) => {
   try {
     window.dispatchEvent(new CustomEvent('folder:changed', { detail }))
-  } catch {}
+  } catch (e) {
+    // ignore dispatch errors
+  }
 }
 
 const wrapperDataProvider = {

--- a/ui/src/layout/PlaylistsSubMenu.jsx
+++ b/ui/src/layout/PlaylistsSubMenu.jsx
@@ -24,12 +24,30 @@ const useStyles = makeStyles((theme) => ({
     paddingTop: 4,
     paddingBottom: 4,
     transition: 'all 0.2s ease-in-out',
-    '&:hover': { backgroundColor: theme.palette.action.hover, transform: 'translateX(2px)' },
+    '&:hover': {
+      backgroundColor: theme.palette.action.hover,
+      transform: 'translateX(2px)',
+    },
+    '&:hover $text': {
+      color: theme.palette.secondary.main,
+    },
+    '&:hover $listItemIcon': {
+      color: theme.palette.secondary.main,
+    },
   },
-  active: { backgroundColor: theme.palette.action.selected, fontWeight: theme.typography.fontWeightMedium },
-  text: { transition: 'color 0.2s ease' },
+  active: {
+    backgroundColor: theme.palette.action.selected,
+    fontWeight: theme.typography.fontWeightMedium,
+    '& $text': {
+      color: theme.palette.secondary.main,
+    },
+    '& $listItemIcon': {
+      color: theme.palette.secondary.main,
+    },
+  },
+  text: { transition: 'color 0.2s ease', color: theme.palette.text.primary },
   toggleButton: { padding: 4, marginRight: 4 },
-  listItemIcon: { minWidth: 28 },
+  listItemIcon: { minWidth: 28, color: theme.palette.text.primary },
   spacer: { width: 24 },
   nested: { paddingLeft: theme.spacing(2) },
   depth: (props) => ({ paddingLeft: theme.spacing(2) + props.depth * theme.spacing(2) }),

--- a/ui/src/themes/jared.js
+++ b/ui/src/themes/jared.js
@@ -6,7 +6,7 @@ const mmCol = {
   accent: '#e91e63',
   text: '#212121',
   textAlt: '#616161',
-  icon: '#e91e63',
+  icon: '#212121',
   link: '#e91e63',
   border: '#bdbdbd',
 }
@@ -61,7 +61,7 @@ export default {
     },
     MuiAppBar: {
       colorSecondary: {
-        color: mmCol['text'],
+        color: mmCol['accent'],
       },
       positionFixed: {
         backgroundColor: mmCol['secondary'],
@@ -134,28 +134,28 @@ export default {
         borderColor: mmCol['border'],
       },
     },
-    //Icons
+    // Icons inherit the current color to allow contextual theming
     MuiIconButton: {
       label: {
-        color: mmCol['icon'],
+        color: 'inherit',
       },
     },
     MuiListItemIcon: {
       root: {
-        color: mmCol['icon'],
+        color: 'inherit',
       },
     },
     MuiSelect: {
       icon: {
-        color: mmCol['icon'],
+        color: 'inherit',
       },
     },
     MuiSvgIcon: {
       root: {
-        color: mmCol['icon'],
+        color: 'inherit',
       },
       colorDisabled: {
-        color: mmCol['icon'],
+        color: 'inherit',
       },
     },
     MuiSwitch: {
@@ -170,7 +170,7 @@ export default {
     },
     RaButton: {
       smallIcon: {
-        color: mmCol['icon'],
+        color: 'inherit',
       },
     },
     RaDatagrid: {


### PR DESCRIPTION
## Summary
- ensure sidebar playlists use accent color only on hover
- color AppBar text and icons with pink accent
- fix empty catch block in wrapperDataProvider

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c01281393c83309c9a332dd6e0ab5e