### PR TITLE
Reduce datagrid row spacing

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -15,3 +15,8 @@ code {
 .rc-slider {
   z-index: 78;
 }
+
+table[class*='RaDatagrid-table'] {
+  border-collapse: separate;
+  border-spacing: 0 1px;
+}


### PR DESCRIPTION
## Summary
- shrink the vertical spacing between react-admin datagrid rows by overriding the table border spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbdce2ec708330a91858b506275450