### PR TITLE
Deduplicate missing track notifications

### DIFF
--- a/server/nativeapi/notifications.go
+++ b/server/nativeapi/notifications.go
@@ -50,7 +50,7 @@ func (n *Router) handleMissingTrackNotifications() http.HandlerFunc {
 			log.Debug(ctx, "Unable to enable WAL for missing tracks database", "path", dbFile, "err", err)
 		}
 
-		rows, err := db.QueryContext(ctx, `SELECT track_path FROM missing_playlist_tracks ORDER BY created_at DESC LIMIT 200`)
+		rows, err := db.QueryContext(ctx, `SELECT track_path FROM missing_playlist_tracks GROUP BY track_path ORDER BY MAX(created_at) DESC LIMIT 200`)
 		if err != nil {
 			if strings.Contains(err.Error(), "no such table") {
 				writeMissingTrackResponse(w, entries, ctx)


### PR DESCRIPTION
## Summary
- ensure missing track notifications query returns unique tracks so the panel does not repeat songs

## Testing
- go test ./... *(fails: ui/embed.go:8:12: pattern build/*: cannot embed directory build/3rdparty: contains no embeddable files)*

------
https://chatgpt.com/codex/tasks/task_e_68def9f318988330b6c493de1a2df770