### PR TITLE
Fix missing playlist track path resolution

### DIFF
--- a/core/playlists.go
+++ b/core/playlists.go
@@ -22,6 +22,7 @@ import (
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/criteria"
 	"github.com/navidrome/navidrome/model/request"
+	"github.com/navidrome/navidrome/utils"
 	"github.com/navidrome/navidrome/utils/slice"
 	"golang.org/x/text/unicode/norm"
 )
@@ -305,6 +306,11 @@ func normalizePathForComparison(path string) string {
 func recordMissingPlaylistTrack(ctx context.Context, playlistPath, trackPath string) {
 	if trackPath == "" || conf.Server.DataFolder == "" {
 		return
+	}
+
+	normalizedPath := utils.ResolvePlaylistEntryPath(playlistPath, trackPath)
+	if normalizedPath != "" {
+		trackPath = normalizedPath
 	}
 
 	dbFile := filepath.Join(conf.Server.DataFolder, "missing_tracks.db")

--- a/core/playlists_test.go
+++ b/core/playlists_test.go
@@ -105,7 +105,8 @@ var _ = Describe("Playlists", func() {
 				var playlistID, trackPath string
 				Expect(row.Scan(&playlistID, &trackPath)).To(Succeed())
 				Expect(playlistID).To(Equal(playlistPath))
-				Expect(trackPath).To(Equal("missing-track.mp3"))
+				expected := filepath.ToSlash(filepath.Join(filepath.Dir(playlistPath), "missing-track.mp3"))
+				Expect(trackPath).To(Equal(expected))
 			})
 
 			It("locates tracks from music library when playlist lives in playlists folder", func() {

--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -14,6 +14,7 @@ import (
 	"github.com/deluan/rest"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/utils"
 	"github.com/navidrome/navidrome/utils/slice"
 	"golang.org/x/text/unicode/norm"
 )
@@ -335,7 +336,10 @@ func mergePlaylistTracksWithMissing(ctx context.Context, tracks model.PlaylistTr
 	missingCount := 0
 
 	for _, entry := range entries {
-		display := filepath.ToSlash(entry)
+		display := utils.ResolvePlaylistEntryPath(pls.Path, entry)
+		if display == "" {
+			display = filepath.ToSlash(entry)
+		}
 		normalizedEntry := normalizePlaylistPath(display)
 		matchIdx, ok := popTrackIndex(normalizedEntry, normalized)
 		if !ok {

--- a/utils/files.go
+++ b/utils/files.go
@@ -23,3 +23,23 @@ func FileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil || !os.IsNotExist(err)
 }
+
+// ResolvePlaylistEntryPath returns an absolute representation of the track path referenced
+// inside a playlist file. If the entry is relative, it is resolved against the playlist
+// location. The returned value always uses forward slashes so it can be safely stored and
+// displayed regardless of the operating system in use.
+func ResolvePlaylistEntryPath(playlistPath, trackPath string) string {
+	if trackPath == "" {
+		return ""
+	}
+
+	cleaned := filepath.Clean(trackPath)
+	if filepath.IsAbs(cleaned) || playlistPath == "" {
+		return filepath.ToSlash(cleaned)
+	}
+
+	baseDir := filepath.Dir(filepath.Clean(playlistPath))
+	resolved := filepath.Join(baseDir, cleaned)
+
+	return filepath.ToSlash(filepath.Clean(resolved))
+}

--- a/utils/files_test.go
+++ b/utils/files_test.go
@@ -176,3 +176,31 @@ var _ = Describe("FileExists", func() {
 		Expect(result).To(Or(BeTrue(), BeFalse()))      // Should not panic
 	})
 })
+
+var _ = Describe("ResolvePlaylistEntryPath", func() {
+	It("returns absolute path unchanged", func() {
+		absolute := filepath.Join(os.TempDir(), "music", "track.mp3")
+
+		resolved := utils.ResolvePlaylistEntryPath("/any/playlist.m3u", absolute)
+
+		Expect(resolved).To(Equal(filepath.ToSlash(filepath.Clean(absolute))))
+	})
+
+	It("resolves relative paths against the playlist file", func() {
+		playlistPath := filepath.Join(os.TempDir(), "playlists", "favorites.m3u")
+		entry := filepath.Join("..", "music", "track.mp3")
+
+		resolved := utils.ResolvePlaylistEntryPath(playlistPath, entry)
+		expected := filepath.ToSlash(filepath.Join(filepath.Dir(playlistPath), entry))
+
+		Expect(resolved).To(Equal(filepath.ToSlash(filepath.Clean(expected))))
+	})
+
+	It("cleans paths when playlist location is unknown", func() {
+		entry := "./mixes/../mixes/song.flac"
+
+		resolved := utils.ResolvePlaylistEntryPath("", entry)
+
+		Expect(resolved).To(Equal(filepath.ToSlash(filepath.Clean(entry))))
+	})
+})


### PR DESCRIPTION
## Summary
- resolve missing playlist track paths relative to the playlist file so notifications store the expected location
- reuse the same normalization when merging playlist tracks to show accurate paths for missing entries
- add coverage for the new resolver and adjust the missing track logging test

## Testing
- go test ./utils

------
https://chatgpt.com/codex/tasks/task_e_68df0a12329c8330808f6915a015e92a