### PR TITLE
Add draggable column ordering to songs list

### DIFF
--- a/ui/src/common/ToggleFieldsMenu.jsx
+++ b/ui/src/common/ToggleFieldsMenu.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import IconButton from '@material-ui/core/IconButton'
 import Menu from '@material-ui/core/Menu'
@@ -9,6 +9,77 @@ import Checkbox from '@material-ui/core/Checkbox'
 import { useDispatch, useSelector } from 'react-redux'
 import { useTranslate } from 'react-admin'
 import { setToggleableFields } from '../actions'
+import { DndProvider, useDrag, useDrop } from 'react-dnd'
+import { HTML5Backend } from 'react-dnd-html5-backend'
+
+const COLUMN_ITEM_TYPE = 'toggle-field-column'
+
+const DraggableMenuItem = ({
+  id,
+  index,
+  moveItem,
+  onToggle,
+  checked,
+  label,
+  disabled,
+  draggingRef,
+}) => {
+  const ref = useRef(null)
+
+  const [, drop] = useDrop({
+    accept: COLUMN_ITEM_TYPE,
+    hover(item) {
+      if (!ref.current) return
+      if (item.index === index) return
+      moveItem(item.index, index)
+      item.index = index
+    },
+  })
+
+  const [{ isDragging }, drag] = useDrag({
+    type: COLUMN_ITEM_TYPE,
+    item: () => {
+      if (draggingRef) draggingRef.current = true
+      return { id, index }
+    },
+    end: () => {
+      if (draggingRef) draggingRef.current = false
+    },
+  })
+
+  drag(drop(ref))
+
+  const handleClick = (event) => {
+    event.preventDefault()
+    event.stopPropagation()
+    if (draggingRef?.current) return
+    onToggle()
+  }
+
+  return (
+    <MenuItem
+      ref={ref}
+      key={id}
+      onClick={handleClick}
+      disabled={disabled}
+      style={{ opacity: isDragging ? 0.6 : 1, cursor: 'move' }}
+    >
+      <Checkbox checked={checked} />
+      {label}
+    </MenuItem>
+  )
+}
+
+DraggableMenuItem.propTypes = {
+  id: PropTypes.string.isRequired,
+  index: PropTypes.number.isRequired,
+  moveItem: PropTypes.func.isRequired,
+  onToggle: PropTypes.func.isRequired,
+  checked: PropTypes.bool.isRequired,
+  label: PropTypes.node.isRequired,
+  disabled: PropTypes.bool,
+  draggingRef: PropTypes.shape({ current: PropTypes.bool }),
+}
 
 const useStyles = makeStyles({
   menuIcon: {
@@ -31,6 +102,8 @@ export const ToggleFieldsMenu = ({
   resource,
   topbarComponent: TopBarComponent,
   hideColumns,
+  columnsOrder,
+  onColumnsOrderChange,
 }) => {
   const [anchorEl, setAnchorEl] = useState(null)
   const dispatch = useDispatch()
@@ -43,12 +116,14 @@ export const ToggleFieldsMenu = ({
 
   const classes = useStyles()
   const open = Boolean(anchorEl)
+  const draggingRef = useRef(false)
 
   const handleOpen = (event) => {
     setAnchorEl(event.currentTarget)
   }
   const handleClose = () => {
     setAnchorEl(null)
+    if (draggingRef) draggingRef.current = false
   }
 
   const handleClick = (selectedColumn) => {
@@ -61,6 +136,44 @@ export const ToggleFieldsMenu = ({
       }),
     )
   }
+
+  const orderedEntries = useMemo(() => {
+    if (!toggleableColumns) return []
+    if (!columnsOrder?.length)
+      return Object.entries(toggleableColumns).filter(
+        ([key]) => !omittedColumns.includes(key),
+      )
+
+    const knownEntries = columnsOrder
+      .filter((key) => key in toggleableColumns)
+      .map((key) => [key, toggleableColumns[key]])
+      .filter(([key]) => !omittedColumns.includes(key))
+
+    const remainingEntries = Object.entries(toggleableColumns).filter(
+      ([key]) =>
+        !omittedColumns.includes(key) && !columnsOrder.includes(key),
+    )
+
+    return [...knownEntries, ...remainingEntries]
+  }, [columnsOrder, toggleableColumns, omittedColumns])
+
+  const moveItem = useCallback(
+    (fromIndex, toIndex) => {
+      if (!onColumnsOrderChange) return
+      if (fromIndex === toIndex) return
+      const keys = orderedEntries.map(([key]) => key)
+      const nextOrder = [...keys]
+      const [removed] = nextOrder.splice(fromIndex, 1)
+      nextOrder.splice(toIndex, 0, removed)
+      if (
+        keys.length !== nextOrder.length ||
+        keys.some((key, idx) => key !== nextOrder[idx])
+      ) {
+        onColumnsOrderChange(nextOrder)
+      }
+    },
+    [onColumnsOrderChange, orderedEntries],
+  )
 
   return (
     <div className={classes.menuIcon}>
@@ -89,13 +202,31 @@ export const ToggleFieldsMenu = ({
               {translate('ra.toggleFieldsMenu.columnsToDisplay')}
             </Typography>
             <div className={classes.columns}>
-              {Object.entries(toggleableColumns).map(([key, val]) =>
-                !omittedColumns.includes(key) ? (
+              {onColumnsOrderChange ? (
+                <DndProvider backend={HTML5Backend}>
+                  {orderedEntries.map(([key, val], index) => (
+                    <DraggableMenuItem
+                      key={key}
+                      id={key}
+                      index={index}
+                      moveItem={moveItem}
+                      onToggle={() => handleClick(key)}
+                      checked={Boolean(val)}
+                      label={translate(
+                        `resources.${resource}.fields.${key}`,
+                      )}
+                      disabled={false}
+                      draggingRef={draggingRef}
+                    />
+                  ))}
+                </DndProvider>
+              ) : (
+                orderedEntries.map(([key, val]) => (
                   <MenuItem key={key} onClick={() => handleClick(key)}>
                     <Checkbox checked={val} />
                     {translate(`resources.${resource}.fields.${key}`)}
                   </MenuItem>
-                ) : null,
+                ))
               )}
             </div>
           </div>
@@ -109,4 +240,6 @@ ToggleFieldsMenu.propTypes = {
   resource: PropTypes.string.isRequired,
   topbarComponent: PropTypes.elementType,
   hideColumns: PropTypes.bool,
+  columnsOrder: PropTypes.arrayOf(PropTypes.string),
+  onColumnsOrderChange: PropTypes.func,
 }

--- a/ui/src/song/ReorderableSongList.jsx
+++ b/ui/src/song/ReorderableSongList.jsx
@@ -1,0 +1,338 @@
+import { useMemo, useCallback, useEffect, useState } from 'react'
+import {
+  AutocompleteArrayInput,
+  Filter,
+  FunctionField,
+  NumberField,
+  ReferenceArrayInput,
+  SearchInput,
+  TextField,
+  useTranslate,
+  NullableBooleanInput,
+  usePermissions,
+} from 'react-admin'
+import { useMediaQuery } from '@material-ui/core'
+import FavoriteIcon from '@material-ui/icons/Favorite'
+import {
+  DateField,
+  DurationField,
+  List,
+  SongContextMenu,
+  SongDatagrid,
+  SongInfo,
+  QuickFilter,
+  SongTitleField,
+  SongSimpleList,
+  RatingField,
+  useResourceRefresh,
+  ArtistLinkField,
+  PathField,
+} from '../common'
+import { useSelector, useDispatch } from 'react-redux'
+import { makeStyles } from '@material-ui/core/styles'
+import FavoriteBorderIcon from '@material-ui/icons/FavoriteBorder'
+import { playTracks } from '../actions'
+import { SongListActions } from './SongListActions'
+import { AlbumLinkField } from './AlbumLinkField'
+import { SongBulkActions, QualityInfo, useSelectedFields } from '../common'
+import config from '../config'
+import ExpandInfoDialog from '../dialogs/ExpandInfoDialog'
+
+const useStyles = makeStyles({
+  contextHeader: {
+    marginLeft: '3px',
+    marginTop: '-2px',
+    verticalAlign: 'text-top',
+  },
+  row: {
+    '&:hover': {
+      '& $contextMenu': {
+        visibility: 'visible',
+      },
+      '& $ratingField': {
+        visibility: 'visible',
+      },
+    },
+  },
+  contextMenu: {
+    visibility: 'hidden',
+  },
+  ratingField: {
+    visibility: 'hidden',
+  },
+  chip: {
+    margin: 0,
+    height: '24px',
+  },
+})
+
+const SongFilter = (props) => {
+  const classes = useStyles()
+  const translate = useTranslate()
+  const { permissions } = usePermissions()
+  const isAdmin = permissions === 'admin'
+  return (
+    <Filter {...props} variant={'outlined'}>
+      <SearchInput source="title" alwaysOn />
+      <ReferenceArrayInput
+        label={translate('resources.song.fields.genre')}
+        source="genre_id"
+        reference="genre"
+        perPage={0}
+        sort={{ field: 'name', order: 'ASC' }}
+        filterToQuery={(searchText) => ({ name: [searchText] })}
+      >
+        <AutocompleteArrayInput emptyText="-- None --" classes={classes} />
+      </ReferenceArrayInput>
+      <ReferenceArrayInput
+        label={translate('resources.song.fields.grouping')}
+        source="grouping"
+        reference="tag"
+        perPage={0}
+        sort={{ field: 'tagValue', order: 'ASC' }}
+        filter={{ tag_name: 'grouping' }}
+        filterToQuery={(searchText) => ({
+          tag_value: [searchText],
+        })}
+      >
+        <AutocompleteArrayInput
+          emptyText="-- None --"
+          classes={classes}
+          optionText="tagValue"
+        />
+      </ReferenceArrayInput>
+      <ReferenceArrayInput
+        label={translate('resources.song.fields.mood')}
+        source="mood"
+        reference="tag"
+        perPage={0}
+        sort={{ field: 'tagValue', order: 'ASC' }}
+        filter={{ tag_name: 'mood' }}
+        filterToQuery={(searchText) => ({
+          tag_value: [searchText],
+        })}
+      >
+        <AutocompleteArrayInput
+          emptyText="-- None --"
+          classes={classes}
+          optionText="tagValue"
+        />
+      </ReferenceArrayInput>
+      {config.enableFavourites && (
+        <QuickFilter
+          source="starred"
+          label={<FavoriteIcon fontSize={'small'} />}
+          defaultValue={true}
+        />
+      )}
+      {isAdmin && <NullableBooleanInput source="missing" />}
+    </Filter>
+  )
+}
+
+const ensureOrderHasKeys = (order, keys) => {
+  const filtered = order.filter((key) => keys.includes(key))
+  const missing = keys.filter((key) => !filtered.includes(key))
+  return [...filtered, ...missing]
+}
+
+const ReorderableSongList = (props) => {
+  const classes = useStyles()
+  const dispatch = useDispatch()
+  const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
+  const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
+  useResourceRefresh('song')
+
+  const songs = useSelector((state) => state.admin.resources.song)
+
+  const handleRowClick = useCallback(
+    (id, basePath, record) => {
+      const songsArray = Array.isArray(songs.data)
+        ? songs.data
+        : Object.values(songs.data)
+
+      if (songsArray.length > 0 && Array.isArray(songs.list?.ids)) {
+        const filteredSongs = songsArray.filter((song) =>
+          songs.list.ids.includes(song.id),
+        )
+
+        const index = filteredSongs.findIndex((song) => song.id === record.id)
+
+        if (index !== -1) {
+          const orderedSongs = [
+            ...filteredSongs.slice(index),
+            ...filteredSongs.slice(0, index),
+          ]
+
+          const updatedSongs = Object.fromEntries(
+            orderedSongs.map((song, idx) => [idx, song]),
+          )
+
+          dispatch(playTracks(updatedSongs, 0))
+        }
+      }
+    },
+    [dispatch, songs.data, songs.list?.ids],
+  )
+
+  const toggleableFields = useMemo(() => {
+    return {
+      album: isDesktop && <AlbumLinkField source="album" sortByOrder={'ASC'} />,
+      artist: <ArtistLinkField source="artist" />,
+      albumArtist: <ArtistLinkField source="albumArtist" />,
+      trackNumber: isDesktop && <NumberField source="trackNumber" />,
+      playCount: isDesktop && (
+        <NumberField source="playCount" sortByOrder={'DESC'} />
+      ),
+      playDate: <DateField source="playDate" sortByOrder={'DESC'} showTime />,
+      year: isDesktop && (
+        <FunctionField
+          source="year"
+          render={(r) => r.year || ''}
+          sortByOrder={'DESC'}
+        />
+      ),
+      quality: isDesktop && <QualityInfo source="quality" sortable={false} />,
+      channels: isDesktop && (
+        <NumberField source="channels" sortByOrder={'ASC'} />
+      ),
+      duration: <DurationField source="duration" />,
+      rating:
+        config.enableStarRating && (
+          <RatingField
+            source="rating"
+            sortByOrder={'DESC'}
+            resource={'song'}
+            className={classes.ratingField}
+          />
+        ),
+      bpm: isDesktop && <NumberField source="bpm" />,
+      genre: <TextField source="genre" />,
+      mood: isDesktop && (
+        <FunctionField
+          source="mood"
+          render={(r) => r.tags?.mood?.[0] || ''}
+          sortable={false}
+        />
+      ),
+      comment: <TextField source="comment" />,
+      path: <PathField source="path" />,
+      createdAt: (
+        <DateField source="createdAt" sortBy="recently_added" showTime />
+      ),
+    }
+  }, [isDesktop, classes.ratingField])
+
+  const [columnOrder, setColumnOrder] = useState(() =>
+    Object.keys(toggleableFields),
+  )
+
+  useEffect(() => {
+    const keys = Object.keys(toggleableFields)
+    setColumnOrder((prev) => {
+      if (!prev.length) return keys
+      const next = ensureOrderHasKeys(prev, keys)
+      if (next.length !== prev.length || prev.some((k, i) => k !== next[i])) {
+        return next
+      }
+      return prev
+    })
+  }, [toggleableFields])
+
+  const orderedColumns = useMemo(() => {
+    const keys = columnOrder.length
+      ? columnOrder
+      : Object.keys(toggleableFields)
+    const ordered = {}
+    for (const key of keys) {
+      if (key in toggleableFields) {
+        ordered[key] = toggleableFields[key]
+      }
+    }
+    for (const key of Object.keys(toggleableFields)) {
+      if (!(key in ordered)) {
+        ordered[key] = toggleableFields[key]
+      }
+    }
+    return ordered
+  }, [columnOrder, toggleableFields])
+
+  const handleColumnOrderChange = useCallback(
+    (order) => {
+      const keys = Object.keys(toggleableFields)
+      setColumnOrder((prev) => {
+        const next = ensureOrderHasKeys(order, keys)
+        if (prev.length === next.length && prev.every((k, i) => k === next[i])) {
+          return prev
+        }
+        return next
+      })
+    },
+    [toggleableFields],
+  )
+
+  const columns = useSelectedFields({
+    resource: 'song',
+    columns: orderedColumns,
+    defaultOff: [
+      'channels',
+      'bpm',
+      'playDate',
+      'albumArtist',
+      'genre',
+      'mood',
+      'comment',
+      'path',
+      'createdAt',
+    ],
+  })
+
+  return (
+    <>
+      <List
+        {...props}
+        sort={{ field: 'title', order: 'ASC' }}
+        exporter={false}
+        bulkActionButtons={<SongBulkActions />}
+        actions={
+          <SongListActions
+            columnsOrder={columnOrder}
+            onColumnsOrderChange={handleColumnOrderChange}
+          />
+        }
+        filters={<SongFilter />}
+        perPage={isXsmall ? 50 : 15}
+      >
+        {isXsmall ? (
+          <SongSimpleList />
+        ) : (
+          <SongDatagrid
+            rowClick={handleRowClick}
+            contextAlwaysVisible={!isDesktop}
+            classes={{ row: classes.row }}
+          >
+            <SongTitleField source="title" showTrackNumbers={false} />
+            {columns}
+            <SongContextMenu
+              source={'starred_at'}
+              sortByOrder={'DESC'}
+              sortable={config.enableFavourites}
+              className={classes.contextMenu}
+              label={
+                config.enableFavourites && (
+                  <FavoriteBorderIcon
+                    fontSize={'small'}
+                    className={classes.contextHeader}
+                  />
+                )
+              }
+            />
+          </SongDatagrid>
+        )}
+      </List>
+      <ExpandInfoDialog content={<SongInfo />} />
+    </>
+  )
+}
+
+export default ReorderableSongList

--- a/ui/src/song/SongListActions.jsx
+++ b/ui/src/song/SongListActions.jsx
@@ -19,6 +19,8 @@ export const SongListActions = ({
   maxResults,
   total,
   ids,
+  columnsOrder,
+  onColumnsOrderChange,
   ...rest
 }) => {
   const isNotSmall = useMediaQuery((theme) => theme.breakpoints.up('sm'))
@@ -33,7 +35,13 @@ export const SongListActions = ({
           filterValues,
           context: 'button',
         })}
-      {isNotSmall && <ToggleFieldsMenu resource="song" />}
+      {isNotSmall && (
+        <ToggleFieldsMenu
+          resource="song"
+          columnsOrder={columnsOrder}
+          onColumnsOrderChange={onColumnsOrderChange}
+        />
+      )}
     </TopToolbar>
   )
 }

--- a/ui/src/song/index.jsx
+++ b/ui/src/song/index.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import SongList from './SongList'
+import ReorderableSongList from './ReorderableSongList'
 import MusicNoteOutlinedIcon from '@material-ui/icons/MusicNoteOutlined'
 import MusicNoteIcon from '@material-ui/icons/MusicNote'
 import DynamicMenuIcon from '../layout/DynamicMenuIcon'
 
 export default {
-  list: SongList,
+  list: ReorderableSongList,
   icon: (
     <DynamicMenuIcon
       path={'song'}


### PR DESCRIPTION
## Summary
- add a reorderable songs list component that keeps column order in state
- enhance the toggle fields menu with drag-and-drop column reordering support
- wire the songs resource to use the new reorderable list implementation

## Testing
- npm run start -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d6708972d8833086cb48e1dcc56598