### PR TITLE
Add persistent theme preference sync

### DIFF
--- a/consts/consts.go
+++ b/consts/consts.go
@@ -25,6 +25,8 @@ const (
 	DefaultSessionTimeout  = 48 * time.Hour
 	CookieExpiry           = 365 * 24 * 3600 // One year
 
+	UserPreferenceThemeKey = "ui.theme"
+
 	OptimizeDBSchedule = "@every 24h"
 
 	// DefaultEncryptionKey This is the encryption key used if none is specified in the `PasswordEncryptionKey` option

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -60,14 +60,15 @@ func (n *Router) routes() http.Handler {
 			n.RX(r, "/share", n.share.NewRepository, true)
 		}
 
-		n.addPlaylistRoute(r)
-		n.addPlaylistFolderRoute(r)
-		n.addPlaylistTrackRoute(r)
-		n.addSongPlaylistsRoute(r)
-		n.addQueueRoute(r)
-		n.addMissingFilesRoute(r)
-		n.addKeepAliveRoute(r)
-		n.addInsightsRoute(r)
+                n.addPlaylistRoute(r)
+                n.addPlaylistFolderRoute(r)
+                n.addPlaylistTrackRoute(r)
+                n.addSongPlaylistsRoute(r)
+                n.addQueueRoute(r)
+                n.addPreferencesRoute(r)
+                n.addMissingFilesRoute(r)
+                n.addKeepAliveRoute(r)
+                n.addInsightsRoute(r)
 
 		r.With(adminOnlyMiddleware).Group(func(r chi.Router) {
 			n.addInspectRoute(r)

--- a/server/nativeapi/preferences.go
+++ b/server/nativeapi/preferences.go
@@ -1,0 +1,93 @@
+package nativeapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/deluan/rest"
+	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/consts"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+)
+
+type userPreferencesResponse struct {
+	Theme     string `json:"theme"`
+	IsDefault bool   `json:"isDefault"`
+}
+
+type updateUserPreferencesRequest struct {
+	Theme string `json:"theme"`
+}
+
+func (n *Router) addPreferencesRoute(r chi.Router) {
+	r.Route("/preferences", func(r chi.Router) {
+		r.Get("/", getUserPreferences(n.ds))
+		r.Put("/", updateUserPreferences(n.ds))
+	})
+}
+
+func getUserPreferences(ds model.DataStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		user, ok := request.UserFrom(ctx)
+		if !ok {
+			http.Error(w, "user not found in context", http.StatusUnauthorized)
+			return
+		}
+
+		repo := ds.UserProps(ctx)
+		theme, err := repo.Get(user.ID, consts.UserPreferenceThemeKey)
+		isDefault := false
+		if errors.Is(err, model.ErrNotFound) {
+			theme = conf.Server.DefaultTheme
+			isDefault = true
+		} else if err != nil {
+			log.Error(ctx, "Error retrieving user theme preference", err)
+			http.Error(w, "failed to load preferences", http.StatusInternalServerError)
+			return
+		}
+
+		resp := userPreferencesResponse{
+			Theme:     theme,
+			IsDefault: isDefault,
+		}
+		if err := rest.RespondWithJSON(w, http.StatusOK, resp); err != nil {
+			log.Error(ctx, "Error sending user preferences response", err)
+		}
+	}
+}
+
+func updateUserPreferences(ds model.DataStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		user, ok := request.UserFrom(ctx)
+		if !ok {
+			http.Error(w, "user not found in context", http.StatusUnauthorized)
+			return
+		}
+
+		var payload updateUserPreferencesRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		theme := strings.TrimSpace(payload.Theme)
+		if theme == "" {
+			http.Error(w, "theme is required", http.StatusBadRequest)
+			return
+		}
+
+		if err := ds.UserProps(ctx).Put(user.ID, consts.UserPreferenceThemeKey, theme); err != nil {
+			log.Error(ctx, "Error saving user theme preference", err)
+			http.Error(w, "failed to save preferences", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/server/nativeapi/preferences_test.go
+++ b/server/nativeapi/preferences_test.go
@@ -1,0 +1,121 @@
+package nativeapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/conf/configtest"
+	"github.com/navidrome/navidrome/consts"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+	"github.com/navidrome/navidrome/tests"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("User preferences API", func() {
+	var (
+		ds      *tests.MockDataStore
+		user    model.User
+		repo    *tests.MockedUserPropsRepo
+		handler http.Handler
+	)
+
+	BeforeEach(func() {
+		DeferCleanup(configtest.SetupConfig())
+		repo = &tests.MockedUserPropsRepo{}
+		ds = &tests.MockDataStore{MockedUserProps: repo, MockedUser: tests.CreateMockUserRepo()}
+		user = model.User{ID: "user-1", UserName: "tester"}
+		Expect(ds.User(nil).Put(&user)).To(Succeed())
+	})
+
+	Describe("GET /api/preferences", func() {
+		It("returns default theme when preference is not stored", func() {
+			req := httptest.NewRequest("GET", "/preferences", nil)
+			req = req.WithContext(request.WithUser(req.Context(), user))
+			w := httptest.NewRecorder()
+
+			handler = getUserPreferences(ds)
+			handler.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp userPreferencesResponse
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp.Theme).To(Equal(conf.Server.DefaultTheme))
+			Expect(resp.IsDefault).To(BeTrue())
+		})
+
+		It("returns stored theme when preference exists", func() {
+			Expect(repo.Put(user.ID, consts.UserPreferenceThemeKey, "DarkTheme")).To(Succeed())
+
+			req := httptest.NewRequest("GET", "/preferences", nil)
+			req = req.WithContext(request.WithUser(req.Context(), user))
+			w := httptest.NewRecorder()
+
+			handler = getUserPreferences(ds)
+			handler.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp userPreferencesResponse
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp.Theme).To(Equal("DarkTheme"))
+			Expect(resp.IsDefault).To(BeFalse())
+		})
+
+		It("returns unauthorized when no user context is present", func() {
+			req := httptest.NewRequest("GET", "/preferences", nil)
+			w := httptest.NewRecorder()
+
+			handler = getUserPreferences(ds)
+			handler.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusUnauthorized))
+		})
+	})
+
+	Describe("PUT /api/preferences", func() {
+		It("stores the provided theme", func() {
+			body := bytes.NewBufferString(`{"theme":"SpotifyTheme"}`)
+			req := httptest.NewRequest("PUT", "/preferences", body)
+			req.Header.Set("Content-Type", "application/json")
+			req = req.WithContext(request.WithUser(req.Context(), user))
+			w := httptest.NewRecorder()
+
+			handler = updateUserPreferences(ds)
+			handler.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusNoContent))
+			stored, err := repo.Get(user.ID, consts.UserPreferenceThemeKey)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stored).To(Equal("SpotifyTheme"))
+		})
+
+		It("validates that theme is provided", func() {
+			body := bytes.NewBufferString(`{"theme":""}`)
+			req := httptest.NewRequest("PUT", "/preferences", body)
+			req.Header.Set("Content-Type", "application/json")
+			req = req.WithContext(request.WithUser(req.Context(), user))
+			w := httptest.NewRecorder()
+
+			handler = updateUserPreferences(ds)
+			handler.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusBadRequest))
+		})
+
+		It("returns unauthorized when no user context is present", func() {
+			body := bytes.NewBufferString(`{"theme":"DarkTheme"}`)
+			req := httptest.NewRequest("PUT", "/preferences", body)
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			handler = updateUserPreferences(ds)
+			handler.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusUnauthorized))
+		})
+	})
+})

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -39,6 +39,7 @@ import { i18nProvider } from './i18n'
 import config, { shareInfo } from './config'
 import { keyMap } from './hotkeys'
 import useChangeThemeColor from './useChangeThemeColor'
+import useThemePreferenceSync from './themes/useThemePreferenceSync'
 import SharePlayer from './share/SharePlayer'
 import { HTML5Backend } from 'react-dnd-html5-backend'
 import { DndProvider } from 'react-dnd'
@@ -85,6 +86,7 @@ const App = () => (
 )
 
 const Admin = (props) => {
+  useThemePreferenceSync()
   useChangeThemeColor()
   /* eslint-disable react/jsx-key */
   return (

--- a/ui/src/themes/useThemePreferenceSync.js
+++ b/ui/src/themes/useThemePreferenceSync.js
@@ -1,0 +1,112 @@
+import { useEffect, useRef, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import httpClient from '../dataProvider/httpClient'
+import { changeTheme } from '../actions'
+import themes from './index'
+import { AUTO_THEME_ID } from '../consts'
+import config from '../config'
+
+const resolveThemePreference = (value) => {
+  if (!value) {
+    return null
+  }
+  if (value === AUTO_THEME_ID) {
+    return AUTO_THEME_ID
+  }
+  if (themes[value]) {
+    return value
+  }
+  const match = Object.keys(themes).find(
+    (key) => themes[key].themeName === value,
+  )
+  return match || null
+}
+
+const fallbackTheme =
+  resolveThemePreference(config.defaultTheme) || 'DarkTheme'
+
+const saveThemePreference = (theme) =>
+  httpClient('/api/preferences', {
+    method: 'PUT',
+    body: JSON.stringify({ theme }),
+  })
+
+const useThemePreferenceSync = () => {
+  const dispatch = useDispatch()
+  const theme = useSelector((state) => state.theme)
+  const themeRef = useRef(theme)
+  const lastSyncedRef = useRef()
+  const [initialSyncComplete, setInitialSyncComplete] = useState(false)
+
+  useEffect(() => {
+    themeRef.current = theme
+  }, [theme])
+
+  useEffect(() => {
+    let cancelled = false
+
+    const fetchPreference = async () => {
+      try {
+        const response = await httpClient('/api/preferences')
+        const payload = response?.json ?? {}
+        const serverTheme = resolveThemePreference(payload.theme)
+        const isDefault = payload.isDefault ?? payload.theme === undefined
+        const resolvedServerTheme = serverTheme || fallbackTheme
+
+        if (isDefault) {
+          const currentTheme = themeRef.current || fallbackTheme
+          if (currentTheme !== resolvedServerTheme) {
+            try {
+              await saveThemePreference(currentTheme)
+              lastSyncedRef.current = currentTheme
+            } catch (error) {
+              lastSyncedRef.current = undefined
+            }
+          } else {
+            lastSyncedRef.current = resolvedServerTheme
+          }
+        } else {
+          const currentTheme = themeRef.current
+          if (resolvedServerTheme && resolvedServerTheme !== currentTheme) {
+            dispatch(changeTheme(resolvedServerTheme))
+            lastSyncedRef.current = resolvedServerTheme
+          } else {
+            lastSyncedRef.current = currentTheme || resolvedServerTheme
+          }
+        }
+      } catch (error) {
+        lastSyncedRef.current = undefined
+      } finally {
+        if (!cancelled) {
+          setInitialSyncComplete(true)
+        }
+      }
+    }
+
+    fetchPreference()
+
+    return () => {
+      cancelled = true
+    }
+  }, [dispatch])
+
+  useEffect(() => {
+    if (!initialSyncComplete) {
+      return
+    }
+    const currentTheme = themeRef.current || fallbackTheme
+    if (!currentTheme) {
+      return
+    }
+    if (lastSyncedRef.current === currentTheme) {
+      return
+    }
+    lastSyncedRef.current = currentTheme
+    saveThemePreference(currentTheme).catch(() => {
+      lastSyncedRef.current = undefined
+    })
+  }, [theme, initialSyncComplete])
+}
+
+export default useThemePreferenceSync
+

--- a/ui/src/themes/useThemePreferenceSync.test.jsx
+++ b/ui/src/themes/useThemePreferenceSync.test.jsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import { Provider } from 'react-redux'
+import { combineReducers, createStore } from 'redux'
+import { renderHook, act } from '@testing-library/react-hooks'
+import { waitFor } from '@testing-library/react'
+import useThemePreferenceSync from './useThemePreferenceSync'
+import { themeReducer } from '../reducers/themeReducer'
+import httpClient from '../dataProvider/httpClient'
+import { changeTheme } from '../actions'
+
+const createThemeStore = (theme) =>
+  createStore(
+    combineReducers({ theme: themeReducer }),
+    theme ? { theme } : undefined,
+  )
+
+vi.mock('../dataProvider/httpClient', () => ({
+  default: vi.fn(),
+}))
+
+describe('useThemePreferenceSync', () => {
+  beforeEach(() => {
+    httpClient.mockReset()
+  })
+
+  it('applies the stored theme from the server', async () => {
+    httpClient.mockResolvedValueOnce({
+      json: { theme: 'SpotifyTheme', isDefault: false },
+    })
+
+    const store = createThemeStore()
+    const wrapper = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+
+    renderHook(() => useThemePreferenceSync(), { wrapper })
+
+    await waitFor(() => expect(store.getState().theme).toBe('SpotifyTheme'))
+    expect(httpClient).toHaveBeenCalledTimes(1)
+  })
+
+  it('persists an existing local theme when the server has no preference', async () => {
+    httpClient
+      .mockResolvedValueOnce({
+        json: { theme: 'Music Matters', isDefault: true },
+      })
+      .mockResolvedValue({ json: {} })
+
+    const store = createThemeStore('DarkTheme')
+    const wrapper = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+
+    renderHook(() => useThemePreferenceSync(), { wrapper })
+
+    await waitFor(() => expect(httpClient).toHaveBeenCalledTimes(2))
+    expect(store.getState().theme).toBe('DarkTheme')
+    expect(JSON.parse(httpClient.mock.calls[1][1].body)).toEqual({
+      theme: 'DarkTheme',
+    })
+  })
+
+  it('saves theme changes after the initial synchronisation', async () => {
+    httpClient
+      .mockResolvedValueOnce({
+        json: { theme: 'Music Matters', isDefault: true },
+      })
+      .mockResolvedValue({ json: {} })
+
+    const store = createThemeStore('MusicMattersTheme')
+    const wrapper = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+
+    renderHook(() => useThemePreferenceSync(), { wrapper })
+
+    await waitFor(() => expect(httpClient).toHaveBeenCalledTimes(1))
+
+    await act(async () => {
+      store.dispatch(changeTheme('GreenTheme'))
+    })
+
+    await waitFor(() => expect(httpClient).toHaveBeenCalledTimes(2))
+    expect(JSON.parse(httpClient.mock.calls[1][1].body)).toEqual({
+      theme: 'GreenTheme',
+    })
+  })
+})
+


### PR DESCRIPTION
## Summary
- add a user preferences endpoint backed by user props to fetch and store UI theme selections
- default to the configured Music Matters theme when no preference exists and expose the route through the native API router
- synchronize the web UI theme state with the server preference and add coverage for the new hook on both backend and frontend

## Testing
- npm --prefix ui test
- go test ./... *(fails: missing taglib development library in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c897ec2d1083308dd977beebbc62c2