### PR TITLE
Adjust mobile song list fields

### DIFF
--- a/ui/src/common/SongSimpleList.jsx
+++ b/ui/src/common/SongSimpleList.jsx
@@ -47,6 +47,16 @@ const useStyles = makeStyles(
     rightIcon: {
       top: '26px',
     },
+    mobilePrimary: {
+      display: 'flex',
+      alignItems: 'baseline',
+      columnGap: 6,
+    },
+    mobileArtist: {
+      fontWeight: 'inherit',
+      fontSize: 'inherit',
+      color: 'inherit',
+    },
   },
   { name: 'RaSongSimpleList' },
 )
@@ -83,8 +93,12 @@ export const SongSimpleList = ({
               <ListItem className={classes.listItem} button={true}>
                 {isMobile ? (
                   <ListItemText
-                    primary={record.title}
-                    secondary={record.artist}
+                    primary={
+                      <span className={classes.mobilePrimary}>
+                        <span>{record.title}</span>
+                        <span className={classes.mobileArtist}>{record.artist}</span>
+                      </span>
+                    }
                   />
                 ) : (
                   <ListItemText
@@ -109,13 +123,11 @@ export const SongSimpleList = ({
                     }
                   />
                 )}
-                {!isMobile && (
-                  <ListItemSecondaryAction className={classes.rightIcon}>
-                    <ListItemIcon>
-                      <SongContextMenu record={record} visible={true} />
-                    </ListItemIcon>
-                  </ListItemSecondaryAction>
-                )}
+                <ListItemSecondaryAction className={classes.rightIcon}>
+                  <ListItemIcon>
+                    <SongContextMenu record={record} visible={true} />
+                  </ListItemIcon>
+                </ListItemSecondaryAction>
               </ListItem>
             </span>
           )

--- a/ui/src/common/SongSimpleList.jsx
+++ b/ui/src/common/SongSimpleList.jsx
@@ -5,7 +5,8 @@ import ListItem from '@material-ui/core/ListItem'
 import ListItemIcon from '@material-ui/core/ListItemIcon'
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
 import ListItemText from '@material-ui/core/ListItemText'
-import { makeStyles } from '@material-ui/core/styles'
+import { useMediaQuery } from '@material-ui/core'
+import { makeStyles, useTheme } from '@material-ui/core/styles'
 import { sanitizeListRestProps } from 'react-admin'
 import { DurationField, SongContextMenu, RatingField } from './index'
 import { setTrack } from '../actions'
@@ -65,51 +66,58 @@ export const SongSimpleList = ({
 }) => {
   const dispatch = useDispatch()
   const classes = useStyles({ classes: classesOverride })
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
   return (
     (loading || total > 0) && (
       <List className={className} {...sanitizeListRestProps(rest)}>
-        {ids.map(
-          (id) =>
-            data[id] && (
-              <span key={id} onClick={() => dispatch(setTrack(data[id]))}>
+        {ids.map((id) => {
+          const record = data[id]
+
+          return (
+            record && (
+              <span key={id} onClick={() => dispatch(setTrack(record))}>
                 <ListItem className={classes.listItem} button={true}>
-                  <ListItemText
-                    primary={
-                      <div className={classes.title}>{data[id].title}</div>
-                    }
-                    secondary={
-                      <>
-                        <span className={classes.secondary}>
-                          <span className={classes.artist}>
-                            {data[id].artist}
+                  {isMobile ? (
+                    <ListItemText
+                      primary={record.title}
+                      secondary={record.artist}
+                    />
+                  ) : (
+                    <ListItemText
+                      primary={<div className={classes.title}>{record.title}</div>}
+                      secondary={
+                        <>
+                          <span className={classes.secondary}>
+                            <span className={classes.artist}>{record.artist}</span>
+                            <span className={classes.timeStamp}>
+                              <DurationField record={record} source={'duration'} />
+                            </span>
                           </span>
-                          <span className={classes.timeStamp}>
-                            <DurationField
-                              record={data[id]}
-                              source={'duration'}
+                          {config.enableStarRating && (
+                            <RatingField
+                              record={record}
+                              source={'rating'}
+                              resource={'song'}
+                              size={'small'}
                             />
-                          </span>
-                        </span>
-                        {config.enableStarRating && (
-                          <RatingField
-                            record={data[id]}
-                            source={'rating'}
-                            resource={'song'}
-                            size={'small'}
-                          />
-                        )}
-                      </>
-                    }
-                  />
-                  <ListItemSecondaryAction className={classes.rightIcon}>
-                    <ListItemIcon>
-                      <SongContextMenu record={data[id]} visible={true} />
-                    </ListItemIcon>
-                  </ListItemSecondaryAction>
+                          )}
+                        </>
+                      }
+                    />
+                  )}
+                  {!isMobile && (
+                    <ListItemSecondaryAction className={classes.rightIcon}>
+                      <ListItemIcon>
+                        <SongContextMenu record={record} visible={true} />
+                      </ListItemIcon>
+                    </ListItemSecondaryAction>
+                  )}
                 </ListItem>
               </span>
             ),
-        )}
+          )
+        })}
       </List>
     )
   )

--- a/ui/src/common/SongSimpleList.jsx
+++ b/ui/src/common/SongSimpleList.jsx
@@ -74,48 +74,50 @@ export const SongSimpleList = ({
         {ids.map((id) => {
           const record = data[id]
 
+          if (!record) {
+            return null
+          }
+
           return (
-            record && (
-              <span key={id} onClick={() => dispatch(setTrack(record))}>
-                <ListItem className={classes.listItem} button={true}>
-                  {isMobile ? (
-                    <ListItemText
-                      primary={record.title}
-                      secondary={record.artist}
-                    />
-                  ) : (
-                    <ListItemText
-                      primary={<div className={classes.title}>{record.title}</div>}
-                      secondary={
-                        <>
-                          <span className={classes.secondary}>
-                            <span className={classes.artist}>{record.artist}</span>
-                            <span className={classes.timeStamp}>
-                              <DurationField record={record} source={'duration'} />
-                            </span>
+            <span key={id} onClick={() => dispatch(setTrack(record))}>
+              <ListItem className={classes.listItem} button={true}>
+                {isMobile ? (
+                  <ListItemText
+                    primary={record.title}
+                    secondary={record.artist}
+                  />
+                ) : (
+                  <ListItemText
+                    primary={<div className={classes.title}>{record.title}</div>}
+                    secondary={
+                      <>
+                        <span className={classes.secondary}>
+                          <span className={classes.artist}>{record.artist}</span>
+                          <span className={classes.timeStamp}>
+                            <DurationField record={record} source={'duration'} />
                           </span>
-                          {config.enableStarRating && (
-                            <RatingField
-                              record={record}
-                              source={'rating'}
-                              resource={'song'}
-                              size={'small'}
-                            />
-                          )}
-                        </>
-                      }
-                    />
-                  )}
-                  {!isMobile && (
-                    <ListItemSecondaryAction className={classes.rightIcon}>
-                      <ListItemIcon>
-                        <SongContextMenu record={record} visible={true} />
-                      </ListItemIcon>
-                    </ListItemSecondaryAction>
-                  )}
-                </ListItem>
-              </span>
-            ),
+                        </span>
+                        {config.enableStarRating && (
+                          <RatingField
+                            record={record}
+                            source={'rating'}
+                            resource={'song'}
+                            size={'small'}
+                          />
+                        )}
+                      </>
+                    }
+                  />
+                )}
+                {!isMobile && (
+                  <ListItemSecondaryAction className={classes.rightIcon}>
+                    <ListItemIcon>
+                      <SongContextMenu record={record} visible={true} />
+                    </ListItemIcon>
+                  </ListItemSecondaryAction>
+                )}
+              </ListItem>
+            </span>
           )
         })}
       </List>


### PR DESCRIPTION
## Summary
- render only title and artist in the mobile song list row
- keep existing desktop fields and actions when viewed above the small breakpoint

## Testing
- npm run build *(fails: Rollup failed to resolve import "@dnd-kit/core" from ToggleFieldsMenu.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb638502c8330aa1a5dc002c40dc7