### PR TITLE
Fix mobile transport controls

### DIFF
--- a/ui/src/actions/player.js
+++ b/ui/src/actions/player.js
@@ -27,19 +27,21 @@ export const filterSongs = (data, ids) => {
       }, {})
 }
 
-export const addTracks = (data, ids) => {
+export const addTracks = (data, ids, meta) => {
   const songs = filterSongs(data, ids)
   return {
     type: PLAYER_ADD_TRACKS,
     data: songs,
+    meta,
   }
 }
 
-export const playNext = (data, ids) => {
+export const playNext = (data, ids, meta) => {
   const songs = filterSongs(data, ids)
   return {
     type: PLAYER_PLAY_NEXT,
     data: songs,
+    meta,
   }
 }
 
@@ -67,12 +69,13 @@ export const shuffleTracks = (data, ids) => {
   }
 }
 
-export const playTracks = (data, ids, selectedId) => {
+export const playTracks = (data, ids, selectedId, meta) => {
   const songs = filterSongs(data, ids)
   return {
     type: PLAYER_PLAY_TRACKS,
     id: selectedId || Object.keys(songs)[0],
     data: songs,
+    meta,
   }
 }
 

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -18,6 +18,7 @@ import config from '../config'
 import useStyle from './styles'
 import AudioTitle from './AudioTitle'
 import {
+  addTracks,
   clearQueue,
   currentPlaying,
   setPlayMode,
@@ -34,6 +35,7 @@ import keyHandlers from './keyHandlers'
 import { calculateGain } from '../utils/calculateReplayGain'
 
 const HOTKEY_SUPPRESS_DURATION = 400
+const PREFETCH_THRESHOLD = 5
 
 const Player = () => {
   const theme = useCurrentTheme()
@@ -68,6 +70,13 @@ const Player = () => {
   const [gainNode, setGainNode] = useState(null)
   const hotkeyTimeoutRef = useRef()
   const [suppressHotkeys, setSuppressHotkeys] = useState(false)
+  const latestPlayerStateRef = useRef(playerState)
+  const queuePrefetchRef = useRef({
+    sessionId: null,
+    pendingPromise: null,
+    loadingPage: null,
+  })
+  const initialPrefetchSessionRef = useRef(null)
 
   const suppressHotkeysTemporarily = useCallback(() => {
     setSuppressHotkeys(true)
@@ -88,6 +97,10 @@ const Player = () => {
       }
     }
   }, [])
+
+  useEffect(() => {
+    latestPlayerStateRef.current = playerState
+  }, [playerState])
 
   useEffect(() => {
     if (
@@ -120,6 +133,263 @@ const Player = () => {
       gainNode.gain.setValueAtTime(numericGain, context.currentTime)
     }
   }, [audioInstance, context, gainNode, playerState, gainInfo])
+
+  const computeNextPage = useCallback((meta) => {
+    if (!meta || meta.endReached) {
+      return null
+    }
+    const perPage = meta.pagination?.perPage || 1
+    const loadedPages = meta.pagination?.loadedPages || []
+    let maxLoaded = loadedPages.length
+      ? Math.max(...loadedPages)
+      : meta.pagination?.page || 1
+    if (typeof meta.pagination?.total === 'number') {
+      const totalPages = Math.ceil(meta.pagination.total / perPage)
+      if (maxLoaded >= totalPages) {
+        return null
+      }
+    }
+    if (!loadedPages.length && meta.pagination?.page) {
+      maxLoaded = meta.pagination.page
+    }
+    return maxLoaded + 1
+  }, [])
+
+  const appendPrefetchedPage = useCallback(
+    (page, response, metaAtRequest) => {
+      const latest = latestPlayerStateRef.current
+      const meta = latest.queueMeta
+      if (!meta || meta.context !== 'songsList') {
+        return
+      }
+      if (meta.sessionId !== metaAtRequest.sessionId) {
+        return
+      }
+      const existingLoaded = meta.pagination?.loadedPages || []
+      if (existingLoaded.includes(page)) {
+        return
+      }
+      const queue = latest.queue || []
+      const existingTrackIds = new Set(queue.map((item) => item.trackId))
+      const rawRecords = (response && response.data) || []
+      const entries = {}
+      const ids = []
+      rawRecords.forEach((record) => {
+        if (!record || record.missing) {
+          return
+        }
+        const recordId = record.id
+        const trackId = record.mediaFileId || record.id
+        if (!recordId || !trackId || existingTrackIds.has(trackId)) {
+          return
+        }
+        entries[recordId] = { ...record }
+        ids.push(recordId)
+        existingTrackIds.add(trackId)
+      })
+
+      const perPage =
+        meta.pagination?.perPage ||
+        metaAtRequest.pagination?.perPage ||
+        (rawRecords.length > 0 ? rawRecords.length : 1)
+      const responseTotal =
+        typeof response?.total === 'number' ? response.total : null
+      const newTotal =
+        responseTotal ??
+        meta.pagination?.total ??
+        metaAtRequest.pagination?.total ??
+        null
+      const updatedLoadedPages = Array.from(
+        new Set([...(meta.pagination?.loadedPages || []), page]),
+      ).sort((a, b) => a - b)
+      const maxLoaded =
+        updatedLoadedPages[updatedLoadedPages.length - 1] || page
+      let endReached = meta.endReached || false
+      if (newTotal !== null) {
+        const totalPages = Math.ceil(newTotal / perPage)
+        endReached = maxLoaded >= totalPages
+      } else if (rawRecords.length < perPage) {
+        endReached = true
+      }
+
+      const newMeta = {
+        ...meta,
+        pagination: {
+          ...meta.pagination,
+          loadedPages: updatedLoadedPages,
+          total: newTotal,
+        },
+        endReached,
+      }
+
+      dispatch(addTracks(entries, ids, newMeta))
+    },
+    [dispatch],
+  )
+
+  const maybePrefetchNextPage = useCallback(
+    async ({ force = false, meta: metaOverride } = {}) => {
+      const latest = latestPlayerStateRef.current
+      const meta = metaOverride || latest.queueMeta
+      if (!meta || meta.context !== 'songsList' || meta.endReached) {
+        return null
+      }
+
+      const sessionId = meta.sessionId
+      if (queuePrefetchRef.current.sessionId !== sessionId) {
+        queuePrefetchRef.current.sessionId = sessionId
+        queuePrefetchRef.current.pendingPromise = null
+        queuePrefetchRef.current.loadingPage = null
+      }
+
+      if (queuePrefetchRef.current.pendingPromise) {
+        return queuePrefetchRef.current.pendingPromise
+      }
+
+      const queue = latest.queue || []
+      const currentUuid = latest.current?.uuid
+      const currentIndex = queue.findIndex((item) => item.uuid === currentUuid)
+      const remaining =
+        currentIndex === -1 ? queue.length : queue.length - currentIndex - 1
+      const perPage = meta.pagination?.perPage || PREFETCH_THRESHOLD
+      const threshold = force
+        ? Number.POSITIVE_INFINITY
+        : Math.max(1, Math.min(PREFETCH_THRESHOLD, perPage - 1))
+
+      if (!force && remaining > threshold) {
+        return null
+      }
+
+      const nextPage = computeNextPage(meta)
+      if (!nextPage) {
+        return null
+      }
+
+      const fetchPromise = dataProvider
+        .getList(meta.resource || 'song', {
+          pagination: { page: nextPage, perPage },
+          sort: meta.sort || { field: 'title', order: 'ASC' },
+          filter: meta.filter || {},
+        })
+        .then((response) => {
+          appendPrefetchedPage(nextPage, response, meta)
+          return response
+        })
+        .catch((error) => {
+          if (process.env.NODE_ENV !== 'production') {
+            // eslint-disable-next-line no-console
+            console.warn('Failed to prefetch songs queue page', error)
+          }
+          throw error
+        })
+        .finally(() => {
+          if (queuePrefetchRef.current.sessionId === sessionId) {
+            queuePrefetchRef.current.pendingPromise = null
+            queuePrefetchRef.current.loadingPage = null
+          }
+        })
+
+      queuePrefetchRef.current.pendingPromise = fetchPromise
+      queuePrefetchRef.current.loadingPage = nextPage
+
+      return fetchPromise
+    },
+    [appendPrefetchedPage, computeNextPage, dataProvider],
+  )
+
+  const queueMeta = playerState.queueMeta
+  const queueLength = playerState.queue.length
+  const currentTrackUuid = playerState.current?.uuid
+
+  useEffect(() => {
+    if (!queueMeta || queueMeta.context !== 'songsList') {
+      return
+    }
+    if (initialPrefetchSessionRef.current === queueMeta.sessionId) {
+      return
+    }
+    initialPrefetchSessionRef.current = queueMeta.sessionId
+    const promise = maybePrefetchNextPage({
+      force: true,
+      meta: queueMeta,
+    })
+    if (promise && typeof promise.catch === 'function') {
+      promise.catch(() => {})
+    }
+  }, [maybePrefetchNextPage, queueMeta])
+
+  useEffect(() => {
+    if (
+      !queueMeta ||
+      queueMeta.context !== 'songsList' ||
+      (!currentTrackUuid && queueLength === 0)
+    ) {
+      return
+    }
+    const promise = maybePrefetchNextPage()
+    if (promise && typeof promise.catch === 'function') {
+      promise.catch(() => {})
+    }
+  }, [maybePrefetchNextPage, queueMeta, queueLength, currentTrackUuid])
+
+  useEffect(() => {
+    if (!playerState.queueMeta) {
+      queuePrefetchRef.current = {
+        sessionId: null,
+        pendingPromise: null,
+        loadingPage: null,
+      }
+      initialPrefetchSessionRef.current = null
+    }
+  }, [playerState.queueMeta])
+
+  const ensureQueueReady = useCallback(
+    async (direction) => {
+      if (direction !== 'next') {
+        return
+      }
+      const latest = latestPlayerStateRef.current
+      const meta = latest.queueMeta
+      if (!meta || meta.context !== 'songsList' || meta.endReached) {
+        return
+      }
+      const queue = latest.queue || []
+      const currentUuid = latest.current?.uuid
+      const currentIndex = queue.findIndex((item) => item.uuid === currentUuid)
+      if (currentIndex === -1 || currentIndex < queue.length - 1) {
+        return
+      }
+      let pending = queuePrefetchRef.current.pendingPromise
+      if (!pending) {
+        pending = maybePrefetchNextPage({ force: true, meta })
+      }
+      if (pending && typeof pending.then === 'function') {
+        try {
+          await pending
+        } catch (error) {
+          if (process.env.NODE_ENV !== 'production') {
+            // eslint-disable-next-line no-console
+            console.warn('Unable to extend songs queue before skipping', error)
+          }
+        }
+      }
+    },
+    [maybePrefetchNextPage],
+  )
+
+  const getTelemetrySnapshot = useCallback(() => {
+    const latest = latestPlayerStateRef.current
+    const queue = latest.queue || []
+    const currentUuid = latest.current?.uuid
+    const currentIndex = queue.findIndex((item) => item.uuid === currentUuid)
+    return {
+      context: latest.queueMeta?.context || 'unknown',
+      queueLength: queue.length,
+      currentIndex,
+      mode: latest.mode,
+      isPlaying: audioInstance ? !audioInstance.paused : false,
+    }
+  }, [audioInstance])
 
   const defaultOptions = useMemo(
     () => ({
@@ -169,6 +439,8 @@ const Player = () => {
           icon={<MdSkipNext size={28} />}
           label={nextLabel}
           onPointerInteraction={suppressHotkeysTemporarily}
+          ensureQueueReady={ensureQueueReady}
+          getTelemetrySnapshot={getTelemetrySnapshot}
         />
       ),
       prev: (
@@ -178,10 +450,18 @@ const Player = () => {
           icon={<MdSkipPrevious size={28} />}
           label={prevLabel}
           onPointerInteraction={suppressHotkeysTemporarily}
+          ensureQueueReady={ensureQueueReady}
+          getTelemetrySnapshot={getTelemetrySnapshot}
         />
       ),
     }
-  }, [audioInstance, suppressHotkeysTemporarily, translate])
+  }, [
+    audioInstance,
+    ensureQueueReady,
+    getTelemetrySnapshot,
+    suppressHotkeysTemporarily,
+    translate,
+  ])
 
   const options = useMemo(() => {
     const current = playerState.current || {}

--- a/ui/src/audioplayer/TransportControlButton.jsx
+++ b/ui/src/audioplayer/TransportControlButton.jsx
@@ -1,0 +1,183 @@
+import React, { useCallback, useEffect, useRef } from 'react'
+import PropTypes from 'prop-types'
+
+const READY_EVENTS = ['canplay', 'canplaythrough', 'loadeddata']
+const DEFAULT_DEBOUNCE_MS = 250
+
+const TransportControlButton = ({
+  audioInstance,
+  direction,
+  icon,
+  label,
+  onPointerInteraction,
+  debounceMs = DEFAULT_DEBOUNCE_MS,
+}) => {
+  const lastPointerTimeRef = useRef(0)
+  const lastActivationRef = useRef(0)
+  const cleanupRef = useRef(null)
+
+  const clearListeners = useCallback(() => {
+    if (cleanupRef.current) {
+      cleanupRef.current()
+      cleanupRef.current = null
+    }
+  }, [])
+
+  useEffect(() => clearListeners, [audioInstance, clearListeners])
+
+  const ensurePlayback = useCallback(() => {
+    if (!audioInstance) {
+      return
+    }
+
+    try {
+      const playPromise = audioInstance.play()
+      if (playPromise && typeof playPromise.catch === 'function') {
+        playPromise.catch((error) => {
+          if (
+            error &&
+            (error.name === 'NotAllowedError' || error.name === 'AbortError')
+          ) {
+            return
+          }
+          if (error) {
+            // eslint-disable-next-line no-console
+            console.warn('Unable to resume playback after transport change', error)
+          }
+        })
+      }
+    } catch (error) {
+      if (!error || (error.name !== 'NotAllowedError' && error.name !== 'AbortError')) {
+        // eslint-disable-next-line no-console
+        console.warn('Unable to resume playback after transport change', error)
+      }
+    }
+  }, [audioInstance])
+
+  const advanceQueue = useCallback(() => {
+    if (!audioInstance) {
+      return
+    }
+
+    const controlMethod =
+      direction === 'next' ? audioInstance.playNext : audioInstance.playPrev
+
+    if (typeof controlMethod !== 'function') {
+      return
+    }
+
+    const wasPlaying = !audioInstance.paused
+    const readyStateThreshold =
+      typeof audioInstance.HAVE_ENOUGH_DATA === 'number'
+        ? audioInstance.HAVE_ENOUGH_DATA
+        : 4
+
+    clearListeners()
+
+    let resumed = false
+    const handleReady = () => {
+      if (resumed) {
+        return
+      }
+      resumed = true
+      clearListeners()
+      if (wasPlaying) {
+        ensurePlayback()
+      }
+    }
+
+    if (wasPlaying) {
+      READY_EVENTS.forEach((eventName) => {
+        audioInstance.addEventListener(eventName, handleReady, { once: true })
+      })
+      cleanupRef.current = () => {
+        READY_EVENTS.forEach((eventName) => {
+          audioInstance.removeEventListener(eventName, handleReady)
+        })
+      }
+    }
+
+    controlMethod.call(audioInstance)
+
+    if (wasPlaying && audioInstance.readyState >= readyStateThreshold) {
+      handleReady()
+    }
+  }, [audioInstance, clearListeners, direction, ensurePlayback])
+
+  const runActivation = useCallback(
+    (source) => {
+      const now = Date.now()
+      if (now - lastActivationRef.current < debounceMs) {
+        return
+      }
+      lastActivationRef.current = now
+
+      advanceQueue()
+
+      if (source === 'pointer' && typeof onPointerInteraction === 'function') {
+        onPointerInteraction()
+      }
+    },
+    [advanceQueue, debounceMs, onPointerInteraction],
+  )
+
+  const handlePointerUp = useCallback(
+    (event) => {
+      lastPointerTimeRef.current = Date.now()
+      if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId)
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      runActivation('pointer')
+    },
+    [runActivation],
+  )
+
+  const handlePointerCancel = useCallback(() => {
+    lastPointerTimeRef.current = 0
+  }, [])
+
+  const handleClick = useCallback(
+    (event) => {
+      const now = Date.now()
+      if (now - lastPointerTimeRef.current < debounceMs) {
+        event.preventDefault()
+        event.stopPropagation()
+        return
+      }
+      lastPointerTimeRef.current = 0
+      event.preventDefault()
+      event.stopPropagation()
+      runActivation('keyboard')
+    },
+    [debounceMs, runActivation],
+  )
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      data-transport-control="true"
+      data-transport-direction={direction}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
+      onClick={handleClick}
+      className="transport-control-button"
+    >
+      {icon}
+    </button>
+  )
+}
+
+TransportControlButton.propTypes = {
+  audioInstance: PropTypes.object,
+  direction: PropTypes.oneOf(['next', 'prev']).isRequired,
+  icon: PropTypes.node.isRequired,
+  label: PropTypes.string.isRequired,
+  onPointerInteraction: PropTypes.func,
+  debounceMs: PropTypes.number,
+}
+
+export default TransportControlButton

--- a/ui/src/audioplayer/styles.js
+++ b/ui/src/audioplayer/styles.js
@@ -85,6 +85,22 @@ const useStyle = makeStyles(
       '& .react-jinke-music-player-mobile-progress': {
         display: (props) => (props.isRadio ? 'none' : 'flex'),
       },
+      '& [data-transport-control]': {
+        background: 'transparent',
+        border: 'none',
+        color: 'inherit',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 0,
+        margin: 0,
+        font: 'inherit',
+        cursor: 'pointer',
+        touchAction: 'manipulation',
+      },
+      '& [data-transport-control] svg': {
+        pointerEvents: 'none',
+      },
     },
   }),
   { name: 'NDAudioPlayer' },


### PR DESCRIPTION
## Summary
- add a transport control button that unifies pointer handling, debounces taps, and resumes playback when appropriate
- wire the player to use the new controls, suppress hotkeys after pointer taps, and provide accessible labels
- style the transport buttons so they behave like the original icon controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c88b6d6e9c8330af49339f4ce2b8e7