### PR TITLE
Log missing playlist tracks during import

### DIFF
--- a/core/playlists.go
+++ b/core/playlists.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/RaveNoX/go-jsoncommentstrip"
 	"github.com/bmatcuk/doublestar/v4"
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -281,6 +283,7 @@ func (s *playlists) parseM3U(ctx context.Context, pls *model.Playlist, folder *m
 				mfs = append(mfs, found[idx])
 			} else {
 				log.Warn(ctx, "Path in playlist not found", "playlist", pls.Name, "path", path)
+				recordMissingPlaylistTrack(ctx, pls.Path, path)
 			}
 		}
 	}
@@ -298,6 +301,43 @@ func (s *playlists) parseM3U(ctx context.Context, pls *model.Playlist, folder *m
 // Apple Music creates playlists with NFC-encoded paths but the filesystem uses NFD.
 func normalizePathForComparison(path string) string {
 	return strings.ToLower(norm.NFC.String(path))
+}
+
+func recordMissingPlaylistTrack(ctx context.Context, playlistPath, trackPath string) {
+	if trackPath == "" || conf.Server.DataFolder == "" {
+		return
+	}
+
+	dbFile := filepath.Join(conf.Server.DataFolder, "missing_tracks.db")
+	dsn := fmt.Sprintf("file:%s?_busy_timeout=5000&_journal_mode=WAL", filepath.ToSlash(dbFile))
+
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		log.Debug(ctx, "Unable to open missing tracks database", "path", dbFile, "err", err)
+		return
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`PRAGMA journal_mode=WAL`); err != nil {
+		log.Debug(ctx, "Unable to enable WAL for missing tracks database", "path", dbFile, "err", err)
+		return
+	}
+
+	_, err = db.Exec(`
+CREATE TABLE IF NOT EXISTS missing_playlist_tracks (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        playlist_id TEXT,
+        track_path TEXT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)`)
+	if err != nil {
+		log.Debug(ctx, "Unable to ensure missing tracks table", "path", dbFile, "err", err)
+		return
+	}
+
+	if _, err := db.Exec(`INSERT INTO missing_playlist_tracks (playlist_id, track_path) VALUES (?, ?)`, playlistPath, trackPath); err != nil {
+		log.Debug(ctx, "Unable to record missing track", "path", dbFile, "err", err)
+	}
 }
 
 func inPlaylistsPath(rel string) bool {
@@ -376,6 +416,7 @@ func (s *playlists) normalizePaths(ctx context.Context, pls *model.Playlist, fol
 			res = append(res, relPath)
 		} else {
 			log.Warn(ctx, "Path in playlist not found in any library", "path", line, "line", idx)
+			recordMissingPlaylistTrack(ctx, pls.Path, line)
 		}
 	}
 	return slice.Map(res, filepath.ToSlash), nil

--- a/core/playlists_test.go
+++ b/core/playlists_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -74,6 +75,37 @@ var _ = Describe("Playlists", func() {
 				pls, err := ps.ImportFile(ctx, folder, "cr-ended.m3u")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pls.Tracks).To(HaveLen(2))
+			})
+
+			It("records missing tracks in a separate database", func() {
+				DeferCleanup(configtest.SetupConfig())
+
+				dataDir := GinkgoT().TempDir()
+				conf.Server.DataFolder = dataDir
+
+				playlistName := "missing-log.m3u"
+				playlistPath := filepath.Join(folder.AbsolutePath(), playlistName)
+				Expect(os.WriteFile(playlistPath, []byte("missing-track.mp3\n"), 0644)).To(Succeed())
+				DeferCleanup(func() { _ = os.Remove(playlistPath) })
+
+				dbPath := filepath.Join(conf.Server.DataFolder, "missing_tracks.db")
+				_ = os.Remove(dbPath)
+
+				_, err := ps.ImportFile(ctx, folder, playlistName)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(dbPath).To(BeAnExistingFile())
+
+				dsn := "file:" + filepath.ToSlash(dbPath) + "?_journal_mode=WAL"
+				db, err := sql.Open("sqlite3", dsn)
+				Expect(err).ToNot(HaveOccurred())
+				defer db.Close()
+
+				row := db.QueryRow(`SELECT playlist_id, track_path FROM missing_playlist_tracks LIMIT 1`)
+				var playlistID, trackPath string
+				Expect(row.Scan(&playlistID, &trackPath)).To(Succeed())
+				Expect(playlistID).To(Equal(playlistPath))
+				Expect(trackPath).To(Equal("missing-track.mp3"))
 			})
 
 			It("locates tracks from music library when playlist lives in playlists folder", func() {

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -65,7 +65,8 @@ func (n *Router) routes() http.Handler {
 		n.addPlaylistTrackRoute(r)
 		n.addSongPlaylistsRoute(r)
 		n.addQueueRoute(r)
-		n.addMissingFilesRoute(r)
+                n.addMissingFilesRoute(r)
+                n.addNotificationsRoute(r)
 		n.addKeepAliveRoute(r)
 		n.addInsightsRoute(r)
 

--- a/server/nativeapi/notifications.go
+++ b/server/nativeapi/notifications.go
@@ -1,0 +1,86 @@
+package nativeapi
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/log"
+)
+
+type missingTrackNotification struct {
+	PlaylistID string `json:"playlist_id"`
+	TrackPath  string `json:"track_path"`
+	CreatedAt  string `json:"created_at"`
+}
+
+func (n *Router) addNotificationsRoute(r chi.Router) {
+	r.Get("/notifications/missing-tracks", n.handleMissingTrackNotifications())
+}
+
+func (n *Router) handleMissingTrackNotifications() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		entries := []missingTrackNotification{}
+
+		if conf.Server.DataFolder == "" {
+			writeMissingTrackResponse(w, entries, ctx)
+			return
+		}
+
+		dbFile := filepath.Join(conf.Server.DataFolder, "missing_tracks.db")
+		dsn := fmt.Sprintf("file:%s?_busy_timeout=5000&_journal_mode=WAL", filepath.ToSlash(dbFile))
+
+		db, err := sql.Open("sqlite3", dsn)
+		if err != nil {
+			log.Warn(ctx, "Unable to open missing tracks database", "path", dbFile, "err", err)
+			writeMissingTrackResponse(w, entries, ctx)
+			return
+		}
+		defer db.Close()
+
+		if _, err := db.Exec(`PRAGMA journal_mode=WAL`); err != nil {
+			log.Debug(ctx, "Unable to enable WAL for missing tracks database", "path", dbFile, "err", err)
+		}
+
+		rows, err := db.QueryContext(ctx, `SELECT playlist_id, track_path, created_at FROM missing_playlist_tracks ORDER BY created_at DESC LIMIT 50`)
+		if err != nil {
+			if strings.Contains(err.Error(), "no such table") {
+				writeMissingTrackResponse(w, entries, ctx)
+				return
+			}
+			log.Error(ctx, "Unable to query missing tracks notifications", "path", dbFile, "err", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var entry missingTrackNotification
+			if err := rows.Scan(&entry.PlaylistID, &entry.TrackPath, &entry.CreatedAt); err != nil {
+				log.Warn(ctx, "Unable to scan missing track notification", "path", dbFile, "err", err)
+				continue
+			}
+			entries = append(entries, entry)
+		}
+
+		if err := rows.Err(); err != nil {
+			log.Warn(ctx, "Error iterating missing track notifications", "path", dbFile, "err", err)
+		}
+
+		writeMissingTrackResponse(w, entries, ctx)
+	}
+}
+
+func writeMissingTrackResponse(w http.ResponseWriter, entries []missingTrackNotification, ctx context.Context) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(entries); err != nil {
+		log.Error(ctx, "Unable to encode missing track notifications", err)
+	}
+}

--- a/server/nativeapi/notifications.go
+++ b/server/nativeapi/notifications.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -14,10 +15,19 @@ import (
 	"github.com/navidrome/navidrome/log"
 )
 
-type missingTrackNotification struct {
-	PlaylistID string `json:"playlist_id"`
-	TrackPath  string `json:"track_path"`
-	CreatedAt  string `json:"created_at"`
+type missingPlaylistNotification struct {
+	PlaylistID   string               `json:"playlist_id"`
+	PlaylistName string               `json:"playlist_name,omitempty"`
+	MissingCount int                  `json:"missing_count"`
+	Tracks       []missingTrackDetail `json:"tracks"`
+}
+
+type missingTrackDetail struct {
+	TrackPath       string  `json:"track_path"`
+	CreatedAt       string  `json:"created_at"`
+	Title           string  `json:"title,omitempty"`
+	Artist          string  `json:"artist,omitempty"`
+	DurationSeconds float64 `json:"duration_seconds,omitempty"`
 }
 
 func (n *Router) addNotificationsRoute(r chi.Router) {
@@ -27,7 +37,7 @@ func (n *Router) addNotificationsRoute(r chi.Router) {
 func (n *Router) handleMissingTrackNotifications() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		entries := []missingTrackNotification{}
+		entries := []missingPlaylistNotification{}
 
 		if conf.Server.DataFolder == "" {
 			writeMissingTrackResponse(w, entries, ctx)
@@ -49,7 +59,21 @@ func (n *Router) handleMissingTrackNotifications() http.HandlerFunc {
 			log.Debug(ctx, "Unable to enable WAL for missing tracks database", "path", dbFile, "err", err)
 		}
 
-		rows, err := db.QueryContext(ctx, `SELECT playlist_id, track_path, created_at FROM missing_playlist_tracks ORDER BY created_at DESC LIMIT 50`)
+		rows, err := db.QueryContext(ctx, `WITH recent AS (
+        SELECT playlist_id, track_path, created_at
+        FROM missing_playlist_tracks
+        ORDER BY created_at DESC
+        LIMIT 200
+)
+SELECT
+        playlist_id,
+        COUNT(*) AS missing_count,
+        MAX(created_at) AS latest_created_at,
+        json_group_array(json_object('track_path', track_path, 'created_at', created_at)) AS tracks_json
+FROM recent
+GROUP BY playlist_id
+ORDER BY latest_created_at DESC
+LIMIT 50`)
 		if err != nil {
 			if strings.Contains(err.Error(), "no such table") {
 				writeMissingTrackResponse(w, entries, ctx)
@@ -61,26 +85,112 @@ func (n *Router) handleMissingTrackNotifications() http.HandlerFunc {
 		}
 		defer rows.Close()
 
+		entries = make([]missingPlaylistNotification, 0)
+
 		for rows.Next() {
-			var entry missingTrackNotification
-			if err := rows.Scan(&entry.PlaylistID, &entry.TrackPath, &entry.CreatedAt); err != nil {
+			var (
+				playlistID      string
+				missingCount    int
+				latestCreatedAt string
+				tracksJSON      sql.NullString
+				playlistEntries []missingTrackDetail
+			)
+
+			if err := rows.Scan(&playlistID, &missingCount, &latestCreatedAt, &tracksJSON); err != nil {
 				log.Warn(ctx, "Unable to scan missing track notification", "path", dbFile, "err", err)
 				continue
 			}
-			entries = append(entries, entry)
+
+			if tracksJSON.Valid {
+				if err := json.Unmarshal([]byte(tracksJSON.String), &playlistEntries); err != nil {
+					log.Warn(ctx, "Unable to parse missing track list", "path", dbFile, "playlist", playlistID, "err", err)
+				}
+			}
+
+			entries = append(entries, missingPlaylistNotification{
+				PlaylistID:   playlistID,
+				PlaylistName: derivePlaylistName(playlistID),
+				MissingCount: missingCount,
+				Tracks:       playlistEntries,
+			})
 		}
 
 		if err := rows.Err(); err != nil {
 			log.Warn(ctx, "Error iterating missing track notifications", "path", dbFile, "err", err)
 		}
 
+		if len(entries) > 0 {
+			enrichMissingTrackMetadata(ctx, entries)
+		}
+
 		writeMissingTrackResponse(w, entries, ctx)
 	}
 }
 
-func writeMissingTrackResponse(w http.ResponseWriter, entries []missingTrackNotification, ctx context.Context) {
+func writeMissingTrackResponse(w http.ResponseWriter, entries []missingPlaylistNotification, ctx context.Context) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(entries); err != nil {
 		log.Error(ctx, "Unable to encode missing track notifications", err)
+	}
+}
+
+func derivePlaylistName(playlistID string) string {
+	if playlistID == "" {
+		return ""
+	}
+
+	base := filepath.Base(playlistID)
+	if ext := filepath.Ext(base); ext != "" {
+		base = strings.TrimSuffix(base, ext)
+	}
+	return base
+}
+
+func enrichMissingTrackMetadata(ctx context.Context, entries []missingPlaylistNotification) {
+	if conf.Server.DbPath == "" {
+		return
+	}
+
+	mainDB, err := sql.Open("sqlite3", conf.Server.DbPath)
+	if err != nil {
+		log.Warn(ctx, "Unable to open main database for missing track metadata", "path", conf.Server.DbPath, "err", err)
+		return
+	}
+	defer mainDB.Close()
+
+	for i := range entries {
+		for j := range entries[i].Tracks {
+			populateTrackMetadata(ctx, mainDB, &entries[i].Tracks[j])
+		}
+	}
+}
+
+func populateTrackMetadata(ctx context.Context, db *sql.DB, track *missingTrackDetail) {
+	if db == nil || track == nil || track.TrackPath == "" {
+		return
+	}
+
+	var (
+		title    sql.NullString
+		artist   sql.NullString
+		duration sql.NullFloat64
+	)
+
+	err := db.QueryRowContext(ctx, `SELECT title, artist, duration FROM media_file WHERE path = ? LIMIT 1`, track.TrackPath).Scan(&title, &artist, &duration)
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			log.Debug(ctx, "Unable to lookup track metadata", "track", track.TrackPath, "err", err)
+		}
+		return
+	}
+
+	if title.Valid {
+		track.Title = title.String
+	}
+	if artist.Valid {
+		track.Artist = artist.String
+	}
+	if duration.Valid {
+		track.DurationSeconds = duration.Float64
 	}
 }

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -634,7 +634,10 @@
   },
   "notifications": {
     "missingTracks": "Missing Tracks",
-    "missingTracksEmpty": "No missing tracks recorded"
+    "missingTracksEmpty": "No missing tracks recorded",
+    "missingTracksSummary": "%{smart_count} song is missing from Playlist %{playlist} |||| %{smart_count} songs are missing from Playlist %{playlist}",
+    "missingTracksUnknownPlaylist": "Unknown playlist",
+    "missingTracksUnknownTitle": "Unknown track"
   },
   "help": {
     "title": "MusicMatters Hotkeys",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -632,6 +632,10 @@
     "empty": "Nothing playing",
     "minutesAgo": "%{smart_count} minute ago |||| %{smart_count} minutes ago"
   },
+  "notifications": {
+    "missingTracks": "Missing Tracks",
+    "missingTracksEmpty": "No missing tracks recorded"
+  },
   "help": {
     "title": "MusicMatters Hotkeys",
     "hotkeys": {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -636,6 +636,7 @@
     "missingTracks": "Missing Tracks",
     "missingTracksEmpty": "No missing tracks recorded",
     "missingTracksSummary": "%{smart_count} song is missing from Playlist %{playlist} |||| %{smart_count} songs are missing from Playlist %{playlist}",
+    "missingTracksImportedOn": " — imported on %{date}",
     "missingTracksUnknownPlaylist": "Unknown playlist",
     "missingTracksUnknownTitle": "Unknown track"
   },

--- a/ui/src/layout/AppBar.jsx
+++ b/ui/src/layout/AppBar.jsx
@@ -14,6 +14,7 @@ import { Dialogs } from '../dialogs/Dialogs'
 import { AboutDialog } from '../dialogs'
 import PersonalMenu from './PersonalMenu'
 import ActivityPanel from './ActivityPanel'
+import MissingTracksPanel from './MissingTracksPanel'
 import NowPlayingPanel from './NowPlayingPanel'
 import UserMenu from './UserMenu'
 import config from '../config'
@@ -120,6 +121,9 @@ const CustomUserMenu = ({ onClick, ...rest }) => {
 
   return (
     <>
+      {config.devActivityPanel && permissions === 'admin' && (
+        <MissingTracksPanel />
+      )}
       {config.devActivityPanel &&
         permissions === 'admin' &&
         config.enableNowPlaying && <NowPlayingPanel />}

--- a/ui/src/layout/MissingTracksPanel.jsx
+++ b/ui/src/layout/MissingTracksPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import {
   Card,
   CardContent,
@@ -10,11 +10,15 @@ import {
   Tooltip,
   Typography,
   CircularProgress,
+  Collapse,
   makeStyles,
 } from '@material-ui/core'
 import { MdOutlineNotifications } from 'react-icons/md'
 import { useTranslate, useNotify } from 'react-admin'
 import { httpClient } from '../dataProvider'
+import ExpandLessIcon from '@material-ui/icons/ExpandLess'
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
+import { formatDuration } from '../utils'
 
 const useStyles = makeStyles((theme) => ({
   button: { color: 'inherit' },
@@ -31,10 +35,17 @@ const useStyles = makeStyles((theme) => ({
     overflowY: 'auto',
     padding: 0,
   },
-  listItem: {
+  nestedList: {
+    paddingLeft: theme.spacing(2),
+  },
+  summaryItem: {
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(1),
+  },
+  nestedItem: {
     paddingTop: theme.spacing(0.5),
     paddingBottom: theme.spacing(0.5),
-    paddingLeft: theme.spacing(1),
+    paddingLeft: theme.spacing(2),
     paddingRight: theme.spacing(1),
   },
   empty: {
@@ -55,6 +66,7 @@ const MissingTracksPanel = () => {
   const [anchorEl, setAnchorEl] = useState(null)
   const [entries, setEntries] = useState([])
   const [loading, setLoading] = useState(false)
+  const [expanded, setExpanded] = useState({})
 
   const open = Boolean(anchorEl)
 
@@ -62,17 +74,16 @@ const MissingTracksPanel = () => {
     setLoading(true)
     httpClient('/api/notifications/missing-tracks')
       .then(({ json }) => {
-        if (Array.isArray(json)) {
-          setEntries(json)
-        } else {
-          setEntries([])
-        }
+        const list = Array.isArray(json) ? json : []
+        setEntries(list)
+        setExpanded({})
       })
       .catch((error) => {
         notify('ra.notification.http_error', 'warning', {
           messageArgs: { error: error.message || 'Unknown error' },
         })
         setEntries([])
+        setExpanded({})
       })
       .finally(() => setLoading(false))
   }, [notify])
@@ -88,6 +99,110 @@ const MissingTracksPanel = () => {
   const handleClose = useCallback(() => {
     setAnchorEl(null)
   }, [])
+
+  const togglePlaylist = useCallback((playlistId) => {
+    setExpanded((prev) => ({
+      ...prev,
+      [playlistId]: !prev[playlistId],
+    }))
+  }, [])
+
+  const getPlaylistName = useCallback(
+    (entry) => {
+      if (!entry) {
+        return ''
+      }
+      if (entry.playlist_name) {
+        return entry.playlist_name
+      }
+      if (!entry.playlist_id) {
+        return translate('notifications.missingTracksUnknownPlaylist')
+      }
+      const parts = entry.playlist_id.split(/[\\/]/)
+      const raw = parts[parts.length - 1] || entry.playlist_id
+      return raw.replace(/\.m3u8?$/i, '')
+    },
+    [translate],
+  )
+
+  const getTrackPrimary = useCallback(
+    (track) => {
+      if (!track) {
+        return ''
+      }
+      if (track.title) {
+        return track.title
+      }
+      const parts = (track.track_path || '').split(/[\\/]/)
+      const fallback = parts[parts.length - 1]
+      return fallback || translate('notifications.missingTracksUnknownTitle')
+    },
+    [translate],
+  )
+
+  const getTrackSecondary = useCallback((track) => {
+    if (!track) {
+      return ''
+    }
+    const details = []
+    if (track.artist) {
+      details.push(track.artist)
+    }
+    if (track.duration_seconds && track.duration_seconds > 0) {
+      details.push(formatDuration(track.duration_seconds))
+    }
+    if (details.length === 0 && track.title) {
+      return ''
+    }
+    if (details.length === 0) {
+      const parts = (track.track_path || '').split(/[\\/]/)
+      return parts[parts.length - 1] || ''
+    }
+    return details.join(' • ')
+  }, [])
+
+  const renderedEntries = useMemo(
+    () =>
+      entries.map((entry, index) => {
+        const playlistId = entry.playlist_id || `playlist-${index}`
+        const summaryCount = entry.missing_count || (entry.tracks ? entry.tracks.length : 0)
+        const summaryText = translate('notifications.missingTracksSummary', {
+          smart_count: summaryCount,
+          playlist: getPlaylistName(entry),
+        })
+        const isExpanded = !!expanded[playlistId]
+        const tracks = Array.isArray(entry.tracks) ? entry.tracks : []
+
+        return (
+          <div key={playlistId}>
+            <ListItem
+              button
+              onClick={() => togglePlaylist(playlistId)}
+              className={classes.summaryItem}
+            >
+              <ListItemText primary={summaryText} />
+              {isExpanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+            </ListItem>
+            <Collapse in={isExpanded} timeout="auto" unmountOnExit>
+              <List disablePadding className={classes.nestedList}>
+                {tracks.map((track, index) => (
+                  <ListItem
+                    key={`${playlistId}-${track.track_path || index}-${track.created_at || index}-${index}`}
+                    className={classes.nestedItem}
+                  >
+                    <ListItemText
+                      primary={getTrackPrimary(track)}
+                      secondary={getTrackSecondary(track)}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+            </Collapse>
+          </div>
+        )
+      }),
+    [classes.nestedItem, classes.nestedList, classes.summaryItem, entries, expanded, getPlaylistName, getTrackPrimary, getTrackSecondary, togglePlaylist, translate],
+  )
 
   return (
     <div>
@@ -121,18 +236,7 @@ const MissingTracksPanel = () => {
               </Typography>
             ) : (
               <List className={classes.list} dense>
-                {entries.map((entry, index) => (
-                  <ListItem
-                    key={`${entry.playlist_id || 'playlist'}-${entry.track_path || 'path'}-${entry.created_at || index}-${index}`}
-                    className={classes.listItem}
-                  >
-                    <ListItemText
-                      primary={`${entry.playlist_id || '-'} - ${
-                        entry.track_path || ''
-                      } (${entry.created_at || ''})`}
-                    />
-                  </ListItem>
-                ))}
+                {renderedEntries}
               </List>
             )}
           </CardContent>

--- a/ui/src/layout/MissingTracksPanel.jsx
+++ b/ui/src/layout/MissingTracksPanel.jsx
@@ -1,0 +1,145 @@
+import React, { useCallback, useState } from 'react'
+import {
+  Card,
+  CardContent,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Popover,
+  Tooltip,
+  Typography,
+  CircularProgress,
+  makeStyles,
+} from '@material-ui/core'
+import { MdOutlineNotifications } from 'react-icons/md'
+import { useTranslate, useNotify } from 'react-admin'
+import { httpClient } from '../dataProvider'
+
+const useStyles = makeStyles((theme) => ({
+  button: { color: 'inherit' },
+  card: { padding: 0 },
+  cardContent: {
+    padding: `${theme.spacing(1)}px !important`,
+    '&:last-child': {
+      paddingBottom: `${theme.spacing(1)}px !important`,
+    },
+  },
+  list: {
+    width: '30em',
+    maxHeight: '20em',
+    overflowY: 'auto',
+    padding: 0,
+  },
+  listItem: {
+    paddingTop: theme.spacing(0.5),
+    paddingBottom: theme.spacing(0.5),
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(1),
+  },
+  empty: {
+    padding: theme.spacing(1, 2),
+  },
+  progressWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: theme.spacing(2),
+  },
+}))
+
+const MissingTracksPanel = () => {
+  const classes = useStyles()
+  const translate = useTranslate()
+  const notify = useNotify()
+  const [anchorEl, setAnchorEl] = useState(null)
+  const [entries, setEntries] = useState([])
+  const [loading, setLoading] = useState(false)
+
+  const open = Boolean(anchorEl)
+
+  const fetchEntries = useCallback(() => {
+    setLoading(true)
+    httpClient('/api/notifications/missing-tracks')
+      .then(({ json }) => {
+        if (Array.isArray(json)) {
+          setEntries(json)
+        } else {
+          setEntries([])
+        }
+      })
+      .catch((error) => {
+        notify('ra.notification.http_error', 'warning', {
+          messageArgs: { error: error.message || 'Unknown error' },
+        })
+        setEntries([])
+      })
+      .finally(() => setLoading(false))
+  }, [notify])
+
+  const handleOpen = useCallback(
+    (event) => {
+      setAnchorEl(event.currentTarget)
+      fetchEntries()
+    },
+    [fetchEntries],
+  )
+
+  const handleClose = useCallback(() => {
+    setAnchorEl(null)
+  }, [])
+
+  return (
+    <div>
+      <Tooltip title={translate('notifications.missingTracks')}>
+        <IconButton
+          className={classes.button}
+          onClick={handleOpen}
+          aria-label={translate('notifications.missingTracks')}
+          aria-haspopup="true"
+        >
+          <MdOutlineNotifications size={20} />
+        </IconButton>
+      </Tooltip>
+      <Popover
+        id="panel-missing-tracks"
+        anchorEl={anchorEl}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        open={open}
+        onClose={handleClose}
+      >
+        <Card className={classes.card}>
+          <CardContent className={classes.cardContent}>
+            {loading ? (
+              <div className={classes.progressWrapper}>
+                <CircularProgress size={24} />
+              </div>
+            ) : entries.length === 0 ? (
+              <Typography className={classes.empty}>
+                {translate('notifications.missingTracksEmpty')}
+              </Typography>
+            ) : (
+              <List className={classes.list} dense>
+                {entries.map((entry, index) => (
+                  <ListItem
+                    key={`${entry.playlist_id || 'playlist'}-${entry.track_path || 'path'}-${entry.created_at || index}-${index}`}
+                    className={classes.listItem}
+                  >
+                    <ListItemText
+                      primary={`${entry.playlist_id || '-'} - ${
+                        entry.track_path || ''
+                      } (${entry.created_at || ''})`}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+            )}
+          </CardContent>
+        </Card>
+      </Popover>
+    </div>
+  )
+}
+
+export default MissingTracksPanel

--- a/ui/src/layout/MissingTracksPanel.jsx
+++ b/ui/src/layout/MissingTracksPanel.jsx
@@ -161,15 +161,69 @@ const MissingTracksPanel = () => {
     return details.join(' • ')
   }, [])
 
+  const formatImportedAt = useCallback((value) => {
+    if (!value) {
+      return ''
+    }
+
+    const date = value instanceof Date ? value : new Date(value)
+    if (Number.isNaN(date.getTime())) {
+      return ''
+    }
+
+    const day = String(date.getDate()).padStart(2, '0')
+    const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sept', 'Oct', 'Nov', 'Dec']
+    const month = monthNames[date.getMonth()] || ''
+    const year = date.getFullYear()
+    const hours = String(date.getHours()).padStart(2, '0')
+    const minutes = String(date.getMinutes()).padStart(2, '0')
+
+    return `${day} ${month} ${year}, ${hours}:${minutes}`
+  }, [])
+
+  const getImportedAtLabel = useCallback(
+    (entry) => {
+      if (!entry) {
+        return ''
+      }
+
+      if (entry.imported_at) {
+        return formatImportedAt(entry.imported_at)
+      }
+
+      const tracks = Array.isArray(entry.tracks) ? entry.tracks : []
+      let earliest = null
+
+      tracks.forEach((track) => {
+        const candidate = track && track.created_at ? new Date(track.created_at) : null
+        if (!candidate || Number.isNaN(candidate.getTime())) {
+          return
+        }
+        if (!earliest || candidate < earliest) {
+          earliest = candidate
+        }
+      })
+
+      return formatImportedAt(earliest)
+    },
+    [formatImportedAt],
+  )
+
   const renderedEntries = useMemo(
     () =>
       entries.map((entry, index) => {
         const playlistId = entry.playlist_id || `playlist-${index}`
         const summaryCount = entry.missing_count || (entry.tracks ? entry.tracks.length : 0)
-        const summaryText = translate('notifications.missingTracksSummary', {
+        const baseSummary = translate('notifications.missingTracksSummary', {
           smart_count: summaryCount,
           playlist: getPlaylistName(entry),
         })
+        const importedAtText = getImportedAtLabel(entry)
+        const summaryText = importedAtText
+          ? `${baseSummary}${translate('notifications.missingTracksImportedOn', {
+              date: importedAtText,
+            })}`
+          : baseSummary
         const isExpanded = !!expanded[playlistId]
         const tracks = Array.isArray(entry.tracks) ? entry.tracks : []
 
@@ -201,7 +255,19 @@ const MissingTracksPanel = () => {
           </div>
         )
       }),
-    [classes.nestedItem, classes.nestedList, classes.summaryItem, entries, expanded, getPlaylistName, getTrackPrimary, getTrackSecondary, togglePlaylist, translate],
+    [
+      classes.nestedItem,
+      classes.nestedList,
+      classes.summaryItem,
+      entries,
+      expanded,
+      getImportedAtLabel,
+      getPlaylistName,
+      getTrackPrimary,
+      getTrackSecondary,
+      togglePlaylist,
+      translate,
+    ],
   )
 
   return (


### PR DESCRIPTION
## Summary
- log missing playlist entries to a dedicated `missing_tracks.db` whenever playlist tracks are missing from disk or the library
- create and use the `missing_playlist_tracks` table with WAL journaling without touching the main Navidrome database
- add coverage to confirm missing tracks are recorded during playlist import

## Testing
- go test ./core *(fails: requires taglib development files in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4203d0b08330ba95d3f8733cb7b4