### PR TITLE
Ensure playlist and album row clicks queue full track list

### DIFF
--- a/ui/src/album/AlbumSongs.jsx
+++ b/ui/src/album/AlbumSongs.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import {
   BulkActionsToolbar,
   FunctionField,
@@ -163,6 +163,29 @@ const AlbumSongs = (props) => {
     ? 'ra.action.bulk_actions'
     : 'ra.action.bulk_actions_mobile'
 
+  const handleRowClick = useCallback(
+    (id) => {
+      if (!ids || ids.length === 0) {
+        dispatch(playTracks(data, ids, id))
+        return
+      }
+
+      const startIndex = ids.indexOf(id)
+      if (startIndex === -1) {
+        dispatch(playTracks(data, ids, id))
+        return
+      }
+
+      const orderedIds = [
+        ...ids.slice(startIndex),
+        ...ids.slice(0, startIndex),
+      ]
+
+      dispatch(playTracks(data, orderedIds, id))
+    },
+    [dispatch, data, ids],
+  )
+
   return (
     <>
       <ListToolbar
@@ -181,7 +204,7 @@ const AlbumSongs = (props) => {
             <SongBulkActions />
           </BulkActionsToolbar>
           <SongDatagrid
-            rowClick={(id) => dispatch(playTracks(data, ids, id))}
+            rowClick={handleRowClick}
             {...props}
             hasBulkActions={true}
             showDiscSubtitles={true}

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -199,6 +199,29 @@ const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
     ],
   })
 
+  const handleRowClick = useCallback(
+    (id) => {
+      if (!ids || ids.length === 0) {
+        dispatch(playTracks(data, ids, id))
+        return
+      }
+
+      const startIndex = ids.indexOf(id)
+      if (startIndex === -1) {
+        dispatch(playTracks(data, ids, id))
+        return
+      }
+
+      const orderedIds = [
+        ...ids.slice(startIndex),
+        ...ids.slice(0, startIndex),
+      ]
+
+      dispatch(playTracks(data, orderedIds, id))
+    },
+    [dispatch, data, ids],
+  )
+
   return (
     <>
       <ListToolbar
@@ -227,7 +250,7 @@ const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
             handleSelector={'.draggable'}
           >
             <SongDatagrid
-              rowClick={(id) => dispatch(playTracks(data, ids, id))}
+              rowClick={handleRowClick}
               {...listContext}
               hasBulkActions={!readOnly}
               contextAlwaysVisible={!isDesktop}


### PR DESCRIPTION
## Summary
- ensure playlist row clicks reorder the available ids so the whole list queues from the selected song
- apply the same ordered queue behaviour when starting playback from an album row

## Testing
- npm --prefix ui test

------
https://chatgpt.com/codex/tasks/task_e_68cf140af1708330974261ea268097ec