### PR TITLE
Add discovery file browser for music library

### DIFF
--- a/server/nativeapi/discoveryfs.go
+++ b/server/nativeapi/discoveryfs.go
@@ -1,0 +1,237 @@
+package nativeapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/conf"
+)
+
+var audioExtensions = map[string]struct{}{
+	".mp3":  {},
+	".flac": {},
+	".ogg":  {},
+	".oga":  {},
+	".wav":  {},
+	".aac":  {},
+	".m4a":  {},
+	".wma":  {},
+	".alac": {},
+	".aiff": {},
+	".dsf":  {},
+	".dff":  {},
+}
+
+type discoveryFSHandler struct {
+	root string
+}
+
+type discoveryItem struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+type discoveryListResponse struct {
+	Path    string          `json:"path"`
+	Folders []discoveryItem `json:"folders"`
+	Files   []discoveryItem `json:"files"`
+}
+
+func (n *Router) addDiscoveryFSRoute(r chi.Router) {
+	handler := discoveryFSHandler{root: conf.Server.MusicFolder}
+
+	r.Route("/discoveryfs", func(r chi.Router) {
+		r.Get("/", handler.list)
+		r.Post("/folder", handler.createFolder)
+		r.Post("/upload", handler.upload)
+	})
+}
+
+func (h discoveryFSHandler) list(w http.ResponseWriter, r *http.Request) {
+	rel := r.URL.Query().Get("path")
+	abs, clean, err := h.resolve(rel)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	entries, err := os.ReadDir(abs)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			http.Error(w, "path not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resp := discoveryListResponse{Path: clean}
+	for _, entry := range entries {
+		name := entry.Name()
+		item := discoveryItem{Name: name, Path: joinRelative(clean, name)}
+		if entry.IsDir() {
+			resp.Folders = append(resp.Folders, item)
+			continue
+		}
+		if isAudioFile(name) {
+			resp.Files = append(resp.Files, item)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+type createFolderRequest struct {
+	Name string `json:"name"`
+}
+
+func (h discoveryFSHandler) createFolder(w http.ResponseWriter, r *http.Request) {
+	rel := r.URL.Query().Get("path")
+	abs, _, err := h.resolve(rel)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var req createFolderRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		http.Error(w, "folder name is required", http.StatusBadRequest)
+		return
+	}
+	if name == "." || name == ".." {
+		http.Error(w, "invalid folder name", http.StatusBadRequest)
+		return
+	}
+	if strings.ContainsAny(name, "/\\") {
+		http.Error(w, "folder name cannot contain path separators", http.StatusBadRequest)
+		return
+	}
+
+	target := filepath.Join(abs, name)
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (h discoveryFSHandler) upload(w http.ResponseWriter, r *http.Request) {
+	rel := r.URL.Query().Get("path")
+	abs, _, err := h.resolve(rel)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if err := r.ParseMultipartForm(64 << 20); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	files := r.MultipartForm.File["files"]
+	if len(files) == 0 {
+		files = r.MultipartForm.File["file"]
+	}
+	if len(files) == 0 {
+		http.Error(w, "no files provided", http.StatusBadRequest)
+		return
+	}
+
+	uploaded := 0
+	for _, fh := range files {
+		filename := filepath.Base(fh.Filename)
+		if !isAudioFile(filename) {
+			http.Error(w, fmt.Sprintf("file %s is not an audio file", filename), http.StatusBadRequest)
+			return
+		}
+		src, err := fh.Open()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		dstPath := filepath.Join(abs, filename)
+		if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+			src.Close()
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		dst, err := os.Create(dstPath)
+		if err != nil {
+			src.Close()
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if _, err := io.Copy(dst, src); err != nil {
+			dst.Close()
+			src.Close()
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		dst.Close()
+		src.Close()
+		uploaded++
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"uploaded": uploaded})
+}
+
+func (h discoveryFSHandler) resolve(rel string) (string, string, error) {
+	root := strings.TrimSpace(h.root)
+	if root == "" {
+		return "", "", errors.New("music folder not configured")
+	}
+
+	cleanInput := strings.TrimSpace(rel)
+	cleanInput = strings.TrimPrefix(cleanInput, string(os.PathSeparator))
+	cleanInput = filepath.Clean(cleanInput)
+	if cleanInput == "." {
+		cleanInput = ""
+	}
+
+	rootClean := filepath.Clean(root)
+	absClean := filepath.Clean(filepath.Join(rootClean, cleanInput))
+	relCheck, err := filepath.Rel(rootClean, absClean)
+	if err != nil {
+		return "", "", errors.New("invalid path")
+	}
+	if relCheck == ".." || strings.HasPrefix(relCheck, "../") || strings.HasPrefix(relCheck, "..\\") {
+		return "", "", errors.New("invalid path")
+	}
+
+	clean := filepath.ToSlash(cleanInput)
+	if clean == "." {
+		clean = ""
+	}
+
+	if clean == "" {
+		return absClean, "", nil
+	}
+	return absClean, clean, nil
+}
+
+func joinRelative(base, name string) string {
+	return strings.TrimPrefix(path.Join(base, name), "./")
+}
+
+func isAudioFile(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	_, ok := audioExtensions[ext]
+	return ok
+}

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -68,6 +68,7 @@ func (n *Router) routes() http.Handler {
 		n.addMissingFilesRoute(r)
 		n.addKeepAliveRoute(r)
 		n.addInsightsRoute(r)
+		n.addDiscoveryFSRoute(r)
 
 		r.With(adminOnlyMiddleware).Group(func(r chi.Router) {
 			n.addInspectRoute(r)

--- a/ui/src/discovery/DiscoveryBrowser.jsx
+++ b/ui/src/discovery/DiscoveryBrowser.jsx
@@ -1,0 +1,201 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  Box,
+  Breadcrumbs,
+  Button,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Typography,
+  makeStyles,
+} from '@material-ui/core'
+import FolderIcon from '@material-ui/icons/Folder'
+import MusicNoteIcon from '@material-ui/icons/MusicNote'
+import CloudUploadIcon from '@material-ui/icons/CloudUpload'
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    padding: theme.spacing(2),
+  },
+  header: {
+    marginBottom: theme.spacing(2),
+  },
+  actions: {
+    display: 'flex',
+    gap: theme.spacing(1),
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(2),
+  },
+  list: {
+    backgroundColor: theme.palette.background.paper,
+  },
+}))
+
+const DiscoveryBrowser = () => {
+  const classes = useStyles()
+  const [path, setPath] = useState('')
+  const [folders, setFolders] = useState([])
+  const [files, setFiles] = useState([])
+  const inputRef = useRef(null)
+
+  const fetchData = useCallback(async () => {
+    const params = path ? `?path=${encodeURIComponent(path)}` : ''
+    const response = await fetch(`/api/discoveryfs${params}`)
+    if (!response.ok) {
+      setFolders([])
+      setFiles([])
+      return
+    }
+    const data = await response.json()
+    const newPath = data.path || ''
+    if (newPath !== path) {
+      setPath(newPath)
+    }
+    setFolders(data.folders || [])
+    setFiles(data.files || [])
+  }, [path])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  const navigateTo = (nextPath) => {
+    setPath(nextPath)
+  }
+
+  const parentPath = () => {
+    if (!path) return ''
+    const parts = path.split('/')
+    parts.pop()
+    return parts.join('/')
+  }
+
+  const handleFolderClick = (folder) => {
+    navigateTo(folder.path)
+  }
+
+  const handleBreadcrumbClick = (index) => {
+    if (index === -1) {
+      navigateTo('')
+    } else {
+      const segments = path.split('/').slice(0, index + 1)
+      navigateTo(segments.join('/'))
+    }
+  }
+
+  const handleNewFolder = async () => {
+    const name = window.prompt('Folder name:')
+    if (!name) {
+      return
+    }
+    const params = path ? `?path=${encodeURIComponent(path)}` : ''
+    const response = await fetch(`/api/discoveryfs/folder${params}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    })
+    if (response.ok) {
+      fetchData()
+    }
+  }
+
+  const handleUploadClick = () => {
+    inputRef.current?.click()
+  }
+
+  const handleUpload = async (event) => {
+    const filesToUpload = event.target.files
+    if (!filesToUpload?.length) {
+      return
+    }
+    const params = path ? `?path=${encodeURIComponent(path)}` : ''
+    const formData = new FormData()
+    Array.from(filesToUpload).forEach((file) => {
+      formData.append('files', file)
+    })
+    const response = await fetch(`/api/discoveryfs/upload${params}`, {
+      method: 'POST',
+      body: formData,
+    })
+    event.target.value = ''
+    if (response.ok) {
+      fetchData()
+    }
+  }
+
+  const crumbs = path ? path.split('/') : []
+
+  return (
+    <Box className={classes.root}>
+      <Box className={classes.header}>
+        <Typography variant="h5">Discovery</Typography>
+        <Breadcrumbs aria-label="breadcrumb">
+          <Button color="primary" onClick={() => handleBreadcrumbClick(-1)}>
+            Root
+          </Button>
+          {crumbs.map((crumb, index) => (
+            <Button
+              color="primary"
+              key={`${crumb}-${index}`}
+              onClick={() => handleBreadcrumbClick(index)}
+            >
+              {crumb}
+            </Button>
+          ))}
+        </Breadcrumbs>
+      </Box>
+      <Box className={classes.actions}>
+        <Button variant="contained" color="primary" onClick={handleNewFolder}>
+          New Folder
+        </Button>
+        <input
+          type="file"
+          accept="audio/*"
+          multiple
+          hidden
+          ref={inputRef}
+          onChange={handleUpload}
+        />
+        <Button
+          variant="contained"
+          color="default"
+          startIcon={<CloudUploadIcon />}
+          onClick={handleUploadClick}
+        >
+          Upload
+        </Button>
+      </Box>
+      <List className={classes.list}>
+        {path && (
+          <ListItem button onClick={() => navigateTo(parentPath())}>
+            <ListItemText primary=".." secondary="Parent Folder" />
+          </ListItem>
+        )}
+        {folders.map((folder) => (
+          <ListItem button key={folder.path} onClick={() => handleFolderClick(folder)}>
+            <ListItemIcon>
+              <FolderIcon />
+            </ListItemIcon>
+            <ListItemText primary={folder.name} secondary="Folder" />
+          </ListItem>
+        ))}
+        {files.map((file) => (
+          <ListItem key={file.path}>
+            <ListItemIcon>
+              <MusicNoteIcon />
+            </ListItemIcon>
+            <ListItemText primary={file.name} secondary="Audio" />
+          </ListItem>
+        ))}
+        {!folders.length && !files.length && (
+          <ListItem>
+            <ListItemText primary="This folder is empty." />
+          </ListItem>
+        )}
+      </List>
+    </Box>
+  )
+}
+
+export default DiscoveryBrowser

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -5,6 +5,7 @@ import clsx from 'clsx'
 import { useTranslate, MenuItemLink, getResources } from 'react-admin'
 import ViewListIcon from '@material-ui/icons/ViewList'
 import AlbumIcon from '@material-ui/icons/Album'
+import ExploreIcon from '@material-ui/icons/Explore'
 import SubMenu from './SubMenu'
 import { humanize, pluralize } from 'inflection'
 import albumLists from '../album/albumLists'
@@ -115,6 +116,16 @@ const Menu = ({ dense = false }) => {
       })}
     >
       {open && <LibrarySelector />}
+      <MenuItemLink
+        key="discovery"
+        to="/discovery"
+        activeClassName={classes.active}
+        primaryText={translate('menu.discovery', { _: 'Discovery' })}
+        leftIcon={<ExploreIcon />}
+        sidebarIsOpen={open}
+        dense={dense}
+        exact
+      />
       <SubMenu
         handleToggle={() => handleToggle('menuAlbumList')}
         isOpen={state.menuAlbumList}

--- a/ui/src/routes.jsx
+++ b/ui/src/routes.jsx
@@ -1,9 +1,16 @@
 import React from 'react'
 import { Route } from 'react-router-dom'
 import Personal from './personal/Personal'
+import DiscoveryBrowser from './discovery/DiscoveryBrowser'
 
 const routes = [
   <Route exact path="/personal" render={() => <Personal />} key={'personal'} />,
+  <Route
+    exact
+    path="/discovery"
+    render={() => <DiscoveryBrowser />}
+    key={'discovery'}
+  />,
 ]
 
 export default routes


### PR DESCRIPTION
## Summary
- add discoveryfs API routes for listing, folder creation, and audio-only uploads under the configured music folder
- register the discovery routes and provide filesystem safeguards for navigation
- add a Discovery browser page with sidebar entry for navigating folders, creating subfolders, and uploading audio files

## Testing
- go test ./... *(fails: requires embedded ui/build assets in ui/embed.go)*

------
https://chatgpt.com/codex/tasks/task_e_68ddac5995fc8330b89c269a931885cb