### PR TITLE
feat(ui): extract playlist publish button

### DIFF
--- a/ui/src/playlist/PlaylistActions.jsx
+++ b/ui/src/playlist/PlaylistActions.jsx
@@ -15,7 +15,6 @@ import CloudDownloadOutlinedIcon from '@material-ui/icons/CloudDownloadOutlined'
 import { RiPlayListAddFill, RiPlayList2Fill } from 'react-icons/ri'
 import QueueMusicIcon from '@material-ui/icons/QueueMusic'
 import ShareIcon from '@material-ui/icons/Share'
-import PublishIcon from '@material-ui/icons/Publish'
 import { httpClient } from '../dataProvider'
 import {
   playNext,
@@ -31,6 +30,7 @@ import PropTypes from 'prop-types'
 import { formatBytes } from '../utils'
 import config from '../config'
 import { ToggleFieldsMenu } from '../common'
+import PublishPlaylistButton from './PublishPlaylistButton'
 
 const useStyles = makeStyles({
   toolbar: { display: 'flex', justifyContent: 'space-between', width: '100%' },
@@ -112,21 +112,6 @@ const PlaylistActions = ({ className, ids, data, record, ...rest }) => {
     [record],
   )
 
-  const handlePublish = React.useCallback(
-    () =>
-      httpClient(`${REST_URL}/playlist/${record.id}/publish`, {
-        method: 'POST',
-      })
-        .then(() =>
-          notify('resources.playlist.notifications.published', 'info', {
-            smart_count: record.songCount,
-            name: record.name,
-          }),
-        )
-        .catch(() => notify('ra.page.error', 'warning')),
-    [record, notify],
-  )
-
   return (
     <TopToolbar className={className} {...sanitizeListRestProps(rest)}>
       <div className={classes.toolbar}>
@@ -177,12 +162,7 @@ const PlaylistActions = ({ className, ids, data, record, ...rest }) => {
           >
             <QueueMusicIcon />
           </Button>
-          <Button
-            onClick={handlePublish}
-            label={translate('resources.playlist.actions.publish')}
-          >
-            <PublishIcon />
-          </Button>
+          <PublishPlaylistButton record={record} />
         </div>
         <div>{isNotSmall && <ToggleFieldsMenu resource="playlistTrack" />}</div>
       </div>

--- a/ui/src/playlist/PublishPlaylistButton.jsx
+++ b/ui/src/playlist/PublishPlaylistButton.jsx
@@ -36,12 +36,15 @@ const useStyles = makeStyles((theme) => ({
   },
   cancelButton: {
     color: theme.palette.text.secondary,
+    '&:hover': {
+      backgroundColor: theme.palette.grey[700],
+    },
   },
   confirmButton: {
     backgroundColor: theme.palette.secondary.main,
     color: theme.palette.getContrastText(theme.palette.secondary.main),
     '&:hover': {
-      backgroundColor: theme.palette.secondary.dark,
+      backgroundColor: theme.palette.grey[700],
     },
   },
 }))

--- a/ui/src/playlist/PublishPlaylistButton.jsx
+++ b/ui/src/playlist/PublishPlaylistButton.jsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import PublishIcon from '@material-ui/icons/Publish'
+import { Button, Confirm, useTranslate, useNotify } from 'react-admin'
+
+import { REST_URL } from '../consts'
+import { httpClient } from '../dataProvider'
+
+const PublishPlaylistButton = ({ record }) => {
+  const translate = useTranslate()
+  const notify = useNotify()
+  const [open, setOpen] = React.useState(false)
+  const [loading, setLoading] = React.useState(false)
+
+  const handleDialogOpen = React.useCallback(() => {
+    setOpen(true)
+  }, [])
+
+  const handleDialogClose = React.useCallback(() => {
+    if (!loading) {
+      setOpen(false)
+    }
+  }, [loading])
+
+  const handlePublish = React.useCallback(() => {
+    if (!record?.id) {
+      setOpen(false)
+      return Promise.resolve()
+    }
+
+    setLoading(true)
+    return httpClient(`${REST_URL}/playlist/${record.id}/publish`, {
+      method: 'POST',
+    })
+      .then(() => {
+        notify('resources.playlist.notifications.published', 'info', {
+          smart_count: record.songCount,
+          name: record.name,
+        })
+        setOpen(false)
+      })
+      .catch(() => {
+        notify('ra.page.error', 'warning')
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+  }, [notify, record])
+
+  return (
+    <>
+      <Button
+        onClick={handleDialogOpen}
+        disabled={loading}
+        label={translate('resources.playlist.actions.publish')}
+      >
+        <PublishIcon />
+      </Button>
+      <Confirm
+        isOpen={open}
+        loading={loading}
+        title={translate('resources.playlist.actions.publish')}
+        content={translate('ra.message.are_you_sure')}
+        onConfirm={handlePublish}
+        onClose={handleDialogClose}
+      />
+    </>
+  )
+}
+
+PublishPlaylistButton.propTypes = {
+  record: PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    name: PropTypes.string,
+    songCount: PropTypes.number,
+  }),
+}
+
+PublishPlaylistButton.defaultProps = {
+  record: null,
+}
+
+export default PublishPlaylistButton

--- a/ui/src/playlist/PublishPlaylistButton.jsx
+++ b/ui/src/playlist/PublishPlaylistButton.jsx
@@ -1,14 +1,55 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import PublishIcon from '@material-ui/icons/Publish'
-import { Button, Confirm, useTranslate, useNotify } from 'react-admin'
+import {
+  Button as RaButton,
+  useTranslate,
+  useNotify,
+} from 'react-admin'
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@material-ui/core'
+import { makeStyles } from '@material-ui/core/styles'
 
 import { REST_URL } from '../consts'
 import { httpClient } from '../dataProvider'
 
+const useStyles = makeStyles((theme) => ({
+  dialogPaper: {
+    backgroundColor: theme.palette.background.default,
+    padding: theme.spacing(3, 4, 2, 4),
+  },
+  dialogTitle: {
+    color: theme.palette.text.primary,
+    fontSize: '1.25rem',
+    fontWeight: theme.typography.fontWeightMedium,
+    paddingBottom: theme.spacing(1),
+  },
+  dialogContentText: {
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.body1.fontSize,
+  },
+  cancelButton: {
+    color: theme.palette.text.secondary,
+  },
+  confirmButton: {
+    backgroundColor: theme.palette.secondary.main,
+    color: theme.palette.getContrastText(theme.palette.secondary.main),
+    '&:hover': {
+      backgroundColor: theme.palette.secondary.dark,
+    },
+  },
+}))
+
 const PublishPlaylistButton = ({ record }) => {
   const translate = useTranslate()
   const notify = useNotify()
+  const classes = useStyles()
   const [open, setOpen] = React.useState(false)
   const [loading, setLoading] = React.useState(false)
 
@@ -49,21 +90,46 @@ const PublishPlaylistButton = ({ record }) => {
 
   return (
     <>
-      <Button
+      <RaButton
         onClick={handleDialogOpen}
         disabled={loading}
         label={translate('resources.playlist.actions.publish')}
       >
         <PublishIcon />
-      </Button>
-      <Confirm
-        isOpen={open}
-        loading={loading}
-        title={translate('resources.playlist.actions.publish')}
-        content={translate('ra.message.are_you_sure')}
-        onConfirm={handlePublish}
+      </RaButton>
+      <Dialog
+        open={open}
         onClose={handleDialogClose}
-      />
+        aria-labelledby="publish-playlist-dialog"
+        PaperProps={{ className: classes.dialogPaper }}
+      >
+        <DialogTitle id="publish-playlist-dialog" className={classes.dialogTitle}>
+          {translate('resources.playlist.actions.publish')}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText className={classes.dialogContentText}>
+            {translate('resources.playlist.dialog.publish_confirmation', {
+              _: 'Are you sure you want to publish this playlist?',
+            })}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={handleDialogClose}
+            disabled={loading}
+            className={classes.cancelButton}
+          >
+            {translate('ra.action.no', { _: 'No' }).toUpperCase()}
+          </Button>
+          <Button
+            onClick={handlePublish}
+            disabled={loading}
+            className={classes.confirmButton}
+          >
+            {translate('ra.action.yes', { _: 'Yes' }).toUpperCase()}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   )
 }

--- a/ui/src/playlist/index.jsx
+++ b/ui/src/playlist/index.jsx
@@ -20,3 +20,5 @@ export default {
     />
   ),
 }
+
+export { default as PublishPlaylistButton } from './PublishPlaylistButton'


### PR DESCRIPTION
## Summary
- add a dedicated PublishPlaylistButton component that shows the publish confirmation dialog and triggers the publish request
- switch PlaylistActions to use the new button component and export it for reuse

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce94d7e1648330a64f57308534a7e0