### PR TITLE
Add missing song notifications

### DIFF
--- a/db/migrations/20250701010110_create_missing_song_notifications.go
+++ b/db/migrations/20250701010110_create_missing_song_notifications.go
@@ -1,0 +1,32 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upCreateMissingSongNotifications, downCreateMissingSongNotifications)
+}
+
+func upCreateMissingSongNotifications(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+        CREATE TABLE IF NOT EXISTS missing_song_notification (
+            media_file_id TEXT PRIMARY KEY REFERENCES media_file(id) ON DELETE CASCADE,
+            playlist_names TEXT NOT NULL DEFAULT '[]',
+            detected_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE INDEX IF NOT EXISTS missing_song_notification_detected_at_idx
+            ON missing_song_notification(detected_at DESC);
+    `)
+	return err
+}
+
+func downCreateMissingSongNotifications(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+        DROP TABLE IF EXISTS missing_song_notification;
+    `)
+	return err
+}

--- a/db/migrations/20250701010111_add_song_title_to_missing_song_notifications.go
+++ b/db/migrations/20250701010111_add_song_title_to_missing_song_notifications.go
@@ -1,0 +1,28 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upAddSongTitleToMissingSongNotifications, downAddSongTitleToMissingSongNotifications)
+}
+
+func upAddSongTitleToMissingSongNotifications(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+        ALTER TABLE missing_song_notification
+            ADD COLUMN song_title TEXT NOT NULL DEFAULT '';
+    `)
+	return err
+}
+
+func downAddSongTitleToMissingSongNotifications(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+        ALTER TABLE missing_song_notification
+            DROP COLUMN IF EXISTS song_title;
+    `)
+	return err
+}

--- a/model/datastore.go
+++ b/model/datastore.go
@@ -1,48 +1,49 @@
-	package model
+package model
 
-	import (
-		"context"
+import (
+	"context"
 
-		"github.com/Masterminds/squirrel"
-		"github.com/deluan/rest"
-	)
+	"github.com/Masterminds/squirrel"
+	"github.com/deluan/rest"
+)
 
-	type QueryOptions struct {
-		Sort    string
-		Order   string
-		Max     int
-		Offset  int
-		Filters squirrel.Sqlizer
-		Seed    string // for random sorting
-	}
+type QueryOptions struct {
+	Sort    string
+	Order   string
+	Max     int
+	Offset  int
+	Filters squirrel.Sqlizer
+	Seed    string // for random sorting
+}
 
-	type ResourceRepository interface {
-		rest.Repository
-	}
+type ResourceRepository interface {
+	rest.Repository
+}
 
-	type DataStore interface {
-		Library(ctx context.Context) LibraryRepository
-		Folder(ctx context.Context) FolderRepository
-		Album(ctx context.Context) AlbumRepository
-		Artist(ctx context.Context) ArtistRepository
-		MediaFile(ctx context.Context) MediaFileRepository
-		Genre(ctx context.Context) GenreRepository
-		Tag(ctx context.Context) TagRepository
-		Playlist(ctx context.Context) PlaylistRepository
-		PlaylistFolder(ctx context.Context) PlaylistFolderRepository
-		PlayQueue(ctx context.Context) PlayQueueRepository
-		Transcoding(ctx context.Context) TranscodingRepository
-		Player(ctx context.Context) PlayerRepository
-		Radio(ctx context.Context) RadioRepository
-		Share(ctx context.Context) ShareRepository
-		Property(ctx context.Context) PropertyRepository
-		User(ctx context.Context) UserRepository
-		UserProps(ctx context.Context) UserPropsRepository
-		ScrobbleBuffer(ctx context.Context) ScrobbleBufferRepository
+type DataStore interface {
+	Library(ctx context.Context) LibraryRepository
+	Folder(ctx context.Context) FolderRepository
+	Album(ctx context.Context) AlbumRepository
+	Artist(ctx context.Context) ArtistRepository
+	MediaFile(ctx context.Context) MediaFileRepository
+	Genre(ctx context.Context) GenreRepository
+	Tag(ctx context.Context) TagRepository
+	Playlist(ctx context.Context) PlaylistRepository
+	PlaylistFolder(ctx context.Context) PlaylistFolderRepository
+	PlayQueue(ctx context.Context) PlayQueueRepository
+	Transcoding(ctx context.Context) TranscodingRepository
+	Player(ctx context.Context) PlayerRepository
+	Radio(ctx context.Context) RadioRepository
+	Share(ctx context.Context) ShareRepository
+	Property(ctx context.Context) PropertyRepository
+	User(ctx context.Context) UserRepository
+	UserProps(ctx context.Context) UserPropsRepository
+	ScrobbleBuffer(ctx context.Context) ScrobbleBufferRepository
+	MissingSongNotification(ctx context.Context) MissingSongNotificationRepository
 
-		Resource(ctx context.Context, model interface{}) ResourceRepository
+	Resource(ctx context.Context, model interface{}) ResourceRepository
 
-		WithTx(block func(tx DataStore) error, scope ...string) error
-		WithTxImmediate(block func(tx DataStore) error, scope ...string) error
-		GC(ctx context.Context) error
-	}
+	WithTx(block func(tx DataStore) error, scope ...string) error
+	WithTxImmediate(block func(tx DataStore) error, scope ...string) error
+	GC(ctx context.Context) error
+}

--- a/model/missing_song_notification.go
+++ b/model/missing_song_notification.go
@@ -1,0 +1,23 @@
+package model
+
+import "time"
+
+type MissingSongNotification struct {
+	MediaFileID   string    `structs:"media_file_id" json:"mediaFileId"`
+	PlaylistNames []string  `structs:"-" json:"playlistNames"`
+	DetectedAt    time.Time `structs:"detected_at" json:"detectedAt"`
+	MediaFile     MediaFile `structs:"-" json:"mediaFile"`
+}
+
+type MissingSongNotifications []MissingSongNotification
+
+type MissingSongNotificationRepository interface {
+	CountAll(options ...QueryOptions) (int64, error)
+	GetAll(options ...QueryOptions) (MissingSongNotifications, error)
+
+	RefreshForMediaFileIDs(ids ...string) error
+	RefreshForFolders(folderIDs ...string) error
+	Delete(ids ...string) error
+	DeleteByFolders(folderIDs ...string) error
+	DeleteAll() error
+}

--- a/model/missing_song_notification.go
+++ b/model/missing_song_notification.go
@@ -4,6 +4,7 @@ import "time"
 
 type MissingSongNotification struct {
 	MediaFileID   string    `structs:"media_file_id" json:"mediaFileId"`
+	SongTitle     string    `structs:"song_title" json:"songTitle"`
 	PlaylistNames []string  `structs:"-" json:"playlistNames"`
 	DetectedAt    time.Time `structs:"detected_at" json:"detectedAt"`
 	MediaFile     MediaFile `structs:"-" json:"mediaFile"`

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -19,6 +19,7 @@ import (
 
 type mediaFileRepository struct {
 	sqlRepository
+	missingRepo model.MissingSongNotificationRepository
 }
 
 type dbMediaFile struct {
@@ -85,6 +86,7 @@ func NewMediaFileRepository(ctx context.Context, db dbx.Builder) model.MediaFile
 		"recently_added": mediaFileRecentlyAddedSort(),
 		"starred_at":     "starred, starred_at",
 	})
+	r.missingRepo = NewMissingSongNotificationRepository(ctx, db)
 	return r
 }
 
@@ -132,6 +134,11 @@ func (r *mediaFileRepository) Put(m *model.MediaFile) error {
 		return err
 	}
 	m.ID = id
+	if r.missingRepo != nil && !m.Missing {
+		if err := r.missingRepo.Delete(m.ID); err != nil {
+			return fmt.Errorf("clearing missing notification: %w", err)
+		}
+	}
 	return r.updateParticipants(m.ID, m.Participants)
 }
 
@@ -211,7 +218,16 @@ func (r *mediaFileRepository) DeleteAllMissing() (int64, error) {
 		return 0, rest.ErrPermissionDenied
 	}
 	del := Delete(r.tableName).Where(Eq{"missing": true})
-	return r.executeSQL(del)
+	count, err := r.executeSQL(del)
+	if err != nil {
+		return count, err
+	}
+	if r.missingRepo != nil {
+		if err := r.missingRepo.DeleteAll(); err != nil {
+			return count, err
+		}
+	}
+	return count, nil
 }
 
 func (r *mediaFileRepository) DeleteMissing(ids []string) error {
@@ -219,12 +235,20 @@ func (r *mediaFileRepository) DeleteMissing(ids []string) error {
 	if !user.IsAdmin {
 		return rest.ErrPermissionDenied
 	}
-	return r.delete(
+	if err := r.delete(
 		And{
 			Eq{"missing": true},
 			Eq{"id": ids},
 		},
-	)
+	); err != nil {
+		return err
+	}
+	if r.missingRepo != nil {
+		if err := r.missingRepo.Delete(ids...); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *mediaFileRepository) MarkMissing(missing bool, mfs ...*model.MediaFile) error {
@@ -240,6 +264,18 @@ func (r *mediaFileRepository) MarkMissing(missing bool, mfs ...*model.MediaFile)
 			return err
 		}
 		log.Debug(r.ctx, "Marked missing mediafiles", "total", c, "ids", chunk)
+		if r.missingRepo != nil {
+			var notifyErr error
+			if missing {
+				notifyErr = r.missingRepo.RefreshForMediaFileIDs(chunk...)
+			} else {
+				notifyErr = r.missingRepo.Delete(chunk...)
+			}
+			if notifyErr != nil {
+				log.Error(r.ctx, "Error syncing missing song notifications", "ids", chunk, notifyErr)
+				return notifyErr
+			}
+		}
 	}
 	return nil
 }
@@ -259,6 +295,18 @@ func (r *mediaFileRepository) MarkMissingByFolder(missing bool, folderIDs ...str
 			return err
 		}
 		log.Debug(r.ctx, "Marked missing mediafiles from missing folders", "total", c, "folders", chunk)
+		if r.missingRepo != nil {
+			var notifyErr error
+			if missing {
+				notifyErr = r.missingRepo.RefreshForFolders(chunk...)
+			} else {
+				notifyErr = r.missingRepo.DeleteByFolders(chunk...)
+			}
+			if notifyErr != nil {
+				log.Error(r.ctx, "Error syncing missing notifications for folders", "folders", chunk, notifyErr)
+				return notifyErr
+			}
+		}
 	}
 	return nil
 }

--- a/persistence/missing_song_notification_repository.go
+++ b/persistence/missing_song_notification_repository.go
@@ -62,9 +62,20 @@ func NewMissingSongNotificationRepository(ctx context.Context, db dbx.Builder) m
 }
 
 func (r *missingSongNotificationRepository) CountAll(options ...model.QueryOptions) (int64, error) {
-	query := Select().
+	countQuery := Select().
+		RemoveColumns().Columns("count(distinct " + r.tableName + ".media_file_id) as count").
+		RemoveOffset().RemoveLimit().
+		OrderBy(r.tableName + ".media_file_id").
+		From(r.tableName).
 		Join("media_file ON media_file.id = " + r.tableName + ".media_file_id")
-	return r.count(query, options...)
+	countQuery = r.applyFilters(countQuery, options...)
+	var res struct {
+		Count int64 `db:"count"`
+	}
+	if err := r.queryOne(countQuery, &res); err != nil {
+		return 0, err
+	}
+	return res.Count, nil
 }
 
 func (r *missingSongNotificationRepository) GetAll(options ...model.QueryOptions) (model.MissingSongNotifications, error) {

--- a/persistence/missing_song_notification_repository.go
+++ b/persistence/missing_song_notification_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"slices"
 	"sort"
 
@@ -23,6 +24,12 @@ type dbMissingSongNotification struct {
 	dbMediaFile
 }
 
+type missingMediaFile struct {
+	ID    string `db:"id"`
+	Title string `db:"title"`
+	Path  string `db:"path"`
+}
+
 type dbMissingSongNotifications []dbMissingSongNotification
 
 func (m dbMissingSongNotifications) toModels() model.MissingSongNotifications {
@@ -38,7 +45,12 @@ func (m *dbMissingSongNotification) PostScan() error {
 	if err := m.dbMediaFile.PostScan(); err != nil {
 		return err
 	}
-	m.MissingSongNotification.MediaFile = *m.dbMediaFile.MediaFile
+	if m.dbMediaFile.MediaFile != nil {
+		m.MissingSongNotification.MediaFile = *m.dbMediaFile.MediaFile
+		if m.MissingSongNotification.SongTitle == "" {
+			m.MissingSongNotification.SongTitle = m.dbMediaFile.MediaFile.Title
+		}
+	}
 	if m.Playlists != "" {
 		if err := json.Unmarshal([]byte(m.Playlists), &m.MissingSongNotification.PlaylistNames); err != nil {
 			return fmt.Errorf("parsing playlist names: %w", err)
@@ -103,18 +115,22 @@ func (r *missingSongNotificationRepository) RefreshForMediaFileIDs(ids ...string
 	}
 
 	for chunk := range slices.Chunk(ids, 200) {
-		missingIDs, err := r.loadMissingMediaFileIDs(chunk)
+		missingFiles, err := r.loadMissingMediaFiles(chunk)
 		if err != nil {
 			return err
 		}
-		if len(missingIDs) == 0 {
+		if len(missingFiles) == 0 {
 			continue
+		}
+		missingIDs := make([]string, len(missingFiles))
+		for i, file := range missingFiles {
+			missingIDs[i] = file.ID
 		}
 		playlists, err := r.loadPlaylistNames(missingIDs)
 		if err != nil {
 			return err
 		}
-		if err := r.upsertNotifications(missingIDs, playlists); err != nil {
+		if err := r.upsertNotifications(missingFiles, playlists); err != nil {
 			return err
 		}
 	}
@@ -173,18 +189,18 @@ func (r *missingSongNotificationRepository) DeleteAll() error {
 	return err
 }
 
-func (r *missingSongNotificationRepository) loadMissingMediaFileIDs(ids []string) ([]string, error) {
+func (r *missingSongNotificationRepository) loadMissingMediaFiles(ids []string) ([]missingMediaFile, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	sel := Select("id").
+	sel := Select("id", "title", "path").
 		From("media_file").
 		Where(And{
 			Eq{"id": ids},
 			Eq{"missing": true},
 		})
-	var res []string
-	if err := r.queryAllSlice(sel, &res); err != nil {
+	var res []missingMediaFile
+	if err := r.queryAll(sel, &res); err != nil {
 		return nil, err
 	}
 	return res, nil
@@ -223,19 +239,25 @@ func (r *missingSongNotificationRepository) loadPlaylistNames(ids []string) (map
 	return result, nil
 }
 
-func (r *missingSongNotificationRepository) upsertNotifications(ids []string, playlists map[string][]string) error {
-	for _, id := range ids {
-		names := playlists[id]
+func (r *missingSongNotificationRepository) upsertNotifications(files []missingMediaFile, playlists map[string][]string) error {
+	for _, file := range files {
+		names := playlists[file.ID]
 		sort.Strings(names)
+		title := file.Title
+		if title == "" {
+			title = filepath.Base(file.Path)
+		}
 		data, err := json.Marshal(names)
 		if err != nil {
 			return fmt.Errorf("marshaling playlist names: %w", err)
 		}
 		stmt := Expr(`
-            INSERT INTO missing_song_notification (media_file_id, playlist_names, detected_at)
-            VALUES (?, ?, CURRENT_TIMESTAMP)
-            ON CONFLICT(media_file_id) DO UPDATE SET playlist_names=excluded.playlist_names;
-        `, id, string(data))
+            INSERT INTO missing_song_notification (media_file_id, song_title, playlist_names, detected_at)
+            VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(media_file_id) DO UPDATE SET
+                song_title=excluded.song_title,
+                playlist_names=excluded.playlist_names;
+        `, file.ID, title, string(data))
 		if _, err := r.executeSQL(stmt); err != nil {
 			return err
 		}

--- a/persistence/missing_song_notification_repository.go
+++ b/persistence/missing_song_notification_repository.go
@@ -91,7 +91,7 @@ func (r *missingSongNotificationRepository) RefreshForMediaFileIDs(ids ...string
 		return nil
 	}
 
-	for _, chunk := range slices.Chunk(ids, 200) {
+	for chunk := range slices.Chunk(ids, 200) {
 		missingIDs, err := r.loadMissingMediaFileIDs(chunk)
 		if err != nil {
 			return err
@@ -115,7 +115,7 @@ func (r *missingSongNotificationRepository) RefreshForFolders(folderIDs ...strin
 	if len(folderIDs) == 0 {
 		return nil
 	}
-	for _, chunk := range slices.Chunk(folderIDs, 100) {
+	for chunk := range slices.Chunk(folderIDs, 100) {
 		ids, err := r.mediaFileIDsByFolders(chunk, true)
 		if err != nil {
 			return err
@@ -132,7 +132,7 @@ func (r *missingSongNotificationRepository) Delete(ids ...string) error {
 	if len(ids) == 0 {
 		return nil
 	}
-	for _, chunk := range slices.Chunk(ids, 200) {
+	for chunk := range slices.Chunk(ids, 200) {
 		if _, err := r.executeSQL(Delete(r.tableName).Where(Eq{"media_file_id": chunk})); err != nil {
 			return err
 		}
@@ -145,7 +145,7 @@ func (r *missingSongNotificationRepository) DeleteByFolders(folderIDs ...string)
 	if len(folderIDs) == 0 {
 		return nil
 	}
-	for _, chunk := range slices.Chunk(folderIDs, 100) {
+	for chunk := range slices.Chunk(folderIDs, 100) {
 		ids, err := r.mediaFileIDsByFolders(chunk, false)
 		if err != nil {
 			return err

--- a/persistence/missing_song_notification_repository.go
+++ b/persistence/missing_song_notification_repository.go
@@ -1,0 +1,270 @@
+package persistence
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"sort"
+
+	. "github.com/Masterminds/squirrel"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/utils/slice"
+	"github.com/pocketbase/dbx"
+)
+
+type missingSongNotificationRepository struct {
+	sqlRepository
+}
+
+type dbMissingSongNotification struct {
+	*model.MissingSongNotification `structs:",flatten"`
+	Playlists                      string `structs:"playlist_names"`
+	dbMediaFile
+}
+
+type dbMissingSongNotifications []dbMissingSongNotification
+
+func (m dbMissingSongNotifications) toModels() model.MissingSongNotifications {
+	return slice.Map(m, func(item dbMissingSongNotification) model.MissingSongNotification {
+		return *item.MissingSongNotification
+	})
+}
+
+func (m *dbMissingSongNotification) PostScan() error {
+	if m.MissingSongNotification == nil {
+		m.MissingSongNotification = &model.MissingSongNotification{}
+	}
+	if err := m.dbMediaFile.PostScan(); err != nil {
+		return err
+	}
+	m.MissingSongNotification.MediaFile = *m.dbMediaFile.MediaFile
+	if m.Playlists != "" {
+		if err := json.Unmarshal([]byte(m.Playlists), &m.MissingSongNotification.PlaylistNames); err != nil {
+			return fmt.Errorf("parsing playlist names: %w", err)
+		}
+	} else {
+		m.MissingSongNotification.PlaylistNames = nil
+	}
+	return nil
+}
+
+func NewMissingSongNotificationRepository(ctx context.Context, db dbx.Builder) model.MissingSongNotificationRepository {
+	r := &missingSongNotificationRepository{}
+	r.ctx = ctx
+	r.db = db
+	r.tableName = "missing_song_notification"
+	r.registerModel(&model.MissingSongNotification{}, nil)
+	r.setSortMappings(map[string]string{
+		"detected_at": "detected_at DESC",
+	})
+	return r
+}
+
+func (r *missingSongNotificationRepository) CountAll(options ...model.QueryOptions) (int64, error) {
+	query := Select().
+		Join("media_file ON media_file.id = " + r.tableName + ".media_file_id")
+	return r.count(query, options...)
+}
+
+func (r *missingSongNotificationRepository) GetAll(options ...model.QueryOptions) (model.MissingSongNotifications, error) {
+	sel := r.newSelect(options...).
+		Columns(
+			r.tableName+".*",
+			"media_file.*",
+			"library.path as library_path",
+			"library.name as library_name",
+		).
+		Join("media_file on media_file.id = " + r.tableName + ".media_file_id").
+		Join("library on library.id = media_file.library_id")
+
+	var res dbMissingSongNotifications
+	if err := r.queryAll(sel, &res, options...); err != nil {
+		return nil, err
+	}
+	return res.toModels(), nil
+}
+
+func (r *missingSongNotificationRepository) RefreshForMediaFileIDs(ids ...string) error {
+	ids = r.unique(ids...)
+	if len(ids) == 0 {
+		return nil
+	}
+
+	for _, chunk := range slices.Chunk(ids, 200) {
+		missingIDs, err := r.loadMissingMediaFileIDs(chunk)
+		if err != nil {
+			return err
+		}
+		if len(missingIDs) == 0 {
+			continue
+		}
+		playlists, err := r.loadPlaylistNames(missingIDs)
+		if err != nil {
+			return err
+		}
+		if err := r.upsertNotifications(missingIDs, playlists); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *missingSongNotificationRepository) RefreshForFolders(folderIDs ...string) error {
+	folderIDs = r.unique(folderIDs...)
+	if len(folderIDs) == 0 {
+		return nil
+	}
+	for _, chunk := range slices.Chunk(folderIDs, 100) {
+		ids, err := r.mediaFileIDsByFolders(chunk, true)
+		if err != nil {
+			return err
+		}
+		if err := r.RefreshForMediaFileIDs(ids...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *missingSongNotificationRepository) Delete(ids ...string) error {
+	ids = r.unique(ids...)
+	if len(ids) == 0 {
+		return nil
+	}
+	for _, chunk := range slices.Chunk(ids, 200) {
+		if _, err := r.executeSQL(Delete(r.tableName).Where(Eq{"media_file_id": chunk})); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *missingSongNotificationRepository) DeleteByFolders(folderIDs ...string) error {
+	folderIDs = r.unique(folderIDs...)
+	if len(folderIDs) == 0 {
+		return nil
+	}
+	for _, chunk := range slices.Chunk(folderIDs, 100) {
+		ids, err := r.mediaFileIDsByFolders(chunk, false)
+		if err != nil {
+			return err
+		}
+		if err := r.Delete(ids...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *missingSongNotificationRepository) DeleteAll() error {
+	_, err := r.executeSQL(Delete(r.tableName))
+	return err
+}
+
+func (r *missingSongNotificationRepository) loadMissingMediaFileIDs(ids []string) ([]string, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	sel := Select("id").
+		From("media_file").
+		Where(And{
+			Eq{"id": ids},
+			Eq{"missing": true},
+		})
+	var res []string
+	if err := r.queryAllSlice(sel, &res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (r *missingSongNotificationRepository) loadPlaylistNames(ids []string) (map[string][]string, error) {
+	if len(ids) == 0 {
+		return map[string][]string{}, nil
+	}
+	type row struct {
+		MediaFileID string `db:"media_file_id"`
+		Name        string `db:"name"`
+	}
+	sel := Select(
+		"playlist_tracks.media_file_id",
+		"playlist.name",
+	).
+		From("playlist_tracks").
+		Join("playlist on playlist.id = playlist_tracks.playlist_id").
+		Where(Eq{"playlist_tracks.media_file_id": ids}).
+		OrderBy("playlist_tracks.media_file_id", "lower(playlist.name)")
+	var rows []row
+	if err := r.queryAll(sel, &rows); err != nil {
+		return nil, err
+	}
+	result := make(map[string][]string, len(ids))
+	for _, id := range ids {
+		result[id] = []string{}
+	}
+	for _, row := range rows {
+		list := result[row.MediaFileID]
+		if len(list) == 0 || list[len(list)-1] != row.Name {
+			result[row.MediaFileID] = append(result[row.MediaFileID], row.Name)
+		}
+	}
+	return result, nil
+}
+
+func (r *missingSongNotificationRepository) upsertNotifications(ids []string, playlists map[string][]string) error {
+	for _, id := range ids {
+		names := playlists[id]
+		sort.Strings(names)
+		data, err := json.Marshal(names)
+		if err != nil {
+			return fmt.Errorf("marshaling playlist names: %w", err)
+		}
+		stmt := Expr(`
+            INSERT INTO missing_song_notification (media_file_id, playlist_names, detected_at)
+            VALUES (?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(media_file_id) DO UPDATE SET playlist_names=excluded.playlist_names;
+        `, id, string(data))
+		if _, err := r.executeSQL(stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *missingSongNotificationRepository) mediaFileIDsByFolders(folderIDs []string, onlyMissing bool) ([]string, error) {
+	if len(folderIDs) == 0 {
+		return nil, nil
+	}
+	conds := And{Eq{"folder_id": folderIDs}}
+	if onlyMissing {
+		conds = append(conds, Eq{"missing": true})
+	}
+	sel := Select("id").From("media_file").Where(conds)
+	var res []string
+	if err := r.queryAllSlice(sel, &res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (r *missingSongNotificationRepository) unique(values ...string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
+var _ model.MissingSongNotificationRepository = (*missingSongNotificationRepository)(nil)

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -58,7 +58,7 @@ func (s *SQLStore) Playlist(ctx context.Context) model.PlaylistRepository {
 }
 
 func (s *SQLStore) PlaylistFolder(ctx context.Context) model.PlaylistFolderRepository {
-    return NewPlaylistFolderRepository(ctx, s.getDBXBuilder())
+	return NewPlaylistFolderRepository(ctx, s.getDBXBuilder())
 }
 
 func (s *SQLStore) Property(ctx context.Context) model.PropertyRepository {
@@ -91,6 +91,10 @@ func (s *SQLStore) Player(ctx context.Context) model.PlayerRepository {
 
 func (s *SQLStore) ScrobbleBuffer(ctx context.Context) model.ScrobbleBufferRepository {
 	return NewScrobbleBufferRepository(ctx, s.getDBXBuilder())
+}
+
+func (s *SQLStore) MissingSongNotification(ctx context.Context) model.MissingSongNotificationRepository {
+	return NewMissingSongNotificationRepository(ctx, s.getDBXBuilder())
 }
 
 func (s *SQLStore) Resource(ctx context.Context, m interface{}) model.ResourceRepository {

--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -167,9 +167,12 @@ func (r *playlistRepository) GetWithTracks(id string, refreshSmartPlaylist, incl
 	if refreshSmartPlaylist {
 		r.refreshSmartPlaylist(pls)
 	}
-	tracks, err := r.loadTracks(Select().From("playlist_tracks").
-		Where(Eq{"missing": false}).
-		OrderBy("playlist_tracks.id"), id)
+	sel := Select().From("playlist_tracks").
+		OrderBy("playlist_tracks.id")
+	if !includeMissing {
+		sel = sel.Where(Eq{"f.missing": false})
+	}
+	tracks, err := r.loadTracks(sel, id)
 	if err != nil {
 		log.Error(r.ctx, "Error loading playlist tracks ", "playlist", pls.Name, "id", pls.ID, err)
 		return nil, err

--- a/server/nativeapi/missing.go
+++ b/server/nativeapi/missing.go
@@ -105,3 +105,33 @@ func deleteMissingFiles(ds model.DataStore, w http.ResponseWriter, r *http.Reque
 }
 
 var _ model.ResourceRepository = &missingRepository{}
+
+func getMissingNotifications(ds model.DataStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		repo := ds.MissingSongNotification(ctx)
+		if repo == nil {
+			http.Error(w, "missing notifications repository not available", http.StatusNotImplemented)
+			return
+		}
+
+		options := model.QueryOptions{Sort: "detected_at", Order: "DESC"}
+		notifications, err := repo.GetAll(options)
+		if err != nil {
+			log.Error(ctx, "Error loading missing song notifications", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		total, err := repo.CountAll()
+		if err != nil {
+			log.Error(ctx, "Error counting missing song notifications", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		rest.RespondWithJSON(w, http.StatusOK, map[string]any{
+			"data":  notifications,
+			"total": total,
+		})
+	}
+}

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -224,6 +224,7 @@ func (n *Router) addMissingFilesRoute(r chi.Router) {
 		r.Delete("/", func(w http.ResponseWriter, r *http.Request) {
 			deleteMissingFiles(n.ds, w, r)
 		})
+		r.With(adminOnlyMiddleware).Get("/notifications", getMissingNotifications(n.ds))
 	})
 }
 

--- a/tests/mock_data_store.go
+++ b/tests/mock_data_store.go
@@ -8,27 +8,28 @@ import (
 )
 
 type MockDataStore struct {
-	RealDS               		model.DataStore
-	MockedLibrary        		model.LibraryRepository
-	MockedFolder         		model.FolderRepository
-	MockedGenre          		model.GenreRepository
-	MockedAlbum          		model.AlbumRepository
-	MockedArtist         		model.ArtistRepository
-	MockedMediaFile      		model.MediaFileRepository
-	MockedTag            		model.TagRepository
-	MockedUser           		model.UserRepository
-	MockedProperty       		model.PropertyRepository
-	MockedPlayer         		model.PlayerRepository
-	MockedPlaylist       		model.PlaylistRepository
-	MockedPlaylistFolder 		model.PlaylistFolderRepository
-	MockedPlayQueue      		model.PlayQueueRepository
-	MockedShare          		model.ShareRepository
-	MockedTranscoding    		model.TranscodingRepository
-	MockedUserProps      		model.UserPropsRepository
-	MockedScrobbleBuffer 		model.ScrobbleBufferRepository
-	MockedRadio          		model.RadioRepository
-	scrobbleBufferMu     		sync.Mutex
-	repoMu               		sync.Mutex
+	RealDS                        model.DataStore
+	MockedLibrary                 model.LibraryRepository
+	MockedFolder                  model.FolderRepository
+	MockedGenre                   model.GenreRepository
+	MockedAlbum                   model.AlbumRepository
+	MockedArtist                  model.ArtistRepository
+	MockedMediaFile               model.MediaFileRepository
+	MockedTag                     model.TagRepository
+	MockedUser                    model.UserRepository
+	MockedProperty                model.PropertyRepository
+	MockedPlayer                  model.PlayerRepository
+	MockedPlaylist                model.PlaylistRepository
+	MockedPlaylistFolder          model.PlaylistFolderRepository
+	MockedPlayQueue               model.PlayQueueRepository
+	MockedShare                   model.ShareRepository
+	MockedTranscoding             model.TranscodingRepository
+	MockedUserProps               model.UserPropsRepository
+	MockedScrobbleBuffer          model.ScrobbleBufferRepository
+	MockedRadio                   model.RadioRepository
+	MockedMissingSongNotification model.MissingSongNotificationRepository
+	scrobbleBufferMu              sync.Mutex
+	repoMu                        sync.Mutex
 }
 
 func (db *MockDataStore) Library(ctx context.Context) model.LibraryRepository {
@@ -231,6 +232,19 @@ func (db *MockDataStore) Radio(ctx context.Context) model.RadioRepository {
 		}
 	}
 	return db.MockedRadio
+}
+
+func (db *MockDataStore) MissingSongNotification(ctx context.Context) model.MissingSongNotificationRepository {
+	if db.MockedMissingSongNotification == nil {
+		if db.RealDS != nil {
+			db.MockedMissingSongNotification = db.RealDS.MissingSongNotification(ctx)
+		} else {
+			db.MockedMissingSongNotification = struct {
+				model.MissingSongNotificationRepository
+			}{}
+		}
+	}
+	return db.MockedMissingSongNotification
 }
 
 func (db *MockDataStore) WithTx(block func(tx model.DataStore) error, label ...string) error {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -342,6 +342,17 @@
       }
     }
   },
+  "notifications": {
+    "missing": {
+      "title": "Missing songs",
+      "empty": "Your playlists are up to date.",
+      "load_error": "Unable to load missing songs: %{error}",
+      "detected": "Detected %{value}",
+      "no_playlists": "Not part of any playlist",
+      "untitled": "Untitled track",
+      "count": "%{count, plural, =0 {No missing songs} one {# missing song} other {# missing songs}}"
+    }
+  },
   "ra": {
     "auth": {
       "welcome1": "Thanks for installing MusicMatters!",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -345,12 +345,13 @@
   "notifications": {
     "missing": {
       "title": "Missing songs",
-      "empty": "Your playlists are up to date.",
+      "empty": "",
       "load_error": "Unable to load missing songs: %{error}",
       "detected": "Detected %{value}",
       "no_playlists": "Not part of any playlist",
       "untitled": "Untitled track",
-      "count": "%{count, plural, =0 {No missing songs} one {# missing song} other {# missing songs}}"
+      "count": "%{smart_count} missing song |||| %{smart_count} missing songs",
+      "none": "No missing songs"
     }
   },
   "ra": {

--- a/ui/src/layout/AppBar.jsx
+++ b/ui/src/layout/AppBar.jsx
@@ -17,6 +17,7 @@ import ActivityPanel from './ActivityPanel'
 import NowPlayingPanel from './NowPlayingPanel'
 import UserMenu from './UserMenu'
 import config from '../config'
+import MissingNotificationsPanel from './MissingNotificationsPanel'
 
 const useStyles = makeStyles(
   (theme) => ({
@@ -123,6 +124,7 @@ const CustomUserMenu = ({ onClick, ...rest }) => {
       {config.devActivityPanel &&
         permissions === 'admin' &&
         config.enableNowPlaying && <NowPlayingPanel />}
+      {permissions === 'admin' && <MissingNotificationsPanel />}
       {config.devActivityPanel && permissions === 'admin' && <ActivityPanel />}
       <UserMenu {...rest}>
         <PersonalMenu sidebarIsOpen={true} onClick={onClick} />

--- a/ui/src/layout/AppBar.test.jsx
+++ b/ui/src/layout/AppBar.test.jsx
@@ -22,6 +22,9 @@ vi.mock('./NowPlayingPanel', () => ({
 vi.mock('./ActivityPanel', () => ({
   default: () => <div data-testid="activity-panel" />,
 }))
+vi.mock('./MissingNotificationsPanel', () => ({
+  default: () => <div data-testid="missing-panel" />,
+}))
 vi.mock('./PersonalMenu', () => ({
   default: () => <div />,
 }))
@@ -51,6 +54,7 @@ describe('<AppBar />', () => {
       </Provider>,
     )
     expect(screen.getByTestId('now-playing-panel')).toBeInTheDocument()
+    expect(screen.getByTestId('missing-panel')).toBeInTheDocument()
   })
 
   it('hides NowPlayingPanel when disabled', () => {
@@ -61,5 +65,6 @@ describe('<AppBar />', () => {
       </Provider>,
     )
     expect(screen.queryByTestId('now-playing-panel')).toBeNull()
+    expect(screen.getByTestId('missing-panel')).toBeInTheDocument()
   })
 })

--- a/ui/src/layout/MissingNotificationsPanel.jsx
+++ b/ui/src/layout/MissingNotificationsPanel.jsx
@@ -1,0 +1,281 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  Badge,
+  Box,
+  Chip,
+  CircularProgress,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Popover,
+  Tooltip,
+  Typography,
+} from '@material-ui/core'
+import { makeStyles } from '@material-ui/core/styles'
+import { MdNotificationsActive } from 'react-icons/md'
+import { useNotify, useTranslate } from 'react-admin'
+import { useSelector } from 'react-redux'
+import { httpClient } from '../dataProvider'
+import { REST_URL } from '../consts'
+import { useInterval } from '../common'
+
+const useStyles = makeStyles(
+  (theme) => ({
+    button: {
+      color: theme.palette.text.secondary,
+    },
+    buttonActive: {
+      color: theme.palette.warning.main,
+    },
+    popoverContent: {
+      width: 360,
+      maxWidth: '90vw',
+    },
+    header: {
+      padding: theme.spacing(2, 3, 1, 3),
+    },
+    listContainer: {
+      maxHeight: 320,
+      overflowY: 'auto',
+    },
+    listItem: {
+      alignItems: 'flex-start',
+    },
+    secondaryLine: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(0.5),
+      marginTop: theme.spacing(0.5),
+    },
+    playlists: {
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: theme.spacing(1),
+    },
+    emptyState: {
+      padding: theme.spacing(2, 3, 3, 3),
+      color: theme.palette.text.secondary,
+    },
+    detectedAt: {
+      color: theme.palette.text.secondary,
+      fontSize: theme.typography.caption.fontSize,
+    },
+    loadingBox: {
+      padding: theme.spacing(3),
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+  }),
+  { name: 'NDMissingNotificationsPanel' },
+)
+
+const formatDetectedAt = (value) => {
+  if (!value) {
+    return ''
+  }
+  try {
+    const date = new Date(value)
+    return date.toLocaleString()
+  } catch (err) {
+    return value
+  }
+}
+
+const MissingNotificationsPanel = () => {
+  const classes = useStyles()
+  const translate = useTranslate()
+  const notify = useNotify()
+  const scanStatus = useSelector((state) => state.activity?.scanStatus)
+  const streamReconnected = useSelector(
+    (state) => state.activity?.streamReconnected,
+  )
+  const [anchorEl, setAnchorEl] = useState(null)
+  const [notifications, setNotifications] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const open = Boolean(anchorEl)
+  const count = notifications.length
+
+  const fetchNotifications = useCallback(() => {
+    setLoading(true)
+    return httpClient(`${REST_URL}/missing/notifications`)
+      .then(({ json }) => {
+        setNotifications(json?.data || [])
+        setError(null)
+      })
+      .catch((err) => {
+        setError(err)
+        notify('notifications.missing.load_error', {
+          type: 'warning',
+          messageArgs: { error: err?.message },
+        })
+      })
+      .finally(() => setLoading(false))
+  }, [notify])
+
+  useEffect(() => {
+    fetchNotifications()
+  }, [fetchNotifications])
+
+  useEffect(() => {
+    if (scanStatus && !scanStatus.scanning) {
+      fetchNotifications()
+    }
+  }, [scanStatus?.scanning, fetchNotifications])
+
+  useEffect(() => {
+    if (streamReconnected) {
+      fetchNotifications()
+    }
+  }, [streamReconnected, fetchNotifications])
+
+  useEffect(() => {
+    if (open) {
+      fetchNotifications()
+    }
+  }, [open, fetchNotifications])
+
+  useInterval(() => {
+    if (!loading) {
+      fetchNotifications()
+    }
+  }, open ? 10000 : 60000)
+
+  const handleOpen = useCallback(
+    (event) => {
+      setAnchorEl(event.currentTarget)
+    },
+    [],
+  )
+
+  const handleClose = useCallback(() => {
+    setAnchorEl(null)
+  }, [])
+
+  const buttonClass = useMemo(
+    () => (count > 0 ? classes.buttonActive : classes.button),
+    [classes.button, classes.buttonActive, count],
+  )
+
+  const listContent = useMemo(() => {
+    if (loading) {
+      return (
+        <Box className={classes.loadingBox}>
+          <CircularProgress size={24} />
+        </Box>
+      )
+    }
+    if (error) {
+      return (
+        <Typography className={classes.emptyState} variant="body2">
+          {translate('notifications.missing.load_error', {
+            error: error?.message || 'unknown',
+          })}
+        </Typography>
+      )
+    }
+    if (notifications.length === 0) {
+      return (
+        <Typography className={classes.emptyState} variant="body2">
+          {translate('notifications.missing.empty')}
+        </Typography>
+      )
+    }
+    return (
+      <List className={classes.listContainer} dense>
+        {notifications.map((item) => {
+          const { mediaFile = {}, playlistNames = [], detectedAt } = item
+          const artist = mediaFile.artist || translate('resources.song.fields.artist')
+          const album = mediaFile.album
+          return (
+            <ListItem key={item.mediaFileId} className={classes.listItem} divider>
+              <ListItemText
+                primary={mediaFile.title || translate('notifications.missing.untitled')}
+                secondary={
+                  <div className={classes.secondaryLine}>
+                    <Typography variant="body2" color="textSecondary">
+                      {artist}
+                    </Typography>
+                    {album && (
+                      <Typography variant="body2" color="textSecondary">
+                        {album}
+                      </Typography>
+                    )}
+                    <Typography className={classes.detectedAt} variant="caption">
+                      {translate('notifications.missing.detected', {
+                        value: formatDetectedAt(detectedAt),
+                      })}
+                    </Typography>
+                    <Box className={classes.playlists}>
+                      {playlistNames.length > 0 ? (
+                        playlistNames.map((name) => (
+                          <Chip key={name} label={name} size="small" />
+                        ))
+                      ) : (
+                        <Typography variant="caption" color="textSecondary">
+                          {translate('notifications.missing.no_playlists')}
+                        </Typography>
+                      )}
+                    </Box>
+                  </div>
+                }
+              />
+            </ListItem>
+          )
+        })}
+      </List>
+    )
+  }, [
+    notifications,
+    loading,
+    error,
+    classes.listContainer,
+    classes.listItem,
+    classes.secondaryLine,
+    classes.playlists,
+    classes.detectedAt,
+    classes.emptyState,
+    classes.loadingBox,
+    translate,
+  ])
+
+  return (
+    <div>
+      <Tooltip title={translate('notifications.missing.title')}>
+        <IconButton className={buttonClass} onClick={handleOpen}>
+          <Badge
+            color="secondary"
+            badgeContent={count}
+            invisible={count === 0}
+          >
+            <MdNotificationsActive size={20} />
+          </Badge>
+        </IconButton>
+      </Tooltip>
+      <Popover
+        id="panel-missing-notifications"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+      >
+        <div className={classes.popoverContent}>
+          <Box className={classes.header}>
+            <Typography variant="subtitle1">
+              {translate('notifications.missing.title')}
+            </Typography>
+            <Typography variant="caption" color="textSecondary">
+              {translate('notifications.missing.count', { count })}
+            </Typography>
+          </Box>
+          {listContent}
+        </div>
+      </Popover>
+    </div>
+  )
+}
+
+export default MissingNotificationsPanel

--- a/ui/src/layout/MissingNotificationsPanel.jsx
+++ b/ui/src/layout/MissingNotificationsPanel.jsx
@@ -159,6 +159,13 @@ const MissingNotificationsPanel = () => {
     [classes.button, classes.buttonActive, count],
   )
 
+  const countLabel = useMemo(() => {
+    if (count === 0) {
+      return translate('notifications.missing.none')
+    }
+    return translate('notifications.missing.count', { smart_count: count })
+  }, [count, translate])
+
   const listContent = useMemo(() => {
     if (loading) {
       return (
@@ -177,22 +184,20 @@ const MissingNotificationsPanel = () => {
       )
     }
     if (notifications.length === 0) {
-      return (
-        <Typography className={classes.emptyState} variant="body2">
-          {translate('notifications.missing.empty')}
-        </Typography>
-      )
+      return null
     }
     return (
       <List className={classes.listContainer} dense>
         {notifications.map((item) => {
-          const { mediaFile = {}, playlistNames = [], detectedAt } = item
+          const { mediaFile = {}, playlistNames = [], detectedAt, songTitle } = item
+          const title =
+            mediaFile.title || songTitle || translate('notifications.missing.untitled')
           const artist = mediaFile.artist || translate('resources.song.fields.artist')
           const album = mediaFile.album
           return (
             <ListItem key={item.mediaFileId} className={classes.listItem} divider>
               <ListItemText
-                primary={mediaFile.title || translate('notifications.missing.untitled')}
+                primary={title}
                 secondary={
                   <div className={classes.secondaryLine}>
                     <Typography variant="body2" color="textSecondary">
@@ -268,7 +273,7 @@ const MissingNotificationsPanel = () => {
               {translate('notifications.missing.title')}
             </Typography>
             <Typography variant="caption" color="textSecondary">
-              {translate('notifications.missing.count', { count })}
+              {countLabel}
             </Typography>
           </Box>
           {listContent}


### PR DESCRIPTION
## Summary
- add a migration, model, and repository to persist missing song notifications
- update media file and playlist persistence along with the native API to maintain and expose notification data
- introduce an admin notification panel in the UI with supporting translations to surface missing songs and their playlists

## Testing
- go test ./... *(fails: missing optional taglib dependency in container)*
- npm run build
- CI=1 npm run test -- src/layout/AppBar.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68dd338292448330a5814d123f9a7857