### PR TITLE
Adjust mobile song list layout

### DIFF
--- a/ui/src/common/SongSimpleList.jsx
+++ b/ui/src/common/SongSimpleList.jsx
@@ -7,10 +7,9 @@ import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
 import ListItemText from '@material-ui/core/ListItemText'
 import { makeStyles } from '@material-ui/core/styles'
 import { sanitizeListRestProps } from 'react-admin'
-import { DurationField, SongContextMenu, RatingField } from './index'
+import { SongContextMenu } from './index'
 import { setTrack } from '../actions'
 import { useDispatch } from 'react-redux'
-import config from '../config'
 
 const useStyles = makeStyles(
   {
@@ -19,32 +18,40 @@ const useStyles = makeStyles(
       color: 'inherit',
     },
     listItem: {
-      padding: '10px',
+      padding: '12px 16px',
+    },
+    primary: {
+      display: 'flex',
+      alignItems: 'center',
+      width: '100%',
+      minWidth: 0,
+      gap: '6px',
     },
     title: {
-      paddingRight: '10px',
-      width: '80%',
+      flex: '1 1 auto',
+      minWidth: 0,
+      fontWeight: 500,
+      color: '#fff',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
     },
-    secondary: {
-      marginTop: '-3px',
-      width: '96%',
-      display: 'flex',
-      alignItems: 'flex-start',
-      justifyContent: 'space-between',
+    separator: {
+      flex: '0 0 auto',
+      color: 'rgba(255, 255, 255, 0.6)',
     },
     artist: {
-      paddingRight: '30px',
-    },
-    timeStamp: {
-      float: 'right',
-      color: '#fff',
-      fontWeight: '200',
-      opacity: 0.6,
-      fontSize: '12px',
-      padding: '2px',
+      flex: '1 1 auto',
+      minWidth: 0,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      color: 'rgba(255, 255, 255, 0.65)',
+      fontWeight: 400,
     },
     rightIcon: {
-      top: '26px',
+      top: '50%',
+      transform: 'translateY(-50%)',
     },
   },
   { name: 'RaSongSimpleList' },
@@ -74,31 +81,23 @@ export const SongSimpleList = ({
               <span key={id} onClick={() => dispatch(setTrack(data[id]))}>
                 <ListItem className={classes.listItem} button={true}>
                   <ListItemText
+                    disableTypography
                     primary={
-                      <div className={classes.title}>{data[id].title}</div>
-                    }
-                    secondary={
-                      <>
-                        <span className={classes.secondary}>
-                          <span className={classes.artist}>
-                            {data[id].artist}
-                          </span>
-                          <span className={classes.timeStamp}>
-                            <DurationField
-                              record={data[id]}
-                              source={'duration'}
-                            />
-                          </span>
+                      <div className={classes.primary}>
+                        <span
+                          className={classes.title}
+                          title={data[id].title}
+                        >
+                          {data[id].title}
                         </span>
-                        {config.enableStarRating && (
-                          <RatingField
-                            record={data[id]}
-                            source={'rating'}
-                            resource={'song'}
-                            size={'small'}
-                          />
-                        )}
-                      </>
+                        <span className={classes.separator}>—</span>
+                        <span
+                          className={classes.artist}
+                          title={data[id].artist}
+                        >
+                          {data[id].artist}
+                        </span>
+                      </div>
                     }
                   />
                   <ListItemSecondaryAction className={classes.rightIcon}>

--- a/ui/src/common/SongSimpleList.jsx
+++ b/ui/src/common/SongSimpleList.jsx
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types'
 import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
+import ListSubheader from '@material-ui/core/ListSubheader'
 import { makeStyles } from '@material-ui/core/styles'
-import { sanitizeListRestProps } from 'react-admin'
+import { sanitizeListRestProps, useTranslate } from 'react-admin'
 import { setTrack } from '../actions'
 import { useDispatch } from 'react-redux'
 
@@ -14,41 +15,50 @@ const useStyles = makeStyles(
       textDecoration: 'none',
       color: 'inherit',
     },
+    subheader: {
+      display: 'grid',
+      gridTemplateColumns: '1fr 1fr',
+      columnGap: '12px',
+      padding: '6px 12px',
+      color: '#D1D5DB',
+      fontWeight: 600,
+      backgroundColor: 'transparent',
+    },
+    subheaderText: {
+      minWidth: 0,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      textAlign: 'left',
+    },
     listItem: {
       padding: '6px 12px',
     },
     primary: {
-      display: 'flex',
+      display: 'grid',
+      gridTemplateColumns: '1fr 1fr',
+      columnGap: '12px',
       alignItems: 'center',
       width: '100%',
       minWidth: 0,
-      gap: '12px',
     },
     title: {
-      flex: '1 1 50%',
       minWidth: 0,
       fontWeight: 500,
       color: '#FFFFFF',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
+      textAlign: 'left',
     },
     artist: {
-      flex: '1 1 50%',
       minWidth: 0,
-      display: 'flex',
-      justifyContent: 'flex-end',
-      overflow: 'hidden',
-    },
-    artistText: {
-      maxWidth: '100%',
       color: '#FFFFFF',
       fontWeight: 400,
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
-      textAlign: 'right',
-      direction: 'ltr',
+      textAlign: 'left',
     },
   },
   { name: 'RaSongSimpleList' },
@@ -69,9 +79,23 @@ export const SongSimpleList = ({
 }) => {
   const dispatch = useDispatch()
   const classes = useStyles({ classes: classesOverride })
+  const translate = useTranslate()
   return (
     (loading || total > 0) && (
-      <List className={className} {...sanitizeListRestProps(rest)}>
+      <List
+        className={className}
+        {...sanitizeListRestProps(rest)}
+        subheader={
+          <ListSubheader component="div" disableSticky className={classes.subheader}>
+            <span className={classes.subheaderText}>
+              {translate('resources.song.fields.title', { _: 'Title' })}
+            </span>
+            <span className={classes.subheaderText}>
+              {translate('resources.song.fields.artist', { _: 'Artist' })}
+            </span>
+          </ListSubheader>
+        }
+      >
         {ids.map(
           (id) =>
             data[id] && (
@@ -87,13 +111,11 @@ export const SongSimpleList = ({
                         >
                           {data[id].title}
                         </span>
-                        <span className={classes.artist}>
-                          <span
-                            className={classes.artistText}
-                            title={data[id].artist}
-                          >
-                            {data[id].artist}
-                          </span>
+                        <span
+                          className={classes.artist}
+                          title={data[id].artist}
+                        >
+                          {data[id].artist}
                         </span>
                       </div>
                     }

--- a/ui/src/common/SongSimpleList.jsx
+++ b/ui/src/common/SongSimpleList.jsx
@@ -2,12 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
-import ListItemIcon from '@material-ui/core/ListItemIcon'
-import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
 import ListItemText from '@material-ui/core/ListItemText'
 import { makeStyles } from '@material-ui/core/styles'
 import { sanitizeListRestProps } from 'react-admin'
-import { SongContextMenu } from './index'
 import { setTrack } from '../actions'
 import { useDispatch } from 'react-redux'
 
@@ -18,40 +15,40 @@ const useStyles = makeStyles(
       color: 'inherit',
     },
     listItem: {
-      padding: '12px 16px',
+      padding: '6px 12px',
     },
     primary: {
       display: 'flex',
       alignItems: 'center',
       width: '100%',
       minWidth: 0,
-      gap: '6px',
+      gap: '12px',
     },
     title: {
-      flex: '1 1 auto',
+      flex: '1 1 50%',
       minWidth: 0,
       fontWeight: 500,
-      color: '#fff',
+      color: '#FFFFFF',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
-    },
-    separator: {
-      flex: '0 0 auto',
-      color: 'rgba(255, 255, 255, 0.6)',
     },
     artist: {
-      flex: '1 1 auto',
+      flex: '1 1 50%',
       minWidth: 0,
+      display: 'flex',
+      justifyContent: 'flex-end',
+      overflow: 'hidden',
+    },
+    artistText: {
+      maxWidth: '100%',
+      color: '#FFFFFF',
+      fontWeight: 400,
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
-      color: 'rgba(255, 255, 255, 0.65)',
-      fontWeight: 400,
-    },
-    rightIcon: {
-      top: '50%',
-      transform: 'translateY(-50%)',
+      textAlign: 'right',
+      direction: 'ltr',
     },
   },
   { name: 'RaSongSimpleList' },
@@ -90,21 +87,17 @@ export const SongSimpleList = ({
                         >
                           {data[id].title}
                         </span>
-                        <span className={classes.separator}>—</span>
-                        <span
-                          className={classes.artist}
-                          title={data[id].artist}
-                        >
-                          {data[id].artist}
+                        <span className={classes.artist}>
+                          <span
+                            className={classes.artistText}
+                            title={data[id].artist}
+                          >
+                            {data[id].artist}
+                          </span>
                         </span>
                       </div>
                     }
                   />
-                  <ListItemSecondaryAction className={classes.rightIcon}>
-                    <ListItemIcon>
-                      <SongContextMenu record={data[id]} visible={true} />
-                    </ListItemIcon>
-                  </ListItemSecondaryAction>
                 </ListItem>
               </span>
             ),

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -133,7 +133,7 @@ const SongFilter = (props) => {
 const SongList = (props) => {
   const classes = useStyles()
   const dispatch = useDispatch()
-  const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
+  const isMobile = useMediaQuery('(max-width:768px)')
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   useResourceRefresh('song')
 
@@ -244,9 +244,9 @@ const SongList = (props) => {
         bulkActionButtons={<SongBulkActions />}
         actions={<SongListActions />}
         filters={<SongFilter />}
-        perPage={isXsmall ? 50 : 15}
+        perPage={isMobile ? 50 : 15}
       >
-        {isXsmall ? (
+        {isMobile ? (
           <SongSimpleList />
         ) : (
           <SongDatagrid


### PR DESCRIPTION
## Summary
- streamline the mobile song list view to show title and artist together with ellipsis truncation and subtle styling
- apply the simplified list up to 768px wide screens while keeping the desktop datagrid unchanged

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9dc5a0e2c833089fc1f92624ae8f5