### PR TITLE
feat: allow column order customization

### DIFF
--- a/ui/dev-dist/registerSW.js
+++ b/ui/dev-dist/registerSW.js
@@ -1,0 +1,1 @@
+if('serviceWorker' in navigator) navigator.serviceWorker.register('/dev-sw.js?dev-sw', { scope: '/', type: 'classic' })

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,6 +9,7 @@
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@material-ui/core": "^4.12.4",
         "@material-ui/icons": "^4.11.3",
         "@material-ui/lab": "^4.0.0-alpha.58",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -7,6 +7,8 @@
       "name": "ui",
       "hasInstallScript": true,
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@material-ui/core": "^4.12.4",
         "@material-ui/icons": "^4.11.3",
         "@material-ui/lab": "^4.0.0-alpha.58",
@@ -1642,6 +1644,59 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emotion/hash": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -38,6 +38,8 @@
     "react-dnd-html5-backend": "^14.1.0",
     "react-dom": "^17.0.2",
     "react-drag-listview": "^0.1.9",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "react-ga": "^3.3.1",
     "react-hotkeys": "^2.0.0",
     "react-icons": "^5.5.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,6 +16,9 @@
     "postinstall": "bin/update-workbox.sh"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.58",
@@ -38,8 +41,6 @@
     "react-dnd-html5-backend": "^14.1.0",
     "react-dom": "^17.0.2",
     "react-drag-listview": "^0.1.9",
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/sortable": "^10.0.0",
     "react-ga": "^3.3.1",
     "react-hotkeys": "^2.0.0",
     "react-icons": "^5.5.0",

--- a/ui/src/actions/settings.js
+++ b/ui/src/actions/settings.js
@@ -1,6 +1,7 @@
 export const SET_NOTIFICATIONS_STATE = 'SET_NOTIFICATIONS_STATE'
 export const SET_TOGGLEABLE_FIELDS = 'SET_TOGGLEABLE_FIELDS'
 export const SET_OMITTED_FIELDS = 'SET_OMITTED_FIELDS'
+export const SET_COLUMNS_ORDER = 'SET_COLUMNS_ORDER'
 
 export const setNotificationsState = (enabled) => ({
   type: SET_NOTIFICATIONS_STATE,
@@ -14,5 +15,10 @@ export const setToggleableFields = (obj) => ({
 
 export const setOmittedFields = (obj) => ({
   type: SET_OMITTED_FIELDS,
+  data: obj,
+})
+
+export const setColumnsOrder = (obj) => ({
+  type: SET_COLUMNS_ORDER,
   data: obj,
 })

--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -1,23 +1,40 @@
-import React, { isValidElement, useMemo, useCallback, forwardRef } from 'react'
-import { useDispatch } from 'react-redux'
+import React, {
+  isValidElement,
+  useMemo,
+  useCallback,
+  forwardRef,
+  useState,
+  Children,
+} from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import {
   Datagrid,
   PureDatagridBody,
   PureDatagridRow,
   useTranslate,
+  useListContext,
+  useResourceContext,
+  DatagridHeaderCell,
 } from 'react-admin'
 import {
   TableCell,
   TableRow,
   Typography,
   useMediaQuery,
+  TableHead,
+  Checkbox,
+  Tooltip,
+  TableSortLabel,
 } from '@material-ui/core'
 import PropTypes from 'prop-types'
 import { makeStyles } from '@material-ui/core/styles'
 import AlbumIcon from '@material-ui/icons/Album'
+import DragIndicatorIcon from '@material-ui/icons/DragIndicator'
 import clsx from 'clsx'
 import { useDrag } from 'react-dnd'
-import { playTracks } from '../actions'
+import { DndContext, useDraggable, useDroppable, DragOverlay } from '@dnd-kit/core'
+import { FieldTitle } from 'ra-core'
+import { playTracks, setColumnsOrder } from '../actions'
 import { AlbumContextMenu } from '../common'
 import { DraggableTypes } from '../consts'
 import { formatFullDate } from '../utils'
@@ -257,6 +274,280 @@ const SongDatagridBody = ({
   )
 }
 
+const useHeaderCellStyles = makeStyles({
+  icon: {
+    display: 'none',
+  },
+  active: {
+    '& $icon': {
+      display: 'inline',
+    },
+  },
+})
+
+const DraggableHeaderCell = ({
+  id,
+  field,
+  currentSort,
+  updateSort,
+  resource,
+  className,
+}) => {
+  const classes = useHeaderCellStyles()
+  const translate = useTranslate()
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id })
+  const { setNodeRef: setDroppableRef } = useDroppable({ id })
+  const ref = (node) => {
+    setNodeRef(node)
+    setDroppableRef(node)
+  }
+
+  return (
+    <TableCell
+      ref={ref}
+      className={clsx(className, field.props.headerClassName)}
+      align={field.props.textAlign}
+      variant="head"
+      style={{ opacity: isDragging ? 0.5 : 1 }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <DragIndicatorIcon className="dragHandle" {...listeners} {...attributes} />
+        {updateSort &&
+        field.props.sortable !== false &&
+        (field.props.sortBy || field.props.source) ? (
+          <Tooltip
+            title={translate('ra.action.sort')}
+            placement={
+              field.props.textAlign === 'right' ? 'bottom-end' : 'bottom-start'
+            }
+            enterDelay={300}
+          >
+            <TableSortLabel
+              active={
+                currentSort.field === (field.props.sortBy || field.props.source)
+              }
+              direction={currentSort.order === 'ASC' ? 'asc' : 'desc'}
+              data-sort={field.props.sortBy || field.props.source}
+              data-field={field.props.sortBy || field.props.source}
+              data-order={field.props.sortByOrder || 'ASC'}
+              onClick={updateSort}
+              classes={classes}
+            >
+              <FieldTitle
+                label={field.props.label}
+                source={field.props.source}
+                resource={resource}
+              />
+            </TableSortLabel>
+          </Tooltip>
+        ) : (
+          <FieldTitle
+            label={field.props.label}
+            source={field.props.source}
+            resource={resource}
+          />
+        )}
+      </div>
+    </TableCell>
+  )
+}
+
+const SongDatagridHeader = (props) => {
+  const {
+    children,
+    classes,
+    className,
+    hasExpand = false,
+    hasBulkActions = false,
+    isRowSelectable,
+  } = props
+
+  const resource = useResourceContext(props)
+  const translate = useTranslate()
+  const dispatch = useDispatch()
+  const columnsOrder =
+    useSelector((state) => state.settings.columnsOrder?.[resource]) || []
+  const [activeId, setActiveId] = useState(null)
+  const { currentSort, data, ids, onSelect, selectedIds, setSort } =
+    useListContext(props)
+
+  const updateSortCallback = useCallback(
+    (event) => {
+      event.stopPropagation()
+      const newField = event.currentTarget.dataset.field
+      const newOrder =
+        currentSort.field === newField
+          ? currentSort.order === 'ASC'
+            ? 'DESC'
+            : 'ASC'
+          : event.currentTarget.dataset.order
+      setSort(newField, newOrder)
+    },
+    [currentSort.field, currentSort.order, setSort],
+  )
+  const updateSort = setSort ? updateSortCallback : null
+
+  const handleSelectAll = useCallback(
+    (event) => {
+      onSelect(
+        event.target.checked
+          ? ids
+              .filter((id) =>
+                isRowSelectable ? isRowSelectable(data[id]) : true,
+              )
+              .concat(selectedIds.filter((id) => !ids.includes(id)))
+          : [],
+      )
+    },
+    [data, ids, onSelect, isRowSelectable, selectedIds],
+  )
+
+  const selectableIds = isRowSelectable
+    ? ids.filter((id) => isRowSelectable(data[id]))
+    : ids
+
+  const childArray = Children.toArray(children).filter((c) => isValidElement(c))
+  const draggable = childArray.filter((f) =>
+    columnsOrder.includes(f.props.source),
+  )
+
+  const staticBefore = []
+  const staticAfter = []
+  let pastDraggable = false
+  childArray.forEach((field) => {
+    if (columnsOrder.includes(field.props.source)) {
+      pastDraggable = true
+    } else if (!pastDraggable) {
+      staticBefore.push(field)
+    } else {
+      staticAfter.push(field)
+    }
+  })
+
+  const visibleIds = draggable.map((f) => f.props.source)
+
+  const handleDragEnd = ({ active, over }) => {
+    if (over && active.id !== over.id) {
+      const visible = [...visibleIds]
+      const fromIndex = visible.indexOf(active.id)
+      const toIndex = visible.indexOf(over.id)
+      visible.splice(fromIndex, 1)
+      visible.splice(toIndex, 0, active.id)
+      const updated = [...columnsOrder]
+      let vi = 0
+      for (let i = 0; i < updated.length; i++) {
+        if (visibleIds.includes(updated[i])) {
+          updated[i] = visible[vi++]
+        }
+      }
+      dispatch(setColumnsOrder({ [resource]: updated }))
+    }
+    setActiveId(null)
+  }
+
+  const renderOverlay = (id) => {
+    const field = draggable.find((f) => f.props.source === id)
+    if (!field) return null
+    return (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          padding: '15px',
+          background: 'white',
+          boxShadow: '0px 3px 3px rgba(0,0,0,0.15)',
+        }}
+      >
+        <DragIndicatorIcon className="dragHandle" />
+        <FieldTitle
+          label={field.props.label}
+          source={field.props.source}
+          resource={resource}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <TableHead className={clsx(className, classes.thead)}>
+      <TableRow className={clsx(classes.row, classes.headerRow)}>
+        {hasExpand && (
+          <TableCell
+            padding="none"
+            className={clsx(classes.headerCell, classes.expandHeader)}
+          />
+        )}
+        {hasBulkActions && selectedIds && (
+          <TableCell padding="checkbox" className={classes.headerCell}>
+            <Checkbox
+              aria-label={translate('ra.action.select_all', { _: 'Select all' })}
+              className="select-all"
+              color="primary"
+              checked={
+                selectedIds.length > 0 &&
+                selectableIds.length > 0 &&
+                selectableIds.every((id) => selectedIds.includes(id))
+              }
+              onChange={handleSelectAll}
+            />
+          </TableCell>
+        )}
+        {staticBefore.map((field, index) => (
+          <DatagridHeaderCell
+            key={field.props.source || index}
+            className={classes.headerCell}
+            currentSort={currentSort}
+            field={field}
+            isSorting={
+              currentSort.field ===
+              (field.props.sortBy || field.props.source)
+            }
+            resource={resource}
+            updateSort={updateSort}
+          />
+        ))}
+        <DndContext onDragStart={({ active }) => setActiveId(active.id)} onDragEnd={handleDragEnd}>
+          {draggable.map((field) => (
+            <DraggableHeaderCell
+              key={field.props.source}
+              id={field.props.source}
+              field={field}
+              currentSort={currentSort}
+              updateSort={updateSort}
+              resource={resource}
+              className={classes.headerCell}
+            />
+          ))}
+          <DragOverlay>{activeId ? renderOverlay(activeId) : null}</DragOverlay>
+        </DndContext>
+        {staticAfter.map((field, index) => (
+          <DatagridHeaderCell
+            key={field.props.source || index}
+            className={classes.headerCell}
+            currentSort={currentSort}
+            field={field}
+            isSorting={
+              currentSort.field ===
+              (field.props.sortBy || field.props.source)
+            }
+            resource={resource}
+            updateSort={updateSort}
+          />
+        ))}
+      </TableRow>
+    </TableHead>
+  )
+}
+
+SongDatagridHeader.propTypes = {
+  children: PropTypes.node,
+  classes: PropTypes.object,
+  className: PropTypes.string,
+  hasExpand: PropTypes.bool,
+  hasBulkActions: PropTypes.bool,
+  isRowSelectable: PropTypes.func,
+}
+
 export const SongDatagrid = ({
   contextAlwaysVisible,
   showDiscSubtitles,
@@ -267,6 +558,7 @@ export const SongDatagrid = ({
     <Datagrid
       className={classes.headerStyle}
       isRowSelectable={(r) => !r?.missing}
+      header={<SongDatagridHeader />}
       {...rest}
       body={
         <SongDatagridBody

--- a/ui/src/common/ToggleFieldsMenu.jsx
+++ b/ui/src/common/ToggleFieldsMenu.jsx
@@ -9,7 +9,12 @@ import DragIndicatorIcon from '@material-ui/icons/DragIndicator'
 import Checkbox from '@material-ui/core/Checkbox'
 import { useDispatch, useSelector } from 'react-redux'
 import { useTranslate } from 'react-admin'
-import ReactDragListView from 'react-drag-listview'
+import {
+  DndContext,
+  useDraggable,
+  useDroppable,
+  DragOverlay,
+} from '@dnd-kit/core'
 import { setToggleableFields, setColumnsOrder } from '../actions'
 
 const useStyles = makeStyles({
@@ -35,6 +40,7 @@ export const ToggleFieldsMenu = ({
   hideColumns,
 }) => {
   const [anchorEl, setAnchorEl] = useState(null)
+  const [activeId, setActiveId] = useState(null)
   const dispatch = useDispatch()
   const translate = useTranslate()
   const toggleableColumns = useSelector(
@@ -67,12 +73,25 @@ export const ToggleFieldsMenu = ({
     )
   }
 
-  const handleDragEnd = (fromIndex, toIndex) => {
-    const updated = [...columnsOrder]
-    const [moved] = updated.splice(fromIndex, 1)
-    updated.splice(toIndex, 0, moved)
-    dispatch(setColumnsOrder({ [resource]: updated }))
+  const handleDragEnd = ({ active, over }) => {
+    if (over && active.id !== over.id) {
+      const updated = [...columnsOrder]
+      const fromIndex = updated.indexOf(active.id)
+      const toIndex = updated.indexOf(over.id)
+      updated.splice(fromIndex, 1)
+      updated.splice(toIndex, 0, active.id)
+      dispatch(setColumnsOrder({ [resource]: updated }))
+    }
+    setActiveId(null)
   }
+
+  const renderOverlay = (id) => (
+    <MenuItem>
+      <DragIndicatorIcon className="dragHandle" />
+      <Checkbox checked={toggleableColumns[id]} />
+      {translate(`resources.${resource}.fields.${id}`)}
+    </MenuItem>
+  )
 
   return (
     <div className={classes.menuIcon}>
@@ -101,21 +120,23 @@ export const ToggleFieldsMenu = ({
               {translate('ra.toggleFieldsMenu.columnsToDisplay')}
             </Typography>
             <div className={classes.columns}>
-              <ReactDragListView
-                nodeSelector={'li'}
-                handleSelector={'.dragHandle'}
+              <DndContext
+                onDragStart={({ active }) => setActiveId(active.id)}
                 onDragEnd={handleDragEnd}
               >
                 {columnsOrder.map((key) =>
                   !omittedColumns.includes(key) ? (
-                    <MenuItem key={key} onClick={() => handleClick(key)}>
-                      <DragIndicatorIcon className="dragHandle" />
-                      <Checkbox checked={toggleableColumns[key]} />
-                      {translate(`resources.${resource}.fields.${key}`)}
-                    </MenuItem>
+                    <DraggableMenuItem
+                      key={key}
+                      id={key}
+                      onClick={() => handleClick(key)}
+                      checked={toggleableColumns[key]}
+                      label={translate(`resources.${resource}.fields.${key}`)}
+                    />
                   ) : null,
                 )}
-              </ReactDragListView>
+                <DragOverlay>{activeId ? renderOverlay(activeId) : null}</DragOverlay>
+              </DndContext>
             </div>
           </div>
         ) : null}
@@ -128,4 +149,33 @@ ToggleFieldsMenu.propTypes = {
   resource: PropTypes.string.isRequired,
   topbarComponent: PropTypes.elementType,
   hideColumns: PropTypes.bool,
+}
+
+const DraggableMenuItem = ({ id, onClick, checked, label }) => {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id })
+  const { setNodeRef: setDroppableRef } = useDroppable({ id })
+
+  const ref = (node) => {
+    setNodeRef(node)
+    setDroppableRef(node)
+  }
+
+  return (
+    <MenuItem
+      ref={ref}
+      style={{ opacity: isDragging ? 0.5 : 1 }}
+      onClick={onClick}
+    >
+      <DragIndicatorIcon className="dragHandle" {...listeners} {...attributes} />
+      <Checkbox checked={checked} />
+      {label}
+    </MenuItem>
+  )
+}
+
+DraggableMenuItem.propTypes = {
+  id: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+  checked: PropTypes.bool,
+  label: PropTypes.node.isRequired,
 }

--- a/ui/src/common/useSelectedFields.jsx
+++ b/ui/src/common/useSelectedFields.jsx
@@ -1,7 +1,11 @@
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { useDispatch, useSelector } from 'react-redux'
-import { setOmittedFields, setToggleableFields } from '../actions'
+import {
+  setOmittedFields,
+  setToggleableFields,
+  setColumnsOrder,
+} from '../actions'
 
 // TODO Refactor
 export const useSelectedFields = ({
@@ -15,6 +19,9 @@ export const useSelectedFields = ({
     (state) => state.settings.toggleableFields,
   )?.[resource]
   const omittedFields = useSelector((state) => state.settings.omittedFields)?.[
+    resource
+  ]
+  const columnsOrder = useSelector((state) => state.settings.columnsOrder)?.[
     resource
   ]
 
@@ -35,6 +42,13 @@ export const useSelectedFields = ({
     if (!omittedFields) {
       dispatch(setOmittedFields({ [resource]: omittedColumns }))
     }
+    if (
+      !columnsOrder ||
+      columnsOrder.length !== Object.keys(columns).length ||
+      !columnsOrder.every((c) => c in columns)
+    ) {
+      dispatch(setColumnsOrder({ [resource]: Object.keys(columns) }))
+    }
   }, [
     columns,
     defaultOff,
@@ -43,13 +57,15 @@ export const useSelectedFields = ({
     omittedFields,
     resource,
     resourceFields,
+    columnsOrder,
   ])
 
   useEffect(() => {
-    if (resourceFields) {
+    if (resourceFields && columnsOrder) {
       const filtered = []
       const omitted = omittedColumns
-      for (const [key, val] of Object.entries(columns)) {
+      for (const key of columnsOrder) {
+        const val = columns[key]
         if (!val) omitted.push(key)
         else if (resourceFields[key]) filtered.push(val)
       }
@@ -66,6 +82,7 @@ export const useSelectedFields = ({
     omittedFields,
     resource,
     filteredComponents.length,
+    columnsOrder,
   ])
 
   return React.Children.toArray(filteredComponents)

--- a/ui/src/reducers/settingsReducer.js
+++ b/ui/src/reducers/settingsReducer.js
@@ -2,12 +2,14 @@ import {
   SET_NOTIFICATIONS_STATE,
   SET_OMITTED_FIELDS,
   SET_TOGGLEABLE_FIELDS,
+  SET_COLUMNS_ORDER,
 } from '../actions'
 
 const initialState = {
   notifications: false,
   toggleableFields: {},
   omittedFields: {},
+  columnsOrder: {},
 }
 
 export const settingsReducer = (previousState = initialState, payload) => {
@@ -31,6 +33,14 @@ export const settingsReducer = (previousState = initialState, payload) => {
         ...previousState,
         omittedFields: {
           ...previousState.omittedFields,
+          ...data,
+        },
+      }
+    case SET_COLUMNS_ORDER:
+      return {
+        ...previousState,
+        columnsOrder: {
+          ...previousState.columnsOrder,
           ...data,
         },
       }


### PR DESCRIPTION
## Summary
- track column order in settings state
- allow reordering columns via drag and drop in toggle menu
- render song datagrid columns according to saved order

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7e384a5b083309596db3eff6d60b6