### PR TITLE
Ensure consistent pagination for songs and playlist tracks

### DIFF
--- a/ui/src/common/List.jsx
+++ b/ui/src/common/List.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { List as RAList } from 'react-admin'
 import { Pagination } from './Pagination'
+import { DEFAULT_PAGE_SIZE, PAGE_SIZES } from '../consts'
 import { Title } from './index'
 
 export const List = (props) => {
@@ -13,8 +14,8 @@ export const List = (props) => {
           args={{ smart_count: 2 }}
         />
       }
-      perPage={15}
-      pagination={<Pagination />}
+      perPage={DEFAULT_PAGE_SIZE}
+      pagination={<Pagination rowsPerPageOptions={PAGE_SIZES} />}
       {...props}
     />
   )

--- a/ui/src/common/Pagination.jsx
+++ b/ui/src/common/Pagination.jsx
@@ -1,6 +1,53 @@
-import React from 'react'
-import { Pagination as RAPagination } from 'react-admin'
+import React, { useEffect, useMemo } from 'react'
+import { Pagination as RAPagination, useListContext } from 'react-admin'
 
-export const Pagination = (props) => (
-  <RAPagination rowsPerPageOptions={[15, 25, 50]} {...props} />
-)
+import { DEFAULT_PAGE_SIZE, PAGE_SIZES } from '../consts'
+
+export const Pagination = ({ rowsPerPageOptions, ...props }) => {
+  const listContext = useListContext(props)
+  const { perPage, setPerPage } = listContext
+
+  const allowedOptions = useMemo(() => {
+    if (rowsPerPageOptions && rowsPerPageOptions.length > 0) {
+      return rowsPerPageOptions
+    }
+    return PAGE_SIZES
+  }, [rowsPerPageOptions])
+
+  const fallbackPerPage = useMemo(() => {
+    if (allowedOptions.includes(DEFAULT_PAGE_SIZE)) {
+      return DEFAULT_PAGE_SIZE
+    }
+    return allowedOptions[0] ?? DEFAULT_PAGE_SIZE
+  }, [allowedOptions])
+
+  const sanitizedPerPage = useMemo(() => {
+    if (allowedOptions.includes(perPage)) {
+      return perPage
+    }
+    return fallbackPerPage
+  }, [allowedOptions, fallbackPerPage, perPage])
+
+  useEffect(() => {
+    if (!setPerPage) {
+      return
+    }
+
+    if (perPage === undefined) {
+      setPerPage(sanitizedPerPage)
+      return
+    }
+
+    if (!allowedOptions.includes(perPage)) {
+      setPerPage(sanitizedPerPage)
+    }
+  }, [allowedOptions, perPage, sanitizedPerPage, setPerPage])
+
+  return (
+    <RAPagination
+      rowsPerPageOptions={allowedOptions}
+      rowsPerPage={sanitizedPerPage}
+      {...props}
+    />
+  )
+}

--- a/ui/src/consts.js
+++ b/ui/src/consts.js
@@ -29,3 +29,7 @@ export const DEFAULT_SHARE_BITRATE = 128
 export const BITRATE_CHOICES = [
   32, 48, 64, 80, 96, 112, 128, 160, 192, 256, 320,
 ].map((b) => ({ id: b, name: b.toString() }))
+
+export const PAGE_SIZES = [15, 25, 50, 100, 200]
+
+export const DEFAULT_PAGE_SIZE = 50

--- a/ui/src/dataProvider/httpClient.js
+++ b/ui/src/dataProvider/httpClient.js
@@ -1,6 +1,34 @@
 import { fetchUtils } from 'react-admin'
 import { v4 as uuidv4 } from 'uuid'
 import { baseUrl } from '../utils'
+
+const addLimitAndOffset = (url) => {
+  try {
+    const parsedUrl = new URL(url, window.location.origin)
+    const startParam = parsedUrl.searchParams.get('_start')
+    const endParam = parsedUrl.searchParams.get('_end')
+
+    if (startParam === null || endParam === null) {
+      return parsedUrl.href
+    }
+
+    const start = Number.parseInt(startParam, 10)
+    const end = Number.parseInt(endParam, 10)
+
+    if (!Number.isNaN(start) && start >= 0) {
+      parsedUrl.searchParams.set('offset', start)
+    }
+
+    const limit = end - start
+    if (!Number.isNaN(limit) && Number.isFinite(limit) && limit > 0) {
+      parsedUrl.searchParams.set('limit', limit)
+    }
+
+    return parsedUrl.href
+  } catch (error) {
+    return url
+  }
+}
 import config from '../config'
 import { jwtDecode } from 'jwt-decode'
 import { removeHomeCache } from '../utils/removeHomeCache'
@@ -10,7 +38,7 @@ const clientUniqueIdHeader = 'X-ND-Client-Unique-Id'
 const clientUniqueId = uuidv4()
 
 const httpClient = (url, options = {}) => {
-  url = baseUrl(url)
+  url = addLimitAndOffset(baseUrl(url))
   if (!options.headers) {
     options.headers = new Headers({ Accept: 'application/json' })
   }

--- a/ui/src/playlist/PlaylistShow.jsx
+++ b/ui/src/playlist/PlaylistShow.jsx
@@ -6,14 +6,14 @@ import {
   useShowController,
   SearchInput,
   Filter,
-  Pagination,
   Title as RaTitle,
 } from 'react-admin'
 import { makeStyles } from '@material-ui/core/styles'
 import PlaylistDetails from './PlaylistDetails'
 import PlaylistSongs from './PlaylistSongs'
 import PlaylistActions from './PlaylistActions'
-import { Title, canChangeTracks, useResourceRefresh } from '../common'
+import { Pagination, Title, canChangeTracks, useResourceRefresh } from '../common'
+import { DEFAULT_PAGE_SIZE, PAGE_SIZES } from '../consts'
 
 const useStyles = makeStyles(
   (theme) => ({
@@ -63,7 +63,7 @@ const PlaylistShowLayout = (props) => {
             reference="playlistTrack"
             target="playlist_id"
             sort={{ field: 'id', order: 'ASC' }}
-            perPage={100}
+            perPage={DEFAULT_PAGE_SIZE}
             filter={{ playlist_id: props.id, title: searchTerm }} // Pass searchTerm as a filter
           >
             <PlaylistSongs
@@ -78,7 +78,7 @@ const PlaylistShowLayout = (props) => {
               }
               resource={'playlistTrack'}
               exporter={false}
-              pagination={<Pagination rowsPerPageOptions={[100, 250, 500]} />}
+              pagination={<Pagination rowsPerPageOptions={PAGE_SIZES} />}
               searchTerm={searchTerm} // Pass search term to child
             />
           </ReferenceManyField>

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -37,6 +37,7 @@ import { AlbumLinkField } from './AlbumLinkField'
 import { SongBulkActions, QualityInfo, useSelectedFields } from '../common'
 import config from '../config'
 import ExpandInfoDialog from '../dialogs/ExpandInfoDialog'
+import { DEFAULT_PAGE_SIZE } from '../consts'
 
 const useStyles = makeStyles({
   contextHeader: {
@@ -244,7 +245,7 @@ const SongList = (props) => {
         bulkActionButtons={<SongBulkActions />}
         actions={<SongListActions />}
         filters={<SongFilter />}
-        perPage={isXsmall ? 50 : 15}
+        perPage={DEFAULT_PAGE_SIZE}
       >
         {isXsmall ? (
           <SongSimpleList />


### PR DESCRIPTION
## Summary
- add shared pagination constants and sanitize the shared pagination component
- default the song list and playlist track tables to 50 items with the shared page size menu
- include limit and offset parameters in data-provider requests to match the selected page size

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbe094997c83309b4a422fc989204e