### PR TITLE
Adjust song and playlist pagination

### DIFF
--- a/ui/src/playlist/PlaylistList.jsx
+++ b/ui/src/playlist/PlaylistList.jsx
@@ -20,6 +20,7 @@ import { useMediaQuery } from '@material-ui/core'
 import {
   DurationField,
   List,
+  Pagination,
   Writable,
   isWritable,
   useSelectedFields,
@@ -155,6 +156,8 @@ const PlaylistList = (props) => {
       filters={<PlaylistFilter />}
       actions={<PlaylistListActions />}
       bulkActionButtons={!isXsmall && <PlaylistListBulkActions />}
+      perPage={50}
+      pagination={<Pagination rowsPerPageOptions={[15, 25, 50, 100, 200]} />}
     >
       <Datagrid rowClick="show" isRowSelectable={(r) => isWritable(r?.ownerId)}>
         <TextField source="name" />

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -17,6 +17,7 @@ import {
   DateField,
   DurationField,
   List,
+  Pagination,
   SongContextMenu,
   SongDatagrid,
   SongInfo,
@@ -244,7 +245,8 @@ const SongList = (props) => {
         bulkActionButtons={<SongBulkActions />}
         actions={<SongListActions />}
         filters={<SongFilter />}
-        perPage={isXsmall ? 50 : 15}
+        perPage={50}
+        pagination={<Pagination rowsPerPageOptions={[15, 25, 50, 100, 200]} />}
       >
         {isXsmall ? (
           <SongSimpleList />


### PR DESCRIPTION
## Summary
- set the songs list to default to 50 rows per page and expose a 15-200 pagination menu
- align the playlists list with the same default and pagination options

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbdad976d88330bcbf72b31c53d1e5