### PR TITLE
Set MusicMatters as UI fallback theme

### DIFF
--- a/ui/src/reducers/themeReducer.js
+++ b/ui/src/reducers/themeReducer.js
@@ -6,7 +6,7 @@ const defaultTheme = () => {
   return (
     Object.keys(themes).find(
       (t) => themes[t].themeName === config.defaultTheme,
-    ) || 'DarkTheme'
+    ) || 'MusicMattersTheme'
   )
 }
 

--- a/ui/src/themes/useCurrentTheme.js
+++ b/ui/src/themes/useCurrentTheme.js
@@ -16,7 +16,7 @@ const useCurrentTheme = () => {
       Object.keys(themes).find(
         (t) => themes[t].themeName === config.defaultTheme,
       ) ||
-      'DarkTheme'
+      'MusicMattersTheme'
     return themes[themeName]
   })
 


### PR DESCRIPTION
## Summary
- ensure theme reducer falls back to MusicMatters when configured theme is unavailable
- update hook to use MusicMatters theme by default instead of Dark

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cbb44f85608330a138af7520bfe668