### PR TITLE
Make song list columns reorderable via display menu

### DIFF
--- a/ui/src/actions/settings.js
+++ b/ui/src/actions/settings.js
@@ -1,6 +1,7 @@
 export const SET_NOTIFICATIONS_STATE = 'SET_NOTIFICATIONS_STATE'
 export const SET_TOGGLEABLE_FIELDS = 'SET_TOGGLEABLE_FIELDS'
 export const SET_OMITTED_FIELDS = 'SET_OMITTED_FIELDS'
+export const SET_FIELDS_ORDER = 'SET_FIELDS_ORDER'
 
 export const setNotificationsState = (enabled) => ({
   type: SET_NOTIFICATIONS_STATE,
@@ -9,6 +10,11 @@ export const setNotificationsState = (enabled) => ({
 
 export const setToggleableFields = (obj) => ({
   type: SET_TOGGLEABLE_FIELDS,
+  data: obj,
+})
+
+export const setFieldsOrder = (obj) => ({
+  type: SET_FIELDS_ORDER,
   data: obj,
 })
 

--- a/ui/src/reducers/settingsReducer.js
+++ b/ui/src/reducers/settingsReducer.js
@@ -2,12 +2,14 @@ import {
   SET_NOTIFICATIONS_STATE,
   SET_OMITTED_FIELDS,
   SET_TOGGLEABLE_FIELDS,
+  SET_FIELDS_ORDER,
 } from '../actions'
 
 const initialState = {
   notifications: false,
   toggleableFields: {},
   omittedFields: {},
+  fieldsOrder: {},
 }
 
 export const settingsReducer = (previousState = initialState, payload) => {
@@ -23,6 +25,14 @@ export const settingsReducer = (previousState = initialState, payload) => {
         ...previousState,
         toggleableFields: {
           ...previousState.toggleableFields,
+          ...data,
+        },
+      }
+    case SET_FIELDS_ORDER:
+      return {
+        ...previousState,
+        fieldsOrder: {
+          ...previousState.fieldsOrder,
           ...data,
         },
       }


### PR DESCRIPTION
## Summary
- allow dragging to reorder columns from the Columns To Display menu
- persist column order in settings and apply it when rendering song tables

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7e2ac5b5c8330be91c6fcfcb1b24e