### PR TITLE
Add settings columns order action to fix missing export

### DIFF
--- a/ui/src/actions/settings.js
+++ b/ui/src/actions/settings.js
@@ -1,5 +1,6 @@
 export const SET_NOTIFICATIONS_STATE = 'SET_NOTIFICATIONS_STATE'
 export const SET_TOGGLEABLE_FIELDS = 'SET_TOGGLEABLE_FIELDS'
+export const SET_COLUMNS_ORDER = 'SET_COLUMNS_ORDER'
 export const SET_OMITTED_FIELDS = 'SET_OMITTED_FIELDS'
 
 export const setNotificationsState = (enabled) => ({
@@ -14,5 +15,10 @@ export const setToggleableFields = (obj) => ({
 
 export const setOmittedFields = (obj) => ({
   type: SET_OMITTED_FIELDS,
+  data: obj,
+})
+
+export const setColumnsOrder = (obj) => ({
+  type: SET_COLUMNS_ORDER,
   data: obj,
 })

--- a/ui/src/reducers/settingsReducer.js
+++ b/ui/src/reducers/settingsReducer.js
@@ -2,12 +2,14 @@ import {
   SET_NOTIFICATIONS_STATE,
   SET_OMITTED_FIELDS,
   SET_TOGGLEABLE_FIELDS,
+  SET_COLUMNS_ORDER,
 } from '../actions'
 
 const initialState = {
   notifications: false,
   toggleableFields: {},
   omittedFields: {},
+  columnsOrder: {},
 }
 
 export const settingsReducer = (previousState = initialState, payload) => {
@@ -23,6 +25,14 @@ export const settingsReducer = (previousState = initialState, payload) => {
         ...previousState,
         toggleableFields: {
           ...previousState.toggleableFields,
+          ...data,
+        },
+      }
+    case SET_COLUMNS_ORDER:
+      return {
+        ...previousState,
+        columnsOrder: {
+          ...previousState.columnsOrder,
           ...data,
         },
       }


### PR DESCRIPTION
## Summary
- add a SET_COLUMNS_ORDER action and creator to expose setColumnsOrder
- store the new columnsOrder state slice in the settings reducer so dispatches succeed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d65e39e78c8330ad1c75330e5528e1