### PR TITLE
ui: drag multiple selected songs

### DIFF
--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -5,6 +5,7 @@ import {
   PureDatagridBody,
   PureDatagridRow,
   useTranslate,
+  useListContext,
 } from 'react-admin'
 import {
   TableCell,
@@ -120,6 +121,17 @@ export const SongDatagridRow = ({
     isValidElement(c),
   )
 
+  const { selectedIds = [], data: listData = {} } = useListContext()
+
+  const dragIds = useMemo(() => {
+    if (selectedIds.includes(record?.id) && selectedIds.length > 1) {
+      return selectedIds.map(
+        (id) => listData[id]?.mediaFileId || listData[id]?.id || id,
+      )
+    }
+    return [record?.mediaFileId || record?.id]
+  }, [selectedIds, listData, record])
+
   const [, dragDiscRef] = useDrag(
     () => ({
       type: DraggableTypes.DISC,
@@ -139,10 +151,10 @@ export const SongDatagridRow = ({
   const [, dragSongRef] = useDrag(
     () => ({
       type: DraggableTypes.SONG,
-      item: { ids: [record?.mediaFileId || record?.id] },
+      item: { ids: dragIds },
       options: { dropEffect: 'copy' },
     }),
-    [record],
+    [dragIds],
   )
 
   if (!record || !record.title) {


### PR DESCRIPTION
## Summary
- allow dragging multiple selected songs by collecting selected IDs

## Testing
- `npm test`
- `npm run lint`
- `go test ./...` *(fails: Package taglib was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68c3465aa67483308e4a72269dd802b1