### PR TITLE
Highlight playing song row in pink

### DIFF
--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -1,5 +1,5 @@
 import React, { isValidElement, useMemo, useCallback, forwardRef } from 'react'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import {
   Datagrid,
   PureDatagridBody,
@@ -22,7 +22,7 @@ import { AlbumContextMenu } from '../common'
 import { DraggableTypes } from '../consts'
 import { formatFullDate } from '../utils'
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme) => ({
   subtitle: {
     whiteSpace: 'nowrap',
     overflow: 'hidden',
@@ -46,6 +46,22 @@ const useStyles = makeStyles({
       },
     },
   },
+  currentRow: {
+    backgroundColor: theme.palette.action.hover,
+    '& td, & th, & .MuiTableCell-root': {
+      color: '#ff66c4',
+    },
+    '& a': {
+      color: '#ff66c4',
+    },
+    '& svg': {
+      fill: '#ff66c4',
+      color: '#ff66c4',
+    },
+    '& $contextMenu': {
+      visibility: 'visible',
+    },
+  },
   missingRow: {
     cursor: 'inherit',
     opacity: 0.3,
@@ -59,10 +75,10 @@ const useStyles = makeStyles({
       padding: '15px',
     },
   },
-  contextMenu: {
-    visibility: (props) => (props.isDesktop ? 'hidden' : 'visible'),
-  },
-})
+  contextMenu: (props) => ({
+    visibility: props?.isDesktop ? 'hidden' : 'visible',
+  }),
+}))
 
 const DiscSubtitleRow = forwardRef(
   ({ record, onClick, colSpan, contextAlwaysVisible }, ref) => {
@@ -121,6 +137,8 @@ export const SongDatagridRow = ({
   ...rest
 }) => {
   const classes = useStyles()
+  const currentTrack = useSelector((state) => state?.player?.current || {})
+  const currentId = currentTrack.trackId
   const fields = React.Children.toArray(children).filter((c) =>
     isValidElement(c),
   )
@@ -156,10 +174,14 @@ export const SongDatagridRow = ({
 
   const rowClick = record.missing ? undefined : rest.rowClick
 
+  const isCurrent =
+    currentId && (currentId === record.id || currentId === record.mediaFileId)
+
   const computedClasses = clsx(
     className,
     classes.row,
     record.missing && classes.missingRow,
+    isCurrent && classes.currentRow,
   )
   const childCount = fields.length
   return (

--- a/ui/src/common/SongTitleField.jsx
+++ b/ui/src/common/SongTitleField.jsx
@@ -1,6 +1,7 @@
 import { makeStyles } from '@material-ui/core/styles'
 import React from 'react'
 import PropTypes from 'prop-types'
+import clsx from 'clsx'
 import { useSelector } from 'react-redux'
 import { FunctionField } from 'react-admin'
 import { useTheme } from '@material-ui/core/styles'
@@ -17,6 +18,10 @@ const useStyles = makeStyles({
     marginLeft: '-8px',
     marginTop: '-7px',
     paddingRight: '3px',
+  },
+  playingIcon: {
+    filter:
+      'invert(72%) sepia(34%) saturate(6113%) hue-rotate(305deg) brightness(103%) contrast(102%)',
   },
   text: {
     verticalAlign: 'text-top',
@@ -64,7 +69,7 @@ export const SongTitleField = ({ showTrackNumbers, ...props }) => {
     return (
       <img
         src={icon}
-        className={classes.icon}
+        className={clsx(classes.icon, !paused && classes.playingIcon)}
         alt={paused ? 'paused' : 'playing'}
       />
     )


### PR DESCRIPTION
## Summary
- add styling that highlights the active song row with pink text and icons while keeping the context menu visible
- tint the now-playing indicator image pink when a track is playing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf063cc6208330afb6067bda403207