### PR TITLE
Use main database for missing playlist track records

### DIFF
--- a/core/playlists.go
+++ b/core/playlists.go
@@ -282,7 +282,7 @@ func (s *playlists) parseM3U(ctx context.Context, pls *model.Playlist, folder *m
 				mfs = append(mfs, found[idx])
 			} else {
 				log.Warn(ctx, "Path in playlist not found", "playlist", pls.Name, "path", path)
-				recordMissingPlaylistTrack(ctx, pls.Path, path)
+				recordMissingPlaylistTrack(ctx, pls, path)
 			}
 		}
 	}
@@ -302,41 +302,71 @@ func normalizePathForComparison(path string) string {
 	return strings.ToLower(norm.NFC.String(path))
 }
 
-func recordMissingPlaylistTrack(ctx context.Context, playlistPath, trackPath string) {
-	if trackPath == "" || conf.Server.DataFolder == "" {
+func recordMissingPlaylistTrack(ctx context.Context, playlist *model.Playlist, trackPath string) {
+	if trackPath == "" || conf.Server.DbPath == "" {
 		return
 	}
 
-	dbFile := filepath.Join(conf.Server.DataFolder, "missing_tracks.db")
-	dsn := fmt.Sprintf("file:%s?_busy_timeout=5000&_journal_mode=WAL", filepath.ToSlash(dbFile))
+	songName := extractSongName(trackPath)
+	if songName == "" {
+		return
+	}
 
-	db, err := sql.Open("sqlite3", dsn)
+	playlistName := ""
+	if playlist != nil {
+		playlistName = playlist.Name
+		if playlistName == "" {
+			playlistName = playlist.Path
+		}
+	}
+
+	db, err := sql.Open("sqlite3", conf.Server.DbPath)
 	if err != nil {
-		log.Debug(ctx, "Unable to open missing tracks database", "path", dbFile, "err", err)
+		log.Debug(ctx, "Unable to open missing tracks database", "path", conf.Server.DbPath, "err", err)
 		return
 	}
 	defer db.Close()
 
-	if _, err := db.Exec(`PRAGMA journal_mode=WAL`); err != nil {
-		log.Debug(ctx, "Unable to enable WAL for missing tracks database", "path", dbFile, "err", err)
+	if _, err := db.ExecContext(ctx, `PRAGMA busy_timeout = 5000`); err != nil {
+		log.Debug(ctx, "Unable to set busy timeout for missing tracks table", "path", conf.Server.DbPath, "err", err)
 		return
 	}
 
-	_, err = db.Exec(`
+	_, err = db.ExecContext(ctx, `
 CREATE TABLE IF NOT EXISTS missing_playlist_tracks (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        playlist_id TEXT,
-        track_path TEXT,
-        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+       song_name TEXT PRIMARY KEY,
+       track_path TEXT,
+       playlist TEXT,
+       time_added TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 )`)
 	if err != nil {
-		log.Debug(ctx, "Unable to ensure missing tracks table", "path", dbFile, "err", err)
+		log.Debug(ctx, "Unable to ensure missing tracks table", "path", conf.Server.DbPath, "err", err)
 		return
 	}
 
-	if _, err := db.Exec(`INSERT INTO missing_playlist_tracks (playlist_id, track_path) VALUES (?, ?)`, playlistPath, trackPath); err != nil {
-		log.Debug(ctx, "Unable to record missing track", "path", dbFile, "err", err)
+	if _, err := db.ExecContext(ctx, `
+INSERT INTO missing_playlist_tracks (song_name, track_path, playlist, time_added)
+VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+ON CONFLICT(song_name) DO UPDATE SET
+       track_path = excluded.track_path,
+       playlist = excluded.playlist,
+       time_added = CURRENT_TIMESTAMP
+`, songName, trackPath, playlistName); err != nil {
+		log.Debug(ctx, "Unable to record missing track", "path", conf.Server.DbPath, "err", err)
 	}
+}
+
+func extractSongName(trackPath string) string {
+	if trackPath == "" {
+		return ""
+	}
+
+	base := filepath.Base(trackPath)
+	if ext := filepath.Ext(base); ext != "" {
+		base = strings.TrimSuffix(base, ext)
+	}
+
+	return base
 }
 
 func inPlaylistsPath(rel string) bool {
@@ -415,7 +445,7 @@ func (s *playlists) normalizePaths(ctx context.Context, pls *model.Playlist, fol
 			res = append(res, relPath)
 		} else {
 			log.Warn(ctx, "Path in playlist not found in any library", "path", line, "line", idx)
-			recordMissingPlaylistTrack(ctx, pls.Path, line)
+			recordMissingPlaylistTrack(ctx, pls, line)
 		}
 	}
 	return slice.Map(res, filepath.ToSlash), nil

--- a/core/playlists_test.go
+++ b/core/playlists_test.go
@@ -77,35 +77,36 @@ var _ = Describe("Playlists", func() {
 				Expect(pls.Tracks).To(HaveLen(2))
 			})
 
-			It("records missing tracks in a separate database", func() {
+			It("records missing tracks in the main database", func() {
 				DeferCleanup(configtest.SetupConfig())
 
 				dataDir := GinkgoT().TempDir()
 				conf.Server.DataFolder = dataDir
+				conf.Server.DbPath = filepath.Join(dataDir, "navidrome.db")
+				DeferCleanup(func() { conf.Server.DbPath = "" })
 
 				playlistName := "missing-log.m3u"
 				playlistPath := filepath.Join(folder.AbsolutePath(), playlistName)
 				Expect(os.WriteFile(playlistPath, []byte("missing-track.mp3\n"), 0644)).To(Succeed())
 				DeferCleanup(func() { _ = os.Remove(playlistPath) })
 
-				dbPath := filepath.Join(conf.Server.DataFolder, "missing_tracks.db")
-				_ = os.Remove(dbPath)
+				_ = os.Remove(conf.Server.DbPath)
 
 				_, err := ps.ImportFile(ctx, folder, playlistName)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(dbPath).To(BeAnExistingFile())
+				Expect(conf.Server.DbPath).To(BeAnExistingFile())
 
-				dsn := "file:" + filepath.ToSlash(dbPath) + "?_journal_mode=WAL"
-				db, err := sql.Open("sqlite3", dsn)
+				db, err := sql.Open("sqlite3", conf.Server.DbPath)
 				Expect(err).ToNot(HaveOccurred())
 				defer db.Close()
 
-				row := db.QueryRow(`SELECT playlist_id, track_path FROM missing_playlist_tracks LIMIT 1`)
-				var playlistID, trackPath string
-				Expect(row.Scan(&playlistID, &trackPath)).To(Succeed())
-				Expect(playlistID).To(Equal(playlistPath))
+				row := db.QueryRow(`SELECT song_name, track_path, playlist FROM missing_playlist_tracks LIMIT 1`)
+				var songName, trackPath, playlist string
+				Expect(row.Scan(&songName, &trackPath, &playlist)).To(Succeed())
+				Expect(songName).To(Equal("missing-track"))
 				Expect(trackPath).To(Equal("missing-track.mp3"))
+				Expect(playlist).To(Equal("missing-log"))
 			})
 
 			It("locates tracks from music library when playlist lives in playlists folder", func() {

--- a/db/migrations/20241106000000_create_missing_playlist_tracks_table.go
+++ b/db/migrations/20241106000000_create_missing_playlist_tracks_table.go
@@ -1,0 +1,29 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upCreateMissingPlaylistTracksTable, downCreateMissingPlaylistTracksTable)
+}
+
+func upCreateMissingPlaylistTracksTable(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+CREATE TABLE IF NOT EXISTS missing_playlist_tracks (
+    song_name TEXT PRIMARY KEY,
+    track_path TEXT,
+    playlist TEXT,
+    time_added TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+`)
+	return err
+}
+
+func downCreateMissingPlaylistTracksTable(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `DROP TABLE IF EXISTS missing_playlist_tracks;`)
+	return err
+}

--- a/server/nativeapi/notifications.go
+++ b/server/nativeapi/notifications.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -30,33 +29,30 @@ func (n *Router) handleMissingTrackNotifications() http.HandlerFunc {
 		ctx := r.Context()
 		entries := []missingTrackNotification{}
 
-		if conf.Server.DataFolder == "" {
+		if conf.Server.DbPath == "" {
 			writeMissingTrackResponse(w, entries, ctx)
 			return
 		}
 
-		dbFile := filepath.Join(conf.Server.DataFolder, "missing_tracks.db")
-		dsn := fmt.Sprintf("file:%s?_busy_timeout=5000&_journal_mode=WAL", filepath.ToSlash(dbFile))
-
-		db, err := sql.Open("sqlite3", dsn)
+		db, err := sql.Open("sqlite3", conf.Server.DbPath)
 		if err != nil {
-			log.Warn(ctx, "Unable to open missing tracks database", "path", dbFile, "err", err)
+			log.Warn(ctx, "Unable to open missing tracks database", "path", conf.Server.DbPath, "err", err)
 			writeMissingTrackResponse(w, entries, ctx)
 			return
 		}
 		defer db.Close()
 
-		if _, err := db.Exec(`PRAGMA journal_mode=WAL`); err != nil {
-			log.Debug(ctx, "Unable to enable WAL for missing tracks database", "path", dbFile, "err", err)
+		if _, err := db.ExecContext(ctx, `PRAGMA busy_timeout = 5000`); err != nil {
+			log.Debug(ctx, "Unable to set busy timeout for missing tracks table", "path", conf.Server.DbPath, "err", err)
 		}
 
-		rows, err := db.QueryContext(ctx, `SELECT track_path FROM missing_playlist_tracks GROUP BY track_path ORDER BY MAX(created_at) DESC LIMIT 200`)
+		rows, err := db.QueryContext(ctx, `SELECT song_name, track_path FROM missing_playlist_tracks ORDER BY time_added DESC LIMIT 200`)
 		if err != nil {
 			if strings.Contains(err.Error(), "no such table") {
 				writeMissingTrackResponse(w, entries, ctx)
 				return
 			}
-			log.Error(ctx, "Unable to query missing tracks notifications", "path", dbFile, "err", err)
+			log.Error(ctx, "Unable to query missing tracks notifications", "path", conf.Server.DbPath, "err", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
@@ -65,25 +61,36 @@ func (n *Router) handleMissingTrackNotifications() http.HandlerFunc {
 		entries = make([]missingTrackNotification, 0)
 
 		for rows.Next() {
-			var trackPath string
+			var (
+				songName  sql.NullString
+				trackPath sql.NullString
+			)
 
-			if err := rows.Scan(&trackPath); err != nil {
-				log.Warn(ctx, "Unable to scan missing track notification", "path", dbFile, "err", err)
+			if err := rows.Scan(&songName, &trackPath); err != nil {
+				log.Warn(ctx, "Unable to scan missing track notification", "path", conf.Server.DbPath, "err", err)
 				continue
 			}
 
-			entries = append(entries, missingTrackNotification{
-				Title:     deriveTrackName(trackPath),
-				TrackPath: trackPath,
-			})
+			entry := missingTrackNotification{}
+			if songName.Valid {
+				entry.Title = songName.String
+			}
+			if trackPath.Valid {
+				entry.TrackPath = trackPath.String
+			}
+			if entry.Title == "" {
+				entry.Title = deriveTrackName(entry.TrackPath)
+			}
+
+			entries = append(entries, entry)
 		}
 
 		if err := rows.Err(); err != nil {
-			log.Warn(ctx, "Error iterating missing track notifications", "path", dbFile, "err", err)
+			log.Warn(ctx, "Error iterating missing track notifications", "path", conf.Server.DbPath, "err", err)
 		}
 
 		if len(entries) > 0 {
-			enrichMissingTrackMetadata(ctx, entries)
+			enrichMissingTrackMetadata(ctx, db, entries)
 			for i := range entries {
 				if entries[i].Title == "" {
 					entries[i].Title = deriveTrackName(entries[i].TrackPath)
@@ -114,20 +121,13 @@ func deriveTrackName(trackPath string) string {
 	return base
 }
 
-func enrichMissingTrackMetadata(ctx context.Context, entries []missingTrackNotification) {
-	if conf.Server.DbPath == "" {
+func enrichMissingTrackMetadata(ctx context.Context, db *sql.DB, entries []missingTrackNotification) {
+	if db == nil {
 		return
 	}
-
-	mainDB, err := sql.Open("sqlite3", conf.Server.DbPath)
-	if err != nil {
-		log.Warn(ctx, "Unable to open main database for missing track metadata", "path", conf.Server.DbPath, "err", err)
-		return
-	}
-	defer mainDB.Close()
 
 	for i := range entries {
-		populateTrackMetadata(ctx, mainDB, &entries[i])
+		populateTrackMetadata(ctx, db, &entries[i])
 	}
 }
 


### PR DESCRIPTION
## Summary
- record missing playlist tracks inside the main SQLite database with a song-name primary key and time-added updates
- expose the new table through the missing-track notifications endpoint ordered by most recent entries
- cover the behavior with a schema migration and updated playlist import tests

## Testing
- go test ./core

------
https://chatgpt.com/codex/tasks/task_e_68df1efe77948330be5e2d72bed7160a