### PR TITLE
Fix song list pagination behavior

### DIFF
--- a/ui/src/common/Pagination.jsx
+++ b/ui/src/common/Pagination.jsx
@@ -2,9 +2,5 @@ import React from 'react'
 import { Pagination as RAPagination } from 'react-admin'
 
 export const Pagination = (props) => (
- 
- <RAPagination
- rowsPerPageOptions={[25, 50, 100, 200, 500]} {...props}
- rowsPerPage={50} //
- />
+  <RAPagination rowsPerPageOptions={[25, 50, 100, 200, 500]} {...props} />
 )

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -21,6 +21,7 @@ import {
   SongDatagrid,
   SongInfo,
   QuickFilter,
+  Pagination,
   SongTitleField,
   SongSimpleList,
   RatingField,
@@ -244,7 +245,8 @@ const SongList = (props) => {
         bulkActionButtons={<SongBulkActions />}
         actions={<SongListActions />}
         filters={<SongFilter />}
-        perPage={isXsmall ? 50 : 50}
+        perPage={50}
+        pagination={<Pagination />}
       >
         {isXsmall ? (
           <SongSimpleList />


### PR DESCRIPTION
## Summary
- use the shared Pagination component in the song list so the controller manages the current page size
- update the custom Pagination wrapper to stop forcing 50 rows, allowing the table to honor the selected page size

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d80709fc2c833091231cf7781fda51