### PR TITLE
Add persistent pagination options to song list

### DIFF
--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -37,6 +37,8 @@ import { AlbumLinkField } from './AlbumLinkField'
 import { SongBulkActions, QualityInfo, useSelectedFields } from '../common'
 import config from '../config'
 import ExpandInfoDialog from '../dialogs/ExpandInfoDialog'
+import { SongsPagination } from './SongsPagination'
+import { getStoredSongsPerPage } from './songsPaginationConfig'
 
 const useStyles = makeStyles({
   contextHeader: {
@@ -138,6 +140,7 @@ const SongList = (props) => {
   useResourceRefresh('song')
 
   const songs = useSelector((state) => state.admin.resources.song)
+  const perPage = useMemo(() => getStoredSongsPerPage(), [])
 
   const handleRowClick = useCallback((id, basePath, record) => {
       // Convert songs.data to an array if it's an object
@@ -244,7 +247,8 @@ const SongList = (props) => {
         bulkActionButtons={<SongBulkActions />}
         actions={<SongListActions />}
         filters={<SongFilter />}
-        perPage={isMobile ? 50 : 15}
+        perPage={perPage}
+        pagination={<SongsPagination />}
       >
         {isMobile ? (
           <SongSimpleList />

--- a/ui/src/song/SongsPagination.jsx
+++ b/ui/src/song/SongsPagination.jsx
@@ -1,0 +1,25 @@
+import React, { useEffect } from 'react'
+import { Pagination as RAPagination, useListContext } from 'react-admin'
+import {
+  SONGS_PAGINATION_OPTIONS,
+  SONGS_PAGINATION_STORAGE_KEY,
+} from './songsPaginationConfig'
+
+export const SongsPagination = (props) => {
+  const { perPage } = useListContext()
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    if (SONGS_PAGINATION_OPTIONS.includes(perPage)) {
+      window.localStorage.setItem(
+        SONGS_PAGINATION_STORAGE_KEY,
+        perPage.toString(),
+      )
+    }
+  }, [perPage])
+
+  return <RAPagination rowsPerPageOptions={SONGS_PAGINATION_OPTIONS} {...props} />
+}

--- a/ui/src/song/songsPaginationConfig.js
+++ b/ui/src/song/songsPaginationConfig.js
@@ -1,0 +1,16 @@
+export const SONGS_PAGINATION_OPTIONS = [15, 25, 50, 100, 200]
+export const SONGS_PAGINATION_STORAGE_KEY = 'songs.rowsPerPage'
+export const SONGS_DEFAULT_PER_PAGE = 50
+
+export const getStoredSongsPerPage = () => {
+  if (typeof window === 'undefined') {
+    return SONGS_DEFAULT_PER_PAGE
+  }
+
+  const storedValue = window.localStorage.getItem(SONGS_PAGINATION_STORAGE_KEY)
+  const parsedValue = storedValue ? parseInt(storedValue, 10) : NaN
+
+  return SONGS_PAGINATION_OPTIONS.includes(parsedValue)
+    ? parsedValue
+    : SONGS_DEFAULT_PER_PAGE
+}


### PR DESCRIPTION
## Summary
- add a dedicated songs pagination component that exposes all per-page options and persists the chosen value
- read the stored rows-per-page preference when rendering the song list and share it across desktop and mobile views

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbccdc405883308326f17f64344f9b