### PR TITLE
Adjust song columns for mobile

### DIFF
--- a/ui/src/common/SongContextMenu.jsx
+++ b/ui/src/common/SongContextMenu.jsx
@@ -7,7 +7,7 @@ import {
   useTranslate,
   useDataProvider,
 } from 'react-admin'
-import { IconButton, Menu, MenuItem } from '@material-ui/core'
+import { IconButton, Menu, MenuItem, useMediaQuery } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core/styles'
 import MoreVertIcon from '@material-ui/icons/MoreVert'
 import { MdQuestionMark } from 'react-icons/md'
@@ -69,6 +69,7 @@ export const SongContextMenu = ({
   const [playlistsLoaded, setPlaylistsLoaded] = useState(false)
   const { permissions } = usePermissions()
   const redirect = useRedirect()
+  const isMobile = useMediaQuery((theme) => theme.breakpoints.down('sm'))
 
   const options = {
     playNow: {
@@ -219,13 +220,18 @@ export const SongContextMenu = ({
 
   const present = !record.missing
 
+  const loveEnabled =
+    config.enableFavourites && showLove && present && !isMobile
+
   return (
     <span className={clsx(classes.noWrap, className)}>
-      <LoveButton
-        record={record}
-        resource={resource}
-        visible={config.enableFavourites && showLove && present}
-      />
+      {loveEnabled && (
+        <LoveButton
+          record={record}
+          resource={resource}
+          visible={loveEnabled}
+        />
+      )}
       <MoreButton record={record} onClick={handleClick} info={options.info} />
       <Menu
         id={'menu' + record.id}

--- a/ui/src/common/SongSimpleList.jsx
+++ b/ui/src/common/SongSimpleList.jsx
@@ -6,6 +6,7 @@ import ListItemIcon from '@material-ui/core/ListItemIcon'
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
 import ListItemText from '@material-ui/core/ListItemText'
 import { makeStyles } from '@material-ui/core/styles'
+import { useMediaQuery } from '@material-ui/core'
 import { sanitizeListRestProps } from 'react-admin'
 import { DurationField, SongContextMenu, RatingField } from './index'
 import { setTrack } from '../actions'
@@ -64,6 +65,7 @@ export const SongSimpleList = ({
   ...rest
 }) => {
   const dispatch = useDispatch()
+  const isMobile = useMediaQuery((theme) => theme.breakpoints.down('sm'))
   const classes = useStyles({ classes: classesOverride })
   return (
     (loading || total > 0) && (
@@ -90,7 +92,7 @@ export const SongSimpleList = ({
                             />
                           </span>
                         </span>
-                        {config.enableStarRating && (
+                        {config.enableStarRating && !isMobile && (
                           <RatingField
                             record={data[id]}
                             source={'rating'}

--- a/ui/src/common/ToggleFieldsMenu.jsx
+++ b/ui/src/common/ToggleFieldsMenu.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import IconButton from '@material-ui/core/IconButton'
 import Menu from '@material-ui/core/Menu'
 import MenuItem from '@material-ui/core/MenuItem'
-import { makeStyles, Typography } from '@material-ui/core'
+import { makeStyles, Typography, useMediaQuery } from '@material-ui/core'
 import MoreVertIcon from '@material-ui/icons/MoreVert'
 import Checkbox from '@material-ui/core/Checkbox'
 import { useDispatch, useSelector } from 'react-redux'
@@ -43,6 +43,19 @@ export const ToggleFieldsMenu = ({
 
   const classes = useStyles()
   const open = Boolean(anchorEl)
+  const isMobile = useMediaQuery((theme) => theme.breakpoints.down('sm'))
+
+  const shouldHideColumn = (key) => {
+    if (!isMobile) {
+      return false
+    }
+
+    if (resource !== 'song') {
+      return false
+    }
+
+    return ['like', 'rating', 'starred', 'starred_at'].includes(key)
+  }
 
   const handleOpen = (event) => {
     setAnchorEl(event.currentTarget)
@@ -90,7 +103,7 @@ export const ToggleFieldsMenu = ({
             </Typography>
             <div className={classes.columns}>
               {Object.entries(toggleableColumns).map(([key, val]) =>
-                !omittedColumns.includes(key) ? (
+                !omittedColumns.includes(key) && !shouldHideColumn(key) ? (
                   <MenuItem key={key} onClick={() => handleClick(key)}>
                     <Checkbox checked={val} />
                     {translate(`resources.${resource}.fields.${key}`)}

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -134,6 +134,7 @@ const SongList = (props) => {
   const classes = useStyles()
   const dispatch = useDispatch()
   const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
+  const isMobile = useMediaQuery((theme) => theme.breakpoints.down('sm'))
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   useResourceRefresh('song')
 
@@ -235,6 +236,46 @@ const SongList = (props) => {
     ],
   })
 
+  const displayedColumns = useMemo(() => {
+    if (!isMobile) {
+      return columns
+    }
+
+    const filtered = []
+    let hasArtist = false
+
+    columns.forEach((column) => {
+      if (!column) {
+        return
+      }
+
+      const source = column.props?.source
+      if (source === 'artist') {
+        hasArtist = true
+      }
+      if (source === 'rating') {
+        return
+      }
+
+      filtered.push(column)
+    })
+
+    if (!hasArtist && toggleableFields.artist) {
+      const insertIndex = filtered.findIndex(
+        (column) => column?.props?.source === 'album',
+      )
+      const artistField = toggleableFields.artist
+
+      if (insertIndex >= 0) {
+        filtered.splice(insertIndex + 1, 0, artistField)
+      } else {
+        filtered.unshift(artistField)
+      }
+    }
+
+    return filtered
+  }, [columns, isMobile, toggleableFields.artist])
+
   return (
     <>
       <List
@@ -255,7 +296,7 @@ const SongList = (props) => {
             classes={{ row: classes.row }}
           >
             <SongTitleField source="title" showTrackNumbers={false} />
-            {columns}
+            {displayedColumns}
             <SongContextMenu
               source={'starred_at'}
               sortByOrder={'DESC'}


### PR DESCRIPTION
## Summary
- filter the songs datagrid columns on small screens to drop rating and force artist into the visible set
- hide like and rating toggles from the mobile columns menu and suppress the love button for compact layouts
- prevent ratings from rendering in the mobile song simple list to keep phone views uncluttered

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c88a71b27483309ae28e8063932207