### PR TITLE
Fix missing track path display and genre filter tooltip

### DIFF
--- a/ui/src/common/ContextMenus.jsx
+++ b/ui/src/common/ContextMenus.jsx
@@ -5,7 +5,6 @@ import IconButton from '@material-ui/core/IconButton'
 import Menu from '@material-ui/core/Menu'
 import MenuItem from '@material-ui/core/MenuItem'
 import MoreVertIcon from '@material-ui/icons/MoreVert'
-import { MdQuestionMark } from 'react-icons/md'
 import { makeStyles } from '@material-ui/core/styles'
 import { useDataProvider, useNotify, useTranslate } from 'react-admin'
 import clsx from 'clsx'
@@ -35,20 +34,17 @@ const useStyles = makeStyles({
 })
 
 const MoreButton = ({ record, onClick, info, ...rest }) => {
-  const handleClick = record.missing
-    ? (e) => {
-        e.preventDefault()
-        info.action(record)
-        e.stopPropagation()
-      }
-    : onClick
+  const handleClick =
+    record.missing && info?.action
+      ? (e) => {
+          e.preventDefault()
+          info.action(record)
+          e.stopPropagation()
+        }
+      : onClick
   return (
     <IconButton onClick={handleClick} size={'small'} {...rest}>
-      {record?.missing ? (
-        <MdQuestionMark fontSize={'large'} />
-      ) : (
-        <MoreVertIcon fontSize={'small'} />
-      )}
+      <MoreVertIcon fontSize={'small'} />
     </IconButton>
   )
 }

--- a/ui/src/common/PathField.jsx
+++ b/ui/src/common/PathField.jsx
@@ -4,17 +4,24 @@ import { usePermissions, useRecordContext } from 'react-admin'
 import config from '../config'
 
 export const PathField = (props) => {
-  const record = useRecordContext(props)
+  const record = useRecordContext(props) || {}
   const { permissions } = usePermissions()
-  let path = permissions === 'admin' ? record.libraryPath : ''
 
-  if (path && path.endsWith(config.separator)) {
-    path = `${path}${record.path}`
-  } else {
-    path = path ? `${path}${config.separator}${record.path}` : record.path
+  if (!record.path || record.missing) {
+    return <span></span>
   }
 
-  return <span>{path}</span>
+  const libraryPath = permissions === 'admin' ? record.libraryPath || '' : ''
+
+  if (!libraryPath) {
+    return <span>{record.path}</span>
+  }
+
+  const separator = libraryPath.endsWith(config.separator)
+    ? ''
+    : config.separator
+
+  return <span>{`${libraryPath}${separator}${record.path}`}</span>
 }
 
 PathField.propTypes = {

--- a/ui/src/common/PathField.test.jsx
+++ b/ui/src/common/PathField.test.jsx
@@ -83,4 +83,29 @@ describe('PathField', () => {
     // Assert
     expect(container.textContent).toBe('C:\\data\\music\\song.mp3')
   })
+
+  it('renders empty string when the song is missing', () => {
+    usePermissions.mockReturnValue({ permissions: 'admin' })
+    useRecordContext.mockReturnValue({
+      path: 'music/song.mp3',
+      libraryPath: '/data/media',
+      missing: true,
+    })
+
+    const { container } = render(<PathField />)
+
+    expect(container.textContent).toBe('')
+  })
+
+  it('renders empty string when no path is present', () => {
+    usePermissions.mockReturnValue({ permissions: 'admin' })
+    useRecordContext.mockReturnValue({
+      path: '',
+      libraryPath: '/data/media',
+    })
+
+    const { container } = render(<PathField />)
+
+    expect(container.textContent).toBe('')
+  })
 })

--- a/ui/src/common/SongContextMenu.jsx
+++ b/ui/src/common/SongContextMenu.jsx
@@ -10,7 +10,6 @@ import {
 import { IconButton, Menu, MenuItem } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core/styles'
 import MoreVertIcon from '@material-ui/icons/MoreVert'
-import { MdQuestionMark } from 'react-icons/md'
 import clsx from 'clsx'
 import {
   playNext,
@@ -34,19 +33,16 @@ const useStyles = makeStyles({
 })
 
 const MoreButton = ({ record, onClick, info }) => {
-  const handleClick = record.missing
-    ? (e) => {
-        info.action(record)
-        e.stopPropagation()
-      }
-    : onClick
+  const handleClick =
+    record.missing && info?.action
+      ? (e) => {
+          info.action(record)
+          e.stopPropagation()
+        }
+      : onClick
   return (
     <IconButton onClick={handleClick} size={'small'}>
-      {record?.missing ? (
-        <MdQuestionMark fontSize={'large'} />
-      ) : (
-        <MoreVertIcon fontSize={'small'} />
-      )}
+      <MoreVertIcon fontSize={'small'} />
     </IconButton>
   )
 }

--- a/ui/src/common/SongInfo.jsx
+++ b/ui/src/common/SongInfo.jsx
@@ -44,7 +44,7 @@ const useStyles = makeStyles({
 export const SongInfo = (props) => {
   const classes = useStyles({ gain: config.enableReplayGain })
   const translate = useTranslate()
-  const record = useRecordContext(props)
+  const record = useRecordContext(props) ?? {}
   const [tab, setTab] = useState(0)
 
   // These are already displayed in other fields or are album-level tags
@@ -87,11 +87,13 @@ export const SongInfo = (props) => {
 
   const roles = []
 
-  for (const name of Object.keys(record.participants)) {
+  const participants = record.participants ?? {}
+
+  for (const name of Object.keys(participants)) {
     if (name === 'albumartist' || name === 'artist') {
       continue
     }
-    roles.push([name, record.participants[name].length])
+    roles.push([name, participants[name].length])
   }
 
   const optionalFields = [
@@ -103,9 +105,15 @@ export const SongInfo = (props) => {
     'sampleRate',
   ]
   optionalFields.forEach((field) => {
-    !record[field] && delete data[field]
+    let hasValue = record?.[field]
+    if (field === 'genre') {
+      hasValue = record?.genres?.length
+    }
+    if (!hasValue) {
+      delete data[field]
+    }
   })
-  if (record.playCount > 0) {
+  if ((record?.playCount ?? 0) > 0) {
     data.playDate = <DateField record={record} source="playDate" showTime />
   }
 

--- a/ui/src/common/SongInfo.test.jsx
+++ b/ui/src/common/SongInfo.test.jsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SongInfo } from './SongInfo'
+
+const useRecordContext = vi.fn()
+
+vi.mock('react-admin', () => ({
+  BooleanField: ({ source }) => <span>boolean-{source}</span>,
+  DateField: ({ source }) => <span>date-{source}</span>,
+  TextField: ({ source }) => <span>text-{source}</span>,
+  NumberField: ({ source }) => <span>number-{source}</span>,
+  FunctionField: () => <span>function-field</span>,
+  useTranslate: () => (key) => key,
+  useRecordContext: (...args) => useRecordContext(...args),
+}))
+
+vi.mock('./index', () => ({
+  ArtistLinkField: () => <span>artist</span>,
+  BitrateField: () => <span>bitrate</span>,
+  ParticipantsInfo: () => null,
+  PathField: () => <span>path</span>,
+  SizeField: () => <span>size</span>,
+}))
+
+vi.mock('./MultiLineTextField', () => ({
+  MultiLineTextField: () => <span>multi</span>,
+}))
+
+vi.mock('../song/AlbumLinkField', () => ({
+  AlbumLinkField: () => <span>album</span>,
+}))
+
+vi.mock('../config', () => ({
+  default: { enableReplayGain: false },
+}))
+
+describe('SongInfo', () => {
+  beforeEach(() => {
+    useRecordContext.mockReset()
+  })
+
+  it('renders without crashing when participants data is missing', () => {
+    useRecordContext.mockReturnValue({
+      id: '1',
+      genres: [{ name: 'Rock' }],
+      tags: {},
+      playCount: 0,
+    })
+
+    const { getByText } = render(<SongInfo />)
+
+    expect(getByText(/resources\.song\.fields\.path/)).toBeInTheDocument()
+  })
+})

--- a/ui/src/layout/AppBar.test.jsx
+++ b/ui/src/layout/AppBar.test.jsx
@@ -13,6 +13,7 @@ vi.mock('react-admin', () => ({
   AppBar: ({ userMenu }) => <div data-testid="appbar">{userMenu}</div>,
   useTranslate: () => (x) => x,
   usePermissions: () => ({ permissions: 'admin' }),
+  useNotify: () => vi.fn(),
   getResources: () => [],
 }))
 

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -81,6 +81,7 @@ const SongFilter = (props) => {
         perPage={0}
         sort={{ field: 'name', order: 'ASC' }}
         filterToQuery={(searchText) => ({ name: [searchText] })}
+        helperText={false}
       >
         <AutocompleteArrayInput emptyText="-- None --" classes={classes} />
       </ReferenceArrayInput>

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -83,7 +83,11 @@ const SongFilter = (props) => {
         filterToQuery={(searchText) => ({ name: [searchText] })}
         helperText={false}
       >
-        <AutocompleteArrayInput emptyText="-- None --" classes={classes} />
+        <AutocompleteArrayInput
+          emptyText="-- None --"
+          classes={classes}
+          helperText={false}
+        />
       </ReferenceArrayInput>
       <ReferenceArrayInput
         label={translate('resources.song.fields.grouping')}
@@ -100,6 +104,7 @@ const SongFilter = (props) => {
           emptyText="-- None --"
           classes={classes}
           optionText="tagValue"
+          helperText={false}
         />
       </ReferenceArrayInput>
       <ReferenceArrayInput
@@ -117,6 +122,7 @@ const SongFilter = (props) => {
           emptyText="-- None --"
           classes={classes}
           optionText="tagValue"
+          helperText={false}
         />
       </ReferenceArrayInput>
       {config.enableFavourites && (


### PR DESCRIPTION
## Summary
- hide file paths for missing tracks and avoid building admin paths when the track has no file
- add tests covering missing file scenarios and update AppBar mocks for new hook usage
- remove the helper tooltip from the genre filter so the hover question mark no longer appears

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df0d7982bc833087d90dea56aa6f02