### PR TITLE
Add discovery entity and schema

### DIFF
--- a/db/migrations/20250901000000_create_discoveries.go
+++ b/db/migrations/20250901000000_create_discoveries.go
@@ -1,0 +1,86 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upCreateDiscoveries, downCreateDiscoveries)
+}
+
+func upCreateDiscoveries(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+        CREATE TABLE IF NOT EXISTS discoveries (
+                id varchar(255) not null
+                        primary key,
+                name varchar(255) default '' not null,
+                comment varchar(255) default '' not null,
+                duration real default 0 not null,
+                song_count integer default 0 not null,
+                public bool default FALSE not null,
+                created_at datetime,
+                updated_at datetime,
+                path string default '' not null,
+                sync bool default false not null,
+                size integer default 0 not null,
+                rules varchar,
+                evaluated_at datetime,
+                owner_id varchar(255) not null
+                        constraint discoveries_user_user_id_fk
+                                references user
+                                        on update cascade on delete cascade,
+                folder_id text null
+        );
+
+        CREATE INDEX IF NOT EXISTS discoveries_created_at
+                ON discoveries (created_at);
+        CREATE INDEX IF NOT EXISTS discoveries_evaluated_at
+                ON discoveries (evaluated_at);
+        CREATE INDEX IF NOT EXISTS discoveries_name
+                ON discoveries (name);
+        CREATE INDEX IF NOT EXISTS discoveries_size
+                ON discoveries (size);
+        CREATE INDEX IF NOT EXISTS discoveries_updated_at
+                ON discoveries (updated_at);
+        CREATE INDEX IF NOT EXISTS idx_discoveries_folder_id
+                ON discoveries (folder_id);
+
+        CREATE TRIGGER IF NOT EXISTS trg_playlist_folder_delete_discoveries
+        AFTER DELETE ON playlist_folder
+        BEGIN
+                DELETE FROM discoveries WHERE folder_id = OLD.id;
+        END;
+
+        CREATE TABLE IF NOT EXISTS discovery_tracks (
+                id integer default 0 not null,
+                discovery_id varchar(255) not null
+                        constraint discovery_tracks_discovery_id_fk
+                                references discoveries
+                                        on update cascade on delete cascade,
+                media_file_id varchar(255) not null
+        );
+
+        CREATE UNIQUE INDEX IF NOT EXISTS discovery_tracks_pos
+                ON discovery_tracks (discovery_id, id);
+    `)
+	return err
+}
+
+func downCreateDiscoveries(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+        DROP INDEX IF EXISTS discovery_tracks_pos;
+        DROP TABLE IF EXISTS discovery_tracks;
+        DROP TRIGGER IF EXISTS trg_playlist_folder_delete_discoveries;
+        DROP INDEX IF EXISTS idx_discoveries_folder_id;
+        DROP INDEX IF EXISTS discoveries_updated_at;
+        DROP INDEX IF EXISTS discoveries_size;
+        DROP INDEX IF EXISTS discoveries_name;
+        DROP INDEX IF EXISTS discoveries_evaluated_at;
+        DROP INDEX IF EXISTS discoveries_created_at;
+        DROP TABLE IF EXISTS discoveries;
+    `)
+	return err
+}

--- a/model/datastore.go
+++ b/model/datastore.go
@@ -1,48 +1,49 @@
-	package model
+package model
 
-	import (
-		"context"
+import (
+	"context"
 
-		"github.com/Masterminds/squirrel"
-		"github.com/deluan/rest"
-	)
+	"github.com/Masterminds/squirrel"
+	"github.com/deluan/rest"
+)
 
-	type QueryOptions struct {
-		Sort    string
-		Order   string
-		Max     int
-		Offset  int
-		Filters squirrel.Sqlizer
-		Seed    string // for random sorting
-	}
+type QueryOptions struct {
+	Sort    string
+	Order   string
+	Max     int
+	Offset  int
+	Filters squirrel.Sqlizer
+	Seed    string // for random sorting
+}
 
-	type ResourceRepository interface {
-		rest.Repository
-	}
+type ResourceRepository interface {
+	rest.Repository
+}
 
-	type DataStore interface {
-		Library(ctx context.Context) LibraryRepository
-		Folder(ctx context.Context) FolderRepository
-		Album(ctx context.Context) AlbumRepository
-		Artist(ctx context.Context) ArtistRepository
-		MediaFile(ctx context.Context) MediaFileRepository
-		Genre(ctx context.Context) GenreRepository
-		Tag(ctx context.Context) TagRepository
-		Playlist(ctx context.Context) PlaylistRepository
-		PlaylistFolder(ctx context.Context) PlaylistFolderRepository
-		PlayQueue(ctx context.Context) PlayQueueRepository
-		Transcoding(ctx context.Context) TranscodingRepository
-		Player(ctx context.Context) PlayerRepository
-		Radio(ctx context.Context) RadioRepository
-		Share(ctx context.Context) ShareRepository
-		Property(ctx context.Context) PropertyRepository
-		User(ctx context.Context) UserRepository
-		UserProps(ctx context.Context) UserPropsRepository
-		ScrobbleBuffer(ctx context.Context) ScrobbleBufferRepository
+type DataStore interface {
+	Library(ctx context.Context) LibraryRepository
+	Folder(ctx context.Context) FolderRepository
+	Album(ctx context.Context) AlbumRepository
+	Artist(ctx context.Context) ArtistRepository
+	MediaFile(ctx context.Context) MediaFileRepository
+	Genre(ctx context.Context) GenreRepository
+	Tag(ctx context.Context) TagRepository
+	Playlist(ctx context.Context) PlaylistRepository
+	Discovery(ctx context.Context) DiscoveryRepository
+	PlaylistFolder(ctx context.Context) PlaylistFolderRepository
+	PlayQueue(ctx context.Context) PlayQueueRepository
+	Transcoding(ctx context.Context) TranscodingRepository
+	Player(ctx context.Context) PlayerRepository
+	Radio(ctx context.Context) RadioRepository
+	Share(ctx context.Context) ShareRepository
+	Property(ctx context.Context) PropertyRepository
+	User(ctx context.Context) UserRepository
+	UserProps(ctx context.Context) UserPropsRepository
+	ScrobbleBuffer(ctx context.Context) ScrobbleBufferRepository
 
-		Resource(ctx context.Context, model interface{}) ResourceRepository
+	Resource(ctx context.Context, model interface{}) ResourceRepository
 
-		WithTx(block func(tx DataStore) error, scope ...string) error
-		WithTxImmediate(block func(tx DataStore) error, scope ...string) error
-		GC(ctx context.Context) error
-	}
+	WithTx(block func(tx DataStore) error, scope ...string) error
+	WithTxImmediate(block func(tx DataStore) error, scope ...string) error
+	GC(ctx context.Context) error
+}

--- a/model/discovery.go
+++ b/model/discovery.go
@@ -1,0 +1,169 @@
+package model
+
+import (
+	"slices"
+	"strconv"
+	"time"
+
+	"github.com/navidrome/navidrome/model/criteria"
+)
+
+type Discovery struct {
+	ID        string          `structs:"id" json:"id"`
+	Name      string          `structs:"name" json:"name"`
+	Comment   string          `structs:"comment" json:"comment"`
+	Duration  float32         `structs:"duration" json:"duration"`
+	Size      int64           `structs:"size" json:"size"`
+	SongCount int             `structs:"song_count" json:"songCount"`
+	OwnerName string          `structs:"-" json:"ownerName"`
+	OwnerID   string          `structs:"owner_id" json:"ownerId"`
+	FolderID  *string         `structs:"folder_id" json:"folderId,omitempty"`
+	Public    bool            `structs:"public" json:"public"`
+	Tracks    DiscoveryTracks `structs:"-" json:"tracks,omitempty"`
+	Path      string          `structs:"path" json:"path"`
+	Sync      bool            `structs:"sync" json:"sync"`
+	CreatedAt time.Time       `structs:"created_at" json:"createdAt"`
+	UpdatedAt time.Time       `structs:"updated_at" json:"updatedAt"`
+
+	Type string `structs:"-" json:"type,omitempty"`
+
+	// SmartDiscovery attributes
+	Rules       *criteria.Criteria `structs:"rules" json:"rules"`
+	EvaluatedAt *time.Time         `structs:"evaluated_at" json:"evaluatedAt"`
+}
+
+func (d Discovery) IsSmartDiscovery() bool {
+	return d.Rules != nil && d.Rules.Expression != nil
+}
+
+func (d Discovery) MediaFiles() MediaFiles {
+	if len(d.Tracks) == 0 {
+		return nil
+	}
+	return d.Tracks.MediaFiles()
+}
+
+func (d *Discovery) refreshStats() {
+	d.SongCount = len(d.Tracks)
+	d.Duration = 0
+	d.Size = 0
+	for _, t := range d.Tracks {
+		d.Duration += t.MediaFile.Duration
+		d.Size += t.MediaFile.Size
+	}
+}
+
+func (d *Discovery) SetTracks(tracks DiscoveryTracks) {
+	d.Tracks = tracks
+	d.refreshStats()
+}
+
+func (d *Discovery) RemoveTracks(idxToRemove []int) {
+	var newTracks DiscoveryTracks
+	for i, t := range d.Tracks {
+		if slices.Contains(idxToRemove, i) {
+			continue
+		}
+		newTracks = append(newTracks, t)
+	}
+	d.Tracks = newTracks
+	d.refreshStats()
+}
+
+// ToM3U8 exports the discovery to the Extended M3U8 format
+func (d *Discovery) ToM3U8() string {
+	return d.MediaFiles().ToM3U8(d.Name, true)
+}
+
+func (d *Discovery) AddMediaFilesByID(mediaFileIds []string) {
+	pos := len(d.Tracks)
+	for _, mfId := range mediaFileIds {
+		pos++
+		t := DiscoveryTrack{
+			ID:          strconv.Itoa(pos),
+			MediaFileID: mfId,
+			DiscoveryID: d.ID,
+			MediaFile:   MediaFile{ID: mfId},
+		}
+		d.Tracks = append(d.Tracks, t)
+	}
+	d.refreshStats()
+}
+
+func (d *Discovery) AddMediaFiles(mfs MediaFiles) {
+	pos := len(d.Tracks)
+	for _, mf := range mfs {
+		pos++
+		t := DiscoveryTrack{
+			ID:          strconv.Itoa(pos),
+			MediaFileID: mf.ID,
+			DiscoveryID: d.ID,
+			MediaFile:   mf,
+		}
+		d.Tracks = append(d.Tracks, t)
+	}
+	d.refreshStats()
+}
+
+func (d Discovery) CoverArtID() ArtworkID {
+	return ArtworkID{
+		Kind:       KindPlaylistArtwork,
+		ID:         d.ID,
+		LastUpdate: d.UpdatedAt,
+	}
+}
+
+type Discoveries []Discovery
+
+type DiscoveryRepository interface {
+	ResourceRepository
+	CountAll(options ...QueryOptions) (int64, error)
+	Exists(id string) (bool, error)
+	Put(d *Discovery) error
+	Get(id string) (*Discovery, error)
+	GetWithTracks(id string, refreshSmartDiscovery, includeMissing bool) (*Discovery, error)
+	GetAll(options ...QueryOptions) (Discoveries, error)
+	FindByPath(path string) (*Discovery, error)
+	GetSyncedByDirectory(dir string) (Discoveries, error)
+	Delete(id string) error
+	Tracks(discoveryId string, refreshSmartDiscovery bool) DiscoveryTrackRepository
+	GetDiscoveries(mediaFileId string) (Discoveries, error)
+
+	UpdateDiscoveryFolder(id string, discoveryFolderId *string) error
+
+	GetAllByDiscoveryFolder(options ...QueryOptions) (Discoveries, error)
+}
+
+type DiscoveryTrack struct {
+	ID          string `json:"id"`
+	MediaFileID string `json:"mediaFileId"`
+	DiscoveryID string `json:"discoveryId"`
+	MediaFile
+}
+
+type DiscoveryTracks []DiscoveryTrack
+
+func (dt DiscoveryTracks) MediaFiles() MediaFiles {
+	mfs := make(MediaFiles, len(dt))
+	for i, t := range dt {
+		mfs[i] = t.MediaFile
+	}
+	return mfs
+}
+
+type DiscoveryTrackRepository interface {
+	ResourceRepository
+	GetAll(options ...QueryOptions) (DiscoveryTracks, error)
+	GetAlbumIDs(options ...QueryOptions) ([]string, error)
+	Add(mediaFileIds []string) (int, error)
+	AddAlbums(albumIds []string) (int, error)
+	AddArtists(artistIds []string) (int, error)
+	AddDiscs(discs []DiscID) (int, error)
+	Delete(id ...string) error
+	DeleteAll() error
+	Reorder(pos int, newPos int) error
+
+	AnnotatedRepository
+
+	SearchableRepository[DiscoveryTracks]
+}

--- a/persistence/discovery_repository.go
+++ b/persistence/discovery_repository.go
@@ -1,0 +1,637 @@
+package persistence
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	. "github.com/Masterminds/squirrel"
+	"github.com/deluan/rest"
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/criteria"
+	"github.com/pocketbase/dbx"
+)
+
+type discoveryRepository struct {
+	sqlRepository
+}
+
+type dbDiscovery struct {
+	model.Discovery `structs:",flatten"`
+	Rules           sql.NullString `structs:"-"`
+}
+
+func (p *dbDiscovery) PostScan() error {
+	if p.Rules.String != "" {
+		return json.Unmarshal([]byte(p.Rules.String), &p.Discovery.Rules)
+	}
+	return nil
+}
+
+func (p dbDiscovery) PostMapArgs(args map[string]any) error {
+	var err error
+	if p.Discovery.IsSmartDiscovery() {
+		args["rules"], err = json.Marshal(p.Discovery.Rules)
+		if err != nil {
+			return fmt.Errorf("invalid criteria expression: %w", err)
+		}
+		return nil
+	}
+	delete(args, "rules")
+	return nil
+}
+
+func NewDiscoveryRepository(ctx context.Context, db dbx.Builder) model.DiscoveryRepository {
+	r := &discoveryRepository{}
+	r.ctx = ctx
+	r.tableName = "discoveries"
+	r.db = db
+	r.registerModel(&model.Discovery{}, map[string]filterFunc{
+		"q":     discoveryFilter,
+		"smart": smartDiscoveryFilter,
+	})
+	r.setSortMappings(map[string]string{
+		"owner_name": "owner_name",
+	})
+	return r
+}
+
+func discoveryFilter(_ string, value interface{}) Sqlizer {
+	return Or{
+		substringFilter("discoveries.name", value),
+		substringFilter("discoveries.comment", value),
+	}
+}
+
+func smartDiscoveryFilter(string, interface{}) Sqlizer {
+	return Or{
+		Eq{"rules": ""},
+		Eq{"rules": nil},
+	}
+}
+
+func (r *discoveryRepository) userFilter() Sqlizer {
+	user := loggedUser(r.ctx)
+	if user.IsAdmin {
+		return And{}
+	}
+	return Or{
+		Eq{"public": true},
+		Eq{"owner_id": user.ID},
+	}
+}
+
+func (r *discoveryRepository) CountAll(options ...model.QueryOptions) (int64, error) {
+	sq := Select().Where(r.userFilter())
+	return r.count(sq, options...)
+}
+
+func (r *discoveryRepository) Exists(id string) (bool, error) {
+	return r.exists(And{Eq{"id": id}, r.userFilter()})
+}
+
+func (r *discoveryRepository) Delete(id string) error {
+	usr := loggedUser(r.ctx)
+	if !usr.IsAdmin {
+		pls, err := r.Get(id)
+		if err != nil {
+			return err
+		}
+		if pls.OwnerID != usr.ID {
+			return rest.ErrPermissionDenied
+		}
+	}
+	return r.delete(And{Eq{"id": id}, r.userFilter()})
+}
+
+func (r *discoveryRepository) Put(p *model.Discovery) error {
+	pls := dbDiscovery{Discovery: *p}
+	if pls.ID == "" {
+		pls.CreatedAt = time.Now()
+	} else {
+		ok, err := r.Exists(pls.ID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return model.ErrNotAuthorized
+		}
+	}
+	if p.Sync && !p.UpdatedAt.IsZero() {
+		pls.UpdatedAt = p.UpdatedAt
+	} else {
+		now := time.Now()
+		pls.UpdatedAt = now
+		p.UpdatedAt = now
+	}
+
+	id, err := r.put(pls.ID, pls)
+	if err != nil {
+		return err
+	}
+	p.ID = id
+	p.Type = "discovery"
+	if p.Sync && !p.UpdatedAt.IsZero() {
+		p.UpdatedAt = pls.UpdatedAt
+	}
+
+	if p.IsSmartDiscovery() {
+		// Do not update tracks at this point, as it may take a long time and lock the DB, breaking the scan process
+		//r.refreshSmartDiscovery(p)
+		return nil
+	}
+	// Only update tracks if they were specified
+	if len(pls.Tracks) > 0 {
+		return r.updateTracks(id, p.MediaFiles())
+	}
+	return r.refreshCounters(&pls.Discovery)
+}
+
+func (r *discoveryRepository) Get(id string) (*model.Discovery, error) {
+	return r.findBy(And{Eq{"discoveries.id": id}, r.userFilter()})
+}
+
+func (r *discoveryRepository) GetWithTracks(id string, refreshSmartDiscovery, includeMissing bool) (*model.Discovery, error) {
+	pls, err := r.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	if refreshSmartDiscovery {
+		r.refreshSmartDiscovery(pls)
+	}
+	tracks, err := r.loadTracks(Select().From("discovery_tracks").
+		Where(Eq{"missing": false}).
+		OrderBy("discovery_tracks.id"), id)
+	if err != nil {
+		log.Error(r.ctx, "Error loading discovery tracks ", "discovery", pls.Name, "id", pls.ID, err)
+		return nil, err
+	}
+	pls.SetTracks(tracks)
+	return pls, nil
+}
+
+func (r *discoveryRepository) FindByPath(path string) (*model.Discovery, error) {
+	return r.findBy(Eq{"path": path})
+}
+
+func (r *discoveryRepository) GetSyncedByDirectory(dir string) (model.Discoveries, error) {
+	cleanedDir := filepath.Clean(dir)
+	pattern := cleanedDir
+	if cleanedDir == "." || cleanedDir == "" {
+		pattern = "%"
+	} else {
+		if !strings.HasSuffix(pattern, string(os.PathSeparator)) {
+			pattern += string(os.PathSeparator)
+		}
+		pattern += "%"
+	}
+
+	where := And{Eq{"sync": true}, r.userFilter()}
+	if pattern != "%" {
+		where = append(where, Like{"path": pattern})
+	}
+
+	sel := r.selectDiscovery().Where(where)
+	var res []dbDiscovery
+	if err := r.queryAll(sel, &res); err != nil {
+		return nil, err
+	}
+
+	discoveries := make(model.Discoveries, 0, len(res))
+	for _, p := range res {
+		if filepath.Clean(filepath.Dir(p.Path)) == cleanedDir {
+			discoveries = append(discoveries, p.Discovery)
+		}
+	}
+	return discoveries, nil
+}
+
+func (r *discoveryRepository) findBy(sql Sqlizer) (*model.Discovery, error) {
+	sel := r.selectDiscovery().Where(sql)
+	var pls []dbDiscovery
+	err := r.queryAll(sel, &pls)
+	if err != nil {
+		return nil, err
+	}
+	if len(pls) == 0 {
+		return nil, model.ErrNotFound
+	}
+
+	p := &pls[0].Discovery
+	p.Type = "discovery"
+	return p, nil
+}
+
+func (r *discoveryRepository) GetAll(options ...model.QueryOptions) (model.Discoveries, error) {
+	sel := r.selectDiscovery(options...).Where(r.userFilter())
+	var res []dbDiscovery
+	err := r.queryAll(sel, &res)
+	if err != nil {
+		return nil, err
+	}
+	discoveries := make(model.Discoveries, len(res))
+	for i, p := range res {
+		discoveries[i] = p.Discovery
+	}
+	return discoveries, err
+}
+
+func (r *discoveryRepository) GetAllByDiscoveryFolder(options ...model.QueryOptions) (model.Discoveries, error) {
+	hasFolderFilter := r.hasFolderIDFilter(options...)
+	sel := r.selectDiscovery(options...).Where(r.userFilter())
+	if !hasFolderFilter {
+		sel = sel.Where(Eq{"folder_id": nil}) // root only
+	}
+	var res []dbDiscovery
+	if err := r.queryAll(sel, &res); err != nil {
+		return nil, err
+	}
+	out := make(model.Discoveries, 0, len(res))
+	for _, pf := range res {
+		out = append(out, pf.Discovery)
+	}
+	return out, nil
+}
+
+func (r *discoveryRepository) hasFolderIDFilter(options ...model.QueryOptions) bool {
+	if len(options) == 0 || options[0].Filters == nil {
+		return false
+	}
+	switch f := options[0].Filters.(type) {
+	case Eq:
+		_, exists := f["folder_id"]
+		return exists
+	case And:
+		for _, sub := range f {
+			if eq, ok := sub.(Eq); ok {
+				if _, exists := eq["folder_id"]; exists {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func (r *discoveryRepository) GetDiscoveries(mediaFileId string) (model.Discoveries, error) {
+	sel := r.selectDiscovery(model.QueryOptions{Sort: "name"}).
+		Join("discovery_tracks on discoveries.id = discovery_tracks.discovery_id").
+		Where(And{Eq{"discovery_tracks.media_file_id": mediaFileId}, r.userFilter()})
+	var res []dbDiscovery
+	err := r.queryAll(sel, &res)
+	if err != nil {
+		if errors.Is(err, model.ErrNotFound) {
+			return model.Discoveries{}, nil
+		}
+		return nil, err
+	}
+	discoveries := make(model.Discoveries, len(res))
+	for i, p := range res {
+		discoveries[i] = p.Discovery
+	}
+	return discoveries, nil
+}
+
+func (r *discoveryRepository) selectDiscovery(options ...model.QueryOptions) SelectBuilder {
+	return r.newSelect(options...).Join("user on user.id = owner_id").
+		Columns(r.tableName+".*", "user.user_name as owner_name")
+}
+
+func (r *discoveryRepository) refreshSmartDiscovery(pls *model.Discovery) bool {
+	// Only refresh if it is a smart discovery and was not refreshed within the interval provided by the refresh delay config
+	if !pls.IsSmartDiscovery() || (pls.EvaluatedAt != nil && time.Since(*pls.EvaluatedAt) < conf.Server.SmartPlaylistRefreshDelay) {
+		return false
+	}
+
+	// Never refresh other users' discoveries
+	usr := loggedUser(r.ctx)
+	if pls.OwnerID != usr.ID {
+		log.Trace(r.ctx, "Not refreshing smart discovery from other user", "discovery", pls.Name, "id", pls.ID)
+		return false
+	}
+
+	log.Debug(r.ctx, "Refreshing smart discovery", "discovery", pls.Name, "id", pls.ID)
+	start := time.Now()
+
+	// Remove old tracks
+	del := Delete("discovery_tracks").Where(Eq{"discovery_id": pls.ID})
+	_, err := r.executeSQL(del)
+	if err != nil {
+		log.Error(r.ctx, "Error deleting old smart discovery tracks", "discovery", pls.Name, "id", pls.ID, err)
+		return false
+	}
+
+	// Re-populate discovery based on Smart Discovery criteria
+	rules := *pls.Rules
+
+	// If the discovery depends on other discoveries, recursively refresh them first
+	childDiscoveryIDs := rules.ChildPlaylistIds()
+	for _, id := range childDiscoveryIDs {
+		childPls, err := r.Get(id)
+		if err != nil {
+			log.Error(r.ctx, "Error loading child discovery", "id", pls.ID, "childId", id, err)
+			return false
+		}
+		r.refreshSmartDiscovery(childPls)
+	}
+
+	sq := Select("row_number() over (order by "+rules.OrderBy()+") as id", "'"+pls.ID+"' as discovery_id", "media_file.id as media_file_id").
+		From("media_file").LeftJoin("annotation on (" +
+		"annotation.item_id = media_file.id" +
+		" AND annotation.item_type = 'media_file'" +
+		" AND annotation.user_id = '" + usr.ID + "')")
+	sq = r.addCriteria(sq, rules)
+	insSql := Insert("discovery_tracks").Columns("id", "discovery_id", "media_file_id").Select(sq)
+	_, err = r.executeSQL(insSql)
+	if err != nil {
+		log.Error(r.ctx, "Error refreshing smart discovery tracks", "discovery", pls.Name, "id", pls.ID, err)
+		return false
+	}
+
+	// Update discovery stats
+	err = r.refreshCounters(pls)
+	if err != nil {
+		log.Error(r.ctx, "Error updating smart discovery stats", "discovery", pls.Name, "id", pls.ID, err)
+		return false
+	}
+
+	// Update when the discovery was last refreshed (for cache purposes)
+	updSql := Update(r.tableName).Set("evaluated_at", time.Now()).Where(Eq{"id": pls.ID})
+	_, err = r.executeSQL(updSql)
+	if err != nil {
+		log.Error(r.ctx, "Error updating smart discovery", "discovery", pls.Name, "id", pls.ID, err)
+		return false
+	}
+
+	log.Debug(r.ctx, "Refreshed discovery", "discovery", pls.Name, "id", pls.ID, "numTracks", pls.SongCount, "elapsed", time.Since(start))
+
+	return true
+}
+
+func (r *discoveryRepository) addCriteria(sql SelectBuilder, c criteria.Criteria) SelectBuilder {
+	sql = sql.Where(c)
+	if c.Limit > 0 {
+		sql = sql.Limit(uint64(c.Limit)).Offset(uint64(c.Offset))
+	}
+	if order := c.OrderBy(); order != "" {
+		sql = sql.OrderBy(order)
+	}
+	return sql
+}
+
+func (r *discoveryRepository) updateTracks(id string, tracks model.MediaFiles) error {
+	ids := make([]string, len(tracks))
+	for i := range tracks {
+		ids[i] = tracks[i].ID
+	}
+	return r.updateDiscovery(id, ids)
+}
+
+func (r *discoveryRepository) updateDiscovery(discoveryId string, mediaFileIds []string) error {
+	if !r.isWritable(discoveryId) {
+		return rest.ErrPermissionDenied
+	}
+
+	// Remove old tracks
+	del := Delete("discovery_tracks").Where(Eq{"discovery_id": discoveryId})
+	_, err := r.executeSQL(del)
+	if err != nil {
+		return err
+	}
+
+	return r.addTracks(discoveryId, 1, mediaFileIds)
+}
+
+func (r *discoveryRepository) addTracks(discoveryId string, startingPos int, mediaFileIds []string) error {
+	// Break the track list in chunks to avoid hitting SQLITE_MAX_VARIABLE_NUMBER limit
+	// Add new tracks, chunk by chunk
+	pos := startingPos
+	for chunk := range slices.Chunk(mediaFileIds, 200) {
+		ins := Insert("discovery_tracks").Columns("discovery_id", "media_file_id", "id")
+		for _, t := range chunk {
+			ins = ins.Values(discoveryId, t, pos)
+			pos++
+		}
+		_, err := r.executeSQL(ins)
+		if err != nil {
+			return err
+		}
+	}
+
+	return r.refreshCounters(&model.Discovery{ID: discoveryId})
+}
+
+// refreshCounters updates total discovery duration, size and count
+func (r *discoveryRepository) refreshCounters(pls *model.Discovery) error {
+	statsSql := Select(
+		"coalesce(sum(duration), 0) as duration",
+		"coalesce(sum(size), 0) as size",
+		"count(*) as count",
+	).
+		From("media_file").
+		Join("discovery_tracks f on f.media_file_id = media_file.id").
+		Where(Eq{"discovery_id": pls.ID})
+	var res struct{ Duration, Size, Count float32 }
+	err := r.queryOne(statsSql, &res)
+	if err != nil {
+		return err
+	}
+
+	// Update discovery's total duration, size and count
+	upd := Update("discoveries").
+		Set("duration", res.Duration).
+		Set("size", res.Size).
+		Set("song_count", res.Count).
+		Set("updated_at", time.Now()).
+		Where(Eq{"id": pls.ID})
+	_, err = r.executeSQL(upd)
+	if err != nil {
+		return err
+	}
+	pls.SongCount = int(res.Count)
+	pls.Duration = res.Duration
+	pls.Size = int64(res.Size)
+	return nil
+}
+
+func (r *discoveryRepository) loadTracks(sel SelectBuilder, id string) (model.DiscoveryTracks, error) {
+	sel = r.applyLibraryFilter(sel, "f")
+	userID := loggedUser(r.ctx).ID
+	tracksQuery := sel.
+		Columns(
+			"coalesce(starred, 0) as starred",
+			"starred_at",
+			"coalesce(play_count, 0) as play_count",
+			"play_date",
+			"coalesce(rating, 0) as rating",
+			"f.*",
+			"discovery_tracks.*",
+			"library.path as library_path",
+			"library.name as library_name",
+		).
+		LeftJoin("annotation on (" +
+			"annotation.item_id = media_file_id" +
+			" AND annotation.item_type = 'media_file'" +
+			" AND annotation.user_id = '" + userID + "')").
+		Join("media_file f on f.id = media_file_id").
+		Join("library on f.library_id = library.id").
+		Where(Eq{"discovery_id": id})
+	tracks := dbDiscoveryTracks{}
+	err := r.queryAll(tracksQuery, &tracks)
+	if err != nil {
+		return nil, err
+	}
+	return tracks.toModels(), err
+}
+
+func (r *discoveryRepository) Count(options ...rest.QueryOptions) (int64, error) {
+	return r.CountAll(r.parseRestOptions(r.ctx, options...))
+}
+
+func (r *discoveryRepository) Read(id string) (interface{}, error) {
+	return r.Get(id)
+}
+
+func (r *discoveryRepository) ReadAll(options ...rest.QueryOptions) (interface{}, error) {
+	return r.GetAll(r.parseRestOptions(r.ctx, options...))
+}
+
+func (r *discoveryRepository) EntityName() string {
+	return "discovery"
+}
+
+func (r *discoveryRepository) NewInstance() interface{} {
+	return &model.Discovery{}
+}
+
+func (r *discoveryRepository) Save(entity interface{}) (string, error) {
+	pls := entity.(*model.Discovery)
+	pls.OwnerID = loggedUser(r.ctx).ID
+	pls.ID = "" // Make sure we don't override an existing discovery
+	err := r.Put(pls)
+	if err != nil {
+		return "", err
+	}
+	return pls.ID, err
+}
+
+func (r *discoveryRepository) Update(id string, entity interface{}, cols ...string) error {
+	pls := dbDiscovery{Discovery: *entity.(*model.Discovery)}
+	current, err := r.Get(id)
+	if err != nil {
+		return err
+	}
+	usr := loggedUser(r.ctx)
+	if !usr.IsAdmin {
+		// Only the owner can update the discovery
+		if current.OwnerID != usr.ID {
+			return rest.ErrPermissionDenied
+		}
+		// Regular users can't change the ownership of a discovery
+		if pls.OwnerID != "" && pls.OwnerID != usr.ID {
+			return rest.ErrPermissionDenied
+		}
+	}
+	pls.ID = id
+	pls.UpdatedAt = time.Now()
+	_, err = r.put(id, pls, append(cols, "updatedAt")...)
+	if errors.Is(err, model.ErrNotFound) {
+		return rest.ErrNotFound
+	}
+	return err
+}
+
+func (r *discoveryRepository) removeOrphans() error {
+	sel := Select("discovery_tracks.discovery_id as id", "p.name").From("discovery_tracks").
+		Join("discoveries p on discovery_tracks.discovery_id = p.id").
+		LeftJoin("media_file mf on discovery_tracks.media_file_id = mf.id").
+		Where(Eq{"mf.id": nil}).
+		GroupBy("discovery_tracks.discovery_id")
+
+	var pls []struct{ Id, Name string }
+	err := r.queryAll(sel, &pls)
+	if err != nil {
+		return fmt.Errorf("fetching discoveries with orphan tracks: %w", err)
+	}
+
+	for _, pl := range pls {
+		log.Debug(r.ctx, "Cleaning-up orphan tracks from discovery", "id", pl.Id, "name", pl.Name)
+		del := Delete("discovery_tracks").Where(And{
+			ConcatExpr("media_file_id not in (select id from media_file)"),
+			Eq{"discovery_id": pl.Id},
+		})
+		n, err := r.executeSQL(del)
+		if n == 0 || err != nil {
+			return fmt.Errorf("deleting orphan tracks from discovery %s: %w", pl.Name, err)
+		}
+		log.Debug(r.ctx, "Deleted tracks, now reordering", "id", pl.Id, "name", pl.Name, "deleted", n)
+
+		// Renumber the discovery if any track was removed
+		if err := r.renumber(pl.Id); err != nil {
+			return fmt.Errorf("renumbering discovery %s: %w", pl.Name, err)
+		}
+	}
+	return nil
+}
+
+func (r *discoveryRepository) renumber(id string) error {
+	var ids []string
+	sq := Select("media_file_id").From("discovery_tracks").Where(Eq{"discovery_id": id}).OrderBy("id")
+	err := r.queryAllSlice(sq, &ids)
+	if err != nil {
+		return err
+	}
+	return r.updateDiscovery(id, ids)
+}
+
+func (r *discoveryRepository) isWritable(discoveryId string) bool {
+	usr := loggedUser(r.ctx)
+	if usr.IsAdmin {
+		return true
+	}
+	pls, err := r.Get(discoveryId)
+	return err == nil && pls.OwnerID == usr.ID
+}
+
+func (r *discoveryRepository) UpdateDiscoveryFolder(id string, folderID *string) error {
+	if err := rejectEmptyOptionalID(folderID); err != nil {
+		return err
+	}
+
+	discovery, err := r.Get(id)
+	if err != nil {
+		return err
+	}
+
+	if (discovery.FolderID == nil && folderID == nil) ||
+		(discovery.FolderID != nil && folderID != nil && *discovery.FolderID == *folderID) {
+		return nil
+	}
+
+	if folderID != nil {
+		var dstOwner struct{ OwnerID string }
+		if err := r.queryOne(Select("owner_id").From("playlist_folder").Where(Eq{"id": *folderID}), &dstOwner); err != nil {
+			return err
+		}
+		usr := loggedUser(r.ctx)
+		if !usr.IsAdmin && dstOwner.OwnerID != usr.ID {
+			return rest.ErrPermissionDenied
+		}
+	}
+
+	discovery.FolderID = folderID
+	return r.Update(id, discovery, "folderId")
+}
+
+var _ model.DiscoveryRepository = (*discoveryRepository)(nil)
+var _ rest.Repository = (*discoveryRepository)(nil)
+var _ rest.Persistable = (*discoveryRepository)(nil)

--- a/persistence/discovery_track_repository.go
+++ b/persistence/discovery_track_repository.go
@@ -1,0 +1,297 @@
+package persistence
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	. "github.com/Masterminds/squirrel"
+	"github.com/deluan/rest"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/utils/slice"
+)
+
+type discoveryTrackRepository struct {
+	sqlRepository
+	discoveryId   string
+	discovery     *model.Discovery
+	discoveryRepo *discoveryRepository
+}
+
+type dbDiscoveryTrack struct {
+	dbMediaFile
+	*model.DiscoveryTrack `structs:",flatten"`
+}
+
+func (t *dbDiscoveryTrack) PostScan() error {
+	if err := t.dbMediaFile.PostScan(); err != nil {
+		return err
+	}
+	t.DiscoveryTrack.MediaFile = *t.dbMediaFile.MediaFile
+	t.DiscoveryTrack.MediaFile.ID = t.MediaFileID
+	return nil
+}
+
+type dbDiscoveryTracks []dbDiscoveryTrack
+
+func (t dbDiscoveryTracks) toModels() model.DiscoveryTracks {
+	return slice.Map(t, func(trk dbDiscoveryTrack) model.DiscoveryTrack {
+		return *trk.DiscoveryTrack
+	})
+}
+
+func (r *discoveryRepository) Tracks(discoveryId string, refreshSmartDiscovery bool) model.DiscoveryTrackRepository {
+	p := &discoveryTrackRepository{}
+	p.discoveryRepo = r
+	p.discoveryId = discoveryId
+	p.ctx = r.ctx
+	p.db = r.db
+	p.tableName = "discovery_tracks"
+	p.registerModel(&model.DiscoveryTrack{}, map[string]filterFunc{
+		"missing":    booleanFilter,
+		"library_id": libraryIdFilter,
+		"q":          fullTextFilter("f"),
+	})
+	p.setSortMappings(
+		map[string]string{
+			"id":           "discovery_tracks.id",
+			"artist":       "order_artist_name",
+			"album_artist": "order_album_artist_name",
+			"album":        "order_album_name, order_album_artist_name",
+			"title":        "order_title",
+			// To make sure these fields will be whitelisted
+			"duration": "duration",
+			"year":     "year",
+			"bpm":      "bpm",
+			"channels": "channels",
+		},
+		"f") // TODO I don't like this solution, but I won't change it now as it's not the focus of BFR.
+
+	pls, err := r.Get(discoveryId)
+	if err != nil {
+		log.Warn(r.ctx, "Error getting discovery's tracks", "discoveryId", discoveryId, err)
+		return nil
+	}
+	if refreshSmartDiscovery {
+		r.refreshSmartDiscovery(pls)
+	}
+	p.discovery = pls
+	return p
+}
+
+func (r *discoveryTrackRepository) Count(options ...rest.QueryOptions) (int64, error) {
+	query := Select().
+		LeftJoin("media_file f on f.id = media_file_id").
+		Where(Eq{"discovery_id": r.discoveryId})
+	return r.count(query, r.parseRestOptions(r.ctx, options...))
+}
+
+func (r *discoveryTrackRepository) Read(id string) (interface{}, error) {
+	userID := loggedUser(r.ctx).ID
+	sel := r.newSelect().
+		LeftJoin("annotation on ("+
+			"annotation.item_id = media_file_id"+
+			" AND annotation.item_type = 'media_file'"+
+			" AND annotation.user_id = '"+userID+"')").
+		Columns(
+			"coalesce(starred, 0) as starred",
+			"coalesce(play_count, 0) as play_count",
+			"coalesce(rating, 0) as rating",
+			"starred_at",
+			"play_date",
+			"f.*",
+			"discovery_tracks.*",
+		).
+		Join("media_file f on f.id = media_file_id").
+		Where(And{Eq{"discovery_id": r.discoveryId}, Eq{"discovery_tracks.id": id}})
+	var trk dbDiscoveryTrack
+	err := r.queryOne(sel, &trk)
+	return trk.DiscoveryTrack, err
+}
+
+func (r *discoveryTrackRepository) GetAll(options ...model.QueryOptions) (model.DiscoveryTracks, error) {
+	tracks, err := r.discoveryRepo.loadTracks(r.newSelect(options...), r.discoveryId)
+	if err != nil {
+		return nil, err
+	}
+	return tracks, err
+}
+
+func (r *discoveryTrackRepository) GetAlbumIDs(options ...model.QueryOptions) ([]string, error) {
+	query := r.newSelect(options...).Columns("distinct mf.album_id").
+		Join("media_file mf on mf.id = media_file_id").
+		Where(Eq{"discovery_id": r.discoveryId})
+	var ids []string
+	err := r.queryAllSlice(query, &ids)
+	if err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
+func (r *discoveryTrackRepository) Search(q string, offset, size int, options ...model.QueryOptions) (model.DiscoveryTracks, error) {
+	q = strings.TrimSpace(q)
+	q = strings.TrimSuffix(q, "*")
+	if len(q) < 2 {
+		return nil, nil
+	}
+
+	sel := r.newSelect(options...).
+		Join("media_file f on f.id = media_file_id").
+		Where(Eq{"discovery_id": r.discoveryId})
+
+	if filter := fullTextExpr("f", q); filter != nil {
+		sel = sel.Where(filter).OrderBy("order_title")
+	} else {
+		sel = sel.OrderBy("discovery_tracks.rowid")
+	}
+	sel = sel.Where(Eq{"f.missing": false}).Limit(uint64(size)).Offset(uint64(offset))
+
+	tracks, err := r.discoveryRepo.loadTracks(sel, r.discoveryId)
+	if err != nil {
+		return nil, fmt.Errorf("searching discovery tracks by query %q: %w", q, err)
+	}
+	return tracks, nil
+}
+
+func (r *discoveryTrackRepository) ReadAll(options ...rest.QueryOptions) (interface{}, error) {
+	return r.GetAll(r.parseRestOptions(r.ctx, options...))
+}
+
+func (r *discoveryTrackRepository) EntityName() string {
+	return "discovery_tracks"
+}
+
+func (r *discoveryTrackRepository) NewInstance() interface{} {
+	return &model.DiscoveryTrack{}
+}
+
+func (r *discoveryTrackRepository) isTracksEditable() bool {
+	return r.discoveryRepo.isWritable(r.discoveryId) && !r.discovery.IsSmartDiscovery()
+}
+
+func (r *discoveryTrackRepository) Add(mediaFileIds []string) (int, error) {
+	if !r.isTracksEditable() {
+		return 0, rest.ErrPermissionDenied
+	}
+
+	if len(mediaFileIds) == 0 {
+		return 0, nil
+	}
+
+	existing, err := r.getTracks()
+	if err != nil {
+		return 0, err
+	}
+
+	seen := make(map[string]struct{}, len(existing))
+	for _, id := range existing {
+		seen[id] = struct{}{}
+	}
+
+	unique := make([]string, 0, len(mediaFileIds))
+	for _, id := range mediaFileIds {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		unique = append(unique, id)
+	}
+
+	if len(unique) == 0 {
+		return 0, nil
+	}
+
+	log.Debug(r.ctx, "Adding songs to discovery", "discoveryId", r.discoveryId, "mediaFileIds", unique)
+
+	// Get next pos (ID) in discovery
+	sq := r.newSelect().Columns("max(id) as max").Where(Eq{"discovery_id": r.discoveryId})
+	var res struct{ Max sql.NullInt32 }
+	err = r.queryOne(sq, &res)
+	if err != nil {
+		return 0, err
+	}
+
+	return len(unique), r.discoveryRepo.addTracks(r.discoveryId, int(res.Max.Int32+1), unique)
+}
+
+func (r *discoveryTrackRepository) addMediaFileIds(cond Sqlizer) (int, error) {
+	sq := Select("id").From("media_file").Where(cond).OrderBy("album_artist, album, release_date, disc_number, track_number")
+	var ids []string
+	err := r.queryAllSlice(sq, &ids)
+	if err != nil {
+		log.Error(r.ctx, "Error getting tracks to add to discovery", err)
+		return 0, err
+	}
+	return r.Add(ids)
+}
+
+func (r *discoveryTrackRepository) AddAlbums(albumIds []string) (int, error) {
+	return r.addMediaFileIds(Eq{"album_id": albumIds})
+}
+
+func (r *discoveryTrackRepository) AddArtists(artistIds []string) (int, error) {
+	return r.addMediaFileIds(Eq{"album_artist_id": artistIds})
+}
+
+func (r *discoveryTrackRepository) AddDiscs(discs []model.DiscID) (int, error) {
+	if len(discs) == 0 {
+		return 0, nil
+	}
+	var clauses Or
+	for _, d := range discs {
+		clauses = append(clauses, And{Eq{"album_id": d.AlbumID}, Eq{"release_date": d.ReleaseDate}, Eq{"disc_number": d.DiscNumber}})
+	}
+	return r.addMediaFileIds(clauses)
+}
+
+// Get ids from all current tracks
+func (r *discoveryTrackRepository) getTracks() ([]string, error) {
+	all := r.newSelect().Columns("media_file_id").Where(Eq{"discovery_id": r.discoveryId}).OrderBy("id")
+	var ids []string
+	err := r.queryAllSlice(all, &ids)
+	if err != nil {
+		log.Error(r.ctx, "Error querying current tracks from discovery", "discoveryId", r.discoveryId, err)
+		return nil, err
+	}
+	return ids, nil
+}
+
+func (r *discoveryTrackRepository) Delete(ids ...string) error {
+	if !r.isTracksEditable() {
+		return rest.ErrPermissionDenied
+	}
+	err := r.delete(And{Eq{"discovery_id": r.discoveryId}, Eq{"id": ids}})
+	if err != nil {
+		return err
+	}
+
+	return r.discoveryRepo.renumber(r.discoveryId)
+}
+
+func (r *discoveryTrackRepository) DeleteAll() error {
+	if !r.isTracksEditable() {
+		return rest.ErrPermissionDenied
+	}
+	err := r.delete(Eq{"discovery_id": r.discoveryId})
+	if err != nil {
+		return err
+	}
+
+	return r.discoveryRepo.renumber(r.discoveryId)
+}
+
+func (r *discoveryTrackRepository) Reorder(pos int, newPos int) error {
+	if !r.isTracksEditable() {
+		return rest.ErrPermissionDenied
+	}
+	ids, err := r.getTracks()
+	if err != nil {
+		return err
+	}
+	newOrder := slice.Move(ids, pos-1, newPos-1)
+	return r.discoveryRepo.updateDiscovery(r.discoveryId, newOrder)
+}
+
+var _ model.DiscoveryTrackRepository = (*discoveryTrackRepository)(nil)

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -57,8 +57,12 @@ func (s *SQLStore) Playlist(ctx context.Context) model.PlaylistRepository {
 	return NewPlaylistRepository(ctx, s.getDBXBuilder())
 }
 
+func (s *SQLStore) Discovery(ctx context.Context) model.DiscoveryRepository {
+	return NewDiscoveryRepository(ctx, s.getDBXBuilder())
+}
+
 func (s *SQLStore) PlaylistFolder(ctx context.Context) model.PlaylistFolderRepository {
-    return NewPlaylistFolderRepository(ctx, s.getDBXBuilder())
+	return NewPlaylistFolderRepository(ctx, s.getDBXBuilder())
 }
 
 func (s *SQLStore) Property(ctx context.Context) model.PropertyRepository {
@@ -111,6 +115,8 @@ func (s *SQLStore) Resource(ctx context.Context, m interface{}) model.ResourceRe
 		return s.Genre(ctx).(model.ResourceRepository)
 	case model.Playlist:
 		return s.Playlist(ctx).(model.ResourceRepository)
+	case model.Discovery:
+		return s.Discovery(ctx).(model.ResourceRepository)
 	case model.PlaylistFolder:
 		return s.PlaylistFolder(ctx).(model.ResourceRepository)
 	case model.Radio:

--- a/server/nativeapi/discovery_service.go
+++ b/server/nativeapi/discovery_service.go
@@ -1,0 +1,55 @@
+package nativeapi
+
+import (
+	"context"
+
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+)
+
+type DiscoveryService struct {
+	ds model.DataStore
+}
+
+func NewDiscoveryService(ds model.DataStore) *DiscoveryService {
+	return &DiscoveryService{ds: ds}
+}
+
+func (s *DiscoveryService) Create(ctx context.Context, discovery *model.Discovery) error {
+	if user, ok := request.UserFrom(ctx); ok {
+		discovery.OwnerID = user.ID
+	}
+	return s.ds.Discovery(ctx).Put(discovery)
+}
+
+func (s *DiscoveryService) Get(ctx context.Context, id string, withTracks bool) (*model.Discovery, error) {
+	repo := s.ds.Discovery(ctx)
+	if withTracks {
+		return repo.GetWithTracks(id, true, false)
+	}
+	return repo.Get(id)
+}
+
+func (s *DiscoveryService) List(ctx context.Context, options ...model.QueryOptions) (model.Discoveries, error) {
+	return s.ds.Discovery(ctx).GetAll(options...)
+}
+
+func (s *DiscoveryService) Update(ctx context.Context, discovery *model.Discovery) error {
+	return s.ds.Discovery(ctx).Put(discovery)
+}
+
+func (s *DiscoveryService) Delete(ctx context.Context, id string) error {
+	return s.ds.Discovery(ctx).Delete(id)
+}
+
+func (s *DiscoveryService) AddTracks(ctx context.Context, discoveryID string, trackIDs []string) (int, error) {
+	return s.ds.Discovery(ctx).Tracks(discoveryID, true).Add(trackIDs)
+}
+
+func (s *DiscoveryService) RemoveTracks(ctx context.Context, discoveryID string, trackIDs []string) error {
+	return s.ds.Discovery(ctx).Tracks(discoveryID, true).Delete(trackIDs...)
+}
+
+func (s *DiscoveryService) ReorderTracks(ctx context.Context, discoveryID string, trackID, newPos int) error {
+	return s.ds.Discovery(ctx).Tracks(discoveryID, true).Reorder(trackID, newPos)
+}

--- a/tests/mock_data_store.go
+++ b/tests/mock_data_store.go
@@ -8,27 +8,28 @@ import (
 )
 
 type MockDataStore struct {
-	RealDS               		model.DataStore
-	MockedLibrary        		model.LibraryRepository
-	MockedFolder         		model.FolderRepository
-	MockedGenre          		model.GenreRepository
-	MockedAlbum          		model.AlbumRepository
-	MockedArtist         		model.ArtistRepository
-	MockedMediaFile      		model.MediaFileRepository
-	MockedTag            		model.TagRepository
-	MockedUser           		model.UserRepository
-	MockedProperty       		model.PropertyRepository
-	MockedPlayer         		model.PlayerRepository
-	MockedPlaylist       		model.PlaylistRepository
-	MockedPlaylistFolder 		model.PlaylistFolderRepository
-	MockedPlayQueue      		model.PlayQueueRepository
-	MockedShare          		model.ShareRepository
-	MockedTranscoding    		model.TranscodingRepository
-	MockedUserProps      		model.UserPropsRepository
-	MockedScrobbleBuffer 		model.ScrobbleBufferRepository
-	MockedRadio          		model.RadioRepository
-	scrobbleBufferMu     		sync.Mutex
-	repoMu               		sync.Mutex
+	RealDS               model.DataStore
+	MockedLibrary        model.LibraryRepository
+	MockedFolder         model.FolderRepository
+	MockedGenre          model.GenreRepository
+	MockedAlbum          model.AlbumRepository
+	MockedArtist         model.ArtistRepository
+	MockedMediaFile      model.MediaFileRepository
+	MockedTag            model.TagRepository
+	MockedUser           model.UserRepository
+	MockedProperty       model.PropertyRepository
+	MockedPlayer         model.PlayerRepository
+	MockedPlaylist       model.PlaylistRepository
+	MockedDiscovery      model.DiscoveryRepository
+	MockedPlaylistFolder model.PlaylistFolderRepository
+	MockedPlayQueue      model.PlayQueueRepository
+	MockedShare          model.ShareRepository
+	MockedTranscoding    model.TranscodingRepository
+	MockedUserProps      model.UserPropsRepository
+	MockedScrobbleBuffer model.ScrobbleBufferRepository
+	MockedRadio          model.RadioRepository
+	scrobbleBufferMu     sync.Mutex
+	repoMu               sync.Mutex
 }
 
 func (db *MockDataStore) Library(ctx context.Context) model.LibraryRepository {
@@ -119,6 +120,16 @@ func (db *MockDataStore) Playlist(ctx context.Context) model.PlaylistRepository 
 		}
 	}
 	return db.MockedPlaylist
+}
+func (db *MockDataStore) Discovery(ctx context.Context) model.DiscoveryRepository {
+	if db.MockedDiscovery == nil {
+		if db.RealDS != nil {
+			db.MockedDiscovery = db.RealDS.Discovery(ctx)
+		} else {
+			db.MockedDiscovery = struct{ model.DiscoveryRepository }{}
+		}
+	}
+	return db.MockedDiscovery
 }
 
 func (db *MockDataStore) PlaylistFolder(ctx context.Context) model.PlaylistFolderRepository {


### PR DESCRIPTION
## Summary
- create migrations for discoveries and discovery_tracks mirroring playlist tables
- add Discovery and DiscoveryTrack models with the same structure as playlists

## Testing
- go test ./... *(fails: pattern build/*: cannot embed directory build/3rdparty)*

------
https://chatgpt.com/codex/tasks/task_e_68dd924cb0a88330b3d2aee607a52b67