### PR TITLE
Run playlist publish only on demand

### DIFF
--- a/server/nativeapi/playlists.go
+++ b/server/nativeapi/playlists.go
@@ -150,11 +150,12 @@ func handleExportPlaylist(ds model.DataStore) http.HandlerFunc {
 func publishPlaylist(ds model.DataStore, playlists core.Playlists) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
-		if err := syncPlaylist(playlists, ds, r.Context(), id); err != nil {
+		filename, err := playlists.Publish(r.Context(), id)
+		if err != nil {
 			http.Error(w, err.Error(), statusFor(err))
 			return
 		}
-		w.WriteHeader(http.StatusNoContent)
+		rest.RespondWithJSON(w, http.StatusOK, map[string]string{"filename": filename})
 	}
 }
 

--- a/server/subsonic/playlists_test.go
+++ b/server/subsonic/playlists_test.go
@@ -86,3 +86,7 @@ func (f *fakePlaylists) Update(ctx context.Context, playlistID string, name *str
 	f.lastRemove = idxToRemove
 	return nil
 }
+
+func (f *fakePlaylists) Publish(context.Context, string) (string, error) {
+	return "", nil
+}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -222,7 +222,7 @@
         "removeFromSelection": "Remove from selection"
       },
       "notifications": {
-        "published": "Published successfully: %{smart_count} song |||| Published successfully: %{smart_count} songs",
+        "published_to_sync": "1 song from \"%{playlist}\" published to Sync folder |||| %{smart_count} songs from \"%{playlist}\" published to Sync folder",
         "publish_error": "Failed to publish playlist. Please try again."
       },
       "message": {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -222,14 +222,15 @@
         "removeFromSelection": "Remove from selection"
       },
       "notifications": {
-        "published": "Published to SyncFolder: %{filename}",
-        "publish_error": "Failed to publish playlist"
+        "published": "Published successfully: %{smart_count} song |||| Published successfully: %{smart_count} songs",
+        "publish_error": "Failed to publish playlist. Please try again."
       },
       "message": {
         "duplicate_song": "Add duplicated songs",
         "song_exist": "There are duplicates being added to the playlist. Would you like to add the duplicates or skip them?",
         "noPlaylistsFound": "No playlists found",
-        "noPlaylists": "No playlists available"
+        "noPlaylists": "No playlists available",
+        "publishConfirm": "Are you sure you want to publish this playlist?"
       }
     },
     "folder": {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -222,7 +222,8 @@
         "removeFromSelection": "Remove from selection"
       },
       "notifications": {
-        "published": "%{smart_count} song from %{name} published to Sync folder |||| %{smart_count} songs from %{name} published to Sync folder"
+        "published": "Published to SyncFolder: %{filename}",
+        "publish_error": "Failed to publish playlist"
       },
       "message": {
         "duplicate_song": "Add duplicated songs",

--- a/ui/src/playlist/PlaylistActions.jsx
+++ b/ui/src/playlist/PlaylistActions.jsx
@@ -56,7 +56,8 @@ const useStyles = makeStyles((theme) => ({
   publishCancelButton: {
     color: theme.palette.common.white,
     '&:hover, &:focus, &:focus-visible': {
-      color: theme.palette.common.white,
+      backgroundColor: 'rgba(128, 128, 128, 0.3)',
+      color: '#FF2B8A',
     },
   },
 }))


### PR DESCRIPTION
## Summary
- remove SyncFolder writes from automatic playlist updates and add a dedicated Publish implementation that exports sanitized .m3u files to the SyncFolder root
- adjust the publish API and UI to report the generated filename, surface clearer notifications, and keep exports idempotent
- cover the new behavior with playlist publish tests and update supporting translations and mocks

## Testing
- `go test ./...` *(fails: taglib development files are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c99c98b4a08330882263c8e3106533