### PR TITLE
Enhance missing tracks notification presentation

### DIFF
--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -634,7 +634,7 @@
   },
   "notifications": {
     "missingTracks": "Missing Tracks",
-    "missingTracksListTitle": "Missing songs list",
+    "missingTracksListTitle": "Missing Tracks",
     "missingTracksEmpty": "No missing tracks recorded",
     "missingTracksSummary": "%{smart_count} song is missing from Playlist %{playlist} |||| %{smart_count} songs are missing from Playlist %{playlist}",
     "missingTracksImportedOn": " — imported on %{date}",

--- a/ui/src/layout/MissingTracksPanel.jsx
+++ b/ui/src/layout/MissingTracksPanel.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from 'react'
 import {
+  Badge,
   Card,
   CardContent,
   IconButton,
@@ -39,7 +40,8 @@ const useStyles = makeStyles((theme) => ({
   },
   header: {
     padding: theme.spacing(0, 1.5, 1),
-    fontWeight: theme.typography.fontWeightMedium,
+    fontWeight: theme.typography.fontWeightBold,
+    color: theme.palette.info.main,
   },
   empty: {
     padding: theme.spacing(1, 2),
@@ -49,6 +51,17 @@ const useStyles = makeStyles((theme) => ({
     alignItems: 'center',
     justifyContent: 'center',
     padding: theme.spacing(2),
+  },
+  notificationBadge: {
+    '& .MuiBadge-badge': {
+      minWidth: theme.spacing(2),
+      height: theme.spacing(2),
+      borderRadius: '50%',
+      fontSize: '0.65rem',
+      padding: 0,
+      top: theme.spacing(0.5),
+      right: theme.spacing(0.5),
+    },
   },
 }))
 
@@ -108,14 +121,21 @@ const MissingTracksPanel = () => {
   return (
     <div>
       <Tooltip title={translate('notifications.missingTracks')}>
-        <IconButton
-          className={classes.button}
-          onClick={handleOpen}
-          aria-label={translate('notifications.missingTracks')}
-          aria-haspopup="true"
+        <Badge
+          badgeContent={entries.length}
+          color="secondary"
+          invisible={entries.length === 0}
+          className={classes.notificationBadge}
         >
-          <MdOutlineNotifications size={20} />
-        </IconButton>
+          <IconButton
+            className={classes.button}
+            onClick={handleOpen}
+            aria-label={translate('notifications.missingTracks')}
+            aria-haspopup="true"
+          >
+            <MdOutlineNotifications size={20} />
+          </IconButton>
+        </Badge>
       </Tooltip>
       <Popover
         id="panel-missing-tracks"


### PR DESCRIPTION
## Summary
- update the missing tracks panel title to "Missing Tracks" with accent styling
- add a notification count badge to the missing tracks icon in the top bar

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68defe0ce5088330a4711ffdde4bd80a