### PR TITLE
Handle playlist track q filter with full-text search

### DIFF
--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -51,6 +51,7 @@ func (r *playlistRepository) Tracks(playlistId string, refreshSmartPlaylist bool
 	p.registerModel(&model.PlaylistTrack{}, map[string]filterFunc{
 		"missing":    booleanFilter,
 		"library_id": libraryIdFilter,
+		"q":          fullTextFilter("f"),
 	})
 	p.setSortMappings(
 		map[string]string{

--- a/ui/src/playlist/PlaylistShow.jsx
+++ b/ui/src/playlist/PlaylistShow.jsx
@@ -50,7 +50,7 @@ const PlaylistShowLayout = (props) => {
           <Filter variant="outlined">
             <SearchInput
               id="search"
-              source="title"
+              source="q"
               alwaysOn
               value={searchTerm}
               onChange={handleSearchChange} // Update parent state on change
@@ -64,7 +64,7 @@ const PlaylistShowLayout = (props) => {
             target="playlist_id"
             sort={{ field: 'id', order: 'ASC' }}
             perPage={50}
-            filter={{ playlist_id: props.id, title: searchTerm }} // Pass searchTerm as a filter
+            filter={{ playlist_id: props.id, q: searchTerm }} // Pass searchTerm as a filter
           >
             <PlaylistSongs
               {...props}


### PR DESCRIPTION
## Summary
- map the playlist track `q` filter to a full-text query on the joined media file table
- ensure playlist track searches using the `q` parameter no longer generate invalid column errors

## Testing
- go test ./... *(fails: ui/embed.go expects prebuilt UI assets and build/3rdparty directory is missing in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf08fa2d6c8330aee8e523c8719ad4