### PR TITLE
Reset search inputs when navigating between folders and playlists

### DIFF
--- a/ui/src/playlist/PlaylistShow.jsx
+++ b/ui/src/playlist/PlaylistShow.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useEffect } from 'react'
 import {
   ReferenceManyField,
   ShowContextProvider,
@@ -34,6 +34,10 @@ const PlaylistShowLayout = (props) => {
 
   // Store search query in state to prevent losing focus
   const [searchTerm, setSearchTerm] = useState('')
+
+  useEffect(() => {
+    setSearchTerm('')
+  }, [record?.id])
 
   // Handle search change
   const handleSearchChange = useCallback((event) => {

--- a/ui/src/playlist_folder/PlaylistFolderShow.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderShow.jsx
@@ -8,6 +8,7 @@ import {
   SearchInput,
   SelectInput,
   TextField,
+  useListContext,
   useUpdate,
   useNotify,
   useRecordContext,
@@ -101,6 +102,27 @@ const TogglePublicInput = ({ source }) => {
 const rowClick = (id, record) =>
   record?.type === 'folder' ? `/folder/${id}/show` : `/playlist/${id}/show`
 
+const ResetFiltersOnParentChange = ({ parentId }) => {
+  const { filterValues, setFilters } = useListContext()
+
+  useEffect(() => {
+    if (!setFilters) {
+      return
+    }
+
+    if (filterValues?.parent_id === parentId && !filterValues?.q) {
+      return
+    }
+
+    const nextFilters = { ...filterValues, parent_id: parentId }
+    delete nextFilters.q
+
+    setFilters(nextFilters, {})
+  }, [filterValues, parentId, setFilters])
+
+  return null
+}
+
 const FolderChildrenList = (props) => {
   const record = useRecordContext()
   const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
@@ -128,6 +150,7 @@ const FolderChildrenList = (props) => {
       {...props}
       resource="folder"
       exporter={false}
+      storeKey={`folder-children-${parentId || 'root'}`}
       title={<Title subTitle={record?.name} />}
       filters={<PlaylistFolderFilter />}
       actions={<PlaylistListActions />}
@@ -137,6 +160,7 @@ const FolderChildrenList = (props) => {
       filter={{ parent_id: parentId }}
       filterDefaultValues={{ parent_id: parentId }}
     >
+      <ResetFiltersOnParentChange parentId={parentId} />
       <PlaylistFolderDataGrid rowClick={rowClick}>
         <TypeIconField label={false} />
         <TextField source="name" />

--- a/ui/src/playlist_folder/PlaylistFolderShow.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderShow.jsx
@@ -114,7 +114,7 @@ const ResetFiltersOnParentChange = ({ parentId }) => {
       return
     }
 
-    const nextFilters = { ...filterValues, parent_id: parentId }
+    const nextFilters = { ...(filterValues ?? {}), parent_id: parentId }
     delete nextFilters.q
 
     setFilters(nextFilters, {})


### PR DESCRIPTION
## Summary
- reset the playlist song search term whenever the viewed playlist changes
- clear folder child list search filters when navigating to a different parent folder

## Testing
- npm run lint --prefix ui

------
https://chatgpt.com/codex/tasks/task_e_68cf25fb8f8c8330b821690bd467353f