### PR TITLE
Add pagination controls to folder child view

### DIFF
--- a/ui/src/playlist_folder/PlaylistFolderShow.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderShow.jsx
@@ -22,6 +22,8 @@ import {
   useSelectedFields,
   useResourceRefresh,
   Title,
+  Pagination,
+  getStoredPageSize,
 } from '../common'
 import PlaylistListActions from './PlaylistListActions'
 import EmptyPlaylist from './EmptyPlaylist'
@@ -123,6 +125,11 @@ const FolderChildrenList = (props) => {
 
   const parentId = record?.id ?? ''
 
+  const initialPerPage = useMemo(
+    () => getStoredPageSize('folderChildren'),
+    [],
+  )
+
   return (
     <List
       {...props}
@@ -133,9 +140,10 @@ const FolderChildrenList = (props) => {
       actions={<PlaylistListActions />}
       bulkActionButtons={!isXsmall && <PlaylistFolderBulkActions />}
       empty={<EmptyPlaylist />}
-      perPage={isXsmall ? 50 : 25}
+      perPage={initialPerPage}
       filter={{ parent_id: parentId }}
       filterDefaultValues={{ parent_id: parentId }}
+      pagination={<Pagination scope="folderChildren" />}
     >
       <PlaylistFolderDataGrid rowClick={rowClick}>
         <TypeIconField label={false} />


### PR DESCRIPTION
## Summary
- persist pagination settings for folder children lists and default to 50 items per page
- render the shared pagination component so the child view shows the current item range

## Testing
- npm --prefix ui run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc6e8f7a348330b6b9077e3179dc4f