### PR TITLE
Limit mobile lists to title and artist

### DIFF
--- a/ui/src/album/AlbumTableView.jsx
+++ b/ui/src/album/AlbumTableView.jsx
@@ -138,29 +138,7 @@ const AlbumTableView = ({
   return isXsmall ? (
     <SimpleList
       primaryText={(r) => r.name}
-      secondaryText={(r) => (
-        <>
-          {r.albumArtist}
-          {config.enableStarRating && (
-            <>
-              <br />
-              <RatingField
-                record={r}
-                sortByOrder={'DESC'}
-                source={'rating'}
-                resource={'album'}
-                size={'small'}
-              />
-            </>
-          )}
-        </>
-      )}
-      tertiaryText={(r) => (
-        <>
-          <RangeField record={r} source={'year'} sortBy={'max_year'} />
-          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-        </>
-      )}
+      secondaryText={(r) => r.albumArtist}
       linkType={'show'}
       rightIcon={(r) => <AlbumContextMenu record={r} />}
       {...rest}

--- a/ui/src/common/SongSimpleList.jsx
+++ b/ui/src/common/SongSimpleList.jsx
@@ -7,10 +7,9 @@ import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
 import ListItemText from '@material-ui/core/ListItemText'
 import { makeStyles } from '@material-ui/core/styles'
 import { sanitizeListRestProps } from 'react-admin'
-import { DurationField, SongContextMenu, RatingField } from './index'
+import { SongContextMenu } from './index'
 import { setTrack } from '../actions'
 import { useDispatch } from 'react-redux'
-import config from '../config'
 
 const useStyles = makeStyles(
   {
@@ -78,27 +77,7 @@ export const SongSimpleList = ({
                       <div className={classes.title}>{data[id].title}</div>
                     }
                     secondary={
-                      <>
-                        <span className={classes.secondary}>
-                          <span className={classes.artist}>
-                            {data[id].artist}
-                          </span>
-                          <span className={classes.timeStamp}>
-                            <DurationField
-                              record={data[id]}
-                              source={'duration'}
-                            />
-                          </span>
-                        </span>
-                        {config.enableStarRating && (
-                          <RatingField
-                            record={data[id]}
-                            source={'rating'}
-                            resource={'song'}
-                            size={'small'}
-                          />
-                        )}
-                      </>
+                      <span className={classes.artist}>{data[id].artist}</span>
                     }
                   />
                   <ListItemSecondaryAction className={classes.rightIcon}>

--- a/ui/src/playlist/PlaylistList.jsx
+++ b/ui/src/playlist/PlaylistList.jsx
@@ -127,17 +127,19 @@ const PlaylistList = (props) => {
 
   const toggleableFields = useMemo(
     () => ({
-      ownerName: isDesktop && <TextField source="ownerName" />,
+      ownerName: <TextField source="ownerName" />,
       songCount: !isXsmall && <NumberField source="songCount" />,
-      duration: <DurationField source="duration" />,
+      duration: !isXsmall && <DurationField source="duration" />,
       updatedAt: isDesktop && (
         <DateField source="updatedAt" sortByOrder={'DESC'} />
       ),
       public: !isXsmall && (
         <TogglePublicInput source="public" sortByOrder={'DESC'} />
       ),
-      comment: <TextField source="comment" />,
-      sync: <ToggleAutoImport source="sync" sortByOrder={'DESC'} />,
+      comment: !isXsmall && <TextField source="comment" />,
+      sync: !isXsmall && (
+        <ToggleAutoImport source="sync" sortByOrder={'DESC'} />
+      ),
     }),
     [isDesktop, isXsmall],
   )


### PR DESCRIPTION
## Summary
- simplify the album mobile table to show only the album title and artist
- trim the song simple list so mobile rows show just the track title and artist
- hide playlist metrics on extra-small screens so only the playlist name and owner remain visible

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf0c623a688330b39f88210a53fe65