### PR TITLE
Fix pagination rows per page selection for songs list

### DIFF
--- a/ui/src/common/Pagination.jsx
+++ b/ui/src/common/Pagination.jsx
@@ -1,10 +1,6 @@
 import React from 'react'
 import { Pagination as RAPagination } from 'react-admin'
 
-export const Pagination = ({ rowsPerPage, ...rest }) => (
-  <RAPagination
-    rowsPerPageOptions={[25, 50, 100, 200, 500]}
-    rowsPerPage={rowsPerPage ?? 50}
-    {...rest}
-  />
+export const Pagination = (props) => (
+  <RAPagination rowsPerPageOptions={[25, 50, 100, 200, 500]} {...props} />
 )

--- a/ui/src/common/Pagination.jsx
+++ b/ui/src/common/Pagination.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Pagination as RAPagination } from 'react-admin'
 
-export const Pagination = (props) => (
- 
- <RAPagination
- rowsPerPageOptions={[25, 50, 100, 200, 500]} {...props}
- rowsPerPage={50} //
- />
+export const Pagination = ({ rowsPerPage, ...rest }) => (
+  <RAPagination
+    rowsPerPageOptions={[25, 50, 100, 200, 500]}
+    rowsPerPage={rowsPerPage ?? 50}
+    {...rest}
+  />
 )

--- a/ui/src/song/ReorderableSongList.jsx
+++ b/ui/src/song/ReorderableSongList.jsx
@@ -365,7 +365,7 @@ const ReorderableSongList = (props) => {
         bulkActionButtons={<SongBulkActions />}
         actions={<SongListActions />}
         filters={<SongFilter />}
-        perPage={isXsmall ? 50 : 15}
+        perPage={50}
       >
         {isXsmall ? (
           <SongSimpleList />


### PR DESCRIPTION
## Summary
- ensure the shared pagination component respects the list controller rows-per-page value so song lists render the requested number of rows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d806a49b8483309f79c7f0df15d64f