### PR TITLE
Fix missing song file path display

### DIFF
--- a/ui/src/common/PathField.jsx
+++ b/ui/src/common/PathField.jsx
@@ -6,6 +6,10 @@ import config from '../config'
 export const PathField = (props) => {
   const record = useRecordContext(props)
   const { permissions } = usePermissions()
+  if (!record || record.missing) {
+    return <span></span>
+  }
+
   let path = permissions === 'admin' ? record.libraryPath : ''
 
   if (path && path.endsWith(config.separator)) {

--- a/ui/src/common/PathField.test.jsx
+++ b/ui/src/common/PathField.test.jsx
@@ -83,4 +83,17 @@ describe('PathField', () => {
     // Assert
     expect(container.textContent).toBe('C:\\data\\music\\song.mp3')
   })
+
+  it('renders empty path for missing records', () => {
+    usePermissions.mockReturnValue({ permissions: 'admin' })
+    useRecordContext.mockReturnValue({
+      path: 'music/song.mp3',
+      libraryPath: '/data/media',
+      missing: true,
+    })
+
+    const { container } = render(<PathField />)
+
+    expect(container.textContent).toBe('')
+  })
 })

--- a/ui/src/common/SongContextMenu.jsx
+++ b/ui/src/common/SongContextMenu.jsx
@@ -10,7 +10,6 @@ import {
 import { IconButton, Menu, MenuItem } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core/styles'
 import MoreVertIcon from '@material-ui/icons/MoreVert'
-import { MdQuestionMark } from 'react-icons/md'
 import clsx from 'clsx'
 import {
   playNext,
@@ -33,20 +32,14 @@ const useStyles = makeStyles({
   },
 })
 
-const MoreButton = ({ record, onClick, info }) => {
-  const handleClick = record.missing
-    ? (e) => {
-        info.action(record)
-        e.stopPropagation()
-      }
-    : onClick
+const MoreButton = ({ record, onClick }) => {
+  if (record?.missing) {
+    return null
+  }
+
   return (
-    <IconButton onClick={handleClick} size={'small'}>
-      {record?.missing ? (
-        <MdQuestionMark fontSize={'large'} />
-      ) : (
-        <MoreVertIcon fontSize={'small'} />
-      )}
+    <IconButton onClick={onClick} size={'small'}>
+      <MoreVertIcon fontSize={'small'} />
     </IconButton>
   )
 }
@@ -226,7 +219,7 @@ export const SongContextMenu = ({
         resource={resource}
         visible={config.enableFavourites && showLove && present}
       />
-      <MoreButton record={record} onClick={handleClick} info={options.info} />
+      <MoreButton record={record} onClick={handleClick} />
       <Menu
         id={'menu' + record.id}
         anchorEl={anchorEl}


### PR DESCRIPTION
## Summary
- return an empty path for missing songs and cover it with a unit test
- hide the context menu trigger so the question mark icon is not rendered on missing tracks

## Testing
- npm --prefix ui test *(fails: Vitest cannot resolve @dnd-kit/core and missing react-admin mocks in unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68df14468d708330ba3aaf0ced3ca920