### PR TITLE
Add missing settings columns order handling

### DIFF
--- a/ui/src/actions/settings.js
+++ b/ui/src/actions/settings.js
@@ -1,6 +1,7 @@
 export const SET_NOTIFICATIONS_STATE = 'SET_NOTIFICATIONS_STATE'
 export const SET_TOGGLEABLE_FIELDS = 'SET_TOGGLEABLE_FIELDS'
 export const SET_OMITTED_FIELDS = 'SET_OMITTED_FIELDS'
+export const SET_COLUMNS_ORDER = 'SET_COLUMNS_ORDER'
 
 export const setNotificationsState = (enabled) => ({
   type: SET_NOTIFICATIONS_STATE,
@@ -14,5 +15,10 @@ export const setToggleableFields = (obj) => ({
 
 export const setOmittedFields = (obj) => ({
   type: SET_OMITTED_FIELDS,
+  data: obj,
+})
+
+export const setColumnsOrder = (obj) => ({
+  type: SET_COLUMNS_ORDER,
   data: obj,
 })

--- a/ui/src/reducers/settingsReducer.js
+++ b/ui/src/reducers/settingsReducer.js
@@ -2,12 +2,14 @@ import {
   SET_NOTIFICATIONS_STATE,
   SET_OMITTED_FIELDS,
   SET_TOGGLEABLE_FIELDS,
+  SET_COLUMNS_ORDER,
 } from '../actions'
 
 const initialState = {
   notifications: false,
   toggleableFields: {},
   omittedFields: {},
+  columnsOrder: {},
 }
 
 export const settingsReducer = (previousState = initialState, payload) => {
@@ -31,6 +33,14 @@ export const settingsReducer = (previousState = initialState, payload) => {
         ...previousState,
         omittedFields: {
           ...previousState.omittedFields,
+          ...data,
+        },
+      }
+    case SET_COLUMNS_ORDER:
+      return {
+        ...previousState,
+        columnsOrder: {
+          ...previousState.columnsOrder,
           ...data,
         },
       }


### PR DESCRIPTION
## Summary
- add an action creator for updating stored columns order
- persist columns order updates inside the settings reducer

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6625a3d7883308ce316253bdda532