### PR TITLE
Move missing playlist tracking into main database

### DIFF
--- a/core/playlists.go
+++ b/core/playlists.go
@@ -316,6 +316,8 @@ func recordMissingPlaylistTrack(ctx context.Context, playlistName, trackPath str
 		dbPath = filepath.Join(conf.Server.DataFolder, consts.DefaultDbPath)
 	}
 
+	cleanupLegacyMissingTracksDB(ctx, dbPath)
+
 	db, err := sql.Open("sqlite3", dbPath)
 	if err != nil {
 		log.Debug(ctx, "Unable to open database for missing tracks", "path", dbPath, "err", err)
@@ -390,6 +392,43 @@ CREATE TABLE IF NOT EXISTS missing_playlist_tracks (
 
 	if err := tx.Commit(); err != nil {
 		log.Debug(ctx, "Unable to commit missing track entry", "path", dbPath, "track", trackPath, "err", err)
+	}
+}
+
+func cleanupLegacyMissingTracksDB(ctx context.Context, dbPath string) {
+	if dbPath == "" || strings.HasPrefix(dbPath, "file:") || strings.HasPrefix(dbPath, ":memory:") {
+		return
+	}
+
+	basePath := stripDSN(dbPath)
+	if basePath == "" {
+		return
+	}
+
+	dataDir := filepath.Dir(basePath)
+	if conf.Server.DataFolder != "" {
+		dataDir = conf.Server.DataFolder
+	}
+
+	legacyBase := filepath.Join(dataDir, "missing_tracks.db")
+	removeLegacyMissingTracksFile(ctx, legacyBase)
+	removeLegacyMissingTracksFile(ctx, legacyBase+"-wal")
+	removeLegacyMissingTracksFile(ctx, legacyBase+"-shm")
+}
+
+func stripDSN(path string) string {
+	if idx := strings.Index(path, "?"); idx >= 0 {
+		return path[:idx]
+	}
+	return path
+}
+
+func removeLegacyMissingTracksFile(ctx context.Context, path string) {
+	if path == "" {
+		return
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Debug(ctx, "Unable to remove legacy missing tracks database", "path", path, "err", err)
 	}
 }
 

--- a/core/playlists.go
+++ b/core/playlists.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/criteria"
@@ -282,7 +283,7 @@ func (s *playlists) parseM3U(ctx context.Context, pls *model.Playlist, folder *m
 				mfs = append(mfs, found[idx])
 			} else {
 				log.Warn(ctx, "Path in playlist not found", "playlist", pls.Name, "path", path)
-				recordMissingPlaylistTrack(ctx, pls.Path, path)
+				recordMissingPlaylistTrack(ctx, pls.Name, path)
 			}
 		}
 	}
@@ -302,40 +303,93 @@ func normalizePathForComparison(path string) string {
 	return strings.ToLower(norm.NFC.String(path))
 }
 
-func recordMissingPlaylistTrack(ctx context.Context, playlistPath, trackPath string) {
-	if trackPath == "" || conf.Server.DataFolder == "" {
+func recordMissingPlaylistTrack(ctx context.Context, playlistName, trackPath string) {
+	if trackPath == "" {
 		return
 	}
 
-	dbFile := filepath.Join(conf.Server.DataFolder, "missing_tracks.db")
-	dsn := fmt.Sprintf("file:%s?_busy_timeout=5000&_journal_mode=WAL", filepath.ToSlash(dbFile))
+	dbPath := conf.Server.DbPath
+	if dbPath == "" {
+		if conf.Server.DataFolder == "" {
+			return
+		}
+		dbPath = filepath.Join(conf.Server.DataFolder, consts.DefaultDbPath)
+	}
 
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := sql.Open("sqlite3", dbPath)
 	if err != nil {
-		log.Debug(ctx, "Unable to open missing tracks database", "path", dbFile, "err", err)
+		log.Debug(ctx, "Unable to open database for missing tracks", "path", dbPath, "err", err)
 		return
 	}
 	defer db.Close()
 
-	if _, err := db.Exec(`PRAGMA journal_mode=WAL`); err != nil {
-		log.Debug(ctx, "Unable to enable WAL for missing tracks database", "path", dbFile, "err", err)
-		return
-	}
-
-	_, err = db.Exec(`
+	const createTableSQL = `
 CREATE TABLE IF NOT EXISTS missing_playlist_tracks (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        playlist_id TEXT,
-        track_path TEXT,
-        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-)`)
-	if err != nil {
-		log.Debug(ctx, "Unable to ensure missing tracks table", "path", dbFile, "err", err)
+        track_path TEXT PRIMARY KEY,
+        playlists TEXT NOT NULL,
+        time_added TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+)`
+
+	if _, err := db.Exec(createTableSQL); err != nil {
+		log.Debug(ctx, "Unable to ensure missing tracks table", "path", dbPath, "err", err)
 		return
 	}
 
-	if _, err := db.Exec(`INSERT INTO missing_playlist_tracks (playlist_id, track_path) VALUES (?, ?)`, playlistPath, trackPath); err != nil {
-		log.Debug(ctx, "Unable to record missing track", "path", dbFile, "err", err)
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		log.Debug(ctx, "Unable to begin transaction for missing track", "path", dbPath, "err", err)
+		return
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var existingPlaylistsJSON sql.NullString
+	err = tx.QueryRowContext(ctx, `SELECT playlists FROM missing_playlist_tracks WHERE track_path = ?`, trackPath).Scan(&existingPlaylistsJSON)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		log.Debug(ctx, "Unable to query existing missing track", "path", dbPath, "track", trackPath, "err", err)
+		return
+	}
+
+	playlists := []string{}
+	if existingPlaylistsJSON.Valid {
+		if err := json.Unmarshal([]byte(existingPlaylistsJSON.String), &playlists); err != nil {
+			log.Debug(ctx, "Unable to unmarshal stored playlists", "path", dbPath, "track", trackPath, "err", err)
+			playlists = []string{}
+		}
+	}
+
+	if playlistName != "" {
+		found := false
+		for _, p := range playlists {
+			if p == playlistName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			playlists = append(playlists, playlistName)
+		}
+	}
+
+	playlistsJSON, err := json.Marshal(playlists)
+	if err != nil {
+		log.Debug(ctx, "Unable to marshal playlists for missing track", "path", dbPath, "track", trackPath, "err", err)
+		return
+	}
+
+	if existingPlaylistsJSON.Valid {
+		if _, err := tx.ExecContext(ctx, `UPDATE missing_playlist_tracks SET playlists = ?, time_added = CURRENT_TIMESTAMP WHERE track_path = ?`, string(playlistsJSON), trackPath); err != nil {
+			log.Debug(ctx, "Unable to update missing track entry", "path", dbPath, "track", trackPath, "err", err)
+			return
+		}
+	} else {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO missing_playlist_tracks (track_path, playlists) VALUES (?, ?)`, trackPath, string(playlistsJSON)); err != nil {
+			log.Debug(ctx, "Unable to record missing track", "path", dbPath, "track", trackPath, "err", err)
+			return
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		log.Debug(ctx, "Unable to commit missing track entry", "path", dbPath, "track", trackPath, "err", err)
 	}
 }
 

--- a/core/playlists.go
+++ b/core/playlists.go
@@ -283,7 +283,7 @@ func (s *playlists) parseM3U(ctx context.Context, pls *model.Playlist, folder *m
 				mfs = append(mfs, found[idx])
 			} else {
 				log.Warn(ctx, "Path in playlist not found", "playlist", pls.Name, "path", path)
-				s.recordMissingPlaylistTrack(ctx, pls.Name, path)
+				s.recordMissingPlaylistTrack(ctx, pls, path)
 			}
 		}
 	}
@@ -303,7 +303,7 @@ func normalizePathForComparison(path string) string {
 	return strings.ToLower(norm.NFC.String(path))
 }
 
-func (s *playlists) recordMissingPlaylistTrack(ctx context.Context, playlistName, trackPath string) {
+func (s *playlists) recordMissingPlaylistTrack(ctx context.Context, playlist *model.Playlist, trackPath string) {
 	if trackPath == "" {
 		return
 	}
@@ -329,15 +329,7 @@ func (s *playlists) recordMissingPlaylistTrack(ctx context.Context, playlistName
 	}
 	defer db.Close()
 
-	const createTableSQL = `
-CREATE TABLE IF NOT EXISTS missing_playlist_tracks (
-        track_path TEXT PRIMARY KEY,
-        playlists TEXT NOT NULL,
-        time_added TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-)`
-
-	if _, err := db.Exec(createTableSQL); err != nil {
-		log.Debug(ctx, "Unable to ensure missing tracks table", "path", dbPath, "err", err)
+	if err := ensureMissingTracksSchema(ctx, db, dbPath); err != nil {
 		return
 	}
 
@@ -348,32 +340,25 @@ CREATE TABLE IF NOT EXISTS missing_playlist_tracks (
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	var existingPlaylistsJSON sql.NullString
-	err = tx.QueryRowContext(ctx, `SELECT playlists FROM missing_playlist_tracks WHERE track_path = ?`, trackPath).Scan(&existingPlaylistsJSON)
+	var (
+		existingPlaylistsJSON sql.NullString
+		existingPathsJSON     sql.NullString
+	)
+
+	err = tx.QueryRowContext(ctx, `SELECT playlists, playlist_paths FROM missing_playlist_tracks WHERE track_path = ?`, trackPath).Scan(&existingPlaylistsJSON, &existingPathsJSON)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Debug(ctx, "Unable to query existing missing track", "path", dbPath, "track", trackPath, "err", err)
 		return
 	}
 
-	playlists := []string{}
-	if existingPlaylistsJSON.Valid {
-		if err := json.Unmarshal([]byte(existingPlaylistsJSON.String), &playlists); err != nil {
-			log.Debug(ctx, "Unable to unmarshal stored playlists", "path", dbPath, "track", trackPath, "err", err)
-			playlists = []string{}
-		}
-	}
+	playlists := decodeStoredStringArray(existingPlaylistsJSON)
+	playlistPaths := decodeStoredStringArray(existingPathsJSON)
 
-	if playlistName != "" {
-		found := false
-		for _, p := range playlists {
-			if p == playlistName {
-				found = true
-				break
-			}
-		}
-		if !found {
-			playlists = append(playlists, playlistName)
-		}
+	if name := playlistNameForStorage(playlist); name != "" {
+		playlists = appendIfMissing(playlists, name)
+	}
+	if p := playlistPathForStorage(playlist); p != "" {
+		playlistPaths = appendIfMissing(playlistPaths, p)
 	}
 
 	playlistsJSON, err := json.Marshal(playlists)
@@ -381,14 +366,19 @@ CREATE TABLE IF NOT EXISTS missing_playlist_tracks (
 		log.Debug(ctx, "Unable to marshal playlists for missing track", "path", dbPath, "track", trackPath, "err", err)
 		return
 	}
+	playlistPathsJSON, err := json.Marshal(playlistPaths)
+	if err != nil {
+		log.Debug(ctx, "Unable to marshal playlist paths for missing track", "path", dbPath, "track", trackPath, "err", err)
+		return
+	}
 
-	if existingPlaylistsJSON.Valid {
-		if _, err := tx.ExecContext(ctx, `UPDATE missing_playlist_tracks SET playlists = ?, time_added = CURRENT_TIMESTAMP WHERE track_path = ?`, string(playlistsJSON), trackPath); err != nil {
+	if existingPlaylistsJSON.Valid || existingPathsJSON.Valid {
+		if _, err := tx.ExecContext(ctx, `UPDATE missing_playlist_tracks SET playlists = ?, playlist_paths = ?, time_added = CURRENT_TIMESTAMP WHERE track_path = ?`, string(playlistsJSON), string(playlistPathsJSON), trackPath); err != nil {
 			log.Debug(ctx, "Unable to update missing track entry", "path", dbPath, "track", trackPath, "err", err)
 			return
 		}
 	} else {
-		if _, err := tx.ExecContext(ctx, `INSERT INTO missing_playlist_tracks (track_path, playlists) VALUES (?, ?)`, trackPath, string(playlistsJSON)); err != nil {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO missing_playlist_tracks (track_path, playlists, playlist_paths) VALUES (?, ?, ?)`, trackPath, string(playlistsJSON), string(playlistPathsJSON)); err != nil {
 			log.Debug(ctx, "Unable to record missing track", "path", dbPath, "track", trackPath, "err", err)
 			return
 		}
@@ -434,6 +424,110 @@ func (s *playlists) trackExistsInLibraries(ctx context.Context, trackPath string
 	}
 
 	return false
+}
+
+func ensureMissingTracksSchema(ctx context.Context, db *sql.DB, dbPath string) error {
+	const createTableSQL = `
+CREATE TABLE IF NOT EXISTS missing_playlist_tracks (
+        track_path TEXT PRIMARY KEY,
+        playlists TEXT NOT NULL,
+        playlist_paths TEXT NOT NULL DEFAULT '[]',
+        time_added TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+)`
+
+	if _, err := db.Exec(createTableSQL); err != nil {
+		log.Debug(ctx, "Unable to ensure missing tracks table", "path", dbPath, "err", err)
+		return err
+	}
+
+	hasColumn, err := tableHasColumn(db, "missing_playlist_tracks", "playlist_paths")
+	if err != nil {
+		log.Debug(ctx, "Unable to inspect missing tracks table", "path", dbPath, "err", err)
+		return err
+	}
+	if !hasColumn {
+		if _, err := db.Exec(`ALTER TABLE missing_playlist_tracks ADD COLUMN playlist_paths TEXT NOT NULL DEFAULT '[]'`); err != nil {
+			if !strings.Contains(strings.ToLower(err.Error()), "duplicate column") {
+				log.Debug(ctx, "Unable to add playlist_paths column", "path", dbPath, "err", err)
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func tableHasColumn(db *sql.DB, table, column string) (bool, error) {
+	query := fmt.Sprintf("PRAGMA table_info(%s)", table)
+	rows, err := db.Query(query)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			cid        int
+			name       string
+			columnType string
+			notNull    int
+			dfltValue  sql.NullString
+			pk         int
+		)
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &dfltValue, &pk); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+func decodeStoredStringArray(value sql.NullString) []string {
+	if !value.Valid {
+		return []string{}
+	}
+	raw := strings.TrimSpace(value.String)
+	if raw == "" {
+		return []string{}
+	}
+
+	var out []string
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return []string{}
+	}
+	return out
+}
+
+func playlistNameForStorage(playlist *model.Playlist) string {
+	if playlist == nil {
+		return ""
+	}
+	return strings.TrimSpace(playlist.Name)
+}
+
+func playlistPathForStorage(playlist *model.Playlist) string {
+	if playlist == nil {
+		return ""
+	}
+	path := strings.TrimSpace(playlist.Path)
+	if path == "" {
+		return ""
+	}
+	cleaned := filepath.Clean(path)
+	if cleaned == "." {
+		return ""
+	}
+	return filepath.ToSlash(cleaned)
+}
+
+func appendIfMissing(items []string, value string) []string {
+	for _, existing := range items {
+		if existing == value {
+			return items
+		}
+	}
+	return append(items, value)
 }
 
 func cleanupLegacyMissingTracksDB(ctx context.Context, dbPath string) {
@@ -549,7 +643,7 @@ func (s *playlists) normalizePaths(ctx context.Context, pls *model.Playlist, fol
 			res = append(res, relPath)
 		} else {
 			log.Warn(ctx, "Path in playlist not found in any library", "path", line, "line", idx)
-			s.recordMissingPlaylistTrack(ctx, pls.Path, line)
+			s.recordMissingPlaylistTrack(ctx, pls, line)
 		}
 	}
 	return slice.Map(res, filepath.ToSlash), nil

--- a/core/playlists.go
+++ b/core/playlists.go
@@ -283,7 +283,7 @@ func (s *playlists) parseM3U(ctx context.Context, pls *model.Playlist, folder *m
 				mfs = append(mfs, found[idx])
 			} else {
 				log.Warn(ctx, "Path in playlist not found", "playlist", pls.Name, "path", path)
-				recordMissingPlaylistTrack(ctx, pls.Name, path)
+				s.recordMissingPlaylistTrack(ctx, pls.Name, path)
 			}
 		}
 	}
@@ -303,8 +303,12 @@ func normalizePathForComparison(path string) string {
 	return strings.ToLower(norm.NFC.String(path))
 }
 
-func recordMissingPlaylistTrack(ctx context.Context, playlistName, trackPath string) {
+func (s *playlists) recordMissingPlaylistTrack(ctx context.Context, playlistName, trackPath string) {
 	if trackPath == "" {
+		return
+	}
+
+	if s.trackExistsInLibraries(ctx, trackPath) {
 		return
 	}
 
@@ -393,6 +397,43 @@ CREATE TABLE IF NOT EXISTS missing_playlist_tracks (
 	if err := tx.Commit(); err != nil {
 		log.Debug(ctx, "Unable to commit missing track entry", "path", dbPath, "track", trackPath, "err", err)
 	}
+}
+
+func (s *playlists) trackExistsInLibraries(ctx context.Context, trackPath string) bool {
+	if s == nil || s.ds == nil {
+		return false
+	}
+
+	libs, err := s.ds.Library(ctx).GetAll()
+	if err != nil {
+		log.Debug(ctx, "Unable to list libraries for missing track check", "err", err)
+		return false
+	}
+
+	cleaned := filepath.Clean(filepath.FromSlash(trackPath))
+
+	for _, lib := range libs {
+		libPath := filepath.Clean(lib.Path)
+		if libPath == "" {
+			continue
+		}
+
+		if filepath.IsAbs(cleaned) {
+			if strings.HasPrefix(cleaned, libPath+string(os.PathSeparator)) || cleaned == libPath {
+				if info, err := os.Stat(cleaned); err == nil && !info.IsDir() {
+					return true
+				}
+			}
+			continue
+		}
+
+		candidate := filepath.Join(libPath, cleaned)
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return true
+		}
+	}
+
+	return false
 }
 
 func cleanupLegacyMissingTracksDB(ctx context.Context, dbPath string) {
@@ -508,7 +549,7 @@ func (s *playlists) normalizePaths(ctx context.Context, pls *model.Playlist, fol
 			res = append(res, relPath)
 		} else {
 			log.Warn(ctx, "Path in playlist not found in any library", "path", line, "line", idx)
-			recordMissingPlaylistTrack(ctx, pls.Path, line)
+			s.recordMissingPlaylistTrack(ctx, pls.Path, line)
 		}
 	}
 	return slice.Map(res, filepath.ToSlash), nil

--- a/core/playlists_test.go
+++ b/core/playlists_test.go
@@ -161,6 +161,35 @@ var _ = Describe("Playlists", func() {
 				Expect(updatedTime.After(initialTime)).To(BeTrue())
 			})
 
+			It("removes legacy missing tracks databases", func() {
+				DeferCleanup(configtest.SetupConfig())
+
+				dataDir := GinkgoT().TempDir()
+				conf.Server.DataFolder = dataDir
+				conf.Server.DbPath = filepath.Join(conf.Server.DataFolder, consts.DefaultDbPath)
+
+				dbFilePath := conf.Server.DbPath
+				if idx := strings.Index(dbFilePath, "?"); idx >= 0 {
+					dbFilePath = dbFilePath[:idx]
+				}
+				_ = os.Remove(dbFilePath)
+
+				legacyDB := filepath.Join(dataDir, "missing_tracks.db")
+				legacyWal := legacyDB + "-wal"
+				legacyShm := legacyDB + "-shm"
+
+				Expect(os.WriteFile(legacyDB, []byte("legacy"), 0644)).To(Succeed())
+				Expect(os.WriteFile(legacyWal, []byte("wal"), 0644)).To(Succeed())
+				Expect(os.WriteFile(legacyShm, []byte("shm"), 0644)).To(Succeed())
+
+				recordMissingPlaylistTrack(ctx, "Playlist A", "missing-track.mp3")
+
+				Expect(legacyDB).ToNot(BeAnExistingFile())
+				Expect(legacyWal).ToNot(BeAnExistingFile())
+				Expect(legacyShm).ToNot(BeAnExistingFile())
+				Expect(dbFilePath).To(BeAnExistingFile())
+			})
+
 			It("locates tracks from music library when playlist lives in playlists folder", func() {
 				DeferCleanup(configtest.SetupConfig())
 

--- a/core/playlists_test.go
+++ b/core/playlists_test.go
@@ -130,7 +130,8 @@ var _ = Describe("Playlists", func() {
 
 				track := "missing-track.mp3"
 
-				recordMissingPlaylistTrack(ctx, "Playlist A", track)
+				psImpl := ps.(*playlists)
+				psImpl.recordMissingPlaylistTrack(ctx, "Playlist A", track)
 
 				db, err := sql.Open("sqlite3", conf.Server.DbPath)
 				Expect(err).ToNot(HaveOccurred())
@@ -144,7 +145,7 @@ var _ = Describe("Playlists", func() {
 
 				time.Sleep(time.Second)
 
-				recordMissingPlaylistTrack(ctx, "Playlist B", track)
+				psImpl.recordMissingPlaylistTrack(ctx, "Playlist B", track)
 
 				var (
 					updatedJSON string
@@ -182,7 +183,8 @@ var _ = Describe("Playlists", func() {
 				Expect(os.WriteFile(legacyWal, []byte("wal"), 0644)).To(Succeed())
 				Expect(os.WriteFile(legacyShm, []byte("shm"), 0644)).To(Succeed())
 
-				recordMissingPlaylistTrack(ctx, "Playlist A", "missing-track.mp3")
+				psImpl := ps.(*playlists)
+				psImpl.recordMissingPlaylistTrack(ctx, "Playlist A", "missing-track.mp3")
 
 				Expect(legacyDB).ToNot(BeAnExistingFile())
 				Expect(legacyWal).ToNot(BeAnExistingFile())
@@ -346,6 +348,48 @@ var _ = Describe("Playlists", func() {
 			Expect(pls.Tracks[2].Path).To(Equal("downloads/newfile.flac"))
 			Expect(pls.Tracks[3].Path).To(Equal("tests/01 Invisible (RED) Edit Version.mp3"))
 			Expect(mockPlsRepo.last).To(Equal(pls))
+		})
+
+		It("does not record missing tracks when files exist on disk", func() {
+			DeferCleanup(configtest.SetupConfig())
+
+			root := GinkgoT().TempDir()
+			musicDir := filepath.Join(root, "music")
+			Expect(os.MkdirAll(musicDir, 0755)).To(Succeed())
+
+			conf.Server.DataFolder = filepath.Join(root, "data")
+			Expect(os.MkdirAll(conf.Server.DataFolder, 0755)).To(Succeed())
+			conf.Server.DbPath = filepath.Join(conf.Server.DataFolder, consts.DefaultDbPath)
+
+			existingTrack := filepath.Join(musicDir, "existing-track.mp3")
+			Expect(os.WriteFile(existingTrack, []byte("test"), 0644)).To(Succeed())
+
+			mockLibRepo.SetData([]model.Library{{ID: 1, Path: musicDir}})
+
+			repo := &mockedMediaFileFromListRepo{}
+			ds.MockedMediaFile = repo
+			ps = NewPlaylists(ds)
+
+			playlist := strings.Join([]string{"existing-track.mp3"}, "\n")
+			_, err := ps.ImportM3U(ctx, strings.NewReader(playlist))
+			Expect(err).ToNot(HaveOccurred())
+
+			dbFilePath := conf.Server.DbPath
+			if idx := strings.Index(dbFilePath, "?"); idx >= 0 {
+				dbFilePath = dbFilePath[:idx]
+			}
+
+			if _, err := os.Stat(dbFilePath); os.IsNotExist(err) {
+				return
+			}
+
+			db, err := sql.Open("sqlite3", conf.Server.DbPath)
+			Expect(err).ToNot(HaveOccurred())
+			defer db.Close()
+
+			var count int
+			scanErr := db.QueryRow(`SELECT COUNT(*) FROM missing_playlist_tracks`).Scan(&count)
+			Expect(scanErr).To(HaveOccurred())
 		})
 
 		It("sets the playlist name as a timestamp if the #PLAYLIST directive is not present", func() {

--- a/core/playlists_test.go
+++ b/core/playlists_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
+	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/criteria"
 	"github.com/navidrome/navidrome/model/request"
@@ -77,35 +79,86 @@ var _ = Describe("Playlists", func() {
 				Expect(pls.Tracks).To(HaveLen(2))
 			})
 
-			It("records missing tracks in a separate database", func() {
+			It("records missing tracks in the main database", func() {
 				DeferCleanup(configtest.SetupConfig())
 
 				dataDir := GinkgoT().TempDir()
 				conf.Server.DataFolder = dataDir
+				conf.Server.DbPath = filepath.Join(conf.Server.DataFolder, consts.DefaultDbPath)
 
 				playlistName := "missing-log.m3u"
 				playlistPath := filepath.Join(folder.AbsolutePath(), playlistName)
 				Expect(os.WriteFile(playlistPath, []byte("missing-track.mp3\n"), 0644)).To(Succeed())
 				DeferCleanup(func() { _ = os.Remove(playlistPath) })
 
-				dbPath := filepath.Join(conf.Server.DataFolder, "missing_tracks.db")
-				_ = os.Remove(dbPath)
+				dbFilePath := conf.Server.DbPath
+				if idx := strings.Index(dbFilePath, "?"); idx >= 0 {
+					dbFilePath = dbFilePath[:idx]
+				}
+				_ = os.Remove(dbFilePath)
 
 				_, err := ps.ImportFile(ctx, folder, playlistName)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(dbPath).To(BeAnExistingFile())
+				Expect(dbFilePath).To(BeAnExistingFile())
 
-				dsn := "file:" + filepath.ToSlash(dbPath) + "?_journal_mode=WAL"
-				db, err := sql.Open("sqlite3", dsn)
+				db, err := sql.Open("sqlite3", conf.Server.DbPath)
 				Expect(err).ToNot(HaveOccurred())
 				defer db.Close()
 
-				row := db.QueryRow(`SELECT playlist_id, track_path FROM missing_playlist_tracks LIMIT 1`)
-				var playlistID, trackPath string
-				Expect(row.Scan(&playlistID, &trackPath)).To(Succeed())
-				Expect(playlistID).To(Equal(playlistPath))
+				row := db.QueryRow(`SELECT playlists, track_path FROM missing_playlist_tracks LIMIT 1`)
+				var playlistsJSON, trackPath string
+				Expect(row.Scan(&playlistsJSON, &trackPath)).To(Succeed())
+				var playlists []string
+				Expect(json.Unmarshal([]byte(playlistsJSON), &playlists)).To(Succeed())
+				Expect(playlists).To(ContainElement("missing-log"))
 				Expect(trackPath).To(Equal("missing-track.mp3"))
+			})
+
+			It("tracks multiple playlists and refreshes the timestamp", func() {
+				DeferCleanup(configtest.SetupConfig())
+
+				dataDir := GinkgoT().TempDir()
+				conf.Server.DataFolder = dataDir
+				conf.Server.DbPath = filepath.Join(conf.Server.DataFolder, consts.DefaultDbPath)
+
+				dbFilePath := conf.Server.DbPath
+				if idx := strings.Index(dbFilePath, "?"); idx >= 0 {
+					dbFilePath = dbFilePath[:idx]
+				}
+				_ = os.Remove(dbFilePath)
+
+				track := "missing-track.mp3"
+
+				recordMissingPlaylistTrack(ctx, "Playlist A", track)
+
+				db, err := sql.Open("sqlite3", conf.Server.DbPath)
+				Expect(err).ToNot(HaveOccurred())
+				defer db.Close()
+
+				var (
+					initialJSON string
+					initialTime time.Time
+				)
+				Expect(db.QueryRow(`SELECT playlists, time_added FROM missing_playlist_tracks WHERE track_path = ?`, track).Scan(&initialJSON, &initialTime)).To(Succeed())
+
+				time.Sleep(time.Second)
+
+				recordMissingPlaylistTrack(ctx, "Playlist B", track)
+
+				var (
+					updatedJSON string
+					updatedTime time.Time
+				)
+				Expect(db.QueryRow(`SELECT playlists, time_added FROM missing_playlist_tracks WHERE track_path = ?`, track).Scan(&updatedJSON, &updatedTime)).To(Succeed())
+
+				var initialPlaylists, updatedPlaylists []string
+				Expect(json.Unmarshal([]byte(initialJSON), &initialPlaylists)).To(Succeed())
+				Expect(json.Unmarshal([]byte(updatedJSON), &updatedPlaylists)).To(Succeed())
+
+				Expect(initialPlaylists).To(ConsistOf("Playlist A"))
+				Expect(updatedPlaylists).To(ConsistOf("Playlist A", "Playlist B"))
+				Expect(updatedTime.After(initialTime)).To(BeTrue())
 			})
 
 			It("locates tracks from music library when playlist lives in playlists folder", func() {

--- a/core/playlists_test.go
+++ b/core/playlists_test.go
@@ -106,12 +106,16 @@ var _ = Describe("Playlists", func() {
 				Expect(err).ToNot(HaveOccurred())
 				defer db.Close()
 
-				row := db.QueryRow(`SELECT playlists, track_path FROM missing_playlist_tracks LIMIT 1`)
-				var playlistsJSON, trackPath string
-				Expect(row.Scan(&playlistsJSON, &trackPath)).To(Succeed())
-				var playlists []string
+				row := db.QueryRow(`SELECT playlists, playlist_paths, track_path FROM missing_playlist_tracks LIMIT 1`)
+				var playlistsJSON, playlistPathsJSON, trackPath string
+				Expect(row.Scan(&playlistsJSON, &playlistPathsJSON, &trackPath)).To(Succeed())
+
+				var playlists, playlistPaths []string
 				Expect(json.Unmarshal([]byte(playlistsJSON), &playlists)).To(Succeed())
+				Expect(json.Unmarshal([]byte(playlistPathsJSON), &playlistPaths)).To(Succeed())
+
 				Expect(playlists).To(ContainElement("missing-log"))
+				Expect(playlistPaths).To(ContainElement(filepath.ToSlash(playlistPath)))
 				Expect(trackPath).To(Equal("missing-track.mp3"))
 			})
 
@@ -131,34 +135,45 @@ var _ = Describe("Playlists", func() {
 				track := "missing-track.mp3"
 
 				psImpl := ps.(*playlists)
-				psImpl.recordMissingPlaylistTrack(ctx, "Playlist A", track)
+				playlistA := &model.Playlist{Name: "Playlist A", Path: filepath.Join(dataDir, "Playlist A.m3u")}
+				psImpl.recordMissingPlaylistTrack(ctx, playlistA, track)
 
 				db, err := sql.Open("sqlite3", conf.Server.DbPath)
 				Expect(err).ToNot(HaveOccurred())
 				defer db.Close()
 
 				var (
-					initialJSON string
-					initialTime time.Time
+					initialJSON  string
+					initialPaths string
+					initialTime  time.Time
 				)
-				Expect(db.QueryRow(`SELECT playlists, time_added FROM missing_playlist_tracks WHERE track_path = ?`, track).Scan(&initialJSON, &initialTime)).To(Succeed())
+				Expect(db.QueryRow(`SELECT playlists, playlist_paths, time_added FROM missing_playlist_tracks WHERE track_path = ?`, track).Scan(&initialJSON, &initialPaths, &initialTime)).To(Succeed())
 
 				time.Sleep(time.Second)
 
-				psImpl.recordMissingPlaylistTrack(ctx, "Playlist B", track)
+				playlistB := &model.Playlist{Name: "Playlist B", Path: filepath.Join(dataDir, "Playlist B.m3u")}
+				psImpl.recordMissingPlaylistTrack(ctx, playlistB, track)
 
 				var (
-					updatedJSON string
-					updatedTime time.Time
+					updatedJSON  string
+					updatedPaths string
+					updatedTime  time.Time
 				)
-				Expect(db.QueryRow(`SELECT playlists, time_added FROM missing_playlist_tracks WHERE track_path = ?`, track).Scan(&updatedJSON, &updatedTime)).To(Succeed())
+				Expect(db.QueryRow(`SELECT playlists, playlist_paths, time_added FROM missing_playlist_tracks WHERE track_path = ?`, track).Scan(&updatedJSON, &updatedPaths, &updatedTime)).To(Succeed())
 
-				var initialPlaylists, updatedPlaylists []string
+				var initialPlaylists, updatedPlaylists, initialPlaylistPaths, updatedPlaylistPaths []string
 				Expect(json.Unmarshal([]byte(initialJSON), &initialPlaylists)).To(Succeed())
 				Expect(json.Unmarshal([]byte(updatedJSON), &updatedPlaylists)).To(Succeed())
+				Expect(json.Unmarshal([]byte(initialPaths), &initialPlaylistPaths)).To(Succeed())
+				Expect(json.Unmarshal([]byte(updatedPaths), &updatedPlaylistPaths)).To(Succeed())
 
 				Expect(initialPlaylists).To(ConsistOf("Playlist A"))
 				Expect(updatedPlaylists).To(ConsistOf("Playlist A", "Playlist B"))
+				Expect(initialPlaylistPaths).To(ConsistOf(filepath.ToSlash(playlistA.Path)))
+				Expect(updatedPlaylistPaths).To(ConsistOf(
+					filepath.ToSlash(playlistA.Path),
+					filepath.ToSlash(playlistB.Path),
+				))
 				Expect(updatedTime.After(initialTime)).To(BeTrue())
 			})
 
@@ -184,12 +199,48 @@ var _ = Describe("Playlists", func() {
 				Expect(os.WriteFile(legacyShm, []byte("shm"), 0644)).To(Succeed())
 
 				psImpl := ps.(*playlists)
-				psImpl.recordMissingPlaylistTrack(ctx, "Playlist A", "missing-track.mp3")
+				playlist := &model.Playlist{Name: "Playlist A", Path: filepath.Join(dataDir, "Playlist A.m3u")}
+				psImpl.recordMissingPlaylistTrack(ctx, playlist, "missing-track.mp3")
 
 				Expect(legacyDB).ToNot(BeAnExistingFile())
 				Expect(legacyWal).ToNot(BeAnExistingFile())
 				Expect(legacyShm).ToNot(BeAnExistingFile())
 				Expect(dbFilePath).To(BeAnExistingFile())
+			})
+
+			It("upgrades legacy missing track tables with playlist paths", func() {
+				DeferCleanup(configtest.SetupConfig())
+
+				dataDir := GinkgoT().TempDir()
+				conf.Server.DataFolder = dataDir
+				conf.Server.DbPath = filepath.Join(conf.Server.DataFolder, consts.DefaultDbPath)
+
+				db, err := sql.Open("sqlite3", conf.Server.DbPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = db.Exec(`CREATE TABLE IF NOT EXISTS missing_playlist_tracks (
+        track_path TEXT PRIMARY KEY,
+        playlists TEXT NOT NULL,
+        time_added TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+)`)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(db.Close()).To(Succeed())
+
+				playlist := &model.Playlist{Name: "Legacy", Path: filepath.Join(dataDir, "Legacy.m3u")}
+				psImpl := ps.(*playlists)
+				psImpl.recordMissingPlaylistTrack(ctx, playlist, "missing-track.mp3")
+
+				db, err = sql.Open("sqlite3", conf.Server.DbPath)
+				Expect(err).ToNot(HaveOccurred())
+				defer db.Close()
+
+				row := db.QueryRow(`SELECT playlist_paths FROM missing_playlist_tracks WHERE track_path = ?`, "missing-track.mp3")
+				var playlistPathsJSON string
+				Expect(row.Scan(&playlistPathsJSON)).To(Succeed())
+
+				var playlistPaths []string
+				Expect(json.Unmarshal([]byte(playlistPathsJSON), &playlistPaths)).To(Succeed())
+				Expect(playlistPaths).To(ContainElement(filepath.ToSlash(playlist.Path)))
 			})
 
 			It("locates tracks from music library when playlist lives in playlists folder", func() {

--- a/server/nativeapi/notifications.go
+++ b/server/nativeapi/notifications.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -16,9 +18,11 @@ import (
 )
 
 type missingTrackNotification struct {
-	Title     string `json:"title"`
-	Artist    string `json:"artist"`
-	TrackPath string `json:"-"`
+	Title     string   `json:"title"`
+	Artist    string   `json:"artist"`
+	TrackPath string   `json:"-"`
+	Playlists []string `json:"playlists,omitempty"`
+	Folders   []string `json:"folders,omitempty"`
 }
 
 func (n *Router) addNotificationsRoute(r chi.Router) {
@@ -47,7 +51,7 @@ func (n *Router) handleMissingTrackNotifications() http.HandlerFunc {
 		}
 		defer db.Close()
 
-		rows, err := db.QueryContext(ctx, `SELECT track_path FROM missing_playlist_tracks ORDER BY time_added DESC LIMIT 200`)
+		rows, err := db.QueryContext(ctx, `SELECT track_path, playlists, playlist_paths FROM missing_playlist_tracks ORDER BY time_added DESC LIMIT 200`)
 		if err != nil {
 			if strings.Contains(err.Error(), "no such table") {
 				writeMissingTrackResponse(w, entries, ctx)
@@ -62,16 +66,25 @@ func (n *Router) handleMissingTrackNotifications() http.HandlerFunc {
 		entries = make([]missingTrackNotification, 0)
 
 		for rows.Next() {
-			var trackPath string
+			var (
+				trackPath         string
+				playlistsJSON     sql.NullString
+				playlistPathsJSON sql.NullString
+			)
 
-			if err := rows.Scan(&trackPath); err != nil {
+			if err := rows.Scan(&trackPath, &playlistsJSON, &playlistPathsJSON); err != nil {
 				log.Warn(ctx, "Unable to scan missing track notification", "path", dbPath, "err", err)
 				continue
 			}
 
+			playlists := decodeNotificationArray(playlistsJSON.String)
+			playlistPaths := decodeNotificationArray(playlistPathsJSON.String)
+
 			entries = append(entries, missingTrackNotification{
 				Title:     deriveTrackName(trackPath),
 				TrackPath: trackPath,
+				Playlists: playlists,
+				Folders:   derivePlaylistFolders(playlistPaths),
 			})
 		}
 
@@ -152,4 +165,83 @@ func populateTrackMetadata(ctx context.Context, db *sql.DB, track *missingTrackN
 	if artist.Valid {
 		track.Artist = artist.String
 	}
+}
+
+func decodeNotificationArray(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+
+	var values []string
+	if err := json.Unmarshal([]byte(raw), &values); err != nil {
+		return nil
+	}
+	return values
+}
+
+func derivePlaylistFolders(paths []string) []string {
+	if len(paths) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(paths))
+	folders := make([]string, 0, len(paths))
+	for _, p := range paths {
+		folder := displayFolderFromPlaylistPath(p)
+		if folder == "" {
+			continue
+		}
+		if _, ok := seen[folder]; ok {
+			continue
+		}
+		seen[folder] = struct{}{}
+		folders = append(folders, folder)
+	}
+	sort.Strings(folders)
+	return folders
+}
+
+func displayFolderFromPlaylistPath(path string) string {
+	cleaned := strings.TrimSpace(path)
+	if cleaned == "" {
+		return ""
+	}
+
+	cleaned = filepath.Clean(cleaned)
+	dir := filepath.Dir(cleaned)
+	if dir == "." || dir == "" {
+		return ""
+	}
+
+	dir = filepath.Clean(dir)
+
+	if conf.Server.PlaylistsPath != "" {
+		for _, root := range strings.Split(conf.Server.PlaylistsPath, string(filepath.ListSeparator)) {
+			root = strings.TrimSpace(root)
+			if root == "" {
+				continue
+			}
+			root = strings.TrimSuffix(root, "**")
+			root = strings.TrimSuffix(root, string(os.PathSeparator))
+			absRoot, err := filepath.Abs(root)
+			if err != nil {
+				continue
+			}
+			rel, err := filepath.Rel(absRoot, dir)
+			if err == nil && !strings.HasPrefix(rel, "..") {
+				rel = filepath.ToSlash(rel)
+				if rel == "." {
+					return filepath.Base(dir)
+				}
+				return rel
+			}
+		}
+	}
+
+	base := filepath.Base(dir)
+	if base == "." || base == string(os.PathSeparator) || base == "" {
+		return filepath.ToSlash(dir)
+	}
+	return base
 }

--- a/server/nativeapi/notifications.go
+++ b/server/nativeapi/notifications.go
@@ -5,13 +5,13 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"path/filepath"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/log"
 )
 
@@ -30,33 +30,30 @@ func (n *Router) handleMissingTrackNotifications() http.HandlerFunc {
 		ctx := r.Context()
 		entries := []missingTrackNotification{}
 
-		if conf.Server.DataFolder == "" {
-			writeMissingTrackResponse(w, entries, ctx)
-			return
+		dbPath := conf.Server.DbPath
+		if dbPath == "" {
+			if conf.Server.DataFolder == "" {
+				writeMissingTrackResponse(w, entries, ctx)
+				return
+			}
+			dbPath = filepath.Join(conf.Server.DataFolder, consts.DefaultDbPath)
 		}
 
-		dbFile := filepath.Join(conf.Server.DataFolder, "missing_tracks.db")
-		dsn := fmt.Sprintf("file:%s?_busy_timeout=5000&_journal_mode=WAL", filepath.ToSlash(dbFile))
-
-		db, err := sql.Open("sqlite3", dsn)
+		db, err := sql.Open("sqlite3", dbPath)
 		if err != nil {
-			log.Warn(ctx, "Unable to open missing tracks database", "path", dbFile, "err", err)
+			log.Warn(ctx, "Unable to open database for missing tracks", "path", dbPath, "err", err)
 			writeMissingTrackResponse(w, entries, ctx)
 			return
 		}
 		defer db.Close()
 
-		if _, err := db.Exec(`PRAGMA journal_mode=WAL`); err != nil {
-			log.Debug(ctx, "Unable to enable WAL for missing tracks database", "path", dbFile, "err", err)
-		}
-
-		rows, err := db.QueryContext(ctx, `SELECT track_path FROM missing_playlist_tracks GROUP BY track_path ORDER BY MAX(created_at) DESC LIMIT 200`)
+		rows, err := db.QueryContext(ctx, `SELECT track_path FROM missing_playlist_tracks ORDER BY time_added DESC LIMIT 200`)
 		if err != nil {
 			if strings.Contains(err.Error(), "no such table") {
 				writeMissingTrackResponse(w, entries, ctx)
 				return
 			}
-			log.Error(ctx, "Unable to query missing tracks notifications", "path", dbFile, "err", err)
+			log.Error(ctx, "Unable to query missing tracks notifications", "path", dbPath, "err", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
@@ -68,7 +65,7 @@ func (n *Router) handleMissingTrackNotifications() http.HandlerFunc {
 			var trackPath string
 
 			if err := rows.Scan(&trackPath); err != nil {
-				log.Warn(ctx, "Unable to scan missing track notification", "path", dbFile, "err", err)
+				log.Warn(ctx, "Unable to scan missing track notification", "path", dbPath, "err", err)
 				continue
 			}
 
@@ -79,7 +76,7 @@ func (n *Router) handleMissingTrackNotifications() http.HandlerFunc {
 		}
 
 		if err := rows.Err(); err != nil {
-			log.Warn(ctx, "Error iterating missing track notifications", "path", dbFile, "err", err)
+			log.Warn(ctx, "Error iterating missing track notifications", "path", dbPath, "err", err)
 		}
 
 		if len(entries) > 0 {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -638,6 +638,7 @@
     "missingTracksEmpty": "No missing tracks recorded",
     "missingTracksSummary": "%{smart_count} song is missing from Playlist %{playlist} |||| %{smart_count} songs are missing from Playlist %{playlist}",
     "missingTracksImportedOn": " — imported on %{date}",
+    "missingTracksFoldersLabel": "Folders",
     "missingTracksUnknownPlaylist": "Unknown playlist",
     "missingTracksUnknownTitle": "Unknown track",
     "missingTracksUnknownArtist": "Unknown artist"

--- a/ui/src/layout/MissingTracksPanel.jsx
+++ b/ui/src/layout/MissingTracksPanel.jsx
@@ -109,11 +109,31 @@ const MissingTracksPanel = () => {
       }
       const rawTitle = (entry.title || '').trim()
       const rawArtist = (entry.artist || '').trim()
-      const title = rawTitle || translate('notifications.missingTracksUnknownTitle')
-      const unknownArtist = translate('notifications.missingTracksUnknownArtist').trim()
+      const title =
+        rawTitle || translate('notifications.missingTracksUnknownTitle')
+      const unknownArtist = translate(
+        'notifications.missingTracksUnknownArtist',
+      ).trim()
       const hasArtist =
-        rawArtist && rawArtist.toLocaleLowerCase() !== unknownArtist.toLocaleLowerCase()
+        rawArtist &&
+        rawArtist.toLocaleLowerCase() !== unknownArtist.toLocaleLowerCase()
       return hasArtist ? `${title} — ${rawArtist}` : title
+    },
+    [translate],
+  )
+
+  const getSecondaryLabel = useCallback(
+    (entry) => {
+      const folders = Array.isArray(entry?.folders)
+        ? entry.folders.filter(
+            (folder) => typeof folder === 'string' && folder.trim() !== '',
+          )
+        : []
+      if (folders.length === 0) {
+        return ''
+      }
+      const folderLabel = folders.join(', ')
+      return `${translate('notifications.missingTracksFoldersLabel')}: ${folderLabel}`
     },
     [translate],
   )
@@ -161,8 +181,18 @@ const MissingTracksPanel = () => {
             ) : (
               <List className={classes.list} dense>
                 {entries.map((entry, index) => (
-                  <ListItem key={`${entry.title || 'missing'}-${entry.artist || index}-${index}`} className={classes.listItem}>
-                    <ListItemText primary={getEntryLabel(entry)} />
+                  <ListItem
+                    key={`${entry.title || 'missing'}-${entry.artist || index}-${index}`}
+                    className={classes.listItem}
+                  >
+                    <ListItemText
+                      primary={getEntryLabel(entry)}
+                      secondary={getSecondaryLabel(entry)}
+                      secondaryTypographyProps={{
+                        variant: 'body2',
+                        color: 'textSecondary',
+                      }}
+                    />
                   </ListItem>
                 ))}
               </List>


### PR DESCRIPTION
## Summary
- persist missing playlist entries inside Navidrome's main SQLite database with a dedicated `missing_playlist_tracks` table that stores playlist names and refreshes timestamps
- surface missing track notifications from the shared table ordered by most recently updated entries
- cover the new persistence behaviour with tests that verify playlist aggregation and timestamp updates

## Testing
- go test ./core ./server/nativeapi *(fails: embed pattern build/3rdparty has no embeddable files)*

------
https://chatgpt.com/codex/tasks/task_e_68df22c2b9788330a290107046b8ca65