### PR TITLE
Swap sync and refresh buttons in activity panel

### DIFF
--- a/ui/src/layout/ActivityPanel.jsx
+++ b/ui/src/layout/ActivityPanel.jsx
@@ -137,20 +137,20 @@ const ActivityPanel = () => {
           </CardContent>
           <Divider />
           <CardActions>
-            <Tooltip title={translate('activity.quickScan')}>
-              <IconButton
-                onClick={triggerScan(false)}
-                disabled={scanStatus.scanning}
-              >
-                <VscSync />
-              </IconButton>
-            </Tooltip>
             <Tooltip title={translate('activity.fullScan')}>
               <IconButton
                 onClick={triggerScan(true)}
                 disabled={scanStatus.scanning}
               >
                 <GiMagnifyingGlass />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title={translate('activity.quickScan')}>
+              <IconButton
+                onClick={triggerScan(false)}
+                disabled={scanStatus.scanning}
+              >
+                <VscSync />
               </IconButton>
             </Tooltip>
           </CardActions>


### PR DESCRIPTION
## Summary
- swap the positions of the sync and full scan buttons in the activity panel popover to match the requested ordering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9bb7fd7248330b2993e09e57e6030