### PR TITLE
Add discovery filesystem API and browser

### DIFF
--- a/conf/discovery.go
+++ b/conf/discovery.go
@@ -1,0 +1,17 @@
+package conf
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/navidrome/navidrome/log"
+)
+
+// DiscoveryRoot returns the path to the discovery filesystem root, ensuring it exists.
+func DiscoveryRoot() string {
+	root := filepath.Join(Server.DataFolder, "discovery")
+	if err := os.MkdirAll(root, os.ModePerm); err != nil {
+		log.Error("creating discovery root", err)
+	}
+	return root
+}

--- a/server/nativeapi/discovery_fs.go
+++ b/server/nativeapi/discovery_fs.go
@@ -1,0 +1,250 @@
+package nativeapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/conf"
+)
+
+const (
+	discoveryItemTypeFolder = "folder"
+	discoveryItemTypeFile   = "file"
+)
+
+var discoveryAudioExtensions = map[string]struct{}{
+	".mp3":  {},
+	".m4a":  {},
+	".flac": {},
+	".wav":  {},
+	".ogg":  {},
+}
+
+type discoveryItem struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type discoveryListResponse struct {
+	Path  string          `json:"path"`
+	Items []discoveryItem `json:"items"`
+}
+
+func (n *Router) addDiscoveryFSRoute(r chi.Router) {
+	r.Route("/discoveryfs", func(r chi.Router) {
+		r.Get("/list", n.discoveryListHandler)
+		r.Post("/folder", n.discoveryCreateFolderHandler)
+		r.Post("/upload", n.discoveryUploadHandler)
+	})
+}
+
+func (n *Router) discoveryListHandler(w http.ResponseWriter, r *http.Request) {
+	rel := r.URL.Query().Get("path")
+	clean, abs, err := sanitizeDiscoveryPath(rel)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	entries, err := os.ReadDir(abs)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			http.Error(w, "path not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "unable to list directory", http.StatusInternalServerError)
+		return
+	}
+
+	items := make([]discoveryItem, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			items = append(items, discoveryItem{Name: entry.Name(), Type: discoveryItemTypeFolder})
+			continue
+		}
+		if isAllowedDiscoveryFile(entry.Name()) {
+			items = append(items, discoveryItem{Name: entry.Name(), Type: discoveryItemTypeFile})
+		}
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Type == items[j].Type {
+			return strings.ToLower(items[i].Name) < strings.ToLower(items[j].Name)
+		}
+		return items[i].Type == discoveryItemTypeFolder
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(discoveryListResponse{Path: clean, Items: items})
+}
+
+func (n *Router) discoveryCreateFolderHandler(w http.ResponseWriter, r *http.Request) {
+	var payload struct {
+		Path string `json:"path"`
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+
+	_, parentAbs, err := sanitizeDiscoveryPath(payload.Path)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	name := strings.TrimSpace(payload.Name)
+	if name == "" {
+		http.Error(w, "folder name required", http.StatusBadRequest)
+		return
+	}
+	if name == "." || name == ".." || strings.ContainsAny(name, "/\\") {
+		http.Error(w, "invalid folder name", http.StatusBadRequest)
+		return
+	}
+
+	if _, err := os.Stat(parentAbs); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			http.Error(w, "path not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "unable to create folder", http.StatusInternalServerError)
+		return
+	}
+
+	folderPath := filepath.Join(parentAbs, name)
+	if err := os.Mkdir(folderPath, os.ModePerm); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			http.Error(w, "folder already exists", http.StatusConflict)
+			return
+		}
+		http.Error(w, "unable to create folder", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (n *Router) discoveryUploadHandler(w http.ResponseWriter, r *http.Request) {
+	rel := r.URL.Query().Get("path")
+	_, abs, err := sanitizeDiscoveryPath(rel)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if _, err := os.Stat(abs); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			http.Error(w, "path not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "unable to upload", http.StatusInternalServerError)
+		return
+	}
+
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
+		http.Error(w, "invalid form", http.StatusBadRequest)
+		return
+	}
+
+	files := r.MultipartForm.File["files"]
+	if len(files) == 0 {
+		http.Error(w, "no files uploaded", http.StatusBadRequest)
+		return
+	}
+
+	uploaded := make([]string, 0, len(files))
+	for _, fh := range files {
+		name := filepath.Base(fh.Filename)
+		if name == "" {
+			http.Error(w, "invalid file name", http.StatusBadRequest)
+			return
+		}
+		if !isAllowedDiscoveryFile(name) {
+			http.Error(w, fmt.Sprintf("unsupported file type: %s", name), http.StatusBadRequest)
+			return
+		}
+
+		src, err := fh.Open()
+		if err != nil {
+			http.Error(w, "unable to read uploaded file", http.StatusInternalServerError)
+			return
+		}
+
+		destPath := filepath.Join(abs, name)
+		dst, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o666)
+		if err != nil {
+			src.Close()
+			http.Error(w, "unable to save file", http.StatusInternalServerError)
+			return
+		}
+
+		if _, err := io.Copy(dst, src); err != nil {
+			dst.Close()
+			src.Close()
+			http.Error(w, "unable to save file", http.StatusInternalServerError)
+			return
+		}
+		dst.Close()
+		src.Close()
+		uploaded = append(uploaded, name)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string][]string{"uploaded": uploaded})
+}
+
+func sanitizeDiscoveryPath(rel string) (string, string, error) {
+	rel = strings.TrimSpace(rel)
+	if rel == "" {
+		root := conf.DiscoveryRoot()
+		return "", root, nil
+	}
+
+	rel = strings.ReplaceAll(rel, "\\", "/")
+	if strings.HasPrefix(rel, "/") {
+		return "", "", errors.New("invalid path")
+	}
+	if filepath.IsAbs(rel) {
+		return "", "", errors.New("invalid path")
+	}
+
+	for _, segment := range strings.Split(rel, "/") {
+		if segment == ".." {
+			return "", "", errors.New("invalid path")
+		}
+	}
+
+	clean := path.Clean(rel)
+	if clean == "." {
+		return "", conf.DiscoveryRoot(), nil
+	}
+
+	parts := strings.Split(clean, "/")
+	for _, p := range parts {
+		if p == ".." || p == "" {
+			return "", "", errors.New("invalid path")
+		}
+	}
+
+	root := conf.DiscoveryRoot()
+	abs := filepath.Join(append([]string{root}, parts...)...)
+	normalized := strings.Join(parts, "/")
+	return normalized, abs, nil
+}
+
+func isAllowedDiscoveryFile(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	_, ok := discoveryAudioExtensions[ext]
+	return ok
+}

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -60,6 +60,7 @@ func (n *Router) routes() http.Handler {
 			n.RX(r, "/share", n.share.NewRepository, true)
 		}
 
+		n.addDiscoveryFSRoute(r)
 		n.addPlaylistRoute(r)
 		n.addPlaylistFolderRoute(r)
 		n.addPlaylistTrackRoute(r)

--- a/ui/src/discovery/DiscoveryBrowser.jsx
+++ b/ui/src/discovery/DiscoveryBrowser.jsx
@@ -1,0 +1,276 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  Breadcrumbs,
+  Button,
+  Card,
+  CardContent,
+  Link,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  makeStyles,
+  TextField,
+  Typography,
+} from '@material-ui/core'
+import FolderIcon from '@material-ui/icons/Folder'
+import MusicNoteIcon from '@material-ui/icons/MusicNote'
+import CloudUploadIcon from '@material-ui/icons/CloudUpload'
+import { Title, useNotify, useTranslate } from 'react-admin'
+import httpClient from '../dataProvider/httpClient'
+
+const useStyles = makeStyles((theme) => ({
+  card: {
+    marginTop: theme.spacing(2),
+  },
+  breadcrumbs: {
+    marginBottom: theme.spacing(2),
+  },
+  actions: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    marginBottom: theme.spacing(2),
+    '& > *': {
+      marginRight: theme.spacing(2),
+      marginBottom: theme.spacing(1),
+    },
+  },
+  newFolderForm: {
+    display: 'flex',
+    alignItems: 'center',
+    '& > *': {
+      marginRight: theme.spacing(1),
+    },
+  },
+  fileInput: {
+    display: 'none',
+  },
+}))
+
+const DiscoveryBrowser = () => {
+  const translate = useTranslate()
+  const notify = useNotify()
+  const classes = useStyles()
+  const [path, setPath] = useState('')
+  const [refreshToken, setRefreshToken] = useState(0)
+  const [items, setItems] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [folderName, setFolderName] = useState('')
+  const fileInputRef = useRef(null)
+
+  const currentTitle = useMemo(
+    () => translate('menu.discovery', { _: 'Discovery' }),
+    [translate],
+  )
+
+  useEffect(() => {
+    let active = true
+    setLoading(true)
+    const query = path ? `?path=${encodeURIComponent(path)}` : ''
+    httpClient(`/api/discoveryfs/list${query}`)
+      .then(({ json }) => {
+        if (!active) {
+          return
+        }
+        setItems(json?.items || [])
+      })
+      .catch((error) => {
+        if (!active) {
+          return
+        }
+        const message =
+          error?.body?.error ||
+          error?.message ||
+          translate('resources.discovery.notifications.load_error', {
+            _: 'Unable to load discovery items',
+          })
+        notify(message, 'warning')
+      })
+      .finally(() => {
+        if (active) {
+          setLoading(false)
+        }
+      })
+    return () => {
+      active = false
+    }
+  }, [path, refreshToken, notify, translate])
+
+  const pathSegments = path ? path.split('/') : []
+
+  const handleNavigate = (index) => {
+    if (index < 0) {
+      setPath('')
+      return
+    }
+    const nextPath = pathSegments.slice(0, index + 1).join('/')
+    setPath(nextPath)
+  }
+
+  const handleFolderClick = (name) => {
+    setPath((current) => (current ? `${current}/${name}` : name))
+  }
+
+  const handleCreateFolder = useCallback(
+    (event) => {
+      event.preventDefault()
+      const trimmed = folderName.trim()
+      if (!trimmed) {
+        return
+      }
+      httpClient('/api/discoveryfs/folder', {
+        method: 'POST',
+        body: JSON.stringify({ path, name: trimmed }),
+        headers: new Headers({
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        }),
+      })
+        .then(() => {
+          setFolderName('')
+          setRefreshToken((value) => value + 1)
+        })
+        .catch((error) => {
+          const message =
+            error?.body?.error ||
+            error?.message ||
+            translate('resources.discovery.notifications.create_error', {
+              _: 'Unable to create folder',
+            })
+          notify(message, 'warning')
+        })
+    },
+    [folderName, path, notify, translate],
+  )
+
+  const handleUploadClick = useCallback(() => {
+    if (fileInputRef.current) {
+      fileInputRef.current.click()
+    }
+  }, [])
+
+  const handleFileChange = useCallback(
+    (event) => {
+      const input = event.target
+      const { files } = input
+      if (!files || files.length === 0) {
+        return
+      }
+      const formData = new FormData()
+      Array.from(files).forEach((file) => {
+        formData.append('files', file)
+      })
+      const query = path ? `?path=${encodeURIComponent(path)}` : ''
+      httpClient(`/api/discoveryfs/upload${query}`, {
+        method: 'POST',
+        body: formData,
+      })
+        .then(() => {
+          setRefreshToken((value) => value + 1)
+        })
+        .catch((error) => {
+          const message =
+            error?.body?.error ||
+            error?.message ||
+            translate('resources.discovery.notifications.upload_error', {
+              _: 'Unable to upload files',
+            })
+          notify(message, 'warning')
+        })
+        .finally(() => {
+          input.value = null
+        })
+    },
+    [path, notify, translate],
+  )
+
+  return (
+    <Card className={classes.card}>
+      <Title title={`MusicMatters - ${currentTitle}`} />
+      <CardContent>
+        <Typography variant="h5" gutterBottom>
+          {currentTitle}
+        </Typography>
+        <Breadcrumbs aria-label="breadcrumb" className={classes.breadcrumbs}>
+          <Link color="inherit" component="button" onClick={() => handleNavigate(-1)}>
+            {currentTitle}
+          </Link>
+          {pathSegments.map((segment, index) => (
+            <Link
+              key={`${segment}-${index}`}
+              color="inherit"
+              component="button"
+              onClick={() => handleNavigate(index)}
+            >
+              {segment}
+            </Link>
+          ))}
+        </Breadcrumbs>
+        <div className={classes.actions}>
+          <form className={classes.newFolderForm} onSubmit={handleCreateFolder}>
+            <TextField
+              label={translate('resources.discovery.new_folder', { _: 'Folder name' })}
+              value={folderName}
+              onChange={(event) => setFolderName(event.target.value)}
+              size="small"
+              variant="outlined"
+            />
+            <Button type="submit" variant="contained" color="primary">
+              {translate('ra.action.create', { _: 'Create' })}
+            </Button>
+          </form>
+          <div>
+            <input
+              accept=".mp3,.m4a,.flac,.wav,.ogg"
+              className={classes.fileInput}
+              multiple
+              onChange={handleFileChange}
+              ref={fileInputRef}
+              type="file"
+            />
+            <Button
+              variant="contained"
+              color="default"
+              startIcon={<CloudUploadIcon />}
+              onClick={handleUploadClick}
+            >
+              {translate('ra.action.upload', { _: 'Upload' })}
+            </Button>
+          </div>
+        </div>
+        {loading ? (
+          <Typography variant="body2">
+            {translate('ra.page.loading', { _: 'Loading' })}
+          </Typography>
+        ) : items.length === 0 ? (
+          <Typography variant="body2">
+            {translate('resources.discovery.empty', { _: 'This folder is empty.' })}
+          </Typography>
+        ) : (
+          <List dense>
+            {items.map((item) => (
+              <ListItem
+                key={`${item.type}-${item.name}`}
+                button={item.type === 'folder'}
+                onClick={
+                  item.type === 'folder'
+                    ? () => handleFolderClick(item.name)
+                    : undefined
+                }
+              >
+                <ListItemIcon>
+                  {item.type === 'folder' ? <FolderIcon /> : <MusicNoteIcon />}
+                </ListItemIcon>
+                <ListItemText primary={item.name} />
+              </ListItem>
+            ))}
+          </List>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+export default DiscoveryBrowser
+

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -559,6 +559,7 @@
       }
     },
     "albumList": "Albums",
+    "discovery": "Discovery",
     "playlists": "Playlists",
     "sharedPlaylists": "Shared Playlists",
     "about": "About"

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -5,6 +5,7 @@ import clsx from 'clsx'
 import { useTranslate, MenuItemLink, getResources } from 'react-admin'
 import ViewListIcon from '@material-ui/icons/ViewList'
 import AlbumIcon from '@material-ui/icons/Album'
+import FolderIcon from '@material-ui/icons/Folder'
 import SubMenu from './SubMenu'
 import { humanize, pluralize } from 'inflection'
 import albumLists from '../album/albumLists'
@@ -128,6 +129,15 @@ const Menu = ({ dense = false }) => {
         )}
       </SubMenu>
       {resources.filter(subItems(undefined)).map(renderResourceMenuItemLink)}
+      <MenuItemLink
+        key="discovery"
+        to="/discovery"
+        activeClassName={classes.active}
+        primaryText={translate('menu.discovery', { _: 'Discovery' })}
+        leftIcon={<FolderIcon />}
+        sidebarIsOpen={open}
+        dense={dense}
+      />
       {config.devSidebarPlaylists && open ? (
         <>
           <Divider />

--- a/ui/src/routes.jsx
+++ b/ui/src/routes.jsx
@@ -1,9 +1,16 @@
 import React from 'react'
 import { Route } from 'react-router-dom'
 import Personal from './personal/Personal'
+import DiscoveryBrowser from './discovery/DiscoveryBrowser'
 
 const routes = [
   <Route exact path="/personal" render={() => <Personal />} key={'personal'} />,
+  <Route
+    exact
+    path="/discovery"
+    render={() => <DiscoveryBrowser />}
+    key={'discovery'}
+  />,
 ]
 
 export default routes


### PR DESCRIPTION
## Summary
- add a discovery filesystem root helper with REST handlers for listing, folder creation, and uploads
- register the discovery routes in the native API and expose a Discovery entry in the sidebar
- implement a Discovery browser page with navigation, folder creation, and file uploads

## Testing
- go test ./... *(fails: requires prebuilt UI assets, taglib library, and existing M3U playlist tests in the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68ddac3861008330bca55852768365d3