### PR TITLE
Add notification panel to app bar

### DIFF
--- a/ui/src/dataProvider/playlistMissingNotifier.js
+++ b/ui/src/dataProvider/playlistMissingNotifier.js
@@ -50,9 +50,11 @@ export const notifyPlaylistMissingSongs = async (playlistId, fallbackName) => {
       return
     }
     const playlistName = await fetchPlaylistName(playlistId, fallbackName)
+    const noun = missingCount === 1 ? 'song' : 'songs'
+    const verb = missingCount === 1 ? 'is' : 'are'
     pushNotification({
       title: 'Missing songs detected',
-      description: `${missingCount} songs in playlist '${playlistName}' are missing from the server.`,
+      description: `${missingCount} ${noun} in playlist '${playlistName}' ${verb} missing from the server.`,
       time: 'Just now',
     })
     notifiedPlaylists.add(playlistId)

--- a/ui/src/dataProvider/playlistMissingNotifier.js
+++ b/ui/src/dataProvider/playlistMissingNotifier.js
@@ -1,0 +1,62 @@
+import httpClient from './httpClient'
+import { REST_URL } from '../consts'
+import { pushNotification } from '../layout/notificationStore'
+
+const notifiedPlaylists = new Set()
+
+const parseTotalCount = (response) => {
+  const header = response.headers?.get('X-Total-Count')
+  if (!header) {
+    return undefined
+  }
+  const parsed = parseInt(header, 10)
+  return Number.isNaN(parsed) ? undefined : parsed
+}
+
+const fetchPlaylistName = async (playlistId, fallbackName) => {
+  if (fallbackName) {
+    return fallbackName
+  }
+  const response = await httpClient(`${REST_URL}/playlist/${playlistId}`)
+  const data = response.json || {}
+  return data.name || fallbackName || playlistId
+}
+
+const fetchMissingCount = async (playlistId) => {
+  const response = await httpClient(
+    `${REST_URL}/playlist/${playlistId}/tracks?missing=true&_start=0&_end=1`,
+  )
+  const headerCount = parseTotalCount(response)
+  if (headerCount !== undefined) {
+    return headerCount
+  }
+  const payload = response.json
+  if (Array.isArray(payload)) {
+    return payload.length
+  }
+  if (payload && Array.isArray(payload.data)) {
+    return payload.data.length
+  }
+  return 0
+}
+
+export const notifyPlaylistMissingSongs = async (playlistId, fallbackName) => {
+  if (!playlistId || notifiedPlaylists.has(playlistId)) {
+    return
+  }
+  try {
+    const missingCount = await fetchMissingCount(playlistId)
+    if (missingCount <= 0) {
+      return
+    }
+    const playlistName = await fetchPlaylistName(playlistId, fallbackName)
+    pushNotification({
+      title: 'Missing songs detected',
+      description: `${missingCount} songs in playlist '${playlistName}' are missing from the server.`,
+      time: 'Just now',
+    })
+    notifiedPlaylists.add(playlistId)
+  } catch (error) {
+    // Silently ignore failures to avoid disrupting create flow
+  }
+}

--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -232,7 +232,10 @@ const wrapperDataProvider = {
     return httpClient(`${REST_URL}/playlist/${playlistId}/tracks`, {
       method: 'POST',
       body: JSON.stringify(data),
-    }).then(({ json }) => ({ data: json }))
+    }).then(({ json }) => {
+      Promise.resolve(notifyPlaylistMissingSongs(playlistId)).catch(() => {})
+      return { data: json }
+    })
   },
   getPlaylists: (songId) => {
     return httpClient(`${REST_URL}/song/${songId}/playlists`).then(

--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -1,6 +1,7 @@
 import jsonServerProvider from 'ra-data-json-server'
 import httpClient from './httpClient'
 import { REST_URL } from '../consts'
+import { notifyPlaylistMissingSongs } from './playlistMissingNotifier'
 
 const dataProvider = jsonServerProvider(REST_URL, httpClient)
 
@@ -197,6 +198,16 @@ const wrapperDataProvider = {
         const parentId =
           (params?.data?.folderId ?? params?.data?.parentId ?? '') || ''
         emitFoldersChanged({ type: 'create', resource, targetParentId: parentId })
+      }
+      if (resource === 'playlist') {
+        Promise.resolve(
+          notifyPlaylistMissingSongs(res?.data?.id, params?.data?.name),
+        ).catch(() => {})
+      }
+      if (resource === 'playlistTrack' && params?.filter?.playlist_id) {
+        Promise.resolve(
+          notifyPlaylistMissingSongs(params.filter.playlist_id),
+        ).catch(() => {})
       }
       return res
     })

--- a/ui/src/layout/AppBar.jsx
+++ b/ui/src/layout/AppBar.jsx
@@ -8,13 +8,20 @@ import {
 } from 'react-admin'
 import { MdInfo, MdPerson, MdSupervisorAccount } from 'react-icons/md'
 import { useSelector } from 'react-redux'
-import { makeStyles, MenuItem, ListItemIcon, Divider } from '@material-ui/core'
+import {
+  makeStyles,
+  MenuItem,
+  ListItemIcon,
+  Divider,
+  Typography,
+} from '@material-ui/core'
 import ViewListIcon from '@material-ui/icons/ViewList'
 import { Dialogs } from '../dialogs/Dialogs'
 import { AboutDialog } from '../dialogs'
 import PersonalMenu from './PersonalMenu'
 import ActivityPanel from './ActivityPanel'
 import NowPlayingPanel from './NowPlayingPanel'
+import NotificationPanel from './NotificationPanel'
 import UserMenu from './UserMenu'
 import config from '../config'
 
@@ -27,6 +34,12 @@ const useStyles = makeStyles(
       color: theme.palette.text.primary,
     },
     icon: { minWidth: theme.spacing(5) },
+    title: {
+      flex: 1,
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+    },
   }),
   {
     name: 'NDAppBar',
@@ -139,8 +152,20 @@ const CustomUserMenu = ({ onClick, ...rest }) => {
   )
 }
 
-const AppBar = (props) => (
-  <RAAppBar {...props} container={Fragment} userMenu={<CustomUserMenu />} />
-)
+const AppBar = (props) => {
+  const classes = useStyles()
+
+  return (
+    <RAAppBar {...props} container={Fragment} userMenu={<CustomUserMenu />}>
+      <Typography
+        variant="h6"
+        color="inherit"
+        className={classes.title}
+        id="react-admin-title"
+      />
+      <NotificationPanel />
+    </RAAppBar>
+  )
+}
 
 export default AppBar

--- a/ui/src/layout/AppBar.test.jsx
+++ b/ui/src/layout/AppBar.test.jsx
@@ -10,7 +10,12 @@ import config from '../config'
 let store
 
 vi.mock('react-admin', () => ({
-  AppBar: ({ userMenu }) => <div data-testid="appbar">{userMenu}</div>,
+  AppBar: ({ userMenu, children }) => (
+    <div data-testid="appbar">
+      {children}
+      {userMenu}
+    </div>
+  ),
   useTranslate: () => (x) => x,
   usePermissions: () => ({ permissions: 'admin' }),
   getResources: () => [],
@@ -18,6 +23,9 @@ vi.mock('react-admin', () => ({
 
 vi.mock('./NowPlayingPanel', () => ({
   default: () => <div data-testid="now-playing-panel" />,
+}))
+vi.mock('./NotificationPanel', () => ({
+  default: () => <div data-testid="notification-panel" />,
 }))
 vi.mock('./ActivityPanel', () => ({
   default: () => <div data-testid="activity-panel" />,
@@ -51,6 +59,7 @@ describe('<AppBar />', () => {
       </Provider>,
     )
     expect(screen.getByTestId('now-playing-panel')).toBeInTheDocument()
+    expect(screen.getByTestId('notification-panel')).toBeInTheDocument()
   })
 
   it('hides NowPlayingPanel when disabled', () => {

--- a/ui/src/layout/NotificationPanel.jsx
+++ b/ui/src/layout/NotificationPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useCallback } from 'react'
+import React, { useMemo, useState, useCallback, useEffect } from 'react'
 import {
   Badge,
   Box,
@@ -13,6 +13,11 @@ import {
   makeStyles,
 } from '@material-ui/core'
 import { FiBell } from 'react-icons/fi'
+import {
+  subscribeToNotifications,
+  getNotifications,
+  clearNotifications,
+} from './notificationStore'
 
 const useStyles = makeStyles((theme) => ({
   button: {
@@ -82,31 +87,12 @@ const useStyles = makeStyles((theme) => ({
   },
 }))
 
-const mockNotifications = [
-  {
-    id: 1,
-    title: 'New album added',
-    description: 'Across 110th Street by Bobby Womack is now available.',
-    time: '2 minutes ago',
-  },
-  {
-    id: 2,
-    title: 'Playlist updated',
-    description: 'Jazz Essentials was refreshed with 5 new tracks.',
-    time: '12 minutes ago',
-  },
-  {
-    id: 3,
-    title: 'Sync complete',
-    description: 'Library sync finished without any conflicts.',
-    time: 'Yesterday',
-  },
-]
-
 const NotificationPanel = () => {
   const classes = useStyles()
   const [anchorEl, setAnchorEl] = useState(null)
-  const [notifications, setNotifications] = useState(mockNotifications)
+  const [notifications, setNotifications] = useState(() => getNotifications())
+
+  useEffect(() => subscribeToNotifications(setNotifications), [])
 
   const badgeCount = notifications.length
   const open = Boolean(anchorEl)
@@ -125,7 +111,7 @@ const NotificationPanel = () => {
   const handleClose = useCallback(() => setAnchorEl(null), [])
 
   const handleClear = useCallback(() => {
-    setNotifications([])
+    clearNotifications()
   }, [])
 
   const notificationItems = useMemo(

--- a/ui/src/layout/NotificationPanel.jsx
+++ b/ui/src/layout/NotificationPanel.jsx
@@ -1,0 +1,206 @@
+import React, { useMemo, useState, useCallback } from 'react'
+import {
+  Badge,
+  Box,
+  Button,
+  Divider,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Popover,
+  Typography,
+  makeStyles,
+} from '@material-ui/core'
+import { FiBell } from 'react-icons/fi'
+
+const useStyles = makeStyles((theme) => ({
+  button: {
+    color: 'inherit',
+  },
+  badge: {
+    '& .MuiBadge-badge': {
+      minWidth: theme.spacing(2.5),
+      height: theme.spacing(2.5),
+      fontSize: '0.7rem',
+      fontWeight: 600,
+      padding: theme.spacing(0.25, 0.75),
+      backgroundColor: theme.palette.primary.main,
+      color: theme.palette.primary.contrastText,
+      boxShadow: `0 0 0 2px ${theme.palette.background.default}`,
+    },
+  },
+  popoverPaper: {
+    width: 320,
+    maxWidth: '80vw',
+    backgroundColor: theme.palette.background.paper,
+    borderRadius: theme.spacing(1.5),
+    boxShadow: theme.shadows[8],
+    color: theme.palette.text.primary,
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: theme.spacing(2, 2, 1.5, 2),
+  },
+  list: {
+    maxHeight: 320,
+    overflowY: 'auto',
+    padding: 0,
+  },
+  item: {
+    alignItems: 'flex-start',
+    padding: theme.spacing(1.5, 2),
+    '&:not(:last-child)': {
+      borderBottom: `1px solid ${theme.palette.divider}`,
+    },
+  },
+  title: {
+    fontWeight: 600,
+    color: theme.palette.text.primary,
+  },
+  description: {
+    marginTop: theme.spacing(0.5),
+    color: theme.palette.text.secondary,
+  },
+  timestamp: {
+    marginTop: theme.spacing(0.75),
+    display: 'block',
+    fontSize: '0.75rem',
+    color: theme.palette.text.secondary,
+  },
+  empty: {
+    padding: theme.spacing(3),
+    textAlign: 'center',
+    color: theme.palette.text.secondary,
+  },
+  clearButton: {
+    color: theme.palette.primary.main,
+    textTransform: 'none',
+    fontWeight: 600,
+  },
+}))
+
+const mockNotifications = [
+  {
+    id: 1,
+    title: 'New album added',
+    description: 'Across 110th Street by Bobby Womack is now available.',
+    time: '2 minutes ago',
+  },
+  {
+    id: 2,
+    title: 'Playlist updated',
+    description: 'Jazz Essentials was refreshed with 5 new tracks.',
+    time: '12 minutes ago',
+  },
+  {
+    id: 3,
+    title: 'Sync complete',
+    description: 'Library sync finished without any conflicts.',
+    time: 'Yesterday',
+  },
+]
+
+const NotificationPanel = () => {
+  const classes = useStyles()
+  const [anchorEl, setAnchorEl] = useState(null)
+  const [notifications, setNotifications] = useState(mockNotifications)
+
+  const badgeCount = notifications.length
+  const open = Boolean(anchorEl)
+
+  const handleToggle = useCallback(
+    (event) => {
+      if (open) {
+        setAnchorEl(null)
+      } else {
+        setAnchorEl(event.currentTarget)
+      }
+    },
+    [open],
+  )
+
+  const handleClose = useCallback(() => setAnchorEl(null), [])
+
+  const handleClear = useCallback(() => {
+    setNotifications([])
+  }, [])
+
+  const notificationItems = useMemo(
+    () =>
+      notifications.map((notification) => (
+        <ListItem key={notification.id} className={classes.item} alignItems="flex-start">
+          <ListItemText
+            primary={
+              <Typography variant="body1" className={classes.title}>
+                {notification.title}
+              </Typography>
+            }
+            secondary={
+              <>
+                <Typography variant="body2" className={classes.description}>
+                  {notification.description}
+                </Typography>
+                <Typography variant="caption" className={classes.timestamp}>
+                  {notification.time}
+                </Typography>
+              </>
+            }
+          />
+        </ListItem>
+      )),
+    [classes.description, classes.item, classes.timestamp, classes.title, notifications],
+  )
+
+  return (
+    <>
+      <IconButton
+        className={classes.button}
+        aria-haspopup="true"
+        aria-controls={open ? 'notification-panel' : undefined}
+        aria-expanded={open ? 'true' : undefined}
+        aria-label="Notifications"
+        onClick={handleToggle}
+      >
+        <Badge
+          badgeContent={badgeCount}
+          color="primary"
+          className={classes.badge}
+          invisible={badgeCount === 0}
+        >
+          <FiBell size={20} />
+        </Badge>
+      </IconButton>
+      <Popover
+        id="notification-panel"
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        classes={{ paper: classes.popoverPaper }}
+      >
+        <Box className={classes.header}>
+          <Typography variant="subtitle1">Notifications</Typography>
+          {notifications.length > 0 && (
+            <Button size="small" onClick={handleClear} className={classes.clearButton}>
+              Clear All
+            </Button>
+          )}
+        </Box>
+        <Divider />
+        {notifications.length > 0 ? (
+          <List className={classes.list}>{notificationItems}</List>
+        ) : (
+          <Typography variant="body2" className={classes.empty}>
+            You\'re all caught up!
+          </Typography>
+        )}
+      </Popover>
+    </>
+  )
+}
+
+export default NotificationPanel

--- a/ui/src/layout/notificationStore.js
+++ b/ui/src/layout/notificationStore.js
@@ -1,0 +1,64 @@
+const listeners = new Set()
+
+const initialNotifications = [
+  {
+    id: 1,
+    title: 'New album added',
+    description: 'Across 110th Street by Bobby Womack is now available.',
+    time: '2 minutes ago',
+  },
+  {
+    id: 2,
+    title: 'Playlist updated',
+    description: 'Jazz Essentials was refreshed with 5 new tracks.',
+    time: '12 minutes ago',
+  },
+  {
+    id: 3,
+    title: 'Sync complete',
+    description: 'Library sync finished without any conflicts.',
+    time: 'Yesterday',
+  },
+]
+
+let notifications = [...initialNotifications]
+let counter = initialNotifications.length + 1
+
+const notifySubscribers = () => {
+  listeners.forEach((listener) => {
+    try {
+      listener([...notifications])
+    } catch (err) {
+      // Ignore subscriber errors
+    }
+  })
+}
+
+export const subscribeToNotifications = (listener) => {
+  listeners.add(listener)
+  listener([...notifications])
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+export const getNotifications = () => [...notifications]
+
+export const clearNotifications = () => {
+  if (notifications.length === 0) {
+    return
+  }
+  notifications = []
+  notifySubscribers()
+}
+
+export const pushNotification = ({ id, ...rest }) => {
+  const notification = {
+    id: id ?? counter++,
+    ...rest,
+  }
+  notifications = [notification, ...notifications]
+  notifySubscribers()
+  return notification
+}
+


### PR DESCRIPTION
## Summary
- add a bell notification panel component with mock data and themed styling
- render the notification trigger in the app bar ahead of the refresh button and keep the title layout intact
- update the app bar test to account for the new panel

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d86d1997048330927c23b50dd4b82f