### PR TITLE
Swap refresh and activity controls in app bar

### DIFF
--- a/ui/src/layout/ActivityPanel.jsx
+++ b/ui/src/layout/ActivityPanel.jsx
@@ -211,17 +211,17 @@ const ActivityPanel = () => {
           </CardContent>
           <Divider />
           <CardActions>
+            <Tooltip title={translate('activity.sync')}>
+              <IconButton onClick={triggerSync} disabled={scanStatus.scanning}>
+                <BiLink />
+              </IconButton>
+            </Tooltip>
             <Tooltip title={translate('activity.quickScan')}>
               <IconButton
                 onClick={triggerScan(false)}
                 disabled={scanStatus.scanning}
               >
                 <VscSync />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title={translate('activity.sync')}>
-              <IconButton onClick={triggerSync} disabled={scanStatus.scanning}>
-                <BiLink />
               </IconButton>
             </Tooltip>
             <Tooltip title={translate('activity.fullScan')}>

--- a/ui/src/layout/AppBar.jsx
+++ b/ui/src/layout/AppBar.jsx
@@ -8,7 +8,13 @@ import {
 } from 'react-admin'
 import { MdInfo, MdPerson, MdSupervisorAccount } from 'react-icons/md'
 import { useSelector } from 'react-redux'
-import { makeStyles, MenuItem, ListItemIcon, Divider } from '@material-ui/core'
+import {
+  makeStyles,
+  MenuItem,
+  ListItemIcon,
+  Divider,
+  Typography,
+} from '@material-ui/core'
 import ViewListIcon from '@material-ui/icons/ViewList'
 import { Dialogs } from '../dialogs/Dialogs'
 import { AboutDialog } from '../dialogs'
@@ -27,6 +33,12 @@ const useStyles = makeStyles(
       color: theme.palette.text.primary,
     },
     icon: { minWidth: theme.spacing(5) },
+    title: {
+      flex: 1,
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+    },
   }),
   {
     name: 'NDAppBar',
@@ -120,10 +132,6 @@ const CustomUserMenu = ({ onClick, ...rest }) => {
 
   return (
     <>
-      {config.devActivityPanel &&
-        permissions === 'admin' &&
-        config.enableNowPlaying && <NowPlayingPanel />}
-      {config.devActivityPanel && permissions === 'admin' && <ActivityPanel />}
       <UserMenu {...rest}>
         <PersonalMenu sidebarIsOpen={true} onClick={onClick} />
         <Divider />
@@ -139,8 +147,25 @@ const CustomUserMenu = ({ onClick, ...rest }) => {
   )
 }
 
-const AppBar = (props) => (
-  <RAAppBar {...props} container={Fragment} userMenu={<CustomUserMenu />} />
-)
+const AppBar = (props) => {
+  const classes = useStyles()
+  const { permissions } = usePermissions()
+  const showActivityPanel =
+    config.devActivityPanel && permissions === 'admin'
+  const showNowPlaying = showActivityPanel && config.enableNowPlaying
+
+  return (
+    <RAAppBar {...props} container={Fragment} userMenu={<CustomUserMenu />}>
+      <Typography
+        variant="h6"
+        color="inherit"
+        className={classes.title}
+        id="react-admin-title"
+      />
+      {showActivityPanel && <ActivityPanel />}
+      {showNowPlaying && <NowPlayingPanel />}
+    </RAAppBar>
+  )
+}
 
 export default AppBar

--- a/ui/src/layout/AppBar.test.jsx
+++ b/ui/src/layout/AppBar.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import { describe, it, beforeEach, vi } from 'vitest'
 import { Provider } from 'react-redux'
 import { createStore, combineReducers } from 'redux'
@@ -10,7 +10,12 @@ import config from '../config'
 let store
 
 vi.mock('react-admin', () => ({
-  AppBar: ({ userMenu }) => <div data-testid="appbar">{userMenu}</div>,
+  AppBar: ({ userMenu, children }) => (
+    <div data-testid="appbar">
+      <div data-testid="appbar-children">{children}</div>
+      {userMenu}
+    </div>
+  ),
   useTranslate: () => (x) => x,
   usePermissions: () => ({ permissions: 'admin' }),
   getResources: () => [],
@@ -51,6 +56,18 @@ describe('<AppBar />', () => {
       </Provider>,
     )
     expect(screen.getByTestId('now-playing-panel')).toBeInTheDocument()
+  })
+
+  it('renders ActivityPanel in the app bar content when enabled', () => {
+    render(
+      <Provider store={store}>
+        <AppBar />
+      </Provider>,
+    )
+    const appBarChildren = screen.getByTestId('appbar-children')
+    expect(
+      within(appBarChildren).getByTestId('activity-panel'),
+    ).toBeInTheDocument()
   })
 
   it('hides NowPlayingPanel when disabled', () => {


### PR DESCRIPTION
## Summary
- render the activity panel button before the refresh indicator in the admin app bar so the controls trade places
- keep the user menu focused on navigation entries while still rendering the activity and now playing widgets from the app bar itself
- extend the app bar tests to cover the new layout and updated mock app bar implementation

## Testing
- npm run test -- AppBar.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d9bf3cd3bc8330a7b133a40d9c0115