### PR TITLE
Set global table row spacing to 1px

### DIFF
--- a/ui/src/themes/index.js
+++ b/ui/src/themes/index.js
@@ -13,7 +13,7 @@ import CatppuccinMacchiatoTheme from './catppuccinMacchiato'
 import NuclearTheme from './nuclear'
 import ItachiTheme from './itachi'
 
-export default {
+const themes = {
   // Classic default themes
   LightTheme,
   DarkTheme,
@@ -32,3 +32,35 @@ export default {
   NuclearTheme,
   SpotifyTheme,
 }
+
+const commonMuiTableRoot = {
+  borderCollapse: 'separate',
+  borderSpacing: '0 1px',
+}
+
+const applyCommonOverrides = (theme) => {
+  const overrides = theme.overrides ?? {}
+  const muiTable = overrides.MuiTable ?? {}
+  const muiTableRoot = muiTable.root ?? {}
+
+  return {
+    ...theme,
+    overrides: {
+      ...overrides,
+      MuiTable: {
+        ...muiTable,
+        root: {
+          ...muiTableRoot,
+          ...commonMuiTableRoot,
+        },
+      },
+    },
+  }
+}
+
+export default Object.fromEntries(
+  Object.entries(themes).map(([name, theme]) => [
+    name,
+    applyCommonOverrides(theme),
+  ]),
+)


### PR DESCRIPTION
## Summary
- add a shared theme override that enforces 1px vertical spacing between table rows across all themes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbe139e5248330a964a3d8d455cc7e