### PR TITLE
Reduce Songs table row gap

### DIFF
--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -260,12 +260,13 @@ const SongDatagridBody = ({
 export const SongDatagrid = ({
   contextAlwaysVisible,
   showDiscSubtitles,
+  className,
   ...rest
 }) => {
   const classes = useStyles()
   return (
     <Datagrid
-      className={classes.headerStyle}
+      className={clsx(classes.headerStyle, className)}
       isRowSelectable={(r) => !r?.missing}
       {...rest}
       body={
@@ -282,4 +283,5 @@ SongDatagrid.propTypes = {
   contextAlwaysVisible: PropTypes.bool,
   showDiscSubtitles: PropTypes.bool,
   classes: PropTypes.object,
+  className: PropTypes.string,
 }

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -64,6 +64,13 @@ const useStyles = makeStyles({
     margin: 0,
     height: '24px',
   },
+  '@global': {
+    '.songsTable--tightGap': {
+      '--song-row-gap': '8px',
+      borderCollapse: 'separate',
+      borderSpacing: '0 var(--song-row-gap)',
+    },
+  },
 })
 
 const SongFilter = (props) => {
@@ -250,6 +257,7 @@ const SongList = (props) => {
           <SongSimpleList />
         ) : (
           <SongDatagrid
+            className="songsTable--tightGap"
             rowClick={handleRowClick}
             contextAlwaysVisible={!isDesktop}
             classes={{ row: classes.row }}


### PR DESCRIPTION
## Summary
- tighten Songs datagrid row spacing with custom `songsTable--tightGap` class
- allow SongDatagrid to accept extra class names for page-specific styling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c46b6c43d0833099f9b7d508905bd9