### PR TITLE
Refine missing track notifications

### DIFF
--- a/server/nativeapi/notifications.go
+++ b/server/nativeapi/notifications.go
@@ -15,19 +15,10 @@ import (
 	"github.com/navidrome/navidrome/log"
 )
 
-type missingPlaylistNotification struct {
-	PlaylistID   string               `json:"playlist_id"`
-	PlaylistName string               `json:"playlist_name,omitempty"`
-	MissingCount int                  `json:"missing_count"`
-	Tracks       []missingTrackDetail `json:"tracks"`
-}
-
 type missingTrackDetail struct {
-	TrackPath       string  `json:"track_path"`
-	CreatedAt       string  `json:"created_at"`
-	Title           string  `json:"title,omitempty"`
-	Artist          string  `json:"artist,omitempty"`
-	DurationSeconds float64 `json:"duration_seconds,omitempty"`
+	TrackPath string `json:"-"`
+	Title     string `json:"title,omitempty"`
+	Artist    string `json:"artist,omitempty"`
 }
 
 func (n *Router) addNotificationsRoute(r chi.Router) {
@@ -37,7 +28,7 @@ func (n *Router) addNotificationsRoute(r chi.Router) {
 func (n *Router) handleMissingTrackNotifications() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		entries := []missingPlaylistNotification{}
+		entries := []missingTrackDetail{}
 
 		if conf.Server.DataFolder == "" {
 			writeMissingTrackResponse(w, entries, ctx)
@@ -59,21 +50,7 @@ func (n *Router) handleMissingTrackNotifications() http.HandlerFunc {
 			log.Debug(ctx, "Unable to enable WAL for missing tracks database", "path", dbFile, "err", err)
 		}
 
-		rows, err := db.QueryContext(ctx, `WITH recent AS (
-        SELECT playlist_id, track_path, created_at
-        FROM missing_playlist_tracks
-        ORDER BY created_at DESC
-        LIMIT 200
-)
-SELECT
-        playlist_id,
-        COUNT(*) AS missing_count,
-        MAX(created_at) AS latest_created_at,
-        json_group_array(json_object('track_path', track_path, 'created_at', created_at)) AS tracks_json
-FROM recent
-GROUP BY playlist_id
-ORDER BY latest_created_at DESC
-LIMIT 50`)
+		rows, err := db.QueryContext(ctx, `SELECT track_path FROM missing_playlist_tracks ORDER BY created_at DESC LIMIT 200`)
 		if err != nil {
 			if strings.Contains(err.Error(), "no such table") {
 				writeMissingTrackResponse(w, entries, ctx)
@@ -85,34 +62,21 @@ LIMIT 50`)
 		}
 		defer rows.Close()
 
-		entries = make([]missingPlaylistNotification, 0)
+		entries = make([]missingTrackDetail, 0)
 
 		for rows.Next() {
-			var (
-				playlistID      string
-				missingCount    int
-				latestCreatedAt string
-				tracksJSON      sql.NullString
-				playlistEntries []missingTrackDetail
-			)
+			var trackPath sql.NullString
 
-			if err := rows.Scan(&playlistID, &missingCount, &latestCreatedAt, &tracksJSON); err != nil {
-				log.Warn(ctx, "Unable to scan missing track notification", "path", dbFile, "err", err)
+			if err := rows.Scan(&trackPath); err != nil {
+				log.Warn(ctx, "Unable to scan missing track entry", "path", dbFile, "err", err)
 				continue
 			}
 
-			if tracksJSON.Valid {
-				if err := json.Unmarshal([]byte(tracksJSON.String), &playlistEntries); err != nil {
-					log.Warn(ctx, "Unable to parse missing track list", "path", dbFile, "playlist", playlistID, "err", err)
-				}
+			if !trackPath.Valid || trackPath.String == "" {
+				continue
 			}
 
-			entries = append(entries, missingPlaylistNotification{
-				PlaylistID:   playlistID,
-				PlaylistName: derivePlaylistName(playlistID),
-				MissingCount: missingCount,
-				Tracks:       playlistEntries,
-			})
+			entries = append(entries, missingTrackDetail{TrackPath: trackPath.String})
 		}
 
 		if err := rows.Err(); err != nil {
@@ -127,26 +91,14 @@ LIMIT 50`)
 	}
 }
 
-func writeMissingTrackResponse(w http.ResponseWriter, entries []missingPlaylistNotification, ctx context.Context) {
+func writeMissingTrackResponse(w http.ResponseWriter, entries []missingTrackDetail, ctx context.Context) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(entries); err != nil {
 		log.Error(ctx, "Unable to encode missing track notifications", err)
 	}
 }
 
-func derivePlaylistName(playlistID string) string {
-	if playlistID == "" {
-		return ""
-	}
-
-	base := filepath.Base(playlistID)
-	if ext := filepath.Ext(base); ext != "" {
-		base = strings.TrimSuffix(base, ext)
-	}
-	return base
-}
-
-func enrichMissingTrackMetadata(ctx context.Context, entries []missingPlaylistNotification) {
+func enrichMissingTrackMetadata(ctx context.Context, entries []missingTrackDetail) {
 	if conf.Server.DbPath == "" {
 		return
 	}
@@ -159,9 +111,7 @@ func enrichMissingTrackMetadata(ctx context.Context, entries []missingPlaylistNo
 	defer mainDB.Close()
 
 	for i := range entries {
-		for j := range entries[i].Tracks {
-			populateTrackMetadata(ctx, mainDB, &entries[i].Tracks[j])
-		}
+		populateTrackMetadata(ctx, mainDB, &entries[i])
 	}
 }
 
@@ -171,26 +121,31 @@ func populateTrackMetadata(ctx context.Context, db *sql.DB, track *missingTrackD
 	}
 
 	var (
-		title    sql.NullString
-		artist   sql.NullString
-		duration sql.NullFloat64
+		title  sql.NullString
+		artist sql.NullString
 	)
 
-	err := db.QueryRowContext(ctx, `SELECT title, artist, duration FROM media_file WHERE path = ? LIMIT 1`, track.TrackPath).Scan(&title, &artist, &duration)
+	err := db.QueryRowContext(ctx, `SELECT title, artist FROM media_file WHERE path = ? LIMIT 1`, track.TrackPath).Scan(&title, &artist)
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
 			log.Debug(ctx, "Unable to lookup track metadata", "track", track.TrackPath, "err", err)
 		}
-		return
+	} else {
+		if title.Valid && title.String != "" {
+			track.Title = title.String
+		}
+		if artist.Valid && artist.String != "" {
+			track.Artist = artist.String
+		}
 	}
 
-	if title.Valid {
-		track.Title = title.String
-	}
-	if artist.Valid {
-		track.Artist = artist.String
-	}
-	if duration.Valid {
-		track.DurationSeconds = duration.Float64
+	if track.Title == "" {
+		base := filepath.Base(track.TrackPath)
+		if ext := filepath.Ext(base); ext != "" {
+			base = strings.TrimSuffix(base, ext)
+		}
+		if base != "" {
+			track.Title = base
+		}
 	}
 }

--- a/server/nativeapi/notifications.go
+++ b/server/nativeapi/notifications.go
@@ -18,7 +18,7 @@ import (
 type missingTrackDetail struct {
 	TrackPath string `json:"-"`
 	Title     string `json:"title,omitempty"`
-	Album     string `json:"album,omitempty"`
+	Artist    string `json:"artist,omitempty"`
 }
 
 func (n *Router) addNotificationsRoute(r chi.Router) {
@@ -121,11 +121,11 @@ func populateTrackMetadata(ctx context.Context, db *sql.DB, track *missingTrackD
 	}
 
 	var (
-		title sql.NullString
-		album sql.NullString
+		title  sql.NullString
+		artist sql.NullString
 	)
 
-	err := db.QueryRowContext(ctx, `SELECT title, album FROM media_file WHERE path = ? LIMIT 1`, track.TrackPath).Scan(&title, &album)
+	err := db.QueryRowContext(ctx, `SELECT title, artist FROM media_file WHERE path = ? LIMIT 1`, track.TrackPath).Scan(&title, &artist)
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
 			log.Debug(ctx, "Unable to lookup track metadata", "track", track.TrackPath, "err", err)
@@ -134,8 +134,8 @@ func populateTrackMetadata(ctx context.Context, db *sql.DB, track *missingTrackD
 		if title.Valid && title.String != "" {
 			track.Title = title.String
 		}
-		if album.Valid && album.String != "" {
-			track.Album = album.String
+		if artist.Valid && artist.String != "" {
+			track.Artist = artist.String
 		}
 	}
 

--- a/server/nativeapi/notifications.go
+++ b/server/nativeapi/notifications.go
@@ -18,7 +18,7 @@ import (
 type missingTrackDetail struct {
 	TrackPath string `json:"-"`
 	Title     string `json:"title,omitempty"`
-	Artist    string `json:"artist,omitempty"`
+	Album     string `json:"album,omitempty"`
 }
 
 func (n *Router) addNotificationsRoute(r chi.Router) {
@@ -121,11 +121,11 @@ func populateTrackMetadata(ctx context.Context, db *sql.DB, track *missingTrackD
 	}
 
 	var (
-		title  sql.NullString
-		artist sql.NullString
+		title sql.NullString
+		album sql.NullString
 	)
 
-	err := db.QueryRowContext(ctx, `SELECT title, artist FROM media_file WHERE path = ? LIMIT 1`, track.TrackPath).Scan(&title, &artist)
+	err := db.QueryRowContext(ctx, `SELECT title, album FROM media_file WHERE path = ? LIMIT 1`, track.TrackPath).Scan(&title, &album)
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
 			log.Debug(ctx, "Unable to lookup track metadata", "track", track.TrackPath, "err", err)
@@ -134,8 +134,8 @@ func populateTrackMetadata(ctx context.Context, db *sql.DB, track *missingTrackD
 		if title.Valid && title.String != "" {
 			track.Title = title.String
 		}
-		if artist.Valid && artist.String != "" {
-			track.Artist = artist.String
+		if album.Valid && album.String != "" {
+			track.Album = album.String
 		}
 	}
 

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -638,7 +638,8 @@
     "missingTracksSummary": "%{smart_count} song is missing from Playlist %{playlist} |||| %{smart_count} songs are missing from Playlist %{playlist}",
     "missingTracksImportedOn": " — imported on %{date}",
     "missingTracksUnknownPlaylist": "Unknown playlist",
-    "missingTracksUnknownTitle": "Unknown track"
+    "missingTracksUnknownTitle": "Unknown track",
+    "missingTracksUnknownArtist": "Unknown artist"
   },
   "help": {
     "title": "MusicMatters Hotkeys",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -639,7 +639,7 @@
     "missingTracksImportedOn": " — imported on %{date}",
     "missingTracksUnknownPlaylist": "Unknown playlist",
     "missingTracksUnknownTitle": "Unknown track",
-    "missingTracksUnknownArtist": "Unknown artist"
+    "missingTracksUnknownAlbum": "Unknown album"
   },
   "help": {
     "title": "MusicMatters Hotkeys",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -639,7 +639,8 @@
     "missingTracksImportedOn": " — imported on %{date}",
     "missingTracksUnknownPlaylist": "Unknown playlist",
     "missingTracksUnknownTitle": "Unknown track",
-    "missingTracksUnknownAlbum": "Unknown album"
+    "missingTracksUnknownArtist": "Unknown artist",
+    "missingTracksMissingSuffix": "is missing"
   },
   "help": {
     "title": "MusicMatters Hotkeys",

--- a/ui/src/layout/MissingTracksPanel.jsx
+++ b/ui/src/layout/MissingTracksPanel.jsx
@@ -83,8 +83,8 @@ const MissingTracksPanel = () => {
   const formatLine = useCallback(
     (track) => {
       const title = track?.title || translate('notifications.missingTracksUnknownTitle')
-      const artist = track?.artist || translate('notifications.missingTracksUnknownArtist')
-      return `${title} — ${artist}`
+      const album = track?.album || translate('notifications.missingTracksUnknownAlbum')
+      return `${title} — ${album}`
     },
     [translate],
   )
@@ -122,7 +122,7 @@ const MissingTracksPanel = () => {
             ) : (
               <List className={classes.list} dense>
                 {entries.map((track, index) => (
-                  <ListItem key={`${track.title || 'track'}-${track.artist || index}-${index}`}>
+                  <ListItem key={`${track.title || 'track'}-${track.album || index}-${index}`}>
                     <ListItemText primary={formatLine(track)} />
                   </ListItem>
                 ))}

--- a/ui/src/layout/MissingTracksPanel.jsx
+++ b/ui/src/layout/MissingTracksPanel.jsx
@@ -83,8 +83,8 @@ const MissingTracksPanel = () => {
   const formatLine = useCallback(
     (track) => {
       const title = track?.title || translate('notifications.missingTracksUnknownTitle')
-      const album = track?.album || translate('notifications.missingTracksUnknownAlbum')
-      return `${title} — ${album}`
+      const artist = track?.artist || translate('notifications.missingTracksUnknownArtist')
+      return `${artist} - ${title} ${translate('notifications.missingTracksMissingSuffix')}`
     },
     [translate],
   )
@@ -122,7 +122,7 @@ const MissingTracksPanel = () => {
             ) : (
               <List className={classes.list} dense>
                 {entries.map((track, index) => (
-                  <ListItem key={`${track.title || 'track'}-${track.album || index}-${index}`}>
+                  <ListItem key={`${track.title || 'track'}-${track.artist || index}-${index}`}>
                     <ListItemText primary={formatLine(track)} />
                   </ListItem>
                 ))}

--- a/ui/src/layout/MissingTracksPanel.jsx
+++ b/ui/src/layout/MissingTracksPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import {
   Card,
   CardContent,
@@ -10,15 +10,11 @@ import {
   Tooltip,
   Typography,
   CircularProgress,
-  Collapse,
   makeStyles,
 } from '@material-ui/core'
 import { MdOutlineNotifications } from 'react-icons/md'
 import { useTranslate, useNotify } from 'react-admin'
 import { httpClient } from '../dataProvider'
-import ExpandLessIcon from '@material-ui/icons/ExpandLess'
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
-import { formatDuration } from '../utils'
 
 const useStyles = makeStyles((theme) => ({
   button: { color: 'inherit' },
@@ -34,19 +30,6 @@ const useStyles = makeStyles((theme) => ({
     maxHeight: '20em',
     overflowY: 'auto',
     padding: 0,
-  },
-  nestedList: {
-    paddingLeft: theme.spacing(2),
-  },
-  summaryItem: {
-    paddingLeft: theme.spacing(1),
-    paddingRight: theme.spacing(1),
-  },
-  nestedItem: {
-    paddingTop: theme.spacing(0.5),
-    paddingBottom: theme.spacing(0.5),
-    paddingLeft: theme.spacing(2),
-    paddingRight: theme.spacing(1),
   },
   empty: {
     padding: theme.spacing(1, 2),
@@ -66,7 +49,6 @@ const MissingTracksPanel = () => {
   const [anchorEl, setAnchorEl] = useState(null)
   const [entries, setEntries] = useState([])
   const [loading, setLoading] = useState(false)
-  const [expanded, setExpanded] = useState({})
 
   const open = Boolean(anchorEl)
 
@@ -76,14 +58,12 @@ const MissingTracksPanel = () => {
       .then(({ json }) => {
         const list = Array.isArray(json) ? json : []
         setEntries(list)
-        setExpanded({})
       })
       .catch((error) => {
         notify('ra.notification.http_error', 'warning', {
           messageArgs: { error: error.message || 'Unknown error' },
         })
         setEntries([])
-        setExpanded({})
       })
       .finally(() => setLoading(false))
   }, [notify])
@@ -100,174 +80,13 @@ const MissingTracksPanel = () => {
     setAnchorEl(null)
   }, [])
 
-  const togglePlaylist = useCallback((playlistId) => {
-    setExpanded((prev) => ({
-      ...prev,
-      [playlistId]: !prev[playlistId],
-    }))
-  }, [])
-
-  const getPlaylistName = useCallback(
-    (entry) => {
-      if (!entry) {
-        return ''
-      }
-      if (entry.playlist_name) {
-        return entry.playlist_name
-      }
-      if (!entry.playlist_id) {
-        return translate('notifications.missingTracksUnknownPlaylist')
-      }
-      const parts = entry.playlist_id.split(/[\\/]/)
-      const raw = parts[parts.length - 1] || entry.playlist_id
-      return raw.replace(/\.m3u8?$/i, '')
-    },
-    [translate],
-  )
-
-  const getTrackPrimary = useCallback(
+  const formatLine = useCallback(
     (track) => {
-      if (!track) {
-        return ''
-      }
-      if (track.title) {
-        return track.title
-      }
-      const parts = (track.track_path || '').split(/[\\/]/)
-      const fallback = parts[parts.length - 1]
-      return fallback || translate('notifications.missingTracksUnknownTitle')
+      const title = track?.title || translate('notifications.missingTracksUnknownTitle')
+      const artist = track?.artist || translate('notifications.missingTracksUnknownArtist')
+      return `${title} — ${artist}`
     },
     [translate],
-  )
-
-  const getTrackSecondary = useCallback((track) => {
-    if (!track) {
-      return ''
-    }
-    const details = []
-    if (track.artist) {
-      details.push(track.artist)
-    }
-    if (track.duration_seconds && track.duration_seconds > 0) {
-      details.push(formatDuration(track.duration_seconds))
-    }
-    if (details.length === 0 && track.title) {
-      return ''
-    }
-    if (details.length === 0) {
-      const parts = (track.track_path || '').split(/[\\/]/)
-      return parts[parts.length - 1] || ''
-    }
-    return details.join(' • ')
-  }, [])
-
-  const formatImportedAt = useCallback((value) => {
-    if (!value) {
-      return ''
-    }
-
-    const date = value instanceof Date ? value : new Date(value)
-    if (Number.isNaN(date.getTime())) {
-      return ''
-    }
-
-    const day = String(date.getDate()).padStart(2, '0')
-    const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sept', 'Oct', 'Nov', 'Dec']
-    const month = monthNames[date.getMonth()] || ''
-    const year = date.getFullYear()
-    const hours = String(date.getHours()).padStart(2, '0')
-    const minutes = String(date.getMinutes()).padStart(2, '0')
-
-    return `${day} ${month} ${year}, ${hours}:${minutes}`
-  }, [])
-
-  const getImportedAtLabel = useCallback(
-    (entry) => {
-      if (!entry) {
-        return ''
-      }
-
-      if (entry.imported_at) {
-        return formatImportedAt(entry.imported_at)
-      }
-
-      const tracks = Array.isArray(entry.tracks) ? entry.tracks : []
-      let earliest = null
-
-      tracks.forEach((track) => {
-        const candidate = track && track.created_at ? new Date(track.created_at) : null
-        if (!candidate || Number.isNaN(candidate.getTime())) {
-          return
-        }
-        if (!earliest || candidate < earliest) {
-          earliest = candidate
-        }
-      })
-
-      return formatImportedAt(earliest)
-    },
-    [formatImportedAt],
-  )
-
-  const renderedEntries = useMemo(
-    () =>
-      entries.map((entry, index) => {
-        const playlistId = entry.playlist_id || `playlist-${index}`
-        const summaryCount = entry.missing_count || (entry.tracks ? entry.tracks.length : 0)
-        const baseSummary = translate('notifications.missingTracksSummary', {
-          smart_count: summaryCount,
-          playlist: getPlaylistName(entry),
-        })
-        const importedAtText = getImportedAtLabel(entry)
-        const summaryText = importedAtText
-          ? `${baseSummary}${translate('notifications.missingTracksImportedOn', {
-              date: importedAtText,
-            })}`
-          : baseSummary
-        const isExpanded = !!expanded[playlistId]
-        const tracks = Array.isArray(entry.tracks) ? entry.tracks : []
-
-        return (
-          <div key={playlistId}>
-            <ListItem
-              button
-              onClick={() => togglePlaylist(playlistId)}
-              className={classes.summaryItem}
-            >
-              <ListItemText primary={summaryText} />
-              {isExpanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
-            </ListItem>
-            <Collapse in={isExpanded} timeout="auto" unmountOnExit>
-              <List disablePadding className={classes.nestedList}>
-                {tracks.map((track, index) => (
-                  <ListItem
-                    key={`${playlistId}-${track.track_path || index}-${track.created_at || index}-${index}`}
-                    className={classes.nestedItem}
-                  >
-                    <ListItemText
-                      primary={getTrackPrimary(track)}
-                      secondary={getTrackSecondary(track)}
-                    />
-                  </ListItem>
-                ))}
-              </List>
-            </Collapse>
-          </div>
-        )
-      }),
-    [
-      classes.nestedItem,
-      classes.nestedList,
-      classes.summaryItem,
-      entries,
-      expanded,
-      getImportedAtLabel,
-      getPlaylistName,
-      getTrackPrimary,
-      getTrackSecondary,
-      togglePlaylist,
-      translate,
-    ],
   )
 
   return (
@@ -302,7 +121,11 @@ const MissingTracksPanel = () => {
               </Typography>
             ) : (
               <List className={classes.list} dense>
-                {renderedEntries}
+                {entries.map((track, index) => (
+                  <ListItem key={`${track.title || 'track'}-${track.artist || index}-${index}`}>
+                    <ListItemText primary={formatLine(track)} />
+                  </ListItem>
+                ))}
               </List>
             )}
           </CardContent>


### PR DESCRIPTION
## Summary
- update the missing track notification endpoint to emit one entry per track with title and artist metadata only
- simplify the missing tracks panel to list each track as “Title — Artist” and add an unknown artist label

## Testing
- go test ./... *(fails: ui/embed.go expects build assets)*

------
https://chatgpt.com/codex/tasks/task_e_68dd394aae388330907915d36808f5cc