### PR TITLE
Reduce row padding in music tables

### DIFF
--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -35,8 +35,8 @@ const useStyles = makeStyles({
   },
   row: {
     cursor: 'pointer',
-    // ↓ shrink row height by reducing vertical padding
-    '& td': {
+    // ↓ shrink row height by reducing vertical padding on all table cells
+    '& td, & th, & .MuiTableCell-root': {
       paddingTop: 1,
       paddingBottom: 1,
     },

--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -35,6 +35,11 @@ const useStyles = makeStyles({
   },
   row: {
     cursor: 'pointer',
+    // ↓ shrink row height by reducing vertical padding
+    '& td': {
+      paddingTop: 1,
+      paddingBottom: 1,
+    },
     '&:hover': {
       '& $contextMenu': {
         visibility: 'visible',

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -64,6 +64,12 @@ const useStyles = makeStyles(
       justifyContent: 'flex-start',
     },
     row: {
+      cursor: 'pointer',
+      // ↓ shrink row height by reducing vertical padding
+      '& td': {
+        paddingTop: 1,
+        paddingBottom: 1,
+      },
       '&:hover': {
         '& $contextMenu': {
           visibility: 'visible',

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -65,8 +65,8 @@ const useStyles = makeStyles(
     },
     row: {
       cursor: 'pointer',
-      // ↓ shrink row height by reducing vertical padding
-      '& td': {
+      // ↓ shrink row height by reducing vertical padding on all table cells
+      '& td, & th, & .MuiTableCell-root': {
         paddingTop: 1,
         paddingBottom: 1,
       },

--- a/ui/src/playlist_folder/PlaylistFolderDataGrid.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderDataGrid.jsx
@@ -18,8 +18,8 @@ import { matchPath } from 'react-router'
 const useStyles = makeStyles({
   row: {
     cursor: 'pointer',
-    // ↓ shrink row height by reducing vertical padding
-    '& td': {
+    // ↓ shrink row height by reducing vertical padding on all table cells
+    '& td, & th, & .MuiTableCell-root': {
       paddingTop: 1,
       paddingBottom: 1,
     },

--- a/ui/src/playlist_folder/PlaylistFolderDataGrid.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderDataGrid.jsx
@@ -25,6 +25,10 @@ const useStyles = makeStyles({
     },
     '&:hover': { backgroundColor: '#f5f5f5' },
   },
+  rowCell: {
+    paddingTop: 1,
+    paddingBottom: 1,
+  },
   missingRow: {
     cursor: 'inherit',
     opacity: 0.3,
@@ -144,12 +148,17 @@ const PlaylistFolderBody = (props) => (
   <PureDatagridBody {...props} row={<PlaylistFolderRow />} />
 )
 
-export const PlaylistFolderDataGrid = (props) => {
+export const PlaylistFolderDataGrid = ({ classes: classesProp, ...props }) => {
   const classes = useStyles()
+  const datagridClasses = {
+    ...classesProp,
+    rowCell: clsx(classes.rowCell, classesProp?.rowCell),
+  }
   return (
     <Datagrid
       className={classes.headerStyle}
       isRowSelectable={(r) => !r?.missing}
+      classes={datagridClasses}
       {...props}
       body={<PlaylistFolderBody />}
     />
@@ -158,4 +167,5 @@ export const PlaylistFolderDataGrid = (props) => {
 
 PlaylistFolderDataGrid.propTypes = {
   children: PropTypes.node,
+  classes: PropTypes.object,
 }

--- a/ui/src/playlist_folder/PlaylistFolderDataGrid.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderDataGrid.jsx
@@ -18,6 +18,11 @@ import { matchPath } from 'react-router'
 const useStyles = makeStyles({
   row: {
     cursor: 'pointer',
+    // ↓ shrink row height by reducing vertical padding
+    '& td': {
+      paddingTop: 1,
+      paddingBottom: 1,
+    },
     '&:hover': { backgroundColor: '#f5f5f5' },
   },
   missingRow: {

--- a/ui/src/playlist_folder/PlaylistFolderShow.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderShow.jsx
@@ -93,6 +93,7 @@ const TogglePublicInput = ({ source }) => {
       onClick={(e) => e.stopPropagation()}
       disabled={isLoading || !isWritable(record?.ownerId)}
       color="primary"
+      size="small"
       inputProps={{ 'aria-label': 'toggle-public' }}
     />
   )

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -46,8 +46,8 @@ const useStyles = makeStyles({
   },
   row: {
     cursor: 'pointer',
-    // ↓ shrink row height by reducing vertical padding
-    '& td': {
+    // ↓ shrink row height by reducing vertical padding on all table cells
+    '& td, & th, & .MuiTableCell-root': {
       paddingTop: 1,
       paddingBottom: 1,
     },

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -45,6 +45,12 @@ const useStyles = makeStyles({
     verticalAlign: 'text-top',
   },
   row: {
+    cursor: 'pointer',
+    // ↓ shrink row height by reducing vertical padding
+    '& td': {
+      paddingTop: 1,
+      paddingBottom: 1,
+    },
     '&:hover': {
       '& $contextMenu': {
         visibility: 'visible',


### PR DESCRIPTION
## Summary
- shrink vertical padding for song, playlist, and playlist folder data grid rows to reduce spacing
- ensure row cursors remain pointers while keeping existing hover behaviors intact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbe865204c8330a701d88772a6a3b4