### PR TITLE
Fix immediate column reorder updates in ToggleFieldsMenu

### DIFF
--- a/ui/src/common/useSelectedFields.jsx
+++ b/ui/src/common/useSelectedFields.jsx
@@ -63,15 +63,30 @@ export const useSelectedFields = ({
   useEffect(() => {
     if (resourceFields && columnsOrder) {
       const filtered = []
-      const omitted = omittedColumns
+      const omitted = [...omittedColumns]
       for (const key of columnsOrder) {
         const val = columns[key]
         if (!val) omitted.push(key)
         else if (resourceFields[key]) filtered.push(val)
       }
-      if (filteredComponents.length !== filtered.length)
-        setFilteredComponents(filtered)
-      if (omittedFields.length !== omitted.length)
+
+      setFilteredComponents((previous) => {
+        const hasSameLength = previous.length === filtered.length
+        const hasSameOrder =
+          hasSameLength &&
+          filtered.every((component, index) => component === previous[index])
+
+        return hasSameOrder ? previous : filtered
+      })
+
+      const currentOmittedFields = omittedFields || []
+      const shouldUpdateOmitted =
+        currentOmittedFields.length !== omitted.length ||
+        omitted.some(
+          (field, index) => field !== currentOmittedFields[index],
+        )
+
+      if (shouldUpdateOmitted)
         dispatch(setOmittedFields({ [resource]: omitted }))
     }
   }, [
@@ -81,7 +96,6 @@ export const useSelectedFields = ({
     omittedColumns,
     omittedFields,
     resource,
-    filteredComponents.length,
     columnsOrder,
   ])
 


### PR DESCRIPTION
## Summary
- ensure column reordering updates the selected field list immediately by comparing component order changes
- avoid mutating omitted column inputs and only update omitted field state when contents change

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8626bab2c8330a82eb592ba939108