### PR TITLE
Fix drag-and-drop adding only one song

### DIFF
--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -36,6 +36,7 @@ const useStyles = makeStyles({
   },
   row: {
     cursor: 'pointer',
+    userSelect: 'none',
     '&:hover': {
       '& $contextMenu': {
         visibility: 'visible',
@@ -45,6 +46,7 @@ const useStyles = makeStyles({
   missingRow: {
     cursor: 'inherit',
     opacity: 0.3,
+    userSelect: 'none',
   },
   headerStyle: {
     '& thead': {
@@ -82,6 +84,7 @@ const DiscSubtitleRow = forwardRef(
         ref={ref}
         onClick={handlePlaySubset(record.discNumber)}
         className={classes.row}
+        draggable
       >
         <TableCell colSpan={colSpan}>
           <Typography variant="h6" className={classes.subtitle}>
@@ -183,6 +186,7 @@ export const SongDatagridRow = ({
         {...rest}
         rowClick={rowClick}
         className={computedClasses}
+        draggable
       >
         {fields}
       </PureDatagridRow>

--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -5,6 +5,7 @@ import {
   PureDatagridBody,
   PureDatagridRow,
   useTranslate,
+  useListContext,
 } from 'react-admin'
 import {
   TableCell,
@@ -116,6 +117,7 @@ export const SongDatagridRow = ({
   ...rest
 }) => {
   const classes = useStyles()
+  const { selectedIds = [], data: listData = {} } = useListContext()
   const fields = React.Children.toArray(children).filter((c) =>
     isValidElement(c),
   )
@@ -139,10 +141,17 @@ export const SongDatagridRow = ({
   const [, dragSongRef] = useDrag(
     () => ({
       type: DraggableTypes.SONG,
-      item: { ids: [record?.mediaFileId || record?.id] },
+      item: {
+        ids: selectedIds.includes(record.id)
+          ? selectedIds.map(
+              (id) =>
+                listData[id]?.mediaFileId || listData[id]?.id || id,
+            )
+          : [record?.mediaFileId || record?.id],
+      },
       options: { dropEffect: 'copy' },
     }),
-    [record],
+    [record, selectedIds, listData],
   )
 
   if (!record || !record.title) {


### PR DESCRIPTION
## Summary
- Allow dragging multiple selected songs onto a playlist to add them all at once

## Testing
- `npm test`
- `npm run lint`
- `go test ./...` *(fails: Package 'taglib' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6925c06508330a51e4197f967e335