### PR TITLE
Handle missing playlist tracks

### DIFF
--- a/model/playlist.go
+++ b/model/playlist.go
@@ -131,9 +131,11 @@ type PlaylistRepository interface {
 }
 
 type PlaylistTrack struct {
-	ID          string `json:"id"`
-	MediaFileID string `json:"mediaFileId"`
-	PlaylistID  string `json:"playlistId"`
+	ID           string `json:"id"`
+	MediaFileID  string `json:"mediaFileId"`
+	PlaylistID   string `json:"playlistId"`
+	OriginalPath string `json:"originalPath,omitempty" structs:"original_path"`
+	Missing      bool   `json:"missing,omitempty" structs:"missing"`
 	MediaFile
 }
 

--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -167,9 +167,11 @@ func (r *playlistRepository) GetWithTracks(id string, refreshSmartPlaylist, incl
 	if refreshSmartPlaylist {
 		r.refreshSmartPlaylist(pls)
 	}
-	tracks, err := r.loadTracks(Select().From("playlist_tracks").
-		Where(Eq{"missing": false}).
-		OrderBy("playlist_tracks.id"), id)
+	sel := Select().From("playlist_tracks").OrderBy("playlist_tracks.id")
+	if !includeMissing {
+		sel = sel.Where(Eq{"missing": false})
+	}
+	tracks, err := r.loadTracks(sel, id)
 	if err != nil {
 		log.Error(r.ctx, "Error loading playlist tracks ", "playlist", pls.Name, "id", pls.ID, err)
 		return nil, err
@@ -463,7 +465,6 @@ func (r *playlistRepository) refreshCounters(pls *model.Playlist) error {
 }
 
 func (r *playlistRepository) loadTracks(sel SelectBuilder, id string) (model.PlaylistTracks, error) {
-	sel = r.applyLibraryFilter(sel, "f")
 	userID := loggedUser(r.ctx).ID
 	tracksQuery := sel.
 		Columns(
@@ -481,9 +482,16 @@ func (r *playlistRepository) loadTracks(sel SelectBuilder, id string) (model.Pla
 			"annotation.item_id = media_file_id" +
 			" AND annotation.item_type = 'media_file'" +
 			" AND annotation.user_id = '" + userID + "')").
-		Join("media_file f on f.id = media_file_id").
-		Join("library on f.library_id = library.id").
+		LeftJoin("media_file f on f.id = media_file_id").
+		LeftJoin("library on f.library_id = library.id").
 		Where(Eq{"playlist_id": id})
+	user := loggedUser(r.ctx)
+	if !user.IsAdmin && user.ID != invalidUserId {
+		tracksQuery = tracksQuery.Where(Or{
+			Expr("f.id IS NULL"),
+			Expr("f.library_id IN (SELECT ul.library_id FROM user_library ul WHERE ul.user_id = ?)", user.ID),
+		})
+	}
 	tracks := dbPlaylistTracks{}
 	err := r.queryAll(tracksQuery, &tracks)
 	if err != nil {

--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"database/sql"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	. "github.com/Masterminds/squirrel"
@@ -25,11 +26,47 @@ type dbPlaylistTrack struct {
 }
 
 func (t *dbPlaylistTrack) PostScan() error {
-	if err := t.dbMediaFile.PostScan(); err != nil {
-		return err
+	if t.dbMediaFile.MediaFile != nil && t.dbMediaFile.MediaFile.ID != "" {
+		if err := t.dbMediaFile.PostScan(); err != nil {
+			return err
+		}
+		t.PlaylistTrack.MediaFile = *t.dbMediaFile.MediaFile
+		t.PlaylistTrack.MediaFile.ID = t.MediaFileID
+		t.PlaylistTrack.Missing = t.PlaylistTrack.MediaFile.Missing
+		return nil
 	}
-	t.PlaylistTrack.MediaFile = *t.dbMediaFile.MediaFile
-	t.PlaylistTrack.MediaFile.ID = t.MediaFileID
+
+	t.PlaylistTrack.Missing = true
+	originalPath := t.PlaylistTrack.OriginalPath
+	title := ""
+	if originalPath != "" {
+		title = filepath.Base(originalPath)
+	}
+	if title == "" || title == "." {
+		fallback := t.MediaFileID
+		if fallback != "" {
+			title = filepath.Base(fallback)
+			if title == "" || title == "." {
+				title = fallback
+			}
+		}
+	}
+	if ext := filepath.Ext(title); ext != "" {
+		title = strings.TrimSuffix(title, ext)
+	}
+	if title == "" || title == "." {
+		title = "(missing track)"
+	}
+	pathValue := originalPath
+	if pathValue == "" {
+		pathValue = t.MediaFileID
+	}
+	t.PlaylistTrack.MediaFile = model.MediaFile{
+		ID:      t.MediaFileID,
+		Title:   title,
+		Path:    pathValue,
+		Missing: true,
+	}
 	return nil
 }
 

--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -23,6 +23,12 @@ import { DraggableTypes } from '../consts'
 import { formatFullDate } from '../utils'
 
 const useStyles = makeStyles((theme) => ({
+  '@global': {
+    '.nd-missing': {
+      opacity: 0.5,
+      fontStyle: 'italic',
+    },
+  },
   subtitle: {
     whiteSpace: 'nowrap',
     overflow: 'hidden',
@@ -64,7 +70,6 @@ const useStyles = makeStyles((theme) => ({
   },
   missingRow: {
     cursor: 'inherit',
-    opacity: 0.3,
   },
   headerStyle: {
     '& thead': {
@@ -175,12 +180,15 @@ export const SongDatagridRow = ({
   const rowClick = record.missing ? undefined : rest.rowClick
 
   const isCurrent =
-    currentId && (currentId === record.id || currentId === record.mediaFileId)
+    !record?.missing &&
+    currentId &&
+    (currentId === record.id || currentId === record.mediaFileId)
 
   const computedClasses = clsx(
     className,
     classes.row,
     record.missing && classes.missingRow,
+    record.missing && 'nd-missing',
     isCurrent && classes.currentRow,
   )
   const childCount = fields.length

--- a/ui/src/common/SongTitleField.jsx
+++ b/ui/src/common/SongTitleField.jsx
@@ -38,6 +38,7 @@ export const SongTitleField = ({ showTrackNumbers, ...props }) => {
   const currentTrack = useSelector((state) => state?.player?.current || {})
   const currentId = currentTrack.trackId
   const paused = currentTrack.paused
+  const isMissing = record?.missing
   const isCurrent =
     currentId && (currentId === record.id || currentId === record.mediaFileId)
 
@@ -77,7 +78,7 @@ export const SongTitleField = ({ showTrackNumbers, ...props }) => {
 
   return (
     <>
-      {isCurrent && <Icon />}
+      {isCurrent && !isMissing && <Icon />}
       <FunctionField
         {...props}
         source="title"


### PR DESCRIPTION
## Summary
- retain unresolved playlist entries by left-joining media metadata, populating a `missing` flag and fallback fields
- extend playlist track models to expose original paths and mark missing items
- grey out missing playlist rows in the UI, disable play indicators, and prevent interaction

## Testing
- `go test ./...` *(fails: ui/embed.go cannot embed build/3rdparty during tests in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de8b8170008330a1982b7aeddad034