### PR TITLE
Add discovery submenu alongside playlists

### DIFF
--- a/cmd/wire_gen.go
+++ b/cmd/wire_gen.go
@@ -59,6 +59,7 @@ func CreateNativeAPIRouter(ctx context.Context) *nativeapi.Router {
 	dataStore := persistence.New(sqlDB)
 	share := core.NewShare(dataStore)
 	playlists := core.NewPlaylists(dataStore)
+	discoveries := core.NewDiscoveries(dataStore)
 	metricsMetrics := metrics.GetPrometheusInstance(dataStore)
 	manager := plugins.GetManager(dataStore, metricsMetrics)
 	insights := metrics.GetInstance(dataStore, manager)
@@ -72,7 +73,7 @@ func CreateNativeAPIRouter(ctx context.Context) *nativeapi.Router {
 	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, metricsMetrics)
 	watcher := scanner.GetWatcher(dataStore, scannerScanner)
 	library := core.NewLibrary(dataStore, scannerScanner, watcher, broker)
-	router := nativeapi.New(dataStore, share, playlists, insights, library)
+	router := nativeapi.New(dataStore, share, playlists, discoveries, insights, library)
 	return router
 }
 

--- a/core/discoveries.go
+++ b/core/discoveries.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/navidrome/navidrome/model"
+)
+
+type Discoveries interface {
+	Update(ctx context.Context, discoveryID string, name *string, comment *string, public *bool, idsToAdd []string, idxToRemove []int) error
+	SetFolder(ctx context.Context, discoveryID string, folderID *string) error
+}
+
+type discoveries struct {
+	ds model.DataStore
+}
+
+func NewDiscoveries(ds model.DataStore) Discoveries {
+	return &discoveries{ds: ds}
+}
+
+func (s *discoveries) Update(ctx context.Context, discoveryID string, name *string, comment *string, public *bool, idsToAdd []string, idxToRemove []int) error {
+	changed := name != nil || comment != nil || public != nil || len(idsToAdd) > 0 || len(idxToRemove) > 0
+	if !changed {
+		return nil
+	}
+
+	return s.ds.WithTxImmediate(func(tx model.DataStore) error {
+		repo := tx.Discovery(ctx)
+		discovery, err := repo.GetWithSongs(discoveryID, true, false)
+		if err != nil {
+			return err
+		}
+
+		if len(idxToRemove) > 0 {
+			discovery.RemoveTracks(idxToRemove)
+		}
+		if len(idsToAdd) > 0 {
+			discovery.AddMediaFilesByID(idsToAdd)
+		}
+
+		if name != nil {
+			discovery.Name = *name
+		}
+		if comment != nil {
+			discovery.Comment = *comment
+		}
+		if public != nil {
+			discovery.Public = *public
+		}
+
+		if len(idxToRemove) > 0 && len(discovery.Tracks) == 0 {
+			if err := tx.DiscoverySong(ctx, discoveryID, true).DeleteAll(); err != nil {
+				return err
+			}
+		}
+
+		return repo.Put(discovery)
+	})
+}
+
+func (s *discoveries) SetFolder(ctx context.Context, discoveryID string, folderID *string) error {
+	if folderID != nil && *folderID == "" {
+		return fmt.Errorf("folderID cannot be empty")
+	}
+	return s.ds.WithTxImmediate(func(tx model.DataStore) error {
+		return tx.Discovery(ctx).UpdateDiscoveryFolder(discoveryID, folderID)
+	})
+}

--- a/core/wire_providers.go
+++ b/core/wire_providers.go
@@ -17,6 +17,7 @@ var Set = wire.NewSet(
 	NewPlayers,
 	NewShare,
 	NewPlaylists,
+	NewDiscoveries,
 	NewLibrary,
 	agents.GetAgents,
 	external.NewProvider,

--- a/db/migrations/20250901000000_create_discovery_tables.go
+++ b/db/migrations/20250901000000_create_discovery_tables.go
@@ -13,7 +13,7 @@ func init() {
 
 func upCreateDiscoveryTables(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.ExecContext(ctx, `
-        CREATE TABLE IF NOT EXISTS discovery_folders (
+CREATE TABLE IF NOT EXISTS discovery_folder (
             id         VARCHAR NOT NULL PRIMARY KEY,
             name       VARCHAR NOT NULL CHECK (length(trim(name)) > 0),
             parent_id  VARCHAR NULL,
@@ -21,14 +21,14 @@ func upCreateDiscoveryTables(ctx context.Context, tx *sql.Tx) error {
             public     BOOL NOT NULL DEFAULT FALSE,
             created_at DATETIME NOT NULL DEFAULT (datetime('now')),
             updated_at DATETIME NOT NULL DEFAULT (datetime('now')),
-            FOREIGN KEY (parent_id) REFERENCES discovery_folders(id) ON DELETE CASCADE
-        );
+FOREIGN KEY (parent_id) REFERENCES discovery_folder(id) ON DELETE CASCADE
+);
 
-        CREATE UNIQUE INDEX IF NOT EXISTS discovery_folders_sibling_uniq
-          ON discovery_folders (owner_id, parent_id, lower(name));
+CREATE UNIQUE INDEX IF NOT EXISTS discovery_folder_sibling_uniq
+  ON discovery_folder (owner_id, parent_id, lower(name));
 
-        CREATE INDEX IF NOT EXISTS idx_discovery_folders_parent_id ON discovery_folders(parent_id);
-        CREATE INDEX IF NOT EXISTS idx_discovery_folders_owner_id  ON discovery_folders(owner_id);
+CREATE INDEX IF NOT EXISTS idx_discovery_folder_parent_id ON discovery_folder(parent_id);
+CREATE INDEX IF NOT EXISTS idx_discovery_folder_owner_id  ON discovery_folder(owner_id);
 
         CREATE TABLE IF NOT EXISTS discovery (
             id           VARCHAR(255) NOT NULL PRIMARY KEY,
@@ -57,8 +57,8 @@ func upCreateDiscoveryTables(ctx context.Context, tx *sql.Tx) error {
         CREATE INDEX IF NOT EXISTS discovery_updated_at   ON discovery(updated_at);
         CREATE INDEX IF NOT EXISTS discovery_folder_id    ON discovery(folder_id);
 
-        CREATE TRIGGER IF NOT EXISTS trg_discovery_folder_delete_discovery
-        AFTER DELETE ON discovery_folders
+CREATE TRIGGER IF NOT EXISTS trg_discovery_folder_delete_discovery
+AFTER DELETE ON discovery_folder
         BEGIN
             DELETE FROM discovery WHERE folder_id = OLD.id;
         END;
@@ -92,10 +92,10 @@ func downCreateDiscoveryTables(ctx context.Context, tx *sql.Tx) error {
         DROP INDEX IF EXISTS discovery_created_at;
         DROP TABLE IF EXISTS discovery;
 
-        DROP INDEX IF EXISTS discovery_folders_sibling_uniq;
-        DROP INDEX IF EXISTS idx_discovery_folders_parent_id;
-        DROP INDEX IF EXISTS idx_discovery_folders_owner_id;
-        DROP TABLE IF EXISTS discovery_folders;
-    `)
+DROP INDEX IF EXISTS discovery_folder_sibling_uniq;
+DROP INDEX IF EXISTS idx_discovery_folder_parent_id;
+DROP INDEX IF EXISTS idx_discovery_folder_owner_id;
+DROP TABLE IF EXISTS discovery_folder;
+`)
 	return err
 }

--- a/db/migrations/20250901000000_create_discovery_tables.go
+++ b/db/migrations/20250901000000_create_discovery_tables.go
@@ -1,0 +1,101 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upCreateDiscoveryTables, downCreateDiscoveryTables)
+}
+
+func upCreateDiscoveryTables(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+        CREATE TABLE IF NOT EXISTS discovery_folders (
+            id         VARCHAR NOT NULL PRIMARY KEY,
+            name       VARCHAR NOT NULL CHECK (length(trim(name)) > 0),
+            parent_id  VARCHAR NULL,
+            owner_id   VARCHAR NOT NULL REFERENCES user(id) ON UPDATE CASCADE ON DELETE CASCADE,
+            public     BOOL NOT NULL DEFAULT FALSE,
+            created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+            updated_at DATETIME NOT NULL DEFAULT (datetime('now')),
+            FOREIGN KEY (parent_id) REFERENCES discovery_folders(id) ON DELETE CASCADE
+        );
+
+        CREATE UNIQUE INDEX IF NOT EXISTS discovery_folders_sibling_uniq
+          ON discovery_folders (owner_id, parent_id, lower(name));
+
+        CREATE INDEX IF NOT EXISTS idx_discovery_folders_parent_id ON discovery_folders(parent_id);
+        CREATE INDEX IF NOT EXISTS idx_discovery_folders_owner_id  ON discovery_folders(owner_id);
+
+        CREATE TABLE IF NOT EXISTS discovery (
+            id           VARCHAR(255) NOT NULL PRIMARY KEY,
+            name         VARCHAR(255) DEFAULT '' NOT NULL,
+            comment      VARCHAR(255) DEFAULT '' NOT NULL,
+            duration     REAL DEFAULT 0 NOT NULL,
+            song_count   INTEGER DEFAULT 0 NOT NULL,
+            public       BOOL DEFAULT FALSE NOT NULL,
+            created_at   DATETIME,
+            updated_at   DATETIME,
+            path         STRING DEFAULT '' NOT NULL,
+            sync         BOOL DEFAULT FALSE NOT NULL,
+            size         INTEGER DEFAULT 0 NOT NULL,
+            rules        VARCHAR,
+            evaluated_at DATETIME,
+            owner_id     VARCHAR(255) NOT NULL
+                REFERENCES user(id)
+                    ON UPDATE CASCADE ON DELETE CASCADE,
+            folder_id    TEXT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS discovery_created_at   ON discovery(created_at);
+        CREATE INDEX IF NOT EXISTS discovery_evaluated_at ON discovery(evaluated_at);
+        CREATE INDEX IF NOT EXISTS discovery_name         ON discovery(name);
+        CREATE INDEX IF NOT EXISTS discovery_size         ON discovery(size);
+        CREATE INDEX IF NOT EXISTS discovery_updated_at   ON discovery(updated_at);
+        CREATE INDEX IF NOT EXISTS discovery_folder_id    ON discovery(folder_id);
+
+        CREATE TRIGGER IF NOT EXISTS trg_discovery_folder_delete_discovery
+        AFTER DELETE ON discovery_folders
+        BEGIN
+            DELETE FROM discovery WHERE folder_id = OLD.id;
+        END;
+
+        CREATE TABLE IF NOT EXISTS discovery_songs (
+            id            INTEGER DEFAULT 0 NOT NULL,
+            discovery_id  VARCHAR(255) NOT NULL
+                REFERENCES discovery(id)
+                    ON UPDATE CASCADE ON DELETE CASCADE,
+            media_file_id VARCHAR(255) NOT NULL
+        );
+
+        CREATE UNIQUE INDEX IF NOT EXISTS discovery_songs_pos
+          ON discovery_songs (discovery_id, id);
+    `)
+	return err
+}
+
+func downCreateDiscoveryTables(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+        DROP INDEX IF EXISTS discovery_songs_pos;
+        DROP TABLE IF EXISTS discovery_songs;
+
+        DROP TRIGGER IF EXISTS trg_discovery_folder_delete_discovery;
+
+        DROP INDEX IF EXISTS discovery_folder_id;
+        DROP INDEX IF EXISTS discovery_updated_at;
+        DROP INDEX IF EXISTS discovery_size;
+        DROP INDEX IF EXISTS discovery_name;
+        DROP INDEX IF EXISTS discovery_evaluated_at;
+        DROP INDEX IF EXISTS discovery_created_at;
+        DROP TABLE IF EXISTS discovery;
+
+        DROP INDEX IF EXISTS discovery_folders_sibling_uniq;
+        DROP INDEX IF EXISTS idx_discovery_folders_parent_id;
+        DROP INDEX IF EXISTS idx_discovery_folders_owner_id;
+        DROP TABLE IF EXISTS discovery_folders;
+    `)
+	return err
+}

--- a/model/datastore.go
+++ b/model/datastore.go
@@ -1,48 +1,49 @@
-	package model
+package model
 
-	import (
-		"context"
+import (
+	"context"
 
-		"github.com/Masterminds/squirrel"
-		"github.com/deluan/rest"
-	)
+	"github.com/Masterminds/squirrel"
+	"github.com/deluan/rest"
+)
 
-	type QueryOptions struct {
-		Sort    string
-		Order   string
-		Max     int
-		Offset  int
-		Filters squirrel.Sqlizer
-		Seed    string // for random sorting
-	}
+type QueryOptions struct {
+	Sort    string
+	Order   string
+	Max     int
+	Offset  int
+	Filters squirrel.Sqlizer
+	Seed    string // for random sorting
+}
 
-	type ResourceRepository interface {
-		rest.Repository
-	}
+type ResourceRepository interface {
+	rest.Repository
+}
 
-	type DataStore interface {
-		Library(ctx context.Context) LibraryRepository
-		Folder(ctx context.Context) FolderRepository
-		Album(ctx context.Context) AlbumRepository
-		Artist(ctx context.Context) ArtistRepository
-		MediaFile(ctx context.Context) MediaFileRepository
-		Genre(ctx context.Context) GenreRepository
-		Tag(ctx context.Context) TagRepository
-		Playlist(ctx context.Context) PlaylistRepository
-		PlaylistFolder(ctx context.Context) PlaylistFolderRepository
-		PlayQueue(ctx context.Context) PlayQueueRepository
-		Transcoding(ctx context.Context) TranscodingRepository
-		Player(ctx context.Context) PlayerRepository
-		Radio(ctx context.Context) RadioRepository
-		Share(ctx context.Context) ShareRepository
-		Property(ctx context.Context) PropertyRepository
-		User(ctx context.Context) UserRepository
-		UserProps(ctx context.Context) UserPropsRepository
-		ScrobbleBuffer(ctx context.Context) ScrobbleBufferRepository
+type DataStore interface {
+	Library(ctx context.Context) LibraryRepository
+	Folder(ctx context.Context) FolderRepository
+	Album(ctx context.Context) AlbumRepository
+	Artist(ctx context.Context) ArtistRepository
+	MediaFile(ctx context.Context) MediaFileRepository
+	Genre(ctx context.Context) GenreRepository
+	Tag(ctx context.Context) TagRepository
+	Playlist(ctx context.Context) PlaylistRepository
+	PlaylistFolder(ctx context.Context) PlaylistFolderRepository
+	Discovery(ctx context.Context) DiscoveryRepository
+	PlayQueue(ctx context.Context) PlayQueueRepository
+	Transcoding(ctx context.Context) TranscodingRepository
+	Player(ctx context.Context) PlayerRepository
+	Radio(ctx context.Context) RadioRepository
+	Share(ctx context.Context) ShareRepository
+	Property(ctx context.Context) PropertyRepository
+	User(ctx context.Context) UserRepository
+	UserProps(ctx context.Context) UserPropsRepository
+	ScrobbleBuffer(ctx context.Context) ScrobbleBufferRepository
 
-		Resource(ctx context.Context, model interface{}) ResourceRepository
+	Resource(ctx context.Context, model interface{}) ResourceRepository
 
-		WithTx(block func(tx DataStore) error, scope ...string) error
-		WithTxImmediate(block func(tx DataStore) error, scope ...string) error
-		GC(ctx context.Context) error
-	}
+	WithTx(block func(tx DataStore) error, scope ...string) error
+	WithTxImmediate(block func(tx DataStore) error, scope ...string) error
+	GC(ctx context.Context) error
+}

--- a/model/datastore.go
+++ b/model/datastore.go
@@ -31,6 +31,8 @@ type DataStore interface {
 	Playlist(ctx context.Context) PlaylistRepository
 	PlaylistFolder(ctx context.Context) PlaylistFolderRepository
 	Discovery(ctx context.Context) DiscoveryRepository
+	DiscoveryFolder(ctx context.Context) DiscoveryFolderRepository
+	DiscoverySong(ctx context.Context, discoveryID string, refreshSmartDiscovery bool) DiscoverySongRepository
 	PlayQueue(ctx context.Context) PlayQueueRepository
 	Transcoding(ctx context.Context) TranscodingRepository
 	Player(ctx context.Context) PlayerRepository

--- a/model/discovery.go
+++ b/model/discovery.go
@@ -42,6 +42,42 @@ type DiscoverySong struct {
 
 type DiscoverySongs []DiscoverySong
 
+type DiscoveryRepository interface {
+	ResourceRepository
+	CountAll(options ...QueryOptions) (int64, error)
+	Exists(id string) (bool, error)
+	Put(d *Discovery) error
+	Get(id string) (*Discovery, error)
+	GetWithSongs(id string, refreshSmartDiscovery, includeMissing bool) (*Discovery, error)
+	GetAll(options ...QueryOptions) (Discoveries, error)
+	FindByPath(path string) (*Discovery, error)
+	GetSyncedByDirectory(dir string) (Discoveries, error)
+	Delete(id string) error
+	Songs(discoveryId string, refreshSmartDiscovery bool) DiscoverySongRepository
+	GetDiscoveries(mediaFileId string) (Discoveries, error)
+
+	UpdateDiscoveryFolder(id string, discoveryFolderId *string) error
+
+	GetAllByDiscoveryFolder(options ...QueryOptions) (Discoveries, error)
+}
+
+type DiscoverySongRepository interface {
+	ResourceRepository
+	GetAll(options ...QueryOptions) (DiscoverySongs, error)
+	GetAlbumIDs(options ...QueryOptions) ([]string, error)
+	Add(mediaFileIds []string) (int, error)
+	AddAlbums(albumIds []string) (int, error)
+	AddArtists(artistIds []string) (int, error)
+	AddDiscs(discs []DiscID) (int, error)
+	Delete(id ...string) error
+	DeleteAll() error
+	Reorder(pos int, newPos int) error
+
+	AnnotatedRepository
+
+	SearchableRepository[DiscoverySongs]
+}
+
 func (d Discovery) IsSmartDiscovery() bool {
 	return d.Rules != nil && d.Rules.Expression != nil
 }

--- a/model/discovery.go
+++ b/model/discovery.go
@@ -1,0 +1,119 @@
+package model
+
+import (
+	"slices"
+	"strconv"
+	"time"
+
+	"github.com/navidrome/navidrome/model/criteria"
+)
+
+type Discovery struct {
+	ID        string         `structs:"id" json:"id"`
+	Name      string         `structs:"name" json:"name"`
+	Comment   string         `structs:"comment" json:"comment"`
+	Duration  float32        `structs:"duration" json:"duration"`
+	Size      int64          `structs:"size" json:"size"`
+	SongCount int            `structs:"song_count" json:"songCount"`
+	OwnerName string         `structs:"-" json:"ownerName"`
+	OwnerID   string         `structs:"owner_id" json:"ownerId"`
+	FolderID  *string        `structs:"folder_id" json:"folderId,omitempty"`
+	Public    bool           `structs:"public" json:"public"`
+	Tracks    DiscoverySongs `structs:"-" json:"tracks,omitempty"`
+	Path      string         `structs:"path" json:"path"`
+	Sync      bool           `structs:"sync" json:"sync"`
+	CreatedAt time.Time      `structs:"created_at" json:"createdAt"`
+	UpdatedAt time.Time      `structs:"updated_at" json:"updatedAt"`
+
+	Type string `structs:"-" json:"type,omitempty"`
+
+	Rules       *criteria.Criteria `structs:"rules" json:"rules"`
+	EvaluatedAt *time.Time         `structs:"evaluated_at" json:"evaluatedAt"`
+}
+
+type Discoveries []Discovery
+
+type DiscoverySong struct {
+	ID          string `json:"id"`
+	MediaFileID string `json:"mediaFileId"`
+	DiscoveryID string `json:"discoveryId"`
+	MediaFile
+}
+
+type DiscoverySongs []DiscoverySong
+
+func (d Discovery) IsSmartDiscovery() bool {
+	return d.Rules != nil && d.Rules.Expression != nil
+}
+
+func (d Discovery) MediaFiles() MediaFiles {
+	if len(d.Tracks) == 0 {
+		return nil
+	}
+	return d.Tracks.MediaFiles()
+}
+
+func (d *Discovery) refreshStats() {
+	d.SongCount = len(d.Tracks)
+	d.Duration = 0
+	d.Size = 0
+	for _, t := range d.Tracks {
+		d.Duration += t.MediaFile.Duration
+		d.Size += t.MediaFile.Size
+	}
+}
+
+func (d *Discovery) SetTracks(tracks DiscoverySongs) {
+	d.Tracks = tracks
+	d.refreshStats()
+}
+
+func (d *Discovery) RemoveTracks(idxToRemove []int) {
+	var newTracks DiscoverySongs
+	for i, t := range d.Tracks {
+		if slices.Contains(idxToRemove, i) {
+			continue
+		}
+		newTracks = append(newTracks, t)
+	}
+	d.Tracks = newTracks
+	d.refreshStats()
+}
+
+func (d *Discovery) AddMediaFilesByID(mediaFileIds []string) {
+	pos := len(d.Tracks)
+	for _, mfId := range mediaFileIds {
+		pos++
+		t := DiscoverySong{
+			ID:          strconv.Itoa(pos),
+			MediaFileID: mfId,
+			MediaFile:   MediaFile{ID: mfId},
+			DiscoveryID: d.ID,
+		}
+		d.Tracks = append(d.Tracks, t)
+	}
+	d.refreshStats()
+}
+
+func (d *Discovery) AddMediaFiles(mfs MediaFiles) {
+	pos := len(d.Tracks)
+	for _, mf := range mfs {
+		pos++
+		t := DiscoverySong{
+			ID:          strconv.Itoa(pos),
+			MediaFileID: mf.ID,
+			MediaFile:   mf,
+			DiscoveryID: d.ID,
+		}
+		d.Tracks = append(d.Tracks, t)
+	}
+	d.refreshStats()
+}
+
+func (ds DiscoverySongs) MediaFiles() MediaFiles {
+	mfs := make(MediaFiles, len(ds))
+	for i, t := range ds {
+		mfs[i] = t.MediaFile
+	}
+	return mfs
+}

--- a/model/discovery_folder.go
+++ b/model/discovery_folder.go
@@ -1,0 +1,21 @@
+package model
+
+import "time"
+
+type DiscoveryFolder struct {
+	ID        string    `structs:"id" json:"id"`
+	Name      string    `structs:"name" json:"name"`
+	ParentID  *string   `structs:"parent_id" json:"parentId,omitempty"`
+	Public    bool      `structs:"public" json:"public"`
+	OwnerID   string    `structs:"owner_id" json:"ownerId"`
+	OwnerName string    `structs:"-" json:"ownerName"`
+	CreatedAt time.Time `structs:"created_at" json:"createdAt"`
+	UpdatedAt time.Time `structs:"updated_at" json:"updatedAt"`
+
+	Type string `structs:"-" json:"type,omitempty"`
+
+	Children    []*DiscoveryFolder `structs:"-" json:"children,omitempty"`
+	Discoveries []*Discovery       `structs:"-" json:"discoveries,omitempty"`
+}
+
+type DiscoveryFolders []*DiscoveryFolder

--- a/model/discovery_folder.go
+++ b/model/discovery_folder.go
@@ -19,3 +19,19 @@ type DiscoveryFolder struct {
 }
 
 type DiscoveryFolders []*DiscoveryFolder
+
+type DiscoveryFolderRepository interface {
+	ResourceRepository
+
+	Get(id string) (*DiscoveryFolder, error)
+	GetAll(options ...QueryOptions) (DiscoveryFolders, error)
+	Put(*DiscoveryFolder) error
+	Delete(id string) error
+	Exists(id string) (bool, error)
+
+	CountAll(options ...QueryOptions) (int64, error)
+
+	UpdateParent(id string, parentId *string) error
+
+	GetAllByParent(options ...QueryOptions) (DiscoveryFolders, error)
+}

--- a/persistence/discovery_folder_repository.go
+++ b/persistence/discovery_folder_repository.go
@@ -1,0 +1,259 @@
+package persistence
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/Masterminds/squirrel"
+	"github.com/deluan/rest"
+	"github.com/navidrome/navidrome/model"
+	"github.com/pocketbase/dbx"
+)
+
+type discoveryFolderRepository struct {
+	sqlRepository
+}
+
+type dbDiscoveryFolder struct {
+	model.DiscoveryFolder `structs:",flatten"`
+}
+
+func NewDiscoveryFolderRepository(ctx context.Context, db dbx.Builder) model.DiscoveryFolderRepository {
+	r := &discoveryFolderRepository{}
+	r.ctx = ctx
+	r.db = db
+
+	r.registerModel(&model.DiscoveryFolder{}, map[string]filterFunc{
+		"q":         r.withTableName(discoveryFolderFilter),
+		"parent_id": r.withTableName(discoveryParentIdFilter),
+		"owner_id":  r.withTableName(discoveryOwnerIdFilter),
+	})
+	r.setSortMappings(map[string]string{
+		"name":       "lower(discovery_folder.name) asc",
+		"owner_name": "owner_name",
+		"updated_at": "discovery_folder.updated_at desc",
+	})
+	return r
+}
+
+func discoveryFolderFilter(_ string, value interface{}) Sqlizer {
+	return substringFilter("discovery_folder.name", value)
+}
+
+func discoveryOwnerIdFilter(_ string, value interface{}) Sqlizer {
+	return Eq{"discovery_folder.owner_id": value}
+}
+
+func discoveryParentIdFilter(_ string, value interface{}) Sqlizer {
+	if value == nil {
+		return Eq{"discovery_folder.parent_id": nil}
+	}
+	if s, ok := value.(string); ok && s == "" {
+		return Eq{"discovery_folder.parent_id": nil}
+	}
+	return Eq{"discovery_folder.parent_id": value}
+}
+
+func (r *discoveryFolderRepository) userFilter() Sqlizer {
+	user := loggedUser(r.ctx)
+	if user.IsAdmin {
+		return And{}
+	}
+	return Or{
+		Eq{"discovery_folder.public": true},
+		Eq{"discovery_folder.owner_id": user.ID},
+	}
+}
+
+func (r *discoveryFolderRepository) CountAll(options ...model.QueryOptions) (int64, error) {
+	sq := Select().Where(r.userFilter())
+	return r.count(sq, options...)
+}
+
+func (r *discoveryFolderRepository) Exists(id string) (bool, error) {
+	return r.exists(And{Eq{"discovery_folder.id": id}, r.userFilter()})
+}
+
+func (r *discoveryFolderRepository) Get(id string) (*model.DiscoveryFolder, error) {
+	return r.findBy(And{Eq{"discovery_folder.id": id}, r.userFilter()})
+}
+
+func (r *discoveryFolderRepository) GetAll(options ...model.QueryOptions) (model.DiscoveryFolders, error) {
+	sel := r.selectFolder(options...).Where(r.userFilter())
+	var rows []dbDiscoveryFolder
+	if err := r.queryAll(sel, &rows); err != nil {
+		return nil, err
+	}
+	out := make(model.DiscoveryFolders, len(rows))
+	for i := range rows {
+		out[i] = &rows[i].DiscoveryFolder
+	}
+	return out, nil
+}
+
+func (r *discoveryFolderRepository) GetAllByParent(options ...model.QueryOptions) (model.DiscoveryFolders, error) {
+	hasParent := r.hasParentIDFilter(options...)
+	sel := r.selectFolder(options...).Where(r.userFilter())
+	if !hasParent {
+		sel = sel.Where(Eq{"discovery_folder.parent_id": nil})
+	}
+	var rows []dbDiscoveryFolder
+	if err := r.queryAll(sel, &rows); err != nil {
+		return nil, err
+	}
+	out := make(model.DiscoveryFolders, 0, len(rows))
+	for i := range rows {
+		out = append(out, &rows[i].DiscoveryFolder)
+	}
+	return out, nil
+}
+
+func (r *discoveryFolderRepository) ensureUniqueName(f *model.DiscoveryFolder) error {
+	cond := And{
+		Eq{"discovery_folder.owner_id": f.OwnerID},
+		Eq{"discovery_folder.name": f.Name},
+	}
+	if f.ParentID == nil {
+		cond = append(cond, Eq{"discovery_folder.parent_id": nil})
+	} else {
+		cond = append(cond, Eq{"discovery_folder.parent_id": *f.ParentID})
+	}
+	if f.ID != "" {
+		cond = append(cond, NotEq{"discovery_folder.id": f.ID})
+	}
+	exists, err := r.exists(cond)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return fmt.Errorf("unique constraint failed: discovery_folder.name")
+	}
+	return nil
+}
+
+func (r *discoveryFolderRepository) Put(f *model.DiscoveryFolder) error {
+	usr := loggedUser(r.ctx)
+	if !usr.IsAdmin && f.OwnerID != usr.ID {
+		return rest.ErrPermissionDenied
+	}
+	if f.ID == "" {
+		f.CreatedAt = time.Now()
+	} else {
+		ok, err := r.Exists(f.ID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return model.ErrNotAuthorized
+		}
+	}
+	if err := r.ensureUniqueName(f); err != nil {
+		return err
+	}
+	f.UpdatedAt = time.Now()
+
+	dbf := dbDiscoveryFolder{DiscoveryFolder: *f}
+	id, err := r.put(dbf.ID, dbf)
+	if err != nil {
+		return err
+	}
+	f.ID = id
+	f.Type = "folder"
+	return nil
+}
+
+func (r *discoveryFolderRepository) Delete(id string) error {
+	usr := loggedUser(r.ctx)
+	if !usr.IsAdmin {
+		existing, err := r.Get(id)
+		if err != nil {
+			return err
+		}
+		if existing.OwnerID != usr.ID {
+			return rest.ErrPermissionDenied
+		}
+	}
+	return r.delete(And{Eq{"discovery_folder.id": id}, r.userFilter()})
+}
+
+func (r *discoveryFolderRepository) UpdateParent(id string, parentId *string) error {
+	if err := rejectEmptyOptionalID(parentId); err != nil {
+		return err
+	}
+
+	usr := loggedUser(r.ctx)
+
+	var src struct {
+		OwnerID string
+		Name    string
+	}
+	if err := r.queryOne(Select("owner_id", "name").From("discovery_folder").Where(Eq{"id": id}), &src); err != nil {
+		return err
+	}
+	if !usr.IsAdmin && src.OwnerID != usr.ID {
+		return rest.ErrPermissionDenied
+	}
+
+	if parentId == nil {
+		return r.Update(id, map[string]any{"parentId": nil}, "parentId")
+	}
+
+	if *parentId == id {
+		return fmt.Errorf("cannot move folder into itself")
+	}
+
+	var dst struct{ OwnerID string }
+	if err := r.queryOne(Select("owner_id").From("discovery_folder").Where(Eq{"id": *parentId}), &dst); err != nil {
+		return err
+	}
+	if !usr.IsAdmin && dst.OwnerID != usr.ID {
+		return rest.ErrPermissionDenied
+	}
+
+	return r.Update(id, map[string]any{"parentId": parentId}, "parentId")
+}
+
+func (r *discoveryFolderRepository) selectFolder(options ...model.QueryOptions) SelectBuilder {
+	return r.newSelect(options...).Join("user on user.id = owner_id").
+		Columns(r.tableName+".*", "user.user_name as owner_name")
+}
+
+func (r *discoveryFolderRepository) hasParentIDFilter(options ...model.QueryOptions) bool {
+	if len(options) == 0 || options[0].Filters == nil {
+		return false
+	}
+	switch f := options[0].Filters.(type) {
+	case Eq:
+		_, exists := f["parent_id"]
+		return exists
+	case And:
+		for _, sub := range f {
+			if eq, ok := sub.(Eq); ok {
+				if _, exists := eq["parent_id"]; exists {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func (r *discoveryFolderRepository) findBy(sql Sqlizer) (*model.DiscoveryFolder, error) {
+	sel := r.selectFolder().Where(sql)
+	var res []dbDiscoveryFolder
+	err := r.queryAll(sel, &res)
+	if err != nil {
+		return nil, err
+	}
+	if len(res) == 0 {
+		return nil, model.ErrNotFound
+	}
+	f := &res[0].DiscoveryFolder
+	f.Type = "folder"
+	return f, nil
+}
+
+var _ model.DiscoveryFolderRepository = (*discoveryFolderRepository)(nil)
+var _ rest.Repository = (*discoveryFolderRepository)(nil)
+var _ rest.Persistable = (*discoveryFolderRepository)(nil)

--- a/persistence/discovery_folder_repository.go
+++ b/persistence/discovery_folder_repository.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -195,28 +196,39 @@ func (r *discoveryFolderRepository) UpdateParent(id string, parentId *string) er
 		return rest.ErrPermissionDenied
 	}
 
-	if parentId == nil {
-		return r.Update(id, map[string]any{"parentId": nil}, "parentId")
+	if parentId != nil {
+		if *parentId == id {
+			return ErrInvalidRequest
+		}
+		isDesc, err := r.isDescendant(*parentId, id)
+		if err != nil {
+			return err
+		}
+		if isDesc {
+			return ErrInvalidRequest
+		}
 	}
 
-	if *parentId == id {
-		return fmt.Errorf("cannot move folder into itself")
-	}
-
-	var dst struct{ OwnerID string }
-	if err := r.queryOne(Select("owner_id").From("discovery_folder").Where(Eq{"id": *parentId}), &dst); err != nil {
+	f := &model.DiscoveryFolder{ID: id, OwnerID: src.OwnerID, Name: src.Name, ParentID: parentId}
+	if err := r.ensureUniqueName(f); err != nil {
 		return err
 	}
-	if !usr.IsAdmin && dst.OwnerID != usr.ID {
-		return rest.ErrPermissionDenied
-	}
 
-	return r.Update(id, map[string]any{"parentId": parentId}, "parentId")
+	upd := Update("discovery_folder").
+		Set("parent_id", parentId).
+		Set("updated_at", time.Now()).
+		Where(Eq{"id": id})
+	_, err := r.executeSQL(upd)
+	return err
 }
 
 func (r *discoveryFolderRepository) selectFolder(options ...model.QueryOptions) SelectBuilder {
 	return r.newSelect(options...).Join("user on user.id = owner_id").
-		Columns(r.tableName+".*", "user.user_name as owner_name")
+		Columns(
+			r.tableName+".*",
+			"user.user_name as owner_name",
+			"'folder' as type",
+		)
 }
 
 func (r *discoveryFolderRepository) hasParentIDFilter(options ...model.QueryOptions) bool {
@@ -252,6 +264,84 @@ func (r *discoveryFolderRepository) findBy(sql Sqlizer) (*model.DiscoveryFolder,
 	f := &res[0].DiscoveryFolder
 	f.Type = "folder"
 	return f, nil
+}
+
+func (r *discoveryFolderRepository) Count(options ...rest.QueryOptions) (int64, error) {
+	return r.CountAll(r.parseRestOptions(r.ctx, options...))
+}
+
+func (r *discoveryFolderRepository) Read(id string) (interface{}, error) {
+	return r.Get(id)
+}
+
+func (r *discoveryFolderRepository) ReadAll(options ...rest.QueryOptions) (interface{}, error) {
+	return r.GetAll(r.parseRestOptions(r.ctx, options...))
+}
+
+func (r *discoveryFolderRepository) EntityName() string { return "discovery_folder" }
+
+func (r *discoveryFolderRepository) NewInstance() interface{} { return &model.DiscoveryFolder{} }
+
+func (r *discoveryFolderRepository) Save(entity interface{}) (string, error) {
+	f := entity.(*model.DiscoveryFolder)
+	f.OwnerID = loggedUser(r.ctx).ID
+	f.ID = ""
+	if err := r.Put(f); err != nil {
+		return "", err
+	}
+	return f.ID, nil
+}
+
+func (r *discoveryFolderRepository) Update(id string, entity interface{}, cols ...string) error {
+	usr := loggedUser(r.ctx)
+	current, err := r.Get(id)
+	if err != nil {
+		return err
+	}
+	if !usr.IsAdmin && current.OwnerID != usr.ID {
+		return rest.ErrPermissionDenied
+	}
+
+	f := entity.(*model.DiscoveryFolder)
+	if !usr.IsAdmin && f.OwnerID != "" && f.OwnerID != usr.ID {
+		return rest.ErrPermissionDenied
+	}
+	f.ID = id
+	if err := r.ensureUniqueName(f); err != nil {
+		return err
+	}
+	f.UpdatedAt = time.Now()
+	f.Type = "folder"
+	_, err = r.put(id, dbDiscoveryFolder{DiscoveryFolder: *f}, append(cols, "updatedAt")...)
+	if errors.Is(err, model.ErrNotFound) {
+		return rest.ErrNotFound
+	}
+	return err
+}
+
+func (r *discoveryFolderRepository) isDescendant(childID, ancestorID string) (bool, error) {
+	for {
+		var row struct {
+			ParentID *string `db:"parent_id"`
+		}
+		err := r.queryOne(
+			Select("parent_id").From("discovery_folder").Where(Eq{"id": childID}),
+			&row,
+		)
+		if errors.Is(err, model.ErrNotFound) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		if row.ParentID == nil {
+			return false, nil
+		}
+		if *row.ParentID == ancestorID {
+			return true, nil
+		}
+		childID = *row.ParentID
+	}
 }
 
 var _ model.DiscoveryFolderRepository = (*discoveryFolderRepository)(nil)

--- a/persistence/discovery_repository.go
+++ b/persistence/discovery_repository.go
@@ -618,7 +618,7 @@ func (r *discoveryRepository) UpdateDiscoveryFolder(id string, folderID *string)
 
 	if folderID != nil {
 		var dstOwner struct{ OwnerID string }
-		if err := r.queryOne(Select("owner_id").From("discovery_folders").Where(Eq{"id": *folderID}), &dstOwner); err != nil {
+		if err := r.queryOne(Select("owner_id").From("discovery_folder").Where(Eq{"id": *folderID}), &dstOwner); err != nil {
 			return err
 		}
 		usr := loggedUser(r.ctx)

--- a/persistence/discovery_repository.go
+++ b/persistence/discovery_repository.go
@@ -1,0 +1,636 @@
+package persistence
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	. "github.com/Masterminds/squirrel"
+	"github.com/deluan/rest"
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/criteria"
+	"github.com/pocketbase/dbx"
+)
+
+type discoveryRepository struct {
+	sqlRepository
+}
+
+type dbDiscovery struct {
+	model.Discovery `structs:",flatten"`
+	Rules           sql.NullString `structs:"-"`
+}
+
+func (p *dbDiscovery) PostScan() error {
+	if p.Rules.String != "" {
+		return json.Unmarshal([]byte(p.Rules.String), &p.Discovery.Rules)
+	}
+	return nil
+}
+
+func (p dbDiscovery) PostMapArgs(args map[string]any) error {
+	var err error
+	if p.Discovery.IsSmartDiscovery() {
+		args["rules"], err = json.Marshal(p.Discovery.Rules)
+		if err != nil {
+			return fmt.Errorf("invalid criteria expression: %w", err)
+		}
+		return nil
+	}
+	delete(args, "rules")
+	return nil
+}
+
+func NewDiscoveryRepository(ctx context.Context, db dbx.Builder) model.DiscoveryRepository {
+	r := &discoveryRepository{}
+	r.ctx = ctx
+	r.db = db
+	r.registerModel(&model.Discovery{}, map[string]filterFunc{
+		"q":     discoveryFilter,
+		"smart": smartDiscoveryFilter,
+	})
+	r.setSortMappings(map[string]string{
+		"owner_name": "owner_name",
+	})
+	return r
+}
+
+func discoveryFilter(_ string, value interface{}) Sqlizer {
+	return Or{
+		substringFilter("discovery.name", value),
+		substringFilter("discovery.comment", value),
+	}
+}
+
+func smartDiscoveryFilter(string, interface{}) Sqlizer {
+	return Or{
+		Eq{"rules": ""},
+		Eq{"rules": nil},
+	}
+}
+
+func (r *discoveryRepository) userFilter() Sqlizer {
+	user := loggedUser(r.ctx)
+	if user.IsAdmin {
+		return And{}
+	}
+	return Or{
+		Eq{"public": true},
+		Eq{"owner_id": user.ID},
+	}
+}
+
+func (r *discoveryRepository) CountAll(options ...model.QueryOptions) (int64, error) {
+	sq := Select().Where(r.userFilter())
+	return r.count(sq, options...)
+}
+
+func (r *discoveryRepository) Exists(id string) (bool, error) {
+	return r.exists(And{Eq{"id": id}, r.userFilter()})
+}
+
+func (r *discoveryRepository) Delete(id string) error {
+	usr := loggedUser(r.ctx)
+	if !usr.IsAdmin {
+		pls, err := r.Get(id)
+		if err != nil {
+			return err
+		}
+		if pls.OwnerID != usr.ID {
+			return rest.ErrPermissionDenied
+		}
+	}
+	return r.delete(And{Eq{"id": id}, r.userFilter()})
+}
+
+func (r *discoveryRepository) Put(p *model.Discovery) error {
+	pls := dbDiscovery{Discovery: *p}
+	if pls.ID == "" {
+		pls.CreatedAt = time.Now()
+	} else {
+		ok, err := r.Exists(pls.ID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return model.ErrNotAuthorized
+		}
+	}
+	if p.Sync && !p.UpdatedAt.IsZero() {
+		pls.UpdatedAt = p.UpdatedAt
+	} else {
+		now := time.Now()
+		pls.UpdatedAt = now
+		p.UpdatedAt = now
+	}
+
+	id, err := r.put(pls.ID, pls)
+	if err != nil {
+		return err
+	}
+	p.ID = id
+	p.Type = "discovery"
+	if p.Sync && !p.UpdatedAt.IsZero() {
+		p.UpdatedAt = pls.UpdatedAt
+	}
+
+	if p.IsSmartDiscovery() {
+		// Do not update tracks at this point, as it may take a long time and lock the DB, breaking the scan process
+		//r.refreshSmartDiscovery(p)
+		return nil
+	}
+	// Only update tracks if they were specified
+	if len(pls.Tracks) > 0 {
+		return r.updateSongs(id, p.MediaFiles())
+	}
+	return r.refreshCounters(&pls.Discovery)
+}
+
+func (r *discoveryRepository) Get(id string) (*model.Discovery, error) {
+	return r.findBy(And{Eq{"discovery.id": id}, r.userFilter()})
+}
+
+func (r *discoveryRepository) GetWithSongs(id string, refreshSmartDiscovery, includeMissing bool) (*model.Discovery, error) {
+	pls, err := r.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	if refreshSmartDiscovery {
+		r.refreshSmartDiscovery(pls)
+	}
+	tracks, err := r.loadSongs(Select().From("discovery_songs").
+		Where(Eq{"missing": false}).
+		OrderBy("discovery_songs.id"), id)
+	if err != nil {
+		log.Error(r.ctx, "Error loading discovery tracks ", "discovery", pls.Name, "id", pls.ID, err)
+		return nil, err
+	}
+	pls.SetTracks(tracks)
+	return pls, nil
+}
+
+func (r *discoveryRepository) FindByPath(path string) (*model.Discovery, error) {
+	return r.findBy(Eq{"path": path})
+}
+
+func (r *discoveryRepository) GetSyncedByDirectory(dir string) (model.Discoveries, error) {
+	cleanedDir := filepath.Clean(dir)
+	pattern := cleanedDir
+	if cleanedDir == "." || cleanedDir == "" {
+		pattern = "%"
+	} else {
+		if !strings.HasSuffix(pattern, string(os.PathSeparator)) {
+			pattern += string(os.PathSeparator)
+		}
+		pattern += "%"
+	}
+
+	where := And{Eq{"sync": true}, r.userFilter()}
+	if pattern != "%" {
+		where = append(where, Like{"path": pattern})
+	}
+
+	sel := r.selectDiscovery().Where(where)
+	var res []dbDiscovery
+	if err := r.queryAll(sel, &res); err != nil {
+		return nil, err
+	}
+
+	discoveries := make(model.Discoveries, 0, len(res))
+	for _, p := range res {
+		if filepath.Clean(filepath.Dir(p.Path)) == cleanedDir {
+			discoveries = append(discoveries, p.Discovery)
+		}
+	}
+	return discoveries, nil
+}
+
+func (r *discoveryRepository) findBy(sql Sqlizer) (*model.Discovery, error) {
+	sel := r.selectDiscovery().Where(sql)
+	var pls []dbDiscovery
+	err := r.queryAll(sel, &pls)
+	if err != nil {
+		return nil, err
+	}
+	if len(pls) == 0 {
+		return nil, model.ErrNotFound
+	}
+
+	p := &pls[0].Discovery
+	p.Type = "discovery"
+	return p, nil
+}
+
+func (r *discoveryRepository) GetAll(options ...model.QueryOptions) (model.Discoveries, error) {
+	sel := r.selectDiscovery(options...).Where(r.userFilter())
+	var res []dbDiscovery
+	err := r.queryAll(sel, &res)
+	if err != nil {
+		return nil, err
+	}
+	discoveries := make(model.Discoveries, len(res))
+	for i, p := range res {
+		discoveries[i] = p.Discovery
+	}
+	return discoveries, err
+}
+
+func (r *discoveryRepository) GetAllByDiscoveryFolder(options ...model.QueryOptions) (model.Discoveries, error) {
+	hasFolderFilter := r.hasFolderIDFilter(options...)
+	sel := r.selectDiscovery(options...).Where(r.userFilter())
+	if !hasFolderFilter {
+		sel = sel.Where(Eq{"folder_id": nil}) // root only
+	}
+	var res []dbDiscovery
+	if err := r.queryAll(sel, &res); err != nil {
+		return nil, err
+	}
+	out := make(model.Discoveries, 0, len(res))
+	for _, pf := range res {
+		out = append(out, pf.Discovery)
+	}
+	return out, nil
+}
+
+func (r *discoveryRepository) hasFolderIDFilter(options ...model.QueryOptions) bool {
+	if len(options) == 0 || options[0].Filters == nil {
+		return false
+	}
+	switch f := options[0].Filters.(type) {
+	case Eq:
+		_, exists := f["folder_id"]
+		return exists
+	case And:
+		for _, sub := range f {
+			if eq, ok := sub.(Eq); ok {
+				if _, exists := eq["folder_id"]; exists {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func (r *discoveryRepository) GetDiscoveries(mediaFileId string) (model.Discoveries, error) {
+	sel := r.selectDiscovery(model.QueryOptions{Sort: "name"}).
+		Join("discovery_songs on discovery.id = discovery_songs.discovery_id").
+		Where(And{Eq{"discovery_songs.media_file_id": mediaFileId}, r.userFilter()})
+	var res []dbDiscovery
+	err := r.queryAll(sel, &res)
+	if err != nil {
+		if errors.Is(err, model.ErrNotFound) {
+			return model.Discoveries{}, nil
+		}
+		return nil, err
+	}
+	discoveries := make(model.Discoveries, len(res))
+	for i, p := range res {
+		discoveries[i] = p.Discovery
+	}
+	return discoveries, nil
+}
+
+func (r *discoveryRepository) selectDiscovery(options ...model.QueryOptions) SelectBuilder {
+	return r.newSelect(options...).Join("user on user.id = owner_id").
+		Columns(r.tableName+".*", "user.user_name as owner_name")
+}
+
+func (r *discoveryRepository) refreshSmartDiscovery(pls *model.Discovery) bool {
+	// Only refresh if it is a smart discovery and was not refreshed within the interval provided by the refresh delay config
+	if !pls.IsSmartDiscovery() || (pls.EvaluatedAt != nil && time.Since(*pls.EvaluatedAt) < conf.Server.SmartPlaylistRefreshDelay) {
+		return false
+	}
+
+	// Never refresh other users' discoveries
+	usr := loggedUser(r.ctx)
+	if pls.OwnerID != usr.ID {
+		log.Trace(r.ctx, "Not refreshing smart discovery from other user", "discovery", pls.Name, "id", pls.ID)
+		return false
+	}
+
+	log.Debug(r.ctx, "Refreshing smart discovery", "discovery", pls.Name, "id", pls.ID)
+	start := time.Now()
+
+	// Remove old tracks
+	del := Delete("discovery_songs").Where(Eq{"discovery_id": pls.ID})
+	_, err := r.executeSQL(del)
+	if err != nil {
+		log.Error(r.ctx, "Error deleting old smart discovery tracks", "discovery", pls.Name, "id", pls.ID, err)
+		return false
+	}
+
+	// Re-populate discovery based on Smart Discovery criteria
+	rules := *pls.Rules
+
+	// If the discovery depends on other discoveries, recursively refresh them first
+	childDiscoveryIds := rules.ChildPlaylistIds()
+	for _, id := range childDiscoveryIds {
+		childPls, err := r.Get(id)
+		if err != nil {
+			log.Error(r.ctx, "Error loading child discovery", "id", pls.ID, "childId", id, err)
+			return false
+		}
+		r.refreshSmartDiscovery(childPls)
+	}
+
+	sq := Select("row_number() over (order by "+rules.OrderBy()+") as id", "'"+pls.ID+"' as discovery_id", "media_file.id as media_file_id").
+		From("media_file").LeftJoin("annotation on (" +
+		"annotation.item_id = media_file.id" +
+		" AND annotation.item_type = 'media_file'" +
+		" AND annotation.user_id = '" + usr.ID + "')")
+	sq = r.addCriteria(sq, rules)
+	insSql := Insert("discovery_songs").Columns("id", "discovery_id", "media_file_id").Select(sq)
+	_, err = r.executeSQL(insSql)
+	if err != nil {
+		log.Error(r.ctx, "Error refreshing smart discovery tracks", "discovery", pls.Name, "id", pls.ID, err)
+		return false
+	}
+
+	// Update discovery stats
+	err = r.refreshCounters(pls)
+	if err != nil {
+		log.Error(r.ctx, "Error updating smart discovery stats", "discovery", pls.Name, "id", pls.ID, err)
+		return false
+	}
+
+	// Update when the discovery was last refreshed (for cache purposes)
+	updSql := Update(r.tableName).Set("evaluated_at", time.Now()).Where(Eq{"id": pls.ID})
+	_, err = r.executeSQL(updSql)
+	if err != nil {
+		log.Error(r.ctx, "Error updating smart discovery", "discovery", pls.Name, "id", pls.ID, err)
+		return false
+	}
+
+	log.Debug(r.ctx, "Refreshed discovery", "discovery", pls.Name, "id", pls.ID, "numSongs", pls.SongCount, "elapsed", time.Since(start))
+
+	return true
+}
+
+func (r *discoveryRepository) addCriteria(sql SelectBuilder, c criteria.Criteria) SelectBuilder {
+	sql = sql.Where(c)
+	if c.Limit > 0 {
+		sql = sql.Limit(uint64(c.Limit)).Offset(uint64(c.Offset))
+	}
+	if order := c.OrderBy(); order != "" {
+		sql = sql.OrderBy(order)
+	}
+	return sql
+}
+
+func (r *discoveryRepository) updateSongs(id string, tracks model.MediaFiles) error {
+	ids := make([]string, len(tracks))
+	for i := range tracks {
+		ids[i] = tracks[i].ID
+	}
+	return r.updateDiscovery(id, ids)
+}
+
+func (r *discoveryRepository) updateDiscovery(discoveryId string, mediaFileIds []string) error {
+	if !r.isWritable(discoveryId) {
+		return rest.ErrPermissionDenied
+	}
+
+	// Remove old tracks
+	del := Delete("discovery_songs").Where(Eq{"discovery_id": discoveryId})
+	_, err := r.executeSQL(del)
+	if err != nil {
+		return err
+	}
+
+	return r.addSongs(discoveryId, 1, mediaFileIds)
+}
+
+func (r *discoveryRepository) addSongs(discoveryId string, startingPos int, mediaFileIds []string) error {
+	// Break the track list in chunks to avoid hitting SQLITE_MAX_VARIABLE_NUMBER limit
+	// Add new tracks, chunk by chunk
+	pos := startingPos
+	for chunk := range slices.Chunk(mediaFileIds, 200) {
+		ins := Insert("discovery_songs").Columns("discovery_id", "media_file_id", "id")
+		for _, t := range chunk {
+			ins = ins.Values(discoveryId, t, pos)
+			pos++
+		}
+		_, err := r.executeSQL(ins)
+		if err != nil {
+			return err
+		}
+	}
+
+	return r.refreshCounters(&model.Discovery{ID: discoveryId})
+}
+
+// refreshCounters updates total discovery duration, size and count
+func (r *discoveryRepository) refreshCounters(pls *model.Discovery) error {
+	statsSql := Select(
+		"coalesce(sum(duration), 0) as duration",
+		"coalesce(sum(size), 0) as size",
+		"count(*) as count",
+	).
+		From("media_file").
+		Join("discovery_songs f on f.media_file_id = media_file.id").
+		Where(Eq{"discovery_id": pls.ID})
+	var res struct{ Duration, Size, Count float32 }
+	err := r.queryOne(statsSql, &res)
+	if err != nil {
+		return err
+	}
+
+	// Update discovery's total duration, size and count
+	upd := Update("discovery").
+		Set("duration", res.Duration).
+		Set("size", res.Size).
+		Set("song_count", res.Count).
+		Set("updated_at", time.Now()).
+		Where(Eq{"id": pls.ID})
+	_, err = r.executeSQL(upd)
+	if err != nil {
+		return err
+	}
+	pls.SongCount = int(res.Count)
+	pls.Duration = res.Duration
+	pls.Size = int64(res.Size)
+	return nil
+}
+
+func (r *discoveryRepository) loadSongs(sel SelectBuilder, id string) (model.DiscoverySongs, error) {
+	sel = r.applyLibraryFilter(sel, "f")
+	userID := loggedUser(r.ctx).ID
+	tracksQuery := sel.
+		Columns(
+			"coalesce(starred, 0) as starred",
+			"starred_at",
+			"coalesce(play_count, 0) as play_count",
+			"play_date",
+			"coalesce(rating, 0) as rating",
+			"f.*",
+			"discovery_songs.*",
+			"library.path as library_path",
+			"library.name as library_name",
+		).
+		LeftJoin("annotation on (" +
+			"annotation.item_id = media_file_id" +
+			" AND annotation.item_type = 'media_file'" +
+			" AND annotation.user_id = '" + userID + "')").
+		Join("media_file f on f.id = media_file_id").
+		Join("library on f.library_id = library.id").
+		Where(Eq{"discovery_id": id})
+	tracks := dbDiscoverySongs{}
+	err := r.queryAll(tracksQuery, &tracks)
+	if err != nil {
+		return nil, err
+	}
+	return tracks.toModels(), err
+}
+
+func (r *discoveryRepository) Count(options ...rest.QueryOptions) (int64, error) {
+	return r.CountAll(r.parseRestOptions(r.ctx, options...))
+}
+
+func (r *discoveryRepository) Read(id string) (interface{}, error) {
+	return r.Get(id)
+}
+
+func (r *discoveryRepository) ReadAll(options ...rest.QueryOptions) (interface{}, error) {
+	return r.GetAll(r.parseRestOptions(r.ctx, options...))
+}
+
+func (r *discoveryRepository) EntityName() string {
+	return "discovery"
+}
+
+func (r *discoveryRepository) NewInstance() interface{} {
+	return &model.Discovery{}
+}
+
+func (r *discoveryRepository) Save(entity interface{}) (string, error) {
+	pls := entity.(*model.Discovery)
+	pls.OwnerID = loggedUser(r.ctx).ID
+	pls.ID = "" // Make sure we don't override an existing discovery
+	err := r.Put(pls)
+	if err != nil {
+		return "", err
+	}
+	return pls.ID, err
+}
+
+func (r *discoveryRepository) Update(id string, entity interface{}, cols ...string) error {
+	pls := dbDiscovery{Discovery: *entity.(*model.Discovery)}
+	current, err := r.Get(id)
+	if err != nil {
+		return err
+	}
+	usr := loggedUser(r.ctx)
+	if !usr.IsAdmin {
+		// Only the owner can update the discovery
+		if current.OwnerID != usr.ID {
+			return rest.ErrPermissionDenied
+		}
+		// Regular users can't change the ownership of a discovery
+		if pls.OwnerID != "" && pls.OwnerID != usr.ID {
+			return rest.ErrPermissionDenied
+		}
+	}
+	pls.ID = id
+	pls.UpdatedAt = time.Now()
+	_, err = r.put(id, pls, append(cols, "updatedAt")...)
+	if errors.Is(err, model.ErrNotFound) {
+		return rest.ErrNotFound
+	}
+	return err
+}
+
+func (r *discoveryRepository) removeOrphans() error {
+	sel := Select("discovery_songs.discovery_id as id", "p.name").From("discovery_songs").
+		Join("discovery p on discovery_songs.discovery_id = p.id").
+		LeftJoin("media_file mf on discovery_songs.media_file_id = mf.id").
+		Where(Eq{"mf.id": nil}).
+		GroupBy("discovery_songs.discovery_id")
+
+	var pls []struct{ Id, Name string }
+	err := r.queryAll(sel, &pls)
+	if err != nil {
+		return fmt.Errorf("fetching discoveries with orphan tracks: %w", err)
+	}
+
+	for _, pl := range pls {
+		log.Debug(r.ctx, "Cleaning-up orphan tracks from discovery", "id", pl.Id, "name", pl.Name)
+		del := Delete("discovery_songs").Where(And{
+			ConcatExpr("media_file_id not in (select id from media_file)"),
+			Eq{"discovery_id": pl.Id},
+		})
+		n, err := r.executeSQL(del)
+		if n == 0 || err != nil {
+			return fmt.Errorf("deleting orphan tracks from discovery %s: %w", pl.Name, err)
+		}
+		log.Debug(r.ctx, "Deleted tracks, now reordering", "id", pl.Id, "name", pl.Name, "deleted", n)
+
+		// Renumber the discovery if any track was removed
+		if err := r.renumber(pl.Id); err != nil {
+			return fmt.Errorf("renumbering discovery %s: %w", pl.Name, err)
+		}
+	}
+	return nil
+}
+
+func (r *discoveryRepository) renumber(id string) error {
+	var ids []string
+	sq := Select("media_file_id").From("discovery_songs").Where(Eq{"discovery_id": id}).OrderBy("id")
+	err := r.queryAllSlice(sq, &ids)
+	if err != nil {
+		return err
+	}
+	return r.updateDiscovery(id, ids)
+}
+
+func (r *discoveryRepository) isWritable(discoveryId string) bool {
+	usr := loggedUser(r.ctx)
+	if usr.IsAdmin {
+		return true
+	}
+	pls, err := r.Get(discoveryId)
+	return err == nil && pls.OwnerID == usr.ID
+}
+
+func (r *discoveryRepository) UpdateDiscoveryFolder(id string, folderID *string) error {
+	if err := rejectEmptyOptionalID(folderID); err != nil {
+		return err
+	}
+
+	discovery, err := r.Get(id)
+	if err != nil {
+		return err
+	}
+
+	if (discovery.FolderID == nil && folderID == nil) ||
+		(discovery.FolderID != nil && folderID != nil && *discovery.FolderID == *folderID) {
+		return nil
+	}
+
+	if folderID != nil {
+		var dstOwner struct{ OwnerID string }
+		if err := r.queryOne(Select("owner_id").From("discovery_folders").Where(Eq{"id": *folderID}), &dstOwner); err != nil {
+			return err
+		}
+		usr := loggedUser(r.ctx)
+		if !usr.IsAdmin && dstOwner.OwnerID != usr.ID {
+			return rest.ErrPermissionDenied
+		}
+	}
+
+	discovery.FolderID = folderID
+	return r.Update(id, discovery, "folderId")
+}
+
+var _ model.DiscoveryRepository = (*discoveryRepository)(nil)
+var _ rest.Repository = (*discoveryRepository)(nil)
+var _ rest.Persistable = (*discoveryRepository)(nil)

--- a/persistence/discovery_separation_test.go
+++ b/persistence/discovery_separation_test.go
@@ -1,0 +1,27 @@
+package persistence
+
+import (
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Discovery repositories", func() {
+	It("do not modify playlist folders", func() {
+		ctx := request.WithUser(log.NewContext(GinkgoT().Context()), adminUser)
+		playlistRepo := NewPlaylistFolderRepository(ctx, GetDBXBuilder())
+		discoveryRepo := NewDiscoveryFolderRepository(ctx, GetDBXBuilder())
+
+		before, err := playlistRepo.CountAll()
+		Expect(err).ToNot(HaveOccurred())
+
+		folder := &model.DiscoveryFolder{Name: "Isolated", OwnerID: adminUser.ID, Public: true}
+		Expect(discoveryRepo.Put(folder)).To(Succeed())
+
+		after, err := playlistRepo.CountAll()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(after).To(Equal(before))
+	})
+})

--- a/persistence/discovery_song_repository.go
+++ b/persistence/discovery_song_repository.go
@@ -1,0 +1,297 @@
+package persistence
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	. "github.com/Masterminds/squirrel"
+	"github.com/deluan/rest"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/utils/slice"
+)
+
+type discoverySongRepository struct {
+	sqlRepository
+	discoveryId   string
+	discovery     *model.Discovery
+	discoveryRepo *discoveryRepository
+}
+
+type dbDiscoverySong struct {
+	dbMediaFile
+	*model.DiscoverySong `structs:",flatten"`
+}
+
+func (t *dbDiscoverySong) PostScan() error {
+	if err := t.dbMediaFile.PostScan(); err != nil {
+		return err
+	}
+	t.DiscoverySong.MediaFile = *t.dbMediaFile.MediaFile
+	t.DiscoverySong.MediaFile.ID = t.MediaFileID
+	return nil
+}
+
+type dbDiscoverySongs []dbDiscoverySong
+
+func (t dbDiscoverySongs) toModels() model.DiscoverySongs {
+	return slice.Map(t, func(trk dbDiscoverySong) model.DiscoverySong {
+		return *trk.DiscoverySong
+	})
+}
+
+func (r *discoveryRepository) Songs(discoveryId string, refreshSmartDiscovery bool) model.DiscoverySongRepository {
+	p := &discoverySongRepository{}
+	p.discoveryRepo = r
+	p.discoveryId = discoveryId
+	p.ctx = r.ctx
+	p.db = r.db
+	p.tableName = "discovery_songs"
+	p.registerModel(&model.DiscoverySong{}, map[string]filterFunc{
+		"missing":    booleanFilter,
+		"library_id": libraryIdFilter,
+		"q":          fullTextFilter("f"),
+	})
+	p.setSortMappings(
+		map[string]string{
+			"id":           "discovery_songs.id",
+			"artist":       "order_artist_name",
+			"album_artist": "order_album_artist_name",
+			"album":        "order_album_name, order_album_artist_name",
+			"title":        "order_title",
+			// To make sure these fields will be whitelisted
+			"duration": "duration",
+			"year":     "year",
+			"bpm":      "bpm",
+			"channels": "channels",
+		},
+		"f") // TODO I don't like this solution, but I won't change it now as it's not the focus of BFR.
+
+	pls, err := r.Get(discoveryId)
+	if err != nil {
+		log.Warn(r.ctx, "Error getting discovery's songs", "discoveryId", discoveryId, err)
+		return nil
+	}
+	if refreshSmartDiscovery {
+		r.refreshSmartDiscovery(pls)
+	}
+	p.discovery = pls
+	return p
+}
+
+func (r *discoverySongRepository) Count(options ...rest.QueryOptions) (int64, error) {
+	query := Select().
+		LeftJoin("media_file f on f.id = media_file_id").
+		Where(Eq{"discovery_id": r.discoveryId})
+	return r.count(query, r.parseRestOptions(r.ctx, options...))
+}
+
+func (r *discoverySongRepository) Read(id string) (interface{}, error) {
+	userID := loggedUser(r.ctx).ID
+	sel := r.newSelect().
+		LeftJoin("annotation on ("+
+			"annotation.item_id = media_file_id"+
+			" AND annotation.item_type = 'media_file'"+
+			" AND annotation.user_id = '"+userID+"')").
+		Columns(
+			"coalesce(starred, 0) as starred",
+			"coalesce(play_count, 0) as play_count",
+			"coalesce(rating, 0) as rating",
+			"starred_at",
+			"play_date",
+			"f.*",
+			"discovery_songs.*",
+		).
+		Join("media_file f on f.id = media_file_id").
+		Where(And{Eq{"discovery_id": r.discoveryId}, Eq{"discovery_songs.id": id}})
+	var trk dbDiscoverySong
+	err := r.queryOne(sel, &trk)
+	return trk.DiscoverySong, err
+}
+
+func (r *discoverySongRepository) GetAll(options ...model.QueryOptions) (model.DiscoverySongs, error) {
+	songs, err := r.discoveryRepo.loadSongs(r.newSelect(options...), r.discoveryId)
+	if err != nil {
+		return nil, err
+	}
+	return songs, err
+}
+
+func (r *discoverySongRepository) GetAlbumIDs(options ...model.QueryOptions) ([]string, error) {
+	query := r.newSelect(options...).Columns("distinct mf.album_id").
+		Join("media_file mf on mf.id = media_file_id").
+		Where(Eq{"discovery_id": r.discoveryId})
+	var ids []string
+	err := r.queryAllSlice(query, &ids)
+	if err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
+func (r *discoverySongRepository) Search(q string, offset, size int, options ...model.QueryOptions) (model.DiscoverySongs, error) {
+	q = strings.TrimSpace(q)
+	q = strings.TrimSuffix(q, "*")
+	if len(q) < 2 {
+		return nil, nil
+	}
+
+	sel := r.newSelect(options...).
+		Join("media_file f on f.id = media_file_id").
+		Where(Eq{"discovery_id": r.discoveryId})
+
+	if filter := fullTextExpr("f", q); filter != nil {
+		sel = sel.Where(filter).OrderBy("order_title")
+	} else {
+		sel = sel.OrderBy("discovery_songs.rowid")
+	}
+	sel = sel.Where(Eq{"f.missing": false}).Limit(uint64(size)).Offset(uint64(offset))
+
+	songs, err := r.discoveryRepo.loadSongs(sel, r.discoveryId)
+	if err != nil {
+		return nil, fmt.Errorf("searching discovery songs by query %q: %w", q, err)
+	}
+	return songs, nil
+}
+
+func (r *discoverySongRepository) ReadAll(options ...rest.QueryOptions) (interface{}, error) {
+	return r.GetAll(r.parseRestOptions(r.ctx, options...))
+}
+
+func (r *discoverySongRepository) EntityName() string {
+	return "discovery_songs"
+}
+
+func (r *discoverySongRepository) NewInstance() interface{} {
+	return &model.DiscoverySong{}
+}
+
+func (r *discoverySongRepository) isSongsEditable() bool {
+	return r.discoveryRepo.isWritable(r.discoveryId) && !r.discovery.IsSmartDiscovery()
+}
+
+func (r *discoverySongRepository) Add(mediaFileIds []string) (int, error) {
+	if !r.isSongsEditable() {
+		return 0, rest.ErrPermissionDenied
+	}
+
+	if len(mediaFileIds) == 0 {
+		return 0, nil
+	}
+
+	existing, err := r.getSongs()
+	if err != nil {
+		return 0, err
+	}
+
+	seen := make(map[string]struct{}, len(existing))
+	for _, id := range existing {
+		seen[id] = struct{}{}
+	}
+
+	unique := make([]string, 0, len(mediaFileIds))
+	for _, id := range mediaFileIds {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		unique = append(unique, id)
+	}
+
+	if len(unique) == 0 {
+		return 0, nil
+	}
+
+	log.Debug(r.ctx, "Adding songs to discovery", "discoveryId", r.discoveryId, "mediaFileIds", unique)
+
+	// Get next pos (ID) in discovery
+	sq := r.newSelect().Columns("max(id) as max").Where(Eq{"discovery_id": r.discoveryId})
+	var res struct{ Max sql.NullInt32 }
+	err = r.queryOne(sq, &res)
+	if err != nil {
+		return 0, err
+	}
+
+	return len(unique), r.discoveryRepo.addSongs(r.discoveryId, int(res.Max.Int32+1), unique)
+}
+
+func (r *discoverySongRepository) addMediaFileIds(cond Sqlizer) (int, error) {
+	sq := Select("id").From("media_file").Where(cond).OrderBy("album_artist, album, release_date, disc_number, track_number")
+	var ids []string
+	err := r.queryAllSlice(sq, &ids)
+	if err != nil {
+		log.Error(r.ctx, "Error getting songs to add to discovery", err)
+		return 0, err
+	}
+	return r.Add(ids)
+}
+
+func (r *discoverySongRepository) AddAlbums(albumIds []string) (int, error) {
+	return r.addMediaFileIds(Eq{"album_id": albumIds})
+}
+
+func (r *discoverySongRepository) AddArtists(artistIds []string) (int, error) {
+	return r.addMediaFileIds(Eq{"album_artist_id": artistIds})
+}
+
+func (r *discoverySongRepository) AddDiscs(discs []model.DiscID) (int, error) {
+	if len(discs) == 0 {
+		return 0, nil
+	}
+	var clauses Or
+	for _, d := range discs {
+		clauses = append(clauses, And{Eq{"album_id": d.AlbumID}, Eq{"release_date": d.ReleaseDate}, Eq{"disc_number": d.DiscNumber}})
+	}
+	return r.addMediaFileIds(clauses)
+}
+
+// Get ids from all current songs
+func (r *discoverySongRepository) getSongs() ([]string, error) {
+	all := r.newSelect().Columns("media_file_id").Where(Eq{"discovery_id": r.discoveryId}).OrderBy("id")
+	var ids []string
+	err := r.queryAllSlice(all, &ids)
+	if err != nil {
+		log.Error(r.ctx, "Error querying current songs from discovery", "discoveryId", r.discoveryId, err)
+		return nil, err
+	}
+	return ids, nil
+}
+
+func (r *discoverySongRepository) Delete(ids ...string) error {
+	if !r.isSongsEditable() {
+		return rest.ErrPermissionDenied
+	}
+	err := r.delete(And{Eq{"discovery_id": r.discoveryId}, Eq{"id": ids}})
+	if err != nil {
+		return err
+	}
+
+	return r.discoveryRepo.renumber(r.discoveryId)
+}
+
+func (r *discoverySongRepository) DeleteAll() error {
+	if !r.isSongsEditable() {
+		return rest.ErrPermissionDenied
+	}
+	err := r.delete(Eq{"discovery_id": r.discoveryId})
+	if err != nil {
+		return err
+	}
+
+	return r.discoveryRepo.renumber(r.discoveryId)
+}
+
+func (r *discoverySongRepository) Reorder(pos int, newPos int) error {
+	if !r.isSongsEditable() {
+		return rest.ErrPermissionDenied
+	}
+	ids, err := r.getSongs()
+	if err != nil {
+		return err
+	}
+	newOrder := slice.Move(ids, pos-1, newPos-1)
+	return r.discoveryRepo.updateDiscovery(r.discoveryId, newOrder)
+}
+
+var _ model.DiscoverySongRepository = (*discoverySongRepository)(nil)

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -61,6 +61,14 @@ func (s *SQLStore) Discovery(ctx context.Context) model.DiscoveryRepository {
 	return NewDiscoveryRepository(ctx, s.getDBXBuilder())
 }
 
+func (s *SQLStore) DiscoveryFolder(ctx context.Context) model.DiscoveryFolderRepository {
+	return NewDiscoveryFolderRepository(ctx, s.getDBXBuilder())
+}
+
+func (s *SQLStore) DiscoverySong(ctx context.Context, discoveryID string, refreshSmartDiscovery bool) model.DiscoverySongRepository {
+	return NewDiscoveryRepository(ctx, s.getDBXBuilder()).Songs(discoveryID, refreshSmartDiscovery)
+}
+
 func (s *SQLStore) PlaylistFolder(ctx context.Context) model.PlaylistFolderRepository {
 	return NewPlaylistFolderRepository(ctx, s.getDBXBuilder())
 }
@@ -119,6 +127,8 @@ func (s *SQLStore) Resource(ctx context.Context, m interface{}) model.ResourceRe
 		return s.PlaylistFolder(ctx).(model.ResourceRepository)
 	case model.Discovery:
 		return s.Discovery(ctx).(model.ResourceRepository)
+	case model.DiscoveryFolder:
+		return s.DiscoveryFolder(ctx).(model.ResourceRepository)
 	case model.Radio:
 		return s.Radio(ctx).(model.ResourceRepository)
 	case model.Share:

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -57,8 +57,12 @@ func (s *SQLStore) Playlist(ctx context.Context) model.PlaylistRepository {
 	return NewPlaylistRepository(ctx, s.getDBXBuilder())
 }
 
+func (s *SQLStore) Discovery(ctx context.Context) model.DiscoveryRepository {
+	return NewDiscoveryRepository(ctx, s.getDBXBuilder())
+}
+
 func (s *SQLStore) PlaylistFolder(ctx context.Context) model.PlaylistFolderRepository {
-    return NewPlaylistFolderRepository(ctx, s.getDBXBuilder())
+	return NewPlaylistFolderRepository(ctx, s.getDBXBuilder())
 }
 
 func (s *SQLStore) Property(ctx context.Context) model.PropertyRepository {
@@ -113,6 +117,8 @@ func (s *SQLStore) Resource(ctx context.Context, m interface{}) model.ResourceRe
 		return s.Playlist(ctx).(model.ResourceRepository)
 	case model.PlaylistFolder:
 		return s.PlaylistFolder(ctx).(model.ResourceRepository)
+	case model.Discovery:
+		return s.Discovery(ctx).(model.ResourceRepository)
 	case model.Radio:
 		return s.Radio(ctx).(model.ResourceRepository)
 	case model.Share:

--- a/server/nativeapi/config_test.go
+++ b/server/nativeapi/config_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Config API", func() {
 		conf.Server.DevUIShowConfig = true // Enable config endpoint for tests
 		ds = &tests.MockDataStore{}
 		auth.Init(ds)
-		nativeRouter := New(ds, nil, nil, nil, core.NewMockLibraryService())
+		nativeRouter := New(ds, nil, nil, nil, nil, core.NewMockLibraryService())
 		router = server.JWTVerifier(nativeRouter)
 
 		// Create test users

--- a/server/nativeapi/discovery.go
+++ b/server/nativeapi/discovery.go
@@ -1,0 +1,337 @@
+package nativeapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/deluan/rest"
+	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/core"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/server"
+	"github.com/navidrome/navidrome/utils/req"
+)
+
+func (n *Router) addDiscoveryRoutes(r chi.Router) {
+	r.Route("/discovery", func(r chi.Router) {
+		constructor := func(ctx context.Context) rest.Repository {
+			return n.ds.Resource(ctx, model.Discovery{})
+		}
+
+		r.Get("/", rest.GetAll(constructor))
+		r.Post("/", rest.Post(constructor))
+
+		r.Route("/folder", func(r chi.Router) {
+			folderConstructor := func(ctx context.Context) rest.Repository {
+				return n.ds.Resource(ctx, model.DiscoveryFolder{})
+			}
+			r.Get("/", rest.GetAll(folderConstructor))
+			r.Post("/", rest.Post(folderConstructor))
+			r.Route("/{id}", func(r chi.Router) {
+				r.Use(server.URLParamsMiddleware)
+				r.Get("/", rest.Get(folderConstructor))
+				r.Put("/", rest.Put(folderConstructor))
+				r.Delete("/", rest.Delete(folderConstructor))
+				r.Patch("/parent", moveDiscoveryFolder(n.ds))
+			})
+			r.Patch("/move", bulkMoveDiscoveries(n.ds, n.discoveries))
+		})
+
+		r.Route("/{id}", func(r chi.Router) {
+			r.Use(server.URLParamsMiddleware)
+			r.Get("/", rest.Get(constructor))
+			r.Put("/", rest.Put(constructor))
+			r.Delete("/", rest.Delete(constructor))
+
+			r.Patch("/folder", func(w http.ResponseWriter, r *http.Request) {
+				id := chi.URLParam(r, "id")
+				type reqBody struct {
+					FolderID *string `json:"folderId"`
+				}
+				var body reqBody
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				if err := n.discoveries.SetFolder(r.Context(), id, body.FolderID); err != nil {
+					http.Error(w, err.Error(), statusFor(err))
+					return
+				}
+				w.WriteHeader(http.StatusNoContent)
+			})
+		})
+
+		r.Route("/{discoveryId}/songs", func(r chi.Router) {
+			r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+				getDiscoverySongs(n.ds)(w, r)
+			})
+			r.With(server.URLParamsMiddleware).Route("/", func(r chi.Router) {
+				r.Post("/", func(w http.ResponseWriter, r *http.Request) {
+					addToDiscovery(n.ds, n.discoveries)(w, r)
+				})
+				r.Delete("/", func(w http.ResponseWriter, r *http.Request) {
+					deleteFromDiscovery(n.ds, n.discoveries)(w, r)
+				})
+			})
+			r.Route("/{id}", func(r chi.Router) {
+				r.Use(server.URLParamsMiddleware)
+				r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+					getDiscoverySong(n.ds)(w, r)
+				})
+				r.Put("/", func(w http.ResponseWriter, r *http.Request) {
+					reorderDiscoverySong(n.ds, n.discoveries)(w, r)
+				})
+				r.Delete("/", func(w http.ResponseWriter, r *http.Request) {
+					deleteFromDiscovery(n.ds, n.discoveries)(w, r)
+				})
+			})
+		})
+	})
+}
+
+func getDiscoverySongs(ds model.DataStore) http.HandlerFunc {
+	wrapper := func(handler restHandler) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			constructor := func(ctx context.Context) rest.Repository {
+				discoveryID := chi.URLParam(r, "discoveryId")
+				p := req.Params(r)
+				start := p.Int64Or("_start", 0)
+				return ds.DiscoverySong(ctx, discoveryID, start == 0)
+			}
+			handler(constructor).ServeHTTP(w, r)
+		}
+	}
+	return wrapper(rest.GetAll)
+}
+
+func getDiscoverySong(ds model.DataStore) http.HandlerFunc {
+	wrapper := func(handler restHandler) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			constructor := func(ctx context.Context) rest.Repository {
+				discoveryID := chi.URLParam(r, "discoveryId")
+				return ds.DiscoverySong(ctx, discoveryID, true)
+			}
+			handler(constructor).ServeHTTP(w, r)
+		}
+	}
+	return wrapper(rest.Get)
+}
+
+func addToDiscovery(ds model.DataStore, discoveries core.Discoveries) http.HandlerFunc {
+	type addSongsPayload struct {
+		Ids       []string       `json:"ids"`
+		AlbumIds  []string       `json:"albumIds"`
+		ArtistIds []string       `json:"artistIds"`
+		Discs     []model.DiscID `json:"discs"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		p := req.Params(r)
+		discoveryID, _ := p.String(":discoveryId")
+		var payload addSongsPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		tracksRepo := ds.DiscoverySong(r.Context(), discoveryID, true)
+		count := 0
+		var err error
+		if len(payload.Ids) > 0 {
+			var added int
+			if added, err = tracksRepo.Add(payload.Ids); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			count += added
+		}
+		if len(payload.AlbumIds) > 0 {
+			var added int
+			if added, err = tracksRepo.AddAlbums(payload.AlbumIds); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			count += added
+		}
+		if len(payload.ArtistIds) > 0 {
+			var added int
+			if added, err = tracksRepo.AddArtists(payload.ArtistIds); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			count += added
+		}
+		if len(payload.Discs) > 0 {
+			var added int
+			if added, err = tracksRepo.AddDiscs(payload.Discs); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			count += added
+		}
+
+		if err := syncDiscovery(discoveries, ds, r.Context(), discoveryID); err != nil {
+			http.Error(w, err.Error(), statusFor(err))
+			return
+		}
+
+		_, err = fmt.Fprintf(w, `{"added":%d}`, count)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+}
+
+func deleteFromDiscovery(ds model.DataStore, discoveries core.Discoveries) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		p := req.Params(r)
+		discoveryID, _ := p.String(":discoveryId")
+		ids, _ := p.Strings("id")
+		err := ds.WithTxImmediate(func(tx model.DataStore) error {
+			return tx.DiscoverySong(r.Context(), discoveryID, true).Delete(ids...)
+		})
+		if len(ids) == 1 && errors.Is(err, model.ErrNotFound) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if err := syncDiscovery(discoveries, ds, r.Context(), discoveryID); err != nil {
+			http.Error(w, err.Error(), statusFor(err))
+			return
+		}
+		writeDeleteManyResponse(w, r, ids)
+	}
+}
+
+func reorderDiscoverySong(ds model.DataStore, discoveries core.Discoveries) http.HandlerFunc {
+	type reorderPayload struct {
+		InsertBefore string `json:"insert_before"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		p := req.Params(r)
+		discoveryID, _ := p.String(":discoveryId")
+		id := p.IntOr(":id", 0)
+		if id == 0 {
+			http.Error(w, "invalid id", http.StatusBadRequest)
+			return
+		}
+		var payload reorderPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		newPos, err := strconv.Atoi(payload.InsertBefore)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		tracksRepo := ds.DiscoverySong(r.Context(), discoveryID, true)
+		if err := tracksRepo.Reorder(id, newPos); err != nil {
+			if errors.Is(err, rest.ErrPermissionDenied) {
+				http.Error(w, err.Error(), http.StatusForbidden)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if err := syncDiscovery(discoveries, ds, r.Context(), discoveryID); err != nil {
+			http.Error(w, err.Error(), statusFor(err))
+			return
+		}
+
+		_, err = w.Write([]byte(fmt.Sprintf(`{"id":"%d"}`, id)))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+}
+
+func syncDiscovery(discoveries core.Discoveries, ds model.DataStore, ctx context.Context, discoveryID string) error {
+	discovery, err := ds.Discovery(ctx).Get(discoveryID)
+	if err != nil {
+		return err
+	}
+	return discoveries.Update(ctx, discoveryID, &discovery.Name, &discovery.Comment, &discovery.Public, nil, nil)
+}
+
+func moveDiscoveryFolder(ds model.DataStore) http.HandlerFunc {
+	type reqBody struct {
+		ParentID *string `json:"parentId"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		var body reqBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if body.ParentID != nil && *body.ParentID == "" {
+			http.Error(w, "parentId cannot be empty; use null for root", http.StatusBadRequest)
+			return
+		}
+		if err := ds.DiscoveryFolder(r.Context()).UpdateParent(id, body.ParentID); err != nil {
+			http.Error(w, err.Error(), statusFor(err))
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func bulkMoveDiscoveries(ds model.DataStore, discoveries core.Discoveries) http.HandlerFunc {
+	type movePayload struct {
+		Ids      []string `json:"ids"`
+		Types    []string `json:"types"`
+		FolderID *string  `json:"folderId"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		var payload movePayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if len(payload.Ids) != len(payload.Types) {
+			http.Error(w, "ids and types length mismatch", http.StatusBadRequest)
+			return
+		}
+		if payload.FolderID != nil && *payload.FolderID == "" {
+			http.Error(w, "folderId cannot be empty; use null for root", http.StatusBadRequest)
+			return
+		}
+
+		ctx := r.Context()
+		updated := 0
+		for i, id := range payload.Ids {
+			switch payload.Types[i] {
+			case "discovery":
+				if err := discoveries.SetFolder(ctx, id, payload.FolderID); err != nil {
+					http.Error(w, err.Error(), statusFor(err))
+					return
+				}
+				updated++
+			case "folder":
+				if err := ds.DiscoveryFolder(ctx).UpdateParent(id, payload.FolderID); err != nil {
+					http.Error(w, err.Error(), statusFor(err))
+					return
+				}
+				updated++
+			default:
+				http.Error(w, "invalid type "+payload.Types[i], http.StatusBadRequest)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(fmt.Sprintf(`{"updated":%d}`, updated)))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+}

--- a/server/nativeapi/library_test.go
+++ b/server/nativeapi/library_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Library API", func() {
 		DeferCleanup(configtest.SetupConfig())
 		ds = &tests.MockDataStore{}
 		auth.Init(ds)
-		nativeRouter := New(ds, nil, nil, nil, core.NewMockLibraryService())
+		nativeRouter := New(ds, nil, nil, nil, nil, core.NewMockLibraryService())
 		router = server.JWTVerifier(nativeRouter)
 
 		// Create test users

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -23,15 +23,16 @@ import (
 
 type Router struct {
 	http.Handler
-	ds        model.DataStore
-	share     core.Share
-	playlists core.Playlists
-	insights  metrics.Insights
-	libs      core.Library
+	ds          model.DataStore
+	share       core.Share
+	playlists   core.Playlists
+	discoveries core.Discoveries
+	insights    metrics.Insights
+	libs        core.Library
 }
 
-func New(ds model.DataStore, share core.Share, playlists core.Playlists, insights metrics.Insights, libraryService core.Library) *Router {
-	r := &Router{ds: ds, share: share, playlists: playlists, insights: insights, libs: libraryService}
+func New(ds model.DataStore, share core.Share, playlists core.Playlists, discoveries core.Discoveries, insights metrics.Insights, libraryService core.Library) *Router {
+	r := &Router{ds: ds, share: share, playlists: playlists, discoveries: discoveries, insights: insights, libs: libraryService}
 	r.Handler = r.routes()
 	return r
 }
@@ -64,6 +65,7 @@ func (n *Router) routes() http.Handler {
 		n.addPlaylistFolderRoute(r)
 		n.addPlaylistTrackRoute(r)
 		n.addSongPlaylistsRoute(r)
+		n.addDiscoveryRoutes(r)
 		n.addQueueRoute(r)
 		n.addMissingFilesRoute(r)
 		n.addKeepAliveRoute(r)

--- a/server/nativeapi/native_api_song_test.go
+++ b/server/nativeapi/native_api_song_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Song Endpoints", func() {
 		mfRepo.SetData(testSongs)
 
 		// Create the native API router and wrap it with the JWTVerifier middleware
-		nativeRouter := New(ds, nil, nil, nil, core.NewMockLibraryService())
+		nativeRouter := New(ds, nil, nil, nil, nil, core.NewMockLibraryService())
 		router = server.JWTVerifier(nativeRouter)
 		w = httptest.NewRecorder()
 	})

--- a/tests/mock_data_store.go
+++ b/tests/mock_data_store.go
@@ -8,28 +8,30 @@ import (
 )
 
 type MockDataStore struct {
-	RealDS               model.DataStore
-	MockedLibrary        model.LibraryRepository
-	MockedFolder         model.FolderRepository
-	MockedGenre          model.GenreRepository
-	MockedAlbum          model.AlbumRepository
-	MockedArtist         model.ArtistRepository
-	MockedMediaFile      model.MediaFileRepository
-	MockedTag            model.TagRepository
-	MockedUser           model.UserRepository
-	MockedProperty       model.PropertyRepository
-	MockedPlayer         model.PlayerRepository
-	MockedPlaylist       model.PlaylistRepository
-	MockedPlaylistFolder model.PlaylistFolderRepository
-	MockedDiscovery      model.DiscoveryRepository
-	MockedPlayQueue      model.PlayQueueRepository
-	MockedShare          model.ShareRepository
-	MockedTranscoding    model.TranscodingRepository
-	MockedUserProps      model.UserPropsRepository
-	MockedScrobbleBuffer model.ScrobbleBufferRepository
-	MockedRadio          model.RadioRepository
-	scrobbleBufferMu     sync.Mutex
-	repoMu               sync.Mutex
+	RealDS                model.DataStore
+	MockedLibrary         model.LibraryRepository
+	MockedFolder          model.FolderRepository
+	MockedGenre           model.GenreRepository
+	MockedAlbum           model.AlbumRepository
+	MockedArtist          model.ArtistRepository
+	MockedMediaFile       model.MediaFileRepository
+	MockedTag             model.TagRepository
+	MockedUser            model.UserRepository
+	MockedProperty        model.PropertyRepository
+	MockedPlayer          model.PlayerRepository
+	MockedPlaylist        model.PlaylistRepository
+	MockedPlaylistFolder  model.PlaylistFolderRepository
+	MockedDiscovery       model.DiscoveryRepository
+	MockedDiscoveryFolder model.DiscoveryFolderRepository
+	MockedDiscoverySong   func(ctx context.Context, discoveryID string, refresh bool) model.DiscoverySongRepository
+	MockedPlayQueue       model.PlayQueueRepository
+	MockedShare           model.ShareRepository
+	MockedTranscoding     model.TranscodingRepository
+	MockedUserProps       model.UserPropsRepository
+	MockedScrobbleBuffer  model.ScrobbleBufferRepository
+	MockedRadio           model.RadioRepository
+	scrobbleBufferMu      sync.Mutex
+	repoMu                sync.Mutex
 }
 
 func (db *MockDataStore) Library(ctx context.Context) model.LibraryRepository {
@@ -142,6 +144,29 @@ func (db *MockDataStore) Discovery(ctx context.Context) model.DiscoveryRepositor
 		}
 	}
 	return db.MockedDiscovery
+}
+
+func (db *MockDataStore) DiscoveryFolder(ctx context.Context) model.DiscoveryFolderRepository {
+	if db.MockedDiscoveryFolder == nil {
+		if db.RealDS != nil {
+			db.MockedDiscoveryFolder = db.RealDS.DiscoveryFolder(ctx)
+		} else {
+			db.MockedDiscoveryFolder = struct {
+				model.DiscoveryFolderRepository
+			}{}
+		}
+	}
+	return db.MockedDiscoveryFolder
+}
+
+func (db *MockDataStore) DiscoverySong(ctx context.Context, discoveryID string, refresh bool) model.DiscoverySongRepository {
+	if db.MockedDiscoverySong != nil {
+		return db.MockedDiscoverySong(ctx, discoveryID, refresh)
+	}
+	if db.RealDS != nil {
+		return db.RealDS.DiscoverySong(ctx, discoveryID, refresh)
+	}
+	return struct{ model.DiscoverySongRepository }{}
 }
 
 func (db *MockDataStore) PlayQueue(ctx context.Context) model.PlayQueueRepository {

--- a/tests/mock_data_store.go
+++ b/tests/mock_data_store.go
@@ -8,27 +8,28 @@ import (
 )
 
 type MockDataStore struct {
-	RealDS               		model.DataStore
-	MockedLibrary        		model.LibraryRepository
-	MockedFolder         		model.FolderRepository
-	MockedGenre          		model.GenreRepository
-	MockedAlbum          		model.AlbumRepository
-	MockedArtist         		model.ArtistRepository
-	MockedMediaFile      		model.MediaFileRepository
-	MockedTag            		model.TagRepository
-	MockedUser           		model.UserRepository
-	MockedProperty       		model.PropertyRepository
-	MockedPlayer         		model.PlayerRepository
-	MockedPlaylist       		model.PlaylistRepository
-	MockedPlaylistFolder 		model.PlaylistFolderRepository
-	MockedPlayQueue      		model.PlayQueueRepository
-	MockedShare          		model.ShareRepository
-	MockedTranscoding    		model.TranscodingRepository
-	MockedUserProps      		model.UserPropsRepository
-	MockedScrobbleBuffer 		model.ScrobbleBufferRepository
-	MockedRadio          		model.RadioRepository
-	scrobbleBufferMu     		sync.Mutex
-	repoMu               		sync.Mutex
+	RealDS               model.DataStore
+	MockedLibrary        model.LibraryRepository
+	MockedFolder         model.FolderRepository
+	MockedGenre          model.GenreRepository
+	MockedAlbum          model.AlbumRepository
+	MockedArtist         model.ArtistRepository
+	MockedMediaFile      model.MediaFileRepository
+	MockedTag            model.TagRepository
+	MockedUser           model.UserRepository
+	MockedProperty       model.PropertyRepository
+	MockedPlayer         model.PlayerRepository
+	MockedPlaylist       model.PlaylistRepository
+	MockedPlaylistFolder model.PlaylistFolderRepository
+	MockedDiscovery      model.DiscoveryRepository
+	MockedPlayQueue      model.PlayQueueRepository
+	MockedShare          model.ShareRepository
+	MockedTranscoding    model.TranscodingRepository
+	MockedUserProps      model.UserPropsRepository
+	MockedScrobbleBuffer model.ScrobbleBufferRepository
+	MockedRadio          model.RadioRepository
+	scrobbleBufferMu     sync.Mutex
+	repoMu               sync.Mutex
 }
 
 func (db *MockDataStore) Library(ctx context.Context) model.LibraryRepository {
@@ -130,6 +131,17 @@ func (db *MockDataStore) PlaylistFolder(ctx context.Context) model.PlaylistFolde
 		}
 	}
 	return db.MockedPlaylistFolder
+}
+
+func (db *MockDataStore) Discovery(ctx context.Context) model.DiscoveryRepository {
+	if db.MockedDiscovery == nil {
+		if db.RealDS != nil {
+			db.MockedDiscovery = db.RealDS.Discovery(ctx)
+		} else {
+			db.MockedDiscovery = struct{ model.DiscoveryRepository }{}
+		}
+	}
+	return db.MockedDiscovery
 }
 
 func (db *MockDataStore) PlayQueue(ctx context.Context) model.PlayQueueRepository {

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -128,6 +128,7 @@ const Admin = (props) => {
           name="discoveryFolder"
           options={{ subMenu: 'discovery' }}
         />,
+        <Resource name="discoverySong" />,
         <Resource name="user" {...user} options={{ subMenu: 'settings' }} />,
         <Resource
           name="player"

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -14,6 +14,8 @@ import album from './album'
 import artist from './artist'
 import playlist from './playlist'
 import playlist_folder from './playlist_folder'
+import discovery from './discovery'
+import discovery_folder from './discovery_folder'
 import radio from './radio'
 import share from './share'
 import library from './library'
@@ -115,10 +117,16 @@ const Admin = (props) => {
           show={PlaylistShow}
           edit={PlaylistEdit}
         />,
+        <Resource name="discovery" {...discovery} />,
         <Resource
           {...playlist_folder}
           name="folder"
           options={{ subMenu: 'playlist' }}
+        />,
+        <Resource
+          {...discovery_folder}
+          name="discoveryFolder"
+          options={{ subMenu: 'discovery' }}
         />,
         <Resource name="user" {...user} options={{ subMenu: 'settings' }} />,
         <Resource

--- a/ui/src/consts.js
+++ b/ui/src/consts.js
@@ -15,6 +15,8 @@ export const DraggableTypes = {
   ALL: [],
   PLAYLIST: 'playlist',
   FOLDER: 'folder',
+  DISCOVERY: 'discovery',
+  DISCOVERY_FOLDER: 'discoveryFolder',
 }
 
 DraggableTypes.ALL.push(

--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -21,7 +21,14 @@ const getSelectedLibraries = () => {
 // Function to apply library filtering to appropriate resources
 const applyLibraryFilter = (resource, params) => {
   // Content resources that should be filtered by selected libraries
-  const filteredResources = ['album', 'song', 'artist', 'playlistTrack', 'tag']
+  const filteredResources = [
+    'album',
+    'song',
+    'artist',
+    'playlistTrack',
+    'discoverySong',
+    'tag',
+  ]
 
   // Get selected libraries from localStorage
   const selectedLibraries = getSelectedLibraries()
@@ -63,6 +70,19 @@ const mapResource = (resource, params) => {
       params = applyLibraryFilter(resource, params)
 
       return [resource, params]
+    }
+    case 'discovery': {
+      return ['discovery', params]
+    }
+    case 'discoveryFolder': {
+      return ['discovery/folder', params]
+    }
+    case 'discoverySong': {
+      params.filter = params.filter || {}
+      const discoveryId = params.filter.discovery_id
+      delete params.filter.discovery_id
+      params = applyLibraryFilter(resource, params)
+      return [`discovery/${discoveryId}/songs`, params]
     }
     default:
       return [resource, params]
@@ -139,6 +159,14 @@ const emitFoldersChanged = (detail) => {
   }
 }
 
+const emitDiscoveryFoldersChanged = (detail) => {
+  try {
+    window.dispatchEvent(new CustomEvent('discoveryFolder:changed', { detail }))
+  } catch (err) {
+    // Ignore errors if dispatching fails
+  }
+}
+
 const wrapperDataProvider = {
   ...dataProvider,
   getList: (resource, params) => {
@@ -180,6 +208,15 @@ const wrapperDataProvider = {
           (params?.data?.folderId ?? params?.data?.parentId ?? '') || ''
         emitFoldersChanged({ type: 'create', resource, targetParentId: parentId })
       }
+      if (resource === 'discovery' || resource === 'discoveryFolder') {
+        const parentId =
+          (params?.data?.folderId ?? params?.data?.parentId ?? '') || ''
+        emitDiscoveryFoldersChanged({
+          type: 'create',
+          resource,
+          targetParentId: parentId,
+        })
+      }
       return res
     })
   },
@@ -198,6 +235,15 @@ const wrapperDataProvider = {
           (params?.data?.folderId ?? params?.data?.parentId ?? '') || ''
         emitFoldersChanged({ type: 'create', resource, targetParentId: parentId })
       }
+      if (resource === 'discovery' || resource === 'discoveryFolder') {
+        const parentId =
+          (params?.data?.folderId ?? params?.data?.parentId ?? '') || ''
+        emitDiscoveryFoldersChanged({
+          type: 'create',
+          resource,
+          targetParentId: parentId,
+        })
+      }
       return res
     })
   },
@@ -206,6 +252,13 @@ const wrapperDataProvider = {
     return dataProvider.delete(r, p).then((res) => {
       if (resource === 'playlist' || resource === 'folder') {
         emitFoldersChanged({ type: 'delete', resource, targetParentId: '' })
+      }
+      if (resource === 'discovery' || resource === 'discoveryFolder') {
+        emitDiscoveryFoldersChanged({
+          type: 'delete',
+          resource,
+          targetParentId: '',
+        })
       }
       return res
     })
@@ -219,6 +272,12 @@ const wrapperDataProvider = {
   },
   addToPlaylist: (playlistId, data) => {
     return httpClient(`${REST_URL}/playlist/${playlistId}/tracks`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }).then(({ json }) => ({ data: json }))
+  },
+  addToDiscovery: (discoveryId, data) => {
+    return httpClient(`${REST_URL}/discovery/${discoveryId}/songs`, {
       method: 'POST',
       body: JSON.stringify(data),
     }).then(({ json }) => ({ data: json }))
@@ -250,6 +309,22 @@ const wrapperDataProvider = {
       return { data: { id: playlistId, folderId: targetFolderId } }
     })
   },
+  setDiscoveryFolder: ({ discoveryId, targetFolderId, sourceParentId }) => {
+    return httpClient(`${REST_URL}/discovery/${discoveryId}/folder`, {
+      method: 'PATCH',
+      body: JSON.stringify({
+        folderId: targetFolderId,
+      }),
+    }).then(() => {
+      emitDiscoveryFoldersChanged({
+        type: 'move',
+        resource: 'discovery',
+        sourceParentId: sourceParentId ?? '',
+        targetParentId: targetFolderId ?? '',
+      })
+      return { data: { id: discoveryId, folderId: targetFolderId } }
+    })
+  },
 
   moveFolder: ({ folderId, targetParentId, sourceParentId }) => {
     return httpClient(`${REST_URL}/folder/${folderId}/parent`, {
@@ -261,6 +336,22 @@ const wrapperDataProvider = {
       emitFoldersChanged({
         type: 'move',
         resource: 'folder',
+        sourceParentId: sourceParentId ?? '',
+        targetParentId: targetParentId ?? '',
+      })
+      return { data: json }
+    })
+  },
+  moveDiscoveryFolder: ({ folderId, targetParentId, sourceParentId }) => {
+    return httpClient(`${REST_URL}/discovery/folder/${folderId}/parent`, {
+      method: 'PATCH',
+      body: JSON.stringify({
+        parentId: targetParentId,
+      }),
+    }).then(({ json }) => {
+      emitDiscoveryFoldersChanged({
+        type: 'move',
+        resource: 'discoveryFolder',
         sourceParentId: sourceParentId ?? '',
         targetParentId: targetParentId ?? '',
       })
@@ -279,6 +370,21 @@ const wrapperDataProvider = {
       })
       if ((targetParentId ?? '') === '') {
         emitFoldersChanged({ type: 'bulkMove', targetParentId: '' })
+      }
+      return { data: json }
+    })
+  },
+  bulkMoveDiscovery: ({ discoveryIds = [], folderIds = [], targetParentId = null }) => {
+    return httpClient(`${REST_URL}/discovery/folder/move`, {
+      method: 'PATCH',
+      body: JSON.stringify({ discoveryIds, folderIds, targetParentId }),
+    }).then(({ json }) => {
+      emitDiscoveryFoldersChanged({
+        type: 'bulkMove',
+        targetParentId: targetParentId ?? '',
+      })
+      if ((targetParentId ?? '') === '') {
+        emitDiscoveryFoldersChanged({ type: 'bulkMove', targetParentId: '' })
       }
       return { data: json }
     })

--- a/ui/src/discovery/index.jsx
+++ b/ui/src/discovery/index.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import QueueMusicOutlinedIcon from '@material-ui/icons/QueueMusicOutlined'
+import QueueMusicIcon from '@material-ui/icons/QueueMusic'
+import DynamicMenuIcon from '../layout/DynamicMenuIcon'
+import PlaylistList from '../playlist/PlaylistList'
+import PlaylistEdit from '../playlist/PlaylistEdit'
+import PlaylistCreate from '../playlist/PlaylistCreate'
+import PlaylistShow from '../playlist/PlaylistShow'
+
+export default {
+  list: PlaylistList,
+  create: PlaylistCreate,
+  edit: PlaylistEdit,
+  show: PlaylistShow,
+  icon: (
+    <DynamicMenuIcon
+      path={'discovery'}
+      icon={QueueMusicOutlinedIcon}
+      activeIcon={QueueMusicIcon}
+    />
+  ),
+}

--- a/ui/src/discovery_folder/index.jsx
+++ b/ui/src/discovery_folder/index.jsx
@@ -14,7 +14,7 @@ export default {
   show: PlaylistFolderShow,
   icon: (
     <DynamicMenuIcon
-      path={'discovery/folders'}
+      path={'discoveryFolder'}
       icon={LibraryMusicOutlinedIcon}
       activeIcon={LibraryMusicIcon}
     />

--- a/ui/src/discovery_folder/index.jsx
+++ b/ui/src/discovery_folder/index.jsx
@@ -1,0 +1,22 @@
+import PlaylistFolderList from '../playlist_folder/PlaylistFolderList'
+import PlaylistFolderCreate from '../playlist_folder/PlaylistFolderCreate'
+import DynamicMenuIcon from '../layout/DynamicMenuIcon'
+import PlaylistFolderEdit from '../playlist_folder/PlaylistFolderEdit'
+import PlaylistFolderShow from '../playlist_folder/PlaylistFolderShow'
+
+import LibraryMusicOutlinedIcon from '@material-ui/icons/LibraryMusicOutlined'
+import LibraryMusicIcon from '@material-ui/icons/LibraryMusic'
+
+export default {
+  list: PlaylistFolderList,
+  create: PlaylistFolderCreate,
+  edit: PlaylistFolderEdit,
+  show: PlaylistFolderShow,
+  icon: (
+    <DynamicMenuIcon
+      path={'discovery/folders'}
+      icon={LibraryMusicOutlinedIcon}
+      activeIcon={LibraryMusicIcon}
+    />
+  ),
+}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -560,6 +560,7 @@
     },
     "albumList": "Albums",
     "playlists": "Playlists",
+    "discovery": "Discovery",
     "sharedPlaylists": "Shared Playlists",
     "about": "About"
   },

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -231,8 +231,55 @@
         "noPlaylists": "No playlists available"
       }
     },
+    "discovery": {
+      "name": "Discovery |||| Discoveries",
+      "fields": {
+        "name": "Name",
+        "duration": "Duration",
+        "ownerName": "Owner",
+        "public": "Public",
+        "updatedAt": "Updated at",
+        "createdAt": "Date added",
+        "songCount": "Songs",
+        "comment": "Comment",
+        "sync": "Auto-import",
+        "path": "Import from"
+      },
+      "actions": {
+        "create": "Create Discovery",
+        "createFolder": "Create Folder",
+        "selectPlaylist": "Select a discovery:",
+        "addNewPlaylist": "Create \"%{name}\"",
+        "export": "Export",
+        "publish": "Publish",
+        "saveQueue": "Save Queue to Discovery",
+        "makePublic": "Make Public",
+        "makePrivate": "Make Private",
+        "searchOrCreate": "Search discoveries or type to create new...",
+        "pressEnterToCreate": "Press Enter to create new discovery",
+        "removeFromSelection": "Remove from selection"
+      },
+      "notifications": {
+        "published": "%{smart_count} song from %{name} published to Sync folder |||| %{smart_count} songs from %{name} published to Sync folder"
+      },
+      "message": {
+        "duplicate_song": "Add duplicated songs",
+        "song_exist": "There are duplicates being added to the discovery. Would you like to add the duplicates or skip them?",
+        "noPlaylistsFound": "No discoveries found",
+        "noPlaylists": "No discoveries available"
+      }
+    },
     "folder": {
       "name": "Folder |||| Folders",
+      "fields": {
+        "name": "Name",
+        "ownerName": "Owner Name",
+        "public": "Public",
+        "updatedAt": "Updated at"
+      }
+    },
+    "discoveryFolder": {
+      "name": "Discovery Folder |||| Discovery Folders",
       "fields": {
         "name": "Name",
         "ownerName": "Owner Name",

--- a/ui/src/layout/DiscoverySubMenu.jsx
+++ b/ui/src/layout/DiscoverySubMenu.jsx
@@ -308,7 +308,7 @@ const FolderRow = memo(function FolderRow({
     <>
       <ListItem
         button
-        onClick={() => history.push(`/discovery/folder/${node.id}/show`)}
+        onClick={() => history.push(`/discoveryFolder/${node.id}/show`)}
         className={`${classes.listItem} ${classes.depth}`}
         ref={dragDropRef}
         style={{ opacity: isDragging ? 0.5 : 1 }}
@@ -363,7 +363,7 @@ const DiscoverySubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
   const handleToggle = (menu) => setState((s) => ({ ...s, [menu]: !s[menu] }))
 
   const onDiscoveryConfig = useCallback(() => {
-    history.push({ pathname: '/discovery/folder', state: { parentId: null } })
+    history.push({ pathname: '/discoveryFolder', state: { parentId: null } })
   }, [history])
 
   const { get, markDirty, ensure, moveItem } = childrenStore

--- a/ui/src/layout/DiscoverySubMenu.jsx
+++ b/ui/src/layout/DiscoverySubMenu.jsx
@@ -1,0 +1,474 @@
+import React, { useState, useCallback, memo, useEffect, useMemo, useRef } from 'react'
+import { useDataProvider, useNotify, useRefresh } from 'react-admin'
+import { useHistory } from 'react-router-dom'
+import {
+  Typography, List, ListItem, ListItemIcon, ListItemText,
+  IconButton, makeStyles, Collapse, CircularProgress,
+} from '@material-ui/core'
+import { BiCog } from 'react-icons/bi'
+import { useDrop } from 'react-dnd'
+import { RiFolder3Fill, RiPlayListFill } from 'react-icons/ri'
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
+import ChevronRightIcon from '@material-ui/icons/ChevronRight'
+import QueueMusicIcon from '@material-ui/icons/QueueMusic'
+import SubMenu from './SubMenu'
+import { canChangeTracks } from '../common'
+import { DraggableTypes, REST_URL } from '../consts'
+import config from '../config'
+import useDragAndDrop from '../common/useDragAndDrop'
+import httpClient from '../dataProvider/httpClient'
+
+const fetchPlaylistTrackIds = async (playlistId) => {
+  const res = await httpClient(`${REST_URL}/playlist/${playlistId}/tracks`)
+  const tracks = Array.isArray(res?.json) ? res.json : []
+  const ids = new Set()
+  tracks.forEach((track) => {
+    if (track?.mediaFileId) {
+      ids.add(track.mediaFileId)
+    }
+  })
+  return ids
+}
+
+const filterSongDropPayload = async (playlistId, item) => {
+  if (!Array.isArray(item?.ids) || item.ids.length === 0) {
+    return item
+  }
+
+  const existingIds = await fetchPlaylistTrackIds(playlistId)
+  const seen = new Set()
+  const uniqueIds = []
+
+  item.ids.forEach((id) => {
+    if (!id || seen.has(id) || existingIds.has(id)) {
+      return
+    }
+    seen.add(id)
+    uniqueIds.push(id)
+  })
+
+  return uniqueIds.length ? { ...item, ids: uniqueIds } : null
+}
+
+const useStyles = makeStyles((theme) => ({
+  listItem: {
+    borderRadius: 6,
+    marginRight: 4,
+    paddingTop: 1,
+    paddingBottom: 1,
+    transition: 'all 0.2s ease-in-out',
+    '&:hover': { backgroundColor: theme.palette.action.hover, transform: 'translateX(2px)' },
+  },
+  active: { backgroundColor: theme.palette.action.selected, fontWeight: theme.typography.fontWeightMedium },
+  text: { transition: 'color 0.2s ease' },
+  toggleButton: { padding: 4, marginRight: 4 },
+  listItemIcon: { minWidth: 28 },
+  spacer: { width: 24 },
+  nested: { paddingLeft: theme.spacing(2) },
+  depth: (props) => ({ paddingLeft: theme.spacing(2) + props.depth * theme.spacing(2) }),
+  spinner: { marginLeft: 6 },
+}))
+
+const parentKey = (id) => (id == null || id === '' ? '' : String(id))
+const parentFilterValue = parentKey
+
+const useChildrenStore = () => {
+  const [store, setStore] = useState({})
+  const inFlightRef = useRef(new Map())
+
+  const setItems = useCallback((parentId, items) => {
+    const key = parentKey(parentId)
+    const enriched = (items || []).map((it) => ({
+      ...it,
+      parent_id:
+        it.parent_id ?? it.parentId ?? it.folder_id ?? it.folderId ?? key,
+    }))
+    setStore((s) => ({ ...s, [key]: { items: enriched, dirty: false, cached: true } }))
+  }, [])
+
+  const markDirty = useCallback((parentIds) => {
+    setStore((s) => {
+      const next = { ...s }
+      parentIds.forEach((pid) => {
+        const key = parentKey(pid)
+        const prev = next[key] || { items: [], cached: false }
+        next[key] = { items: prev.items, dirty: true, cached: !!prev.cached }
+      })
+      return next
+    })
+  }, [])
+
+  const get = useCallback(
+    (pid) => store[parentKey(pid)] || { items: [], dirty: true, cached: false },
+    [store]
+  )
+
+  const ensure = useCallback(async (parentId, fetcher) => {
+    const key = parentKey(parentId)
+    const entry = store[key]
+    if (entry && entry.cached && !entry.dirty) return entry.items
+
+    const inFlight = inFlightRef.current.get(key)
+    if (inFlight) return inFlight
+
+    const p = (async () => {
+      const data = await fetcher()
+      setItems(parentId, data || [])
+      inFlightRef.current.delete(key)
+      return data
+    })().catch((e) => {
+      inFlightRef.current.delete(key)
+      throw e
+    })
+    inFlightRef.current.set(key, p)
+    return p
+  }, [setItems, store])
+
+  const moveItem = useCallback((item, fromPid, toPid) => {
+    setStore((s) => {
+      const next = { ...s }
+      const fromKey = parentKey(fromPid)
+      const toKey = parentKey(toPid)
+
+      if (next[fromKey]?.items) {
+        next[fromKey] = {
+          ...next[fromKey],
+          items: next[fromKey].items.filter((i) => !(i.id === item.id && i.type === item.type)),
+        }
+      }
+      if (next[toKey]?.items) {
+        const withoutDup = next[toKey].items.filter((i) => !(i.id === item.id && i.type === item.type))
+        next[toKey] = {
+          ...next[toKey],
+          items: [...withoutDup, { ...item, parent_id: toPid }],
+        }
+      }
+      return next
+    })
+  }, [])
+
+  return { get, setItems, markDirty, moveItem, ensure }
+}
+
+const DiscoveryMenuItemLink = memo(({ pls, depth = 0 }) => {
+  const classes = useStyles({ depth })
+  const dataProvider = useDataProvider()
+  const notify = useNotify()
+  const history = useHistory()
+
+  const parentIdForDnD = pls.parent_id ?? ''
+
+  const handleDrop = useCallback(
+    async (item) => {
+      let payload = item
+      if (Array.isArray(item?.ids) && item.ids.length) {
+        try {
+          const filtered = await filterSongDropPayload(pls.id, item)
+          if (!filtered) {
+            notify('Skipped duplicate song.', { type: 'info' })
+            return
+          }
+          payload = filtered
+        } catch (error) {
+          // Ignore filter errors and let the backend handle any duplicates
+        }
+      }
+
+      return dataProvider
+        .addToPlaylist(pls.id, payload)
+        .then((res) => notify('message.songsAddedToPlaylist', 'info', { smart_count: res?.data?.added }))
+        .catch(() => notify('ra.page.error', 'warning'))
+    },
+    [dataProvider, notify, pls.id]
+  )
+
+  const { dragDropRef, isDragging } = useDragAndDrop(
+    DraggableTypes.PLAYLIST,
+    { id: pls.id, type: 'playlist', parentId: parentIdForDnD },
+    canChangeTracks(pls) ? DraggableTypes.ALL : [],
+    handleDrop
+  )
+
+  return (
+    <ListItem
+      button
+      onClick={() => history.push(`/playlist/${pls.id}/show`)}
+      className={`${classes.listItem} ${classes.depth}`}
+      ref={dragDropRef}
+      style={{ opacity: isDragging ? 0.5 : 1 }}
+    >
+      <span className={classes.spacer} />
+      <ListItemIcon className={classes.listItemIcon}><RiPlayListFill /></ListItemIcon>
+      <ListItemText primary={<Typography variant="body2" noWrap className={classes.text}>{pls.name}</Typography>} />
+    </ListItem>
+  )
+})
+DiscoveryMenuItemLink.displayName = 'DiscoveryMenuItemLink'
+
+const FolderRow = memo(function FolderRow({
+  node,
+  depth,
+  open,
+  openMap = {},
+  setOpenMap,
+  childrenStore,
+  onAnyMove,
+}) {
+  const classes = useStyles({ depth })
+  const dataProvider = useDataProvider()
+  const notify = useNotify()
+  const history = useHistory()
+  const refresh = useRefresh()
+  const [loading, setLoading] = useState(false)
+
+  const { get, markDirty, moveItem, ensure } = childrenStore
+  const { items, dirty, cached } = get(node.id)
+
+  const fetchChildrenOnce = useCallback(async () => {
+    if (!open) return
+    if (!dirty && cached) return
+    setLoading(true)
+    try {
+      await ensure(node.id, async () => {
+        const res = await dataProvider.getList('folder', {
+          pagination: { page: 1, perPage: config.maxSidebarPlaylistFolders },
+          sort: { field: 'name', order: 'ASC' },
+          filter: { parent_id: parentFilterValue(node.id) },
+        })
+        return res?.data || []
+      })
+    } catch {
+      notify('ra.page.error', 'warning')
+    } finally {
+      setLoading(false)
+    }
+  }, [open, dirty, cached, ensure, node.id, dataProvider, notify])
+
+  useEffect(() => { fetchChildrenOnce() }, [fetchChildrenOnce])
+
+  const toggle = (e) => {
+    e.stopPropagation()
+    setOpenMap((s) => ({ ...s, [node.id]: !open }))
+  }
+
+  const parentIdForDnD = node.parent_id ?? ''
+
+  const { dragDropRef, isDragging } = useDragAndDrop(
+    DraggableTypes.FOLDER,
+    { id: node.id, type: 'folder', parentId: parentIdForDnD },
+    [DraggableTypes.FOLDER, DraggableTypes.PLAYLIST],
+    async (item) => {
+      try {
+        if (item.id === node.id) return
+
+        const sourceParentId = item.parentId ?? ''
+
+        if (item.type === 'playlist') {
+          await dataProvider.setPlaylistFolder({
+            playlistId: item.id,
+            targetFolderId: node.id,
+            sourceParentId,
+          })
+        } else if (item.type === 'folder') {
+          await dataProvider.moveFolder({
+            folderId: item.id,
+            targetParentId: node.id,
+            sourceParentId,
+          })
+        }
+
+        moveItem(
+          { id: item.id, type: item.type, name: item.name ?? '', parent_id: node.id },
+          sourceParentId,
+          node.id
+        )
+        markDirty([node.id])
+
+        refresh()
+        onAnyMove?.()
+        await fetchChildrenOnce()
+      } catch {
+        notify('ra.page.error', 'warning')
+      }
+    }
+  )
+
+  const childrenTyped = useMemo(() => ({
+    folders: (items || []).filter((i) => i.type === 'folder'),
+    playlists: (items || []).filter((i) => i.type === 'playlist'),
+  }), [items])
+
+  return (
+    <>
+      <ListItem
+        button
+        onClick={() => history.push(`/folder/${node.id}/show`)}
+        className={`${classes.listItem} ${classes.depth}`}
+        ref={dragDropRef}
+        style={{ opacity: isDragging ? 0.5 : 1 }}
+      >
+        <IconButton size="small" className={classes.toggleButton} onClick={toggle}>
+          {open ? <ExpandMoreIcon fontSize="small" /> : <ChevronRightIcon fontSize="small" />}
+        </IconButton>
+        <ListItemIcon className={classes.listItemIcon}><RiFolder3Fill /></ListItemIcon>
+        <ListItemText primary={<Typography variant="body2" noWrap className={classes.text}>{node.name}</Typography>} />
+        {loading && <CircularProgress size={14} className={classes.spinner} />}
+      </ListItem>
+
+      <Collapse in={open} timeout="auto" unmountOnExit>
+        <List disablePadding className={classes.nested}>
+          {childrenTyped.folders.map((f) => (
+            <FolderRow
+              key={f.id}
+              node={f}
+              depth={depth + 1}
+              open={!!openMap[f.id]}
+              openMap={openMap}
+              setOpenMap={setOpenMap}
+              childrenStore={childrenStore}
+              onAnyMove={onAnyMove}
+            />
+          ))}
+          {childrenTyped.playlists.map((p) => (
+            <DiscoveryMenuItemLink key={p.id} pls={p} depth={depth + 1} />
+          ))}
+        </List>
+      </Collapse>
+    </>
+  )
+}, (prev, next) => {
+  return (
+    prev.node.id === next.node.id &&
+    prev.open === next.open &&
+    prev.depth === next.depth &&
+    prev.childrenStore === next.childrenStore
+  )
+})
+
+const DiscoverySubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
+  const history = useHistory()
+  const dataProvider = useDataProvider()
+  const notify = useNotify()
+  const refresh = useRefresh()
+  const classes = useStyles()
+  const [openMap, setOpenMap] = useState({})
+  const childrenStore = useChildrenStore()
+
+  const handleToggle = (menu) => setState((s) => ({ ...s, [menu]: !s[menu] }))
+
+  const onDiscoveryConfig = useCallback(() => {
+    history.push({ pathname: '/folder', state: { parentId: null } })
+  }, [history])
+
+  const { get, markDirty, ensure, moveItem } = childrenStore
+  const { items: rootItems, dirty: rootDirty, cached: rootCached } = get('')
+
+  const fetchRootOnce = useCallback(async () => {
+    if (!rootDirty && rootCached) return
+    try {
+      await ensure('', async () => {
+        const res = await dataProvider.getList('folder', {
+          pagination: { page: 1, perPage: config.maxSidebarPlaylistFolders },
+          sort: { field: 'name', order: 'ASC' },
+          filter: { parent_id: parentFilterValue('') },
+        })
+        return res?.data || []
+      })
+    } catch {
+      notify('ra.page.error', 'warning')
+    }
+  }, [rootDirty, rootCached, ensure, dataProvider, notify])
+
+  useEffect(() => { fetchRootOnce() }, [fetchRootOnce])
+
+  useEffect(() => {
+    const onChanged = (e) => {
+      const { sourceParentId, targetParentId } = e.detail || {}
+      const targets = []
+      if (sourceParentId !== undefined) targets.push(parentKey(sourceParentId))
+      if (targetParentId !== undefined) targets.push(parentKey(targetParentId))
+      if (!targets.length) targets.push('')
+      markDirty(targets)
+
+      refresh()
+    }
+    window.addEventListener('folder:changed', onChanged)
+    return () => window.removeEventListener('folder:changed', onChanged)
+  }, [markDirty, refresh])
+
+  const [, dropRef] = useDrop(() => ({
+    accept: [DraggableTypes.PLAYLIST, DraggableTypes.FOLDER],
+    drop: async (item) => {
+      try {
+        const sourceParentId = item.parentId ?? ''
+
+        if (item.type === 'playlist') {
+          await dataProvider.setPlaylistFolder({
+            playlistId: item.id,
+            targetFolderId: null,
+            sourceParentId,
+          })
+        } else if (item.type === 'folder') {
+          await dataProvider.moveFolder({
+            folderId: item.id,
+            targetParentId: null,
+            sourceParentId,
+          })
+        }
+        moveItem(
+          { id: item.id, type: item.type, name: item.name ?? '', parent_id: '' },
+          sourceParentId,
+          ''
+        )
+        markDirty([''])
+
+        refresh()
+      } catch {
+        notify('ra.page.error', 'warning')
+      }
+    },
+  }), [dataProvider, notify, moveItem, markDirty, refresh])
+
+  const folders = useMemo(() => (rootItems || []).filter((i) => i.type === 'folder'), [rootItems])
+  const playlists = useMemo(() => (rootItems || []).filter((i) => i.type === 'playlist'), [rootItems])
+
+  return (
+    <SubMenu
+      handleToggle={() => handleToggle('menuDiscovery')}
+      isOpen={state.menuDiscovery}
+      sidebarIsOpen={sidebarIsOpen}
+      name={'menu.discovery'}
+      icon={<QueueMusicIcon />}
+      dense={dense}
+      actionIcon={<BiCog />}
+      onAction={onDiscoveryConfig}
+      ref={dropRef}
+    >
+      <List disablePadding>
+        {!rootCached && rootDirty ? (
+          <ListItem><CircularProgress size={16} className={classes.spinner} /></ListItem>
+        ) : (
+          <>
+            {folders.map((f) => (
+              <FolderRow
+                key={f.id}
+                node={f}
+                depth={0}
+                open={!!openMap[f.id]}
+                openMap={openMap}
+                setOpenMap={setOpenMap}
+                childrenStore={childrenStore}
+                onAnyMove={refresh}
+              />
+            ))}
+            {playlists.map((p) => (
+              <DiscoveryMenuItemLink key={p.id} pls={p} depth={0} />
+            ))}
+          </>
+        )}
+      </List>
+    </SubMenu>
+  )
+}
+
+export default DiscoverySubMenu

--- a/ui/src/layout/DiscoverySubMenu.jsx
+++ b/ui/src/layout/DiscoverySubMenu.jsx
@@ -198,7 +198,7 @@ const DiscoveryMenuItemLink = memo(({ pls, depth = 0 }) => {
   return (
     <ListItem
       button
-      onClick={() => history.push(`/playlist/${pls.id}/show`)}
+      onClick={() => history.push(`/discovery/${pls.id}/show`)}
       className={`${classes.listItem} ${classes.depth}`}
       ref={dragDropRef}
       style={{ opacity: isDragging ? 0.5 : 1 }}
@@ -308,7 +308,7 @@ const FolderRow = memo(function FolderRow({
     <>
       <ListItem
         button
-        onClick={() => history.push(`/folder/${node.id}/show`)}
+        onClick={() => history.push(`/discovery/folder/${node.id}/show`)}
         className={`${classes.listItem} ${classes.depth}`}
         ref={dragDropRef}
         style={{ opacity: isDragging ? 0.5 : 1 }}
@@ -363,7 +363,7 @@ const DiscoverySubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
   const handleToggle = (menu) => setState((s) => ({ ...s, [menu]: !s[menu] }))
 
   const onDiscoveryConfig = useCallback(() => {
-    history.push({ pathname: '/folder', state: { parentId: null } })
+    history.push({ pathname: '/discovery/folder', state: { parentId: null } })
   }, [history])
 
   const { get, markDirty, ensure, moveItem } = childrenStore

--- a/ui/src/layout/DiscoverySubMenu.jsx
+++ b/ui/src/layout/DiscoverySubMenu.jsx
@@ -18,8 +18,8 @@ import config from '../config'
 import useDragAndDrop from '../common/useDragAndDrop'
 import httpClient from '../dataProvider/httpClient'
 
-const fetchPlaylistTrackIds = async (playlistId) => {
-  const res = await httpClient(`${REST_URL}/playlist/${playlistId}/tracks`)
+const fetchDiscoverySongIds = async (discoveryId) => {
+  const res = await httpClient(`${REST_URL}/discovery/${discoveryId}/songs`)
   const tracks = Array.isArray(res?.json) ? res.json : []
   const ids = new Set()
   tracks.forEach((track) => {
@@ -30,12 +30,12 @@ const fetchPlaylistTrackIds = async (playlistId) => {
   return ids
 }
 
-const filterSongDropPayload = async (playlistId, item) => {
+const filterDiscoverySongDropPayload = async (discoveryId, item) => {
   if (!Array.isArray(item?.ids) || item.ids.length === 0) {
     return item
   }
 
-  const existingIds = await fetchPlaylistTrackIds(playlistId)
+  const existingIds = await fetchDiscoverySongIds(discoveryId)
   const seen = new Set()
   const uniqueIds = []
 
@@ -80,6 +80,12 @@ const useChildrenStore = () => {
     const key = parentKey(parentId)
     const enriched = (items || []).map((it) => ({
       ...it,
+      type:
+        it.type === 'folder'
+          ? 'discoveryFolder'
+          : it.type === 'playlist'
+          ? 'discovery'
+          : it.type,
       parent_id:
         it.parent_id ?? it.parentId ?? it.folder_id ?? it.folderId ?? key,
     }))
@@ -163,7 +169,7 @@ const DiscoveryMenuItemLink = memo(({ pls, depth = 0 }) => {
       let payload = item
       if (Array.isArray(item?.ids) && item.ids.length) {
         try {
-          const filtered = await filterSongDropPayload(pls.id, item)
+          const filtered = await filterDiscoverySongDropPayload(pls.id, item)
           if (!filtered) {
             notify('Skipped duplicate song.', { type: 'info' })
             return
@@ -175,7 +181,7 @@ const DiscoveryMenuItemLink = memo(({ pls, depth = 0 }) => {
       }
 
       return dataProvider
-        .addToPlaylist(pls.id, payload)
+        .addToDiscovery(pls.id, payload)
         .then((res) => notify('message.songsAddedToPlaylist', 'info', { smart_count: res?.data?.added }))
         .catch(() => notify('ra.page.error', 'warning'))
     },
@@ -183,8 +189,8 @@ const DiscoveryMenuItemLink = memo(({ pls, depth = 0 }) => {
   )
 
   const { dragDropRef, isDragging } = useDragAndDrop(
-    DraggableTypes.PLAYLIST,
-    { id: pls.id, type: 'playlist', parentId: parentIdForDnD },
+    DraggableTypes.DISCOVERY,
+    { id: pls.id, type: 'discovery', parentId: parentIdForDnD },
     canChangeTracks(pls) ? DraggableTypes.ALL : [],
     handleDrop
   )
@@ -230,7 +236,7 @@ const FolderRow = memo(function FolderRow({
     setLoading(true)
     try {
       await ensure(node.id, async () => {
-        const res = await dataProvider.getList('folder', {
+        const res = await dataProvider.getList('discoveryFolder', {
           pagination: { page: 1, perPage: config.maxSidebarPlaylistFolders },
           sort: { field: 'name', order: 'ASC' },
           filter: { parent_id: parentFilterValue(node.id) },
@@ -254,23 +260,23 @@ const FolderRow = memo(function FolderRow({
   const parentIdForDnD = node.parent_id ?? ''
 
   const { dragDropRef, isDragging } = useDragAndDrop(
-    DraggableTypes.FOLDER,
-    { id: node.id, type: 'folder', parentId: parentIdForDnD },
-    [DraggableTypes.FOLDER, DraggableTypes.PLAYLIST],
+    DraggableTypes.DISCOVERY_FOLDER,
+    { id: node.id, type: 'discoveryFolder', parentId: parentIdForDnD },
+    [DraggableTypes.DISCOVERY_FOLDER, DraggableTypes.DISCOVERY],
     async (item) => {
       try {
         if (item.id === node.id) return
 
         const sourceParentId = item.parentId ?? ''
 
-        if (item.type === 'playlist') {
-          await dataProvider.setPlaylistFolder({
-            playlistId: item.id,
+        if (item.type === 'discovery') {
+          await dataProvider.setDiscoveryFolder({
+            discoveryId: item.id,
             targetFolderId: node.id,
             sourceParentId,
           })
-        } else if (item.type === 'folder') {
-          await dataProvider.moveFolder({
+        } else if (item.type === 'discoveryFolder') {
+          await dataProvider.moveDiscoveryFolder({
             folderId: item.id,
             targetParentId: node.id,
             sourceParentId,
@@ -294,8 +300,8 @@ const FolderRow = memo(function FolderRow({
   )
 
   const childrenTyped = useMemo(() => ({
-    folders: (items || []).filter((i) => i.type === 'folder'),
-    playlists: (items || []).filter((i) => i.type === 'playlist'),
+    folders: (items || []).filter((i) => i.type === 'discoveryFolder'),
+    playlists: (items || []).filter((i) => i.type === 'discovery'),
   }), [items])
 
   return (
@@ -367,7 +373,7 @@ const DiscoverySubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
     if (!rootDirty && rootCached) return
     try {
       await ensure('', async () => {
-        const res = await dataProvider.getList('folder', {
+        const res = await dataProvider.getList('discoveryFolder', {
           pagination: { page: 1, perPage: config.maxSidebarPlaylistFolders },
           sort: { field: 'name', order: 'ASC' },
           filter: { parent_id: parentFilterValue('') },
@@ -392,24 +398,24 @@ const DiscoverySubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
 
       refresh()
     }
-    window.addEventListener('folder:changed', onChanged)
-    return () => window.removeEventListener('folder:changed', onChanged)
+    window.addEventListener('discoveryFolder:changed', onChanged)
+    return () => window.removeEventListener('discoveryFolder:changed', onChanged)
   }, [markDirty, refresh])
 
   const [, dropRef] = useDrop(() => ({
-    accept: [DraggableTypes.PLAYLIST, DraggableTypes.FOLDER],
+    accept: [DraggableTypes.DISCOVERY, DraggableTypes.DISCOVERY_FOLDER],
     drop: async (item) => {
       try {
         const sourceParentId = item.parentId ?? ''
 
-        if (item.type === 'playlist') {
-          await dataProvider.setPlaylistFolder({
-            playlistId: item.id,
+        if (item.type === 'discovery') {
+          await dataProvider.setDiscoveryFolder({
+            discoveryId: item.id,
             targetFolderId: null,
             sourceParentId,
           })
-        } else if (item.type === 'folder') {
-          await dataProvider.moveFolder({
+        } else if (item.type === 'discoveryFolder') {
+          await dataProvider.moveDiscoveryFolder({
             folderId: item.id,
             targetParentId: null,
             sourceParentId,
@@ -429,8 +435,14 @@ const DiscoverySubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
     },
   }), [dataProvider, notify, moveItem, markDirty, refresh])
 
-  const folders = useMemo(() => (rootItems || []).filter((i) => i.type === 'folder'), [rootItems])
-  const playlists = useMemo(() => (rootItems || []).filter((i) => i.type === 'playlist'), [rootItems])
+  const folders = useMemo(
+    () => (rootItems || []).filter((i) => i.type === 'discoveryFolder'),
+    [rootItems],
+  )
+  const playlists = useMemo(
+    () => (rootItems || []).filter((i) => i.type === 'discovery'),
+    [rootItems],
+  )
 
   return (
     <SubMenu

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -9,6 +9,7 @@ import SubMenu from './SubMenu'
 import { humanize, pluralize } from 'inflection'
 import albumLists from '../album/albumLists'
 import PlaylistsSubMenu from './PlaylistsSubMenu'
+import DiscoverySubMenu from './DiscoverySubMenu'
 import LibrarySelector from '../common/LibrarySelector'
 import config from '../config'
 
@@ -59,6 +60,7 @@ const Menu = ({ dense = false }) => {
   const [state, setState] = useState({
     menuAlbumList: true,
     menuPlaylists: true,
+    menuDiscovery: true,
     menuSharedPlaylists: true,
   })
 
@@ -132,6 +134,12 @@ const Menu = ({ dense = false }) => {
         <>
           <Divider />
           <PlaylistsSubMenu
+            state={state}
+            setState={setState}
+            sidebarIsOpen={open}
+            dense={dense}
+          />
+          <DiscoverySubMenu
             state={state}
             setState={setState}
             sidebarIsOpen={open}

--- a/ui/src/playlist/PlaylistActions.jsx
+++ b/ui/src/playlist/PlaylistActions.jsx
@@ -7,6 +7,7 @@ import {
   useTranslate,
   useDataProvider,
   useNotify,
+  useResourceContext,
 } from 'react-admin'
 import { useMediaQuery, makeStyles } from '@material-ui/core'
 import PlayArrowIcon from '@material-ui/icons/PlayArrow'
@@ -44,6 +45,13 @@ const PlaylistActions = ({ className, ids, data, record, ...rest }) => {
   const notify = useNotify()
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   const isNotSmall = useMediaQuery((theme) => theme.breakpoints.up('sm'))
+  const resource = useResourceContext() || 'playlist'
+  const isDiscovery = resource === 'discovery'
+  const trackResource = isDiscovery ? 'discoverySong' : 'playlistTrack'
+  const trackFilterKey = isDiscovery ? 'discovery_id' : 'playlist_id'
+  const tracksEndpoint = isDiscovery
+    ? `${REST_URL}/discovery/${record.id}/songs`
+    : `${REST_URL}/playlist/${record.id}/tracks`
 
   const getAllSongsAndDispatch = React.useCallback(
     (action) => {
@@ -52,10 +60,10 @@ const PlaylistActions = ({ className, ids, data, record, ...rest }) => {
       }
 
       dataProvider
-        .getList('playlistTrack', {
+        .getList(trackResource, {
           pagination: { page: 1, perPage: 0 },
           sort: { field: 'id', order: 'ASC' },
-          filter: { playlist_id: record.id },
+          filter: { [trackFilterKey]: record.id },
         })
         .then((res) => {
           const data = res.data.reduce(
@@ -68,7 +76,7 @@ const PlaylistActions = ({ className, ids, data, record, ...rest }) => {
           notify('ra.page.error', 'warning')
         })
     },
-    [dataProvider, dispatch, record, data, ids, notify],
+    [dataProvider, dispatch, record, data, ids, notify, trackFilterKey, trackResource],
   )
 
   const handlePlay = React.useCallback(() => {
@@ -88,8 +96,8 @@ const PlaylistActions = ({ className, ids, data, record, ...rest }) => {
   }, [getAllSongsAndDispatch])
 
   const handleShare = React.useCallback(() => {
-    dispatch(openShareMenu([record.id], 'playlist', record.name))
-  }, [dispatch, record])
+    dispatch(openShareMenu([record.id], resource, record.name))
+  }, [dispatch, record, resource])
 
   const handleDownload = React.useCallback(() => {
     dispatch(openDownloadMenu(record, DOWNLOAD_MENU_PLAY))
@@ -97,7 +105,7 @@ const PlaylistActions = ({ className, ids, data, record, ...rest }) => {
 
   const handleExport = React.useCallback(
     () =>
-      httpClient(`${REST_URL}/playlist/${record.id}/tracks`, {
+      httpClient(tracksEndpoint, {
         headers: new Headers({ Accept: M3U_MIME_TYPE }),
       }).then((res) => {
         const blob = new Blob([res.body], { type: M3U_MIME_TYPE })
@@ -109,7 +117,7 @@ const PlaylistActions = ({ className, ids, data, record, ...rest }) => {
         link.click()
         link.parentNode.removeChild(link)
       }),
-    [record],
+    [record, tracksEndpoint],
   )
 
   return (
@@ -140,7 +148,7 @@ const PlaylistActions = ({ className, ids, data, record, ...rest }) => {
           >
             <RiPlayListAddFill />
           </Button>
-          {config.enableSharing && (
+          {!isDiscovery && config.enableSharing && (
             <Button onClick={handleShare} label={translate('ra.action.share')}>
               <ShareIcon />
             </Button>
@@ -156,15 +164,17 @@ const PlaylistActions = ({ className, ids, data, record, ...rest }) => {
               <CloudDownloadOutlinedIcon />
             </Button>
           )}
-          <Button
-            onClick={handleExport}
-            label={translate('resources.playlist.actions.export')}
-          >
-            <QueueMusicIcon />
-          </Button>
-          <PublishPlaylistButton record={record} />
+          {!isDiscovery && (
+            <Button
+              onClick={handleExport}
+              label={translate('resources.playlist.actions.export')}
+            >
+              <QueueMusicIcon />
+            </Button>
+          )}
+          {!isDiscovery && <PublishPlaylistButton record={record} />}
         </div>
-        <div>{isNotSmall && <ToggleFieldsMenu resource="playlistTrack" />}</div>
+        <div>{isNotSmall && <ToggleFieldsMenu resource={trackResource} />}</div>
       </div>
     </TopToolbar>
   )

--- a/ui/src/playlist/PlaylistCreate.jsx
+++ b/ui/src/playlist/PlaylistCreate.jsx
@@ -7,7 +7,8 @@ import {
   useTranslate,
   useRefresh,
   useNotify,
-  useRedirect
+  useRedirect,
+  useResourceContext,
 } from 'react-admin'
 import { Title } from '../common'
 import { useLocation } from 'react-router-dom'
@@ -17,17 +18,25 @@ const PlaylistCreate = (props) => {
   const notify = useNotify()
   const redirect = useRedirect()
   const translate = useTranslate()
-  const resourceName = translate('resources.playlist.name', { smart_count: 1 })
+  const resource = useResourceContext() || 'playlist'
+  const resourceName = translate(`resources.${resource}.name`, { smart_count: 1 })
   const title = translate('ra.page.create', {
     name: `${resourceName}`,
   })
   const location = useLocation()
-  const playlistFolderId = location.state?.playlistFolderId || null
+  const folderStateKey = resource === 'discovery' ? 'discoveryFolderId' : 'playlistFolderId'
+  const fallbackKey = resource === 'discovery' ? 'discoveryId' : 'playlistId'
+  const folderId =
+    location.state?.[folderStateKey] ??
+    location.state?.folderId ??
+    location.state?.[fallbackKey] ??
+    null
+  const folderBasePath = resource === 'discovery' ? '/discovery/folder' : '/folder'
 
   const onSuccess = () => {
     notify('ra.notification.created', 'info', { smart_count: 1 })
-    if (playlistFolderId) redirect(`/folder/${playlistFolderId}/show`)
-    else redirect('list', '/folder')
+    if (folderId) redirect(`${folderBasePath}/${folderId}/show`)
+    else redirect('list', folderBasePath)
     refresh()
   }
 
@@ -36,7 +45,7 @@ const PlaylistCreate = (props) => {
       <SimpleForm redirect="list" variant={'outlined'}>
         <TextInput source="name" validate={required()} />
         <TextInput multiline source="comment" />
-        <TextInput source="folderId" defaultValue={playlistFolderId} style={{ display: 'none' }} />
+        <TextInput source="folderId" defaultValue={folderId} style={{ display: 'none' }} />
         <BooleanInput source="public" initialValue={true} />
       </SimpleForm>
     </Create>

--- a/ui/src/playlist/PlaylistCreate.jsx
+++ b/ui/src/playlist/PlaylistCreate.jsx
@@ -31,7 +31,7 @@ const PlaylistCreate = (props) => {
     location.state?.folderId ??
     location.state?.[fallbackKey] ??
     null
-  const folderBasePath = resource === 'discovery' ? '/discovery/folder' : '/folder'
+  const folderBasePath = resource === 'discovery' ? '/discoveryFolder' : '/folder'
 
   const onSuccess = () => {
     notify('ra.notification.created', 'info', { smart_count: 1 })

--- a/ui/src/playlist/PlaylistEdit.jsx
+++ b/ui/src/playlist/PlaylistEdit.jsx
@@ -58,7 +58,7 @@ const PlaylistEditToolbar = ({ handleSubmitWithRedirect, saving }) => {
   const refresh = useRefresh()
   const location = useLocation()
   const resource = useResourceContext() || 'playlist'
-  const folderBasePath = resource === 'discovery' ? '/discovery/folder' : '/folder'
+  const folderBasePath = resource === 'discovery' ? '/discoveryFolder' : '/folder'
   const folderStateKey = resource === 'discovery' ? 'discoveryFolderId' : 'playlistFolderId'
 
   const { pristine, submitting, invalid } = useFormState({
@@ -112,7 +112,7 @@ const PlaylistEditForm = () => {
   const refresh = useRefresh()
   const location = useLocation()
   const resource = useResourceContext() || 'playlist'
-  const folderBasePath = resource === 'discovery' ? '/discovery/folder' : '/folder'
+  const folderBasePath = resource === 'discovery' ? '/discoveryFolder' : '/folder'
   const folderStateKey = resource === 'discovery' ? 'discoveryFolderId' : 'playlistFolderId'
 
   const savePlaylist = useCallback(

--- a/ui/src/playlist/PlaylistEdit.jsx
+++ b/ui/src/playlist/PlaylistEdit.jsx
@@ -16,6 +16,7 @@ import {
   useRefresh,
   useDataProvider,
   useRecordContext,
+  useResourceContext,
   Toolbar,
   SaveButton,
 } from 'react-admin'
@@ -37,7 +38,8 @@ const SyncFragment = ({ formData, variant, ...rest }) => {
 
 const PlaylistTitle = ({ record }) => {
   const translate = useTranslate()
-  const resourceName = translate('resources.playlist.name', { smart_count: 1 })
+  const resource = useResourceContext() || 'playlist'
+  const resourceName = translate(`resources.${resource}.name`, { smart_count: 1 })
   return <Title subTitle={`${resourceName} "${record ? record.name : ''}"`} />
 }
 
@@ -55,6 +57,9 @@ const PlaylistEditToolbar = ({ handleSubmitWithRedirect, saving }) => {
   const redirect = useRedirect()
   const refresh = useRefresh()
   const location = useLocation()
+  const resource = useResourceContext() || 'playlist'
+  const folderBasePath = resource === 'discovery' ? '/discovery/folder' : '/folder'
+  const folderStateKey = resource === 'discovery' ? 'discoveryFolderId' : 'playlistFolderId'
 
   const { pristine, submitting, invalid } = useFormState({
     subscription: { pristine: true, submitting: true, invalid: true },
@@ -64,12 +69,16 @@ const PlaylistEditToolbar = ({ handleSubmitWithRedirect, saving }) => {
   const handleDelete = async () => {
     if (!record?.id) return
     try {
-      await dataProvider.delete('playlist', { id: record.id })
+      await dataProvider.delete(resource, { id: record.id })
       notify('ra.notification.deleted', { type: 'info', messageArgs: { smart_count: 1 } })
 
-      const folderId = record?.folderId ?? location.state?.folderId ?? null
-      if (folderId) redirect(`/folder/${folderId}/show`)
-      else redirect('list', '/folder')
+      const folderId =
+        record?.folderId ??
+        location.state?.folderId ??
+        location.state?.[folderStateKey] ??
+        null
+      if (folderId) redirect(`${folderBasePath}/${folderId}/show`)
+      else redirect('list', folderBasePath)
 
       refresh()
     } catch (e) {
@@ -102,27 +111,34 @@ const PlaylistEditForm = () => {
   const redirect = useRedirect()
   const refresh = useRefresh()
   const location = useLocation()
+  const resource = useResourceContext() || 'playlist'
+  const folderBasePath = resource === 'discovery' ? '/discovery/folder' : '/folder'
+  const folderStateKey = resource === 'discovery' ? 'discoveryFolderId' : 'playlistFolderId'
 
   const savePlaylist = useCallback(
     async (values) => {
       if (!record?.id) return
       try {
-        const res = await dataProvider.update('playlist', { id: record.id, data: values })
+        const res = await dataProvider.update(resource, { id: record.id, data: values })
         const saved = res?.data ?? values
         notify('ra.notification.updated', { type: 'info', messageArgs: { smart_count: 1 } })
 
         const folderId =
-          saved?.folderId ?? saved?.folder_id ?? location.state?.folderId ?? null
+          saved?.folderId ??
+          saved?.folder_id ??
+          location.state?.folderId ??
+          location.state?.[folderStateKey] ??
+          null
 
-        if (folderId) redirect(`/folder/${folderId}/show`)
-        else redirect('list', '/folder')
+        if (folderId) redirect(`${folderBasePath}/${folderId}/show`)
+        else redirect('list', folderBasePath)
 
         refresh()
       } catch (e) {
         notify(e?.message || 'ra.page.error', { type: 'warning' })
       }
     },
-    [dataProvider, record?.id, notify, redirect, refresh, location]
+    [dataProvider, record?.id, notify, redirect, refresh, location, resource, folderBasePath, folderStateKey]
   )
 
   return (
@@ -142,7 +158,7 @@ const PlaylistEditForm = () => {
           sort={{ field: 'name', order: 'ASC' }}
         >
           <SelectInput
-            label={'resources.playlist.fields.ownerName'}
+            label={`resources.${resource}.fields.ownerName`}
             optionText="userName"
           />
         </ReferenceInput>

--- a/ui/src/playlist/PlaylistList.jsx
+++ b/ui/src/playlist/PlaylistList.jsx
@@ -14,6 +14,7 @@ import {
   useRecordContext,
   BulkDeleteButton,
   usePermissions,
+  useResourceContext,
 } from 'react-admin'
 import Switch from '@material-ui/core/Switch'
 import { useMediaQuery } from '@material-ui/core'
@@ -30,13 +31,14 @@ import ChangePublicStatusButton from './ChangePublicStatusButton'
 
 const PlaylistFilter = (props) => {
   const { permissions } = usePermissions()
+  const resource = useResourceContext() || 'playlist'
   return (
     <Filter {...props} variant={'outlined'}>
       <SearchInput source="q" alwaysOn />
       {permissions === 'admin' && (
         <ReferenceInput
           source="owner_id"
-          label={'resources.playlist.fields.ownerName'}
+          label={`resources.${resource}.fields.ownerName`}
           reference="user"
           perPage={0}
           sort={{ field: 'name', order: 'ASC' }}
@@ -52,8 +54,10 @@ const PlaylistFilter = (props) => {
 const TogglePublicInput = ({ resource, source }) => {
   const record = useRecordContext()
   const notify = useNotify()
+  const contextResource = useResourceContext()
+  const targetResource = resource || contextResource || 'playlist'
   const [togglePublic] = useUpdate(
-    resource,
+    targetResource,
     record.id,
     {
       ...record,
@@ -84,8 +88,10 @@ const TogglePublicInput = ({ resource, source }) => {
 const ToggleAutoImport = ({ resource, source }) => {
   const record = useRecordContext()
   const notify = useNotify()
+  const contextResource = useResourceContext()
+  const targetResource = resource || contextResource || 'playlist'
   const [ToggleAutoImport] = useUpdate(
-    resource,
+    targetResource,
     record.id,
     {
       ...record,
@@ -121,9 +127,10 @@ const PlaylistListBulkActions = (props) => (
 )
 
 const PlaylistList = (props) => {
+  const resource = useResourceContext() || 'playlist'
   const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
-  useResourceRefresh('playlist')
+  useResourceRefresh(resource)
 
   const toggleableFields = useMemo(
     () => ({
@@ -134,17 +141,18 @@ const PlaylistList = (props) => {
         <DateField source="updatedAt" sortByOrder={'DESC'} />
       ),
       createdAt: <DateField source="createdAt" showTime />,
-      public: !isXsmall && (
-        <TogglePublicInput source="public" sortByOrder={'DESC'} />
-      ),
+      public:
+        !isXsmall && (
+          <TogglePublicInput resource={resource} source="public" sortByOrder={'DESC'} />
+        ),
       comment: <TextField source="comment" />,
-      sync: <ToggleAutoImport source="sync" sortByOrder={'DESC'} />,
+      sync: <ToggleAutoImport resource={resource} source="sync" sortByOrder={'DESC'} />,
     }),
-    [isDesktop, isXsmall],
+    [isDesktop, isXsmall, resource],
   )
 
   const columns = useSelectedFields({
-    resource: 'playlist',
+    resource,
     columns: toggleableFields,
     defaultOff: ['comment'],
   })

--- a/ui/src/playlist/PlaylistListActions.jsx
+++ b/ui/src/playlist/PlaylistListActions.jsx
@@ -4,6 +4,7 @@ import {
   TopToolbar,
   CreateButton,
   useTranslate,
+  useResourceContext,
 } from 'react-admin'
 import { useMediaQuery } from '@material-ui/core'
 import { ToggleFieldsMenu } from '../common'
@@ -11,14 +12,16 @@ import { ToggleFieldsMenu } from '../common'
 const PlaylistListActions = ({ className, ...rest }) => {
   const isNotSmall = useMediaQuery((theme) => theme.breakpoints.up('sm'))
   const translate = useTranslate()
+  const resource = useResourceContext() || 'playlist'
+  const basePath = resource === 'discovery' ? '/discovery' : '/playlist'
 
   return (
     <TopToolbar className={className} {...sanitizeListRestProps(rest)}>
       {cloneElement(rest.filters, { context: 'button' })}
-      <CreateButton basePath="/playlist">
+      <CreateButton basePath={basePath}>
         {translate('ra.action.create')}
       </CreateButton>
-      {isNotSmall && <ToggleFieldsMenu resource="playlist" />}
+      {isNotSmall && <ToggleFieldsMenu resource={resource} />}
     </TopToolbar>
   )
 }

--- a/ui/src/playlist/PlaylistShow.jsx
+++ b/ui/src/playlist/PlaylistShow.jsx
@@ -8,8 +8,8 @@ import {
   Filter,
   Pagination,
   Title as RaTitle,
-} 
-from 'react-admin'
+  useResourceContext,
+} from 'react-admin'
 import { makeStyles } from '@material-ui/core/styles'
 import PlaylistDetails from './PlaylistDetails'
 import PlaylistSongs from './PlaylistSongs'
@@ -32,6 +32,9 @@ const PlaylistShowLayout = (props) => {
   const { record } = context
   const classes = useStyles()
   useResourceRefresh('song')
+  const resource = useResourceContext() || 'playlist'
+  const trackResource = resource === 'discovery' ? 'discoverySong' : 'playlistTrack'
+  const trackFilterKey = resource === 'discovery' ? 'discovery_id' : 'playlist_id'
 
   // Store search query in state to prevent losing focus
   const [searchTerm, setSearchTerm] = useState('')
@@ -61,11 +64,11 @@ const PlaylistShowLayout = (props) => {
           <ReferenceManyField
             {...context}
             addLabel={false}
-            reference="playlistTrack"
-            target="playlist_id"
+            reference={trackResource}
+            target={trackFilterKey}
             sort={{ field: 'id', order: 'ASC' }}
             perPage={50}
-            filter={{ playlist_id: props.id, q: searchTerm }} // Pass searchTerm as a filter
+            filter={{ [trackFilterKey]: props.id, q: searchTerm }} // Pass searchTerm as a filter
           >
             <PlaylistSongs
               {...props}
@@ -77,7 +80,7 @@ const PlaylistShowLayout = (props) => {
                   record={record}
                 />
               }
-              resource={'playlistTrack'}
+              resource={trackResource}
               exporter={false}
               pagination={<Pagination rowsPerPageOptions={[25, 50, 100, 200]}
               perPage={50}

--- a/ui/src/playlist/PlaylistSongBulkActions.jsx
+++ b/ui/src/playlist/PlaylistSongBulkActions.jsx
@@ -22,6 +22,8 @@ const PlaylistSongBulkActions = ({
   resource,
   selectedIds,
   onUnselectItems,
+  parentResource = 'playlist',
+  readOnly,
   ...rest
 }) => {
   const classes = useStyles()
@@ -29,10 +31,13 @@ const PlaylistSongBulkActions = ({
   const listContext = useListContext()
   const data = listContext?.data
   useEffect(() => {
-    unselectAll('playlistTrack')
-  }, [unselectAll])
+    unselectAll(resource)
+  }, [unselectAll, resource])
 
-  const mappedResource = `playlist/${playlistId}/tracks`
+  const mappedResource =
+    parentResource === 'discovery'
+      ? `discovery/${playlistId}/songs`
+      : `playlist/${playlistId}/tracks`
   const selectedMediaIds = selectedIds.map(
     (id) => data?.[id]?.mediaFileId ?? id,
   )
@@ -46,12 +51,13 @@ const PlaylistSongBulkActions = ({
           resource={mappedResource}
           onClick={onUnselectItems}
         />
-        {/* Add the AddToPlaylistButton */}
-        <AddToPlaylistButton
-          resource={mappedResource} // Use the mapped resource for consistency
-          selectedIds={selectedMediaIds} // Pass the mapped media IDs
-          className={classes.button} // Apply custom styles
-        />
+        {!readOnly && (
+          <AddToPlaylistButton
+            resource={mappedResource}
+            selectedIds={selectedMediaIds}
+            className={classes.button}
+          />
+        )}
       </Fragment>
     </ResourceContextProvider>
   )
@@ -64,6 +70,8 @@ PlaylistSongBulkActions.propTypes = {
     PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   ).isRequired,
   onUnselectItems: PropTypes.func,
+  parentResource: PropTypes.string,
+  readOnly: PropTypes.bool,
 }
 
 export default PlaylistSongBulkActions

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -9,6 +9,7 @@ import {
   useVersion,
   useListContext,
   FunctionField,
+  useResourceContext,
 } from 'react-admin'
 import clsx from 'clsx'
 import { useDispatch } from 'react-redux'
@@ -104,7 +105,11 @@ const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
   const dataProvider = useDataProvider()
   const notify = useNotify()
   const version = useVersion()
-  useResourceRefresh('song', 'playlist')
+  const resource = useResourceContext() || props.resource || 'playlistTrack'
+  const isDiscovery = resource === 'discoverySong'
+  const parentResource = isDiscovery ? 'discovery' : 'playlist'
+  const parentFilterKey = isDiscovery ? 'discovery_id' : 'playlist_id'
+  useResourceRefresh('song', parentResource)
 
   useEffect(() => {
     setPage(1)
@@ -123,10 +128,10 @@ const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
   const reorder = useCallback(
     (playlistId, id, newPos) => {
       dataProvider
-        .update('playlistTrack', {
+        .update(resource, {
           id,
           data: { insert_before: newPos },
-          filter: { playlist_id: playlistId },
+          filter: { [parentFilterKey]: playlistId },
         })
         .then(() => {
           refetch()
@@ -135,7 +140,7 @@ const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
           notify('ra.page.error', 'warning')
         })
     },
-    [dataProvider, notify, refetch],
+    [dataProvider, notify, refetch, resource, parentFilterKey],
   )
 
   const handleDragEnd = useCallback(
@@ -191,7 +196,7 @@ const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
   }, [isDesktop, classes.draggable, classes.ratingField])
 
   const columns = useSelectedFields({
-    resource: 'playlistTrack',
+    resource,
     columns: toggleableFields,
     defaultOff: [
       'channels',
@@ -248,6 +253,9 @@ const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
               playlistId={playlistId}
               onUnselectItems={onUnselectItems}
               readOnly={readOnly}
+              resource={resource}
+              parentResource={parentResource}
+              selectedIds={selectedIds}
             />
           </BulkActionsToolbar>
           <ReorderableList

--- a/ui/src/playlist_folder/PlaylistFolderBulkActions.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderBulkActions.jsx
@@ -58,6 +58,8 @@ const useBulkActionHandler = (listResource, actionKind, makePublic) => {
   const unselectAll = useUnselectAll()
   const refresh = useRefresh()
   const [loading, setLoading] = useState(false)
+  const folderResource = listResource || 'folder'
+  const playlistResource = folderResource === 'discoveryFolder' ? 'discovery' : 'playlist'
 
   return useMemo(
     () =>
@@ -66,12 +68,14 @@ const useBulkActionHandler = (listResource, actionKind, makePublic) => {
         setLoading(true)
         try {
           const playlistIds = []
+          const discoveryIds = []
           const folderIds = []
 
           selectedIds.forEach((id) => {
             const rec = getRecord(data, id)
             if (!rec) return
             if (rec.type === 'playlist') playlistIds.push(id)
+            else if (rec.type === 'discovery') discoveryIds.push(id)
             else if (rec.type === 'folder') folderIds.push(id)
           })
 
@@ -80,18 +84,28 @@ const useBulkActionHandler = (listResource, actionKind, makePublic) => {
           if (actionKind === 'togglePublic') {
             if (playlistIds.length)
               ops.push(safeUpdateMany(dataProvider, 'playlist', playlistIds, { public: makePublic }))
+            if (discoveryIds.length)
+              ops.push(
+                safeUpdateMany(dataProvider, playlistResource, discoveryIds, {
+                  public: makePublic,
+                })
+              )
             if (folderIds.length)
               ops.push(
-                safeUpdateMany(dataProvider, 'folder', folderIds, { public: makePublic })
+                safeUpdateMany(dataProvider, folderResource, folderIds, {
+                  public: makePublic,
+                })
               )
           }
 
           if (actionKind === 'delete') {
             if (playlistIds.length)
               ops.push(safeDeleteMany(dataProvider, 'playlist', playlistIds))
+            if (discoveryIds.length)
+              ops.push(safeDeleteMany(dataProvider, playlistResource, discoveryIds))
             if (folderIds.length)
               ops.push(
-                safeDeleteMany(dataProvider, 'folder', folderIds)
+                safeDeleteMany(dataProvider, folderResource, folderIds)
               )
           }
 
@@ -117,17 +131,29 @@ const useBulkActionHandler = (listResource, actionKind, makePublic) => {
             )
           }
 
-          unselectAll(listResource)
+          unselectAll(folderResource)
           refresh({ hard: true })
         } finally {
           setLoading(false)
         }
       },
-    [selectedIds, data, dataProvider, notify, unselectAll, refresh, listResource, actionKind, makePublic, loading]
+    [
+      selectedIds,
+      data,
+      dataProvider,
+      notify,
+      unselectAll,
+      refresh,
+      folderResource,
+      playlistResource,
+      actionKind,
+      makePublic,
+      loading,
+    ]
   )
 }
 
-const CustomBulkDeleteButton = ({ resource }) => {
+const CustomBulkDeleteButton = ({ resource = 'folder' }) => {
   const classes = useStyles()
   const translate = useTranslate()
   const handleBulkDelete = useBulkActionHandler(resource, 'delete')
@@ -144,13 +170,14 @@ const CustomBulkDeleteButton = ({ resource }) => {
   )
 }
 
-const ChangePublicStatusButton = ({ resource, makePublic }) => {
+const ChangePublicStatusButton = ({ resource = 'folder', makePublic }) => {
   const classes = useStyles()
   const translate = useTranslate()
   const handleChangeStatus = useBulkActionHandler(resource, 'togglePublic', makePublic)
+  const baseKey = resource === 'discoveryFolder' ? 'resources.discovery.actions' : 'resources.playlist.actions'
   const label = makePublic
-    ? translate('resources.playlist.actions.makePublic')
-    : translate('resources.playlist.actions.makePrivate')
+    ? translate(`${baseKey}.makePublic`)
+    : translate(`${baseKey}.makePrivate`)
   const icon = makePublic ? <LockOpen /> : <Lock />
 
   return (

--- a/ui/src/playlist_folder/PlaylistFolderCreate.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderCreate.jsx
@@ -22,7 +22,7 @@ const PlaylistFolderCreate = (props) => {
   const translate = useTranslate()
   const resource = useResourceContext() || 'folder'
   const isDiscovery = resource === 'discoveryFolder'
-  const basePath = isDiscovery ? '/discovery/folder' : '/folder'
+  const basePath = isDiscovery ? '/discoveryFolder' : '/folder'
 
   const resourceName = translate(`resources.${resource}.name`, { smart_count: 1 })
   const title = translate('ra.page.create', { name: resourceName })

--- a/ui/src/playlist_folder/PlaylistFolderCreate.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderCreate.jsx
@@ -8,20 +8,23 @@ import {
   useRedirect,
   useRefresh,
   useTranslate,
+  useResourceContext,
 } from 'react-admin'
 import { useLocation } from 'react-router-dom'
 import { Title } from '../common'
 
 const PlaylistFolderCreate = (props) => {
-  const { basePath } = props
   const location = useLocation()
   const parentId = location.state?.parentId || null
   const refresh = useRefresh()
   const notify = useNotify()
   const redirect = useRedirect()
   const translate = useTranslate()
+  const resource = useResourceContext() || 'folder'
+  const isDiscovery = resource === 'discoveryFolder'
+  const basePath = isDiscovery ? '/discovery/folder' : '/folder'
 
-  const resourceName = translate('resources.folder.name', { smart_count: 1 })
+  const resourceName = translate(`resources.${resource}.name`, { smart_count: 1 })
   const title = translate('ra.page.create', { name: resourceName })
 
   const onSuccess = () => {

--- a/ui/src/playlist_folder/PlaylistFolderCreateButton.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderCreateButton.jsx
@@ -4,22 +4,27 @@ import AddIcon from '@material-ui/icons/Add'
 import { useTranslate } from 'react-admin'
 import { useHistory } from 'react-router-dom'
 
-const PlaylistFolderCreateButton = ({ recordId = null }) => {
+const PlaylistFolderCreateButton = ({ recordId = null, resource = 'folder' }) => {
   const translate = useTranslate()
   const history = useHistory()
   const [anchorEl, setAnchorEl] = useState(null)
+  const isDiscovery = resource === 'discoveryFolder'
 
   const open = (e) => setAnchorEl(e.currentTarget)
   const close = () => setAnchorEl(null)
 
   const goFolder = () => {
     const state = recordId ? { parentId: recordId } : {}
-    history.push({ pathname: '/folder/create', state })
+    const pathname = isDiscovery ? '/discovery/folder/create' : '/folder/create'
+    history.push({ pathname, state })
     close()
   }
   const goPlaylist = () => {
-    const state = recordId ? { playlistFolderId: recordId } : {}
-    history.push({ pathname: '/playlist/create', state })
+    const state = recordId
+      ? { [isDiscovery ? 'discoveryFolderId' : 'playlistFolderId']: recordId }
+      : {}
+    const pathname = isDiscovery ? '/discovery/create' : '/playlist/create'
+    history.push({ pathname, state })
     close()
   }
 
@@ -30,10 +35,10 @@ const PlaylistFolderCreateButton = ({ recordId = null }) => {
       </Button>
       <Menu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={close}>
         <MenuItem onClick={goFolder}>
-          {translate('resources.playlist.actions.createFolder')}
+          {translate(`resources.${isDiscovery ? 'discovery' : 'playlist'}.actions.createFolder`)}
         </MenuItem>
         <MenuItem onClick={goPlaylist}>
-          {translate('resources.playlist.actions.create')}
+          {translate(`resources.${isDiscovery ? 'discovery' : 'playlist'}.actions.create`)}
         </MenuItem>
       </Menu>
     </>

--- a/ui/src/playlist_folder/PlaylistFolderCreateButton.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderCreateButton.jsx
@@ -15,7 +15,7 @@ const PlaylistFolderCreateButton = ({ recordId = null, resource = 'folder' }) =>
 
   const goFolder = () => {
     const state = recordId ? { parentId: recordId } : {}
-    const pathname = isDiscovery ? '/discovery/folder/create' : '/folder/create'
+    const pathname = isDiscovery ? '/discoveryFolder/create' : '/folder/create'
     history.push({ pathname, state })
     close()
   }

--- a/ui/src/playlist_folder/PlaylistFolderDataGrid.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderDataGrid.jsx
@@ -45,7 +45,7 @@ const PlaylistFolderRow = ({ record, children, className, rowClick, ...rest }) =
   const pathname = location?.pathname || '/'
 
   const sourceId = (() => {
-    const pattern = isDiscovery ? '/discovery/folder/:id/show' : '/folder/:id/show'
+    const pattern = isDiscovery ? '/discoveryFolder/:id/show' : '/folder/:id/show'
     const m = matchPath(pathname, { path: pattern, exact: false })
     return m?.params?.id ?? ''
   })()

--- a/ui/src/playlist_folder/PlaylistFolderDataGrid.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderDataGrid.jsx
@@ -6,6 +6,7 @@ import {
   useDataProvider,
   useNotify,
   useRefresh,
+  useResourceContext,
 } from 'react-admin'
 import PropTypes from 'prop-types'
 import clsx from 'clsx'
@@ -38,11 +39,14 @@ const PlaylistFolderRow = ({ record, children, className, rowClick, ...rest }) =
   const refresh = useRefresh()
   const history = useHistory()
   const location = useLocation()
+  const listResource = useResourceContext() || 'folder'
+  const isDiscovery = listResource === 'discoveryFolder' || record.type === 'discovery'
 
   const pathname = location?.pathname || '/'
 
   const sourceId = (() => {
-    const m = matchPath(pathname, { path: '/folder/:id/show', exact: false })
+    const pattern = isDiscovery ? '/discovery/folder/:id/show' : '/folder/:id/show'
+    const m = matchPath(pathname, { path: pattern, exact: false })
     return m?.params?.id ?? ''
   })()
 
@@ -58,11 +62,14 @@ const PlaylistFolderRow = ({ record, children, className, rowClick, ...rest }) =
       try {
         if (!item) return
         const currentSourceId = sourceIdRef.current ?? ''
+        const playlistType = isDiscovery ? 'discovery' : 'playlist'
+        const folderType = isDiscovery ? 'discoveryFolder' : 'folder'
         const isTargetFolder = record.type === 'folder'
-        const isTargetPlaylist = record.type === 'playlist'
+        const isTargetPlaylist = record.type === 'playlist' || record.type === 'discovery'
 
-        if (isTargetPlaylist && item.type !== 'playlist' && item.type !== 'folder') {
-          const res = await dataProvider.addToPlaylist(record.id, item)
+        if (isTargetPlaylist && item.type !== playlistType && item.type !== folderType) {
+          const addFn = isDiscovery ? dataProvider.addToDiscovery : dataProvider.addToPlaylist
+          const res = await addFn(record.id, item)
           notify('message.songsAddedToPlaylist', 'info', { smart_count: res?.data?.added })
           refresh()
           return
@@ -70,20 +77,36 @@ const PlaylistFolderRow = ({ record, children, className, rowClick, ...rest }) =
 
         if (item.id === record.id) return
 
-        if (item.type === 'playlist') {
+        if (item.type === playlistType) {
           const targetFolderId = isTargetFolder ? record.id : null
-          await dataProvider.setPlaylistFolder({
-            playlistId: item.id,
-            targetFolderId: targetFolderId,
-            sourceParentId: currentSourceId
-          })
-        } else if (item.type === 'folder') {
+          if (isDiscovery) {
+            await dataProvider.setDiscoveryFolder({
+              discoveryId: item.id,
+              targetFolderId,
+              sourceParentId: currentSourceId,
+            })
+          } else {
+            await dataProvider.setPlaylistFolder({
+              playlistId: item.id,
+              targetFolderId,
+              sourceParentId: currentSourceId,
+            })
+          }
+        } else if (item.type === folderType) {
           const targetParentId = isTargetFolder ? record.id : null
-          await dataProvider.moveFolder({
-            folderId: item.id,
-            targetParentId: targetParentId,
-            sourceParentId: currentSourceId
-          })
+          if (isDiscovery) {
+            await dataProvider.moveDiscoveryFolder({
+              folderId: item.id,
+              targetParentId,
+              sourceParentId: currentSourceId,
+            })
+          } else {
+            await dataProvider.moveFolder({
+              folderId: item.id,
+              targetParentId,
+              sourceParentId: currentSourceId,
+            })
+          }
         }
         notify('message.movedSuccess', 'info')
         refresh()
@@ -91,13 +114,30 @@ const PlaylistFolderRow = ({ record, children, className, rowClick, ...rest }) =
         notify('ra.page.error', 'warning')
       }
     },
-    [dataProvider, notify, refresh, record.id, record.type]
+    [
+      dataProvider,
+      notify,
+      refresh,
+      record.id,
+      record.type,
+      isDiscovery,
+    ]
   )
 
   const { dragDropRef, isDragging } = useDragAndDrop(
-    record.type === 'playlist' ? DraggableTypes.PLAYLIST : DraggableTypes.FOLDER,
-    { id: record.id, type: record.type },
-    record.type === 'playlist' ? DraggableTypes.ALL : [DraggableTypes.PLAYLIST, DraggableTypes.FOLDER],
+    record.type === 'playlist'
+      ? DraggableTypes.PLAYLIST
+      : record.type === 'discovery'
+      ? DraggableTypes.DISCOVERY
+      : isDiscovery
+      ? DraggableTypes.DISCOVERY_FOLDER
+      : DraggableTypes.FOLDER,
+    { id: record.id, type: record.type === 'folder' && isDiscovery ? 'discoveryFolder' : record.type },
+    record.type === 'playlist' || record.type === 'discovery'
+      ? DraggableTypes.ALL
+      : isDiscovery
+      ? [DraggableTypes.DISCOVERY, DraggableTypes.DISCOVERY_FOLDER]
+      : [DraggableTypes.PLAYLIST, DraggableTypes.FOLDER],
     handleDrop
   )
 

--- a/ui/src/playlist_folder/PlaylistFolderEdit.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderEdit.jsx
@@ -57,7 +57,7 @@ const FolderEditToolbar = ({ handleSubmitWithRedirect, saving }) => {
   const location = useLocation()
   const resource = useResourceContext() || 'folder'
   const isDiscovery = resource === 'discoveryFolder'
-  const basePath = isDiscovery ? '/discovery/folder' : '/folder'
+  const basePath = isDiscovery ? '/discoveryFolder' : '/folder'
 
   const { pristine, submitting, invalid } = useFormState({
     subscription: { pristine: true, submitting: true, invalid: true },
@@ -106,7 +106,7 @@ const PlaylistFolderEditForm = () => {
   const refresh = useRefresh()
   const location = useLocation()
   const resource = useResourceContext() || 'folder'
-  const basePath = resource === 'discoveryFolder' ? '/discovery/folder' : '/folder'
+  const basePath = resource === 'discoveryFolder' ? '/discoveryFolder' : '/folder'
 
   const saveFolder = useCallback(
     async (values) => {

--- a/ui/src/playlist_folder/PlaylistFolderEdit.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderEdit.jsx
@@ -16,6 +16,7 @@ import {
   useRefresh,
   useDataProvider,
   useRecordContext,
+  useResourceContext,
   Toolbar,
   SaveButton,
 } from 'react-admin'
@@ -35,7 +36,8 @@ const SyncFragment = ({ formData, ...rest }) => (
 
 const PlaylistFolderTitle = ({ record }) => {
   const translate = useTranslate()
-  const resourceName = translate('resources.folder.name', { smart_count: 1 })
+  const resource = useResourceContext() || 'folder'
+  const resourceName = translate(`resources.${resource}.name`, { smart_count: 1 })
   return <Title subTitle={`${resourceName} "${record ? record.name : ''}"`} />
 }
 
@@ -53,6 +55,9 @@ const FolderEditToolbar = ({ handleSubmitWithRedirect, saving }) => {
   const redirect = useRedirect()
   const refresh = useRefresh()
   const location = useLocation()
+  const resource = useResourceContext() || 'folder'
+  const isDiscovery = resource === 'discoveryFolder'
+  const basePath = isDiscovery ? '/discovery/folder' : '/folder'
 
   const { pristine, submitting, invalid } = useFormState({
     subscription: { pristine: true, submitting: true, invalid: true },
@@ -62,12 +67,12 @@ const FolderEditToolbar = ({ handleSubmitWithRedirect, saving }) => {
   const handleDelete = async () => {
     if (!record?.id) return
     try {
-      await dataProvider.delete('folder', { id: record.id })
+      await dataProvider.delete(resource, { id: record.id })
       notify('ra.notification.deleted', { type: 'info', messageArgs: { smart_count: 1 } })
 
       const parentId = record?.parentId ?? location.state?.parentId ?? null
-      if (parentId) redirect(`/folder/${parentId}/show`)
-      else redirect('list', '/folder')
+      if (parentId) redirect(`${basePath}/${parentId}/show`)
+      else redirect('list', basePath)
 
       refresh()
     } catch (e) {
@@ -100,27 +105,29 @@ const PlaylistFolderEditForm = () => {
   const redirect = useRedirect()
   const refresh = useRefresh()
   const location = useLocation()
+  const resource = useResourceContext() || 'folder'
+  const basePath = resource === 'discoveryFolder' ? '/discovery/folder' : '/folder'
 
   const saveFolder = useCallback(
     async (values) => {
       if (!record?.id) return
       try {
-        const res = await dataProvider.update('folder', { id: record.id, data: values })
+        const res = await dataProvider.update(resource, { id: record.id, data: values })
         const saved = res?.data ?? values
         notify('ra.notification.updated', { type: 'info', messageArgs: { smart_count: 1 } })
 
         const parentId =
           saved?.parentId ?? saved?.parent_id ?? location.state?.parentId ?? null
 
-        if (parentId) redirect(`/folder/${parentId}/show`)
-        else redirect('list', '/folder')
+        if (parentId) redirect(`${basePath}/${parentId}/show`)
+        else redirect('list', basePath)
 
         refresh()
       } catch (e) {
         notify(e?.message || 'ra.page.error', { type: 'warning' })
       }
     },
-    [dataProvider, record?.id, notify, redirect, refresh, location]
+    [dataProvider, record?.id, notify, redirect, refresh, location, resource, basePath]
   )
 
   return (
@@ -140,7 +147,7 @@ const PlaylistFolderEditForm = () => {
           sort={{ field: 'name', order: 'ASC' }}
         >
           <SelectInput
-            label="resources.folder.fields.ownerName"
+            label={`resources.${resource}.fields.ownerName`}
             optionText="userName"
           />
         </ReferenceInput>

--- a/ui/src/playlist_folder/PlaylistFolderList.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderList.jsx
@@ -129,7 +129,7 @@ const PlaylistFolderList = (props) => {
 
   const rowClick = useCallback(
     (id, record) => {
-      const folderPath = isDiscovery ? '/discovery/folder' : '/folder'
+      const folderPath = isDiscovery ? '/discoveryFolder' : '/folder'
       const playlistPath = isDiscovery ? '/discovery' : '/playlist'
       return record?.type === 'folder'
         ? `${folderPath}/${id}/show`

--- a/ui/src/playlist_folder/PlaylistFolderList.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderList.jsx
@@ -10,6 +10,7 @@ import {
   useNotify,
   useRecordContext,
   usePermissions,
+  useResourceContext,
 } from 'react-admin'
 import { useMediaQuery } from '@material-ui/core'
 import Switch from '@material-ui/core/Switch'
@@ -30,13 +31,14 @@ import { PlaylistFolderDataGrid } from './PlaylistFolderDataGrid'
 
 const PlaylistFolderFilter = (props) => {
   const { permissions } = usePermissions()
+  const resource = useResourceContext() || 'folder'
   return (
     <Filter {...props} variant="outlined">
       <SearchInput source="q" alwaysOn />
       {permissions === 'admin' && (
         <ReferenceInput
           source="owner_id"
-          label="resources.playlist.fields.ownerName"
+          label={`resources.${resource}.fields.ownerName`}
           reference="user"
           perPage={50}
           sort={{ field: 'name', order: 'ASC' }}
@@ -53,6 +55,7 @@ const TogglePublicInput = ({ source }) => {
   const record = useRecordContext()
   const notify = useNotify()
   const [update, { isLoading }] = useUpdate()
+  const parentResource = useResourceContext() || 'folder'
 
   const serverValue = Boolean(record?.[source])
 
@@ -66,7 +69,12 @@ const TogglePublicInput = ({ source }) => {
     (e) => {
       e.stopPropagation()
       if (!record?.id) return
-      const resource = record.type
+      const resource =
+        record.type === 'folder'
+          ? parentResource === 'discoveryFolder'
+            ? 'discoveryFolder'
+            : 'folder'
+          : record.type
       const next = !checked
       setChecked(next)
 
@@ -81,8 +89,8 @@ const TogglePublicInput = ({ source }) => {
           },
         }
       )
-    },
-    [checked, notify, record, update]
+      },
+      [checked, notify, parentResource, record, update]
   )
 
   return (
@@ -98,13 +106,12 @@ const TogglePublicInput = ({ source }) => {
   )
 }
 
-const rowClick = (id, record) =>
-  record?.type === 'folder' ? `/folder/${id}/show` : `/playlist/${id}/show`
-
 const PlaylistFolderList = (props) => {
+  const resource = useResourceContext() || 'folder'
+  const isDiscovery = resource === 'discoveryFolder'
   const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
-  useResourceRefresh('folder')
+  useResourceRefresh(resource)
 
   const toggleableFields = useMemo(
     () => ({
@@ -116,9 +123,20 @@ const PlaylistFolderList = (props) => {
   )
 
   const columns = useSelectedFields({
-    resource: 'folder',
+    resource,
     columns: toggleableFields,
   })
+
+  const rowClick = useCallback(
+    (id, record) => {
+      const folderPath = isDiscovery ? '/discovery/folder' : '/folder'
+      const playlistPath = isDiscovery ? '/discovery' : '/playlist'
+      return record?.type === 'folder'
+        ? `${folderPath}/${id}/show`
+        : `${playlistPath}/${id}/show`
+    },
+    [isDiscovery],
+  )
 
   return (
     <List
@@ -126,7 +144,7 @@ const PlaylistFolderList = (props) => {
       exporter={false}
       filters={<PlaylistFolderFilter />}
       actions={<PlaylistListActions />}
-      bulkActionButtons={!isXsmall && <PlaylistFolderBulkActions />}
+      bulkActionButtons={!isXsmall && <PlaylistFolderBulkActions resource={resource} />}
       empty={<EmptyPlaylist />}
       perPage={isXsmall ? 50 : 50}
     >

--- a/ui/src/playlist_folder/PlaylistFolderShow.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderShow.jsx
@@ -12,6 +12,7 @@ import {
   useNotify,
   useRecordContext,
   usePermissions,
+  useResourceContext,
 } from 'react-admin'
 import { useMediaQuery } from '@material-ui/core'
 import Switch from '@material-ui/core/Switch'
@@ -32,13 +33,14 @@ import { PlaylistFolderDataGrid } from './PlaylistFolderDataGrid'
 
 const PlaylistFolderFilter = (props) => {
   const { permissions } = usePermissions()
+  const resource = useResourceContext() || 'folder'
   return (
     <Filter {...props} variant="outlined">
       <SearchInput source="q" alwaysOn resettable />
       {permissions === 'admin' && (
         <ReferenceInput
           source="owner_id"
-          label="resources.playlist.fields.ownerName"
+          label={`resources.${resource}.fields.ownerName`}
           reference="user"
           perPage={50}
           sort={{ field: 'name', order: 'ASC' }}
@@ -55,6 +57,7 @@ const TogglePublicInput = ({ source }) => {
   const record = useRecordContext()
   const notify = useNotify()
   const [update, { isLoading }] = useUpdate()
+  const parentResource = useResourceContext() || 'folder'
 
   const serverValue = Boolean(record?.[source])
 
@@ -68,7 +71,12 @@ const TogglePublicInput = ({ source }) => {
     (e) => {
       e.stopPropagation()
       if (!record?.id) return
-      const resource = record.type
+      const resource =
+        record.type === 'folder'
+          ? parentResource === 'discoveryFolder'
+            ? 'discoveryFolder'
+            : 'folder'
+          : record.type
       const next = !checked
       setChecked(next)
       update(
@@ -83,7 +91,7 @@ const TogglePublicInput = ({ source }) => {
         }
       )
     },
-    [checked, notify, record, update]
+    [checked, notify, parentResource, record, update]
   )
 
   return (
@@ -99,14 +107,13 @@ const TogglePublicInput = ({ source }) => {
   )
 }
 
-const rowClick = (id, record) =>
-  record?.type === 'folder' ? `/folder/${id}/show` : `/playlist/${id}/show`
-
 const FolderChildrenList = (props) => {
   const record = useRecordContext()
+  const resource = useResourceContext() || 'folder'
+  const isDiscovery = resource === 'discoveryFolder'
   const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
-  useResourceRefresh('folder')
+  useResourceRefresh(resource)
 
   const toggleableFields = useMemo(
     () => ({
@@ -118,27 +125,38 @@ const FolderChildrenList = (props) => {
   )
 
   const columns = useSelectedFields({
-    resource: 'folder',
+    resource,
     columns: toggleableFields,
   })
 
   const parentId = record?.id ?? ''
 
+  const handleRowClick = useCallback(
+    (id, rec) => {
+      const folderPath = isDiscovery ? '/discovery/folder' : '/folder'
+      const playlistPath = isDiscovery ? '/discovery' : '/playlist'
+      return rec?.type === 'folder'
+        ? `${folderPath}/${id}/show`
+        : `${playlistPath}/${id}/show`
+    },
+    [isDiscovery],
+  )
+
   return (
     <List
       {...props}
-      resource="folder"
+      resource={resource}
       exporter={false}
       title={<Title subTitle={record?.name} />}
       filters={<PlaylistFolderFilter />}
       actions={<PlaylistListActions />}
-      bulkActionButtons={!isXsmall && <PlaylistFolderBulkActions />}
+      bulkActionButtons={!isXsmall && <PlaylistFolderBulkActions resource={resource} />}
       empty={<EmptyPlaylist />}
       perPage={isXsmall ? 50 : 50}
       filter={{ parent_id: parentId }}
       filterDefaultValues={{ parent_id: parentId }}
     >
-      <PlaylistFolderDataGrid rowClick={rowClick}>
+      <PlaylistFolderDataGrid rowClick={handleRowClick}>
         <TypeIconField label={false} />
         <TextField source="name" />
         {columns}

--- a/ui/src/playlist_folder/PlaylistFolderShow.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderShow.jsx
@@ -133,7 +133,7 @@ const FolderChildrenList = (props) => {
 
   const handleRowClick = useCallback(
     (id, rec) => {
-      const folderPath = isDiscovery ? '/discovery/folder' : '/folder'
+      const folderPath = isDiscovery ? '/discoveryFolder' : '/folder'
       const playlistPath = isDiscovery ? '/discovery' : '/playlist'
       return rec?.type === 'folder'
         ? `${folderPath}/${id}/show`

--- a/ui/src/playlist_folder/PlaylistListActions.jsx
+++ b/ui/src/playlist_folder/PlaylistListActions.jsx
@@ -1,17 +1,21 @@
 import { cloneElement } from 'react'
-import { sanitizeListRestProps, TopToolbar } from 'react-admin'
+import { sanitizeListRestProps, TopToolbar, useResourceContext } from 'react-admin'
 import { useMediaQuery } from '@material-ui/core'
 import { ToggleFieldsMenu } from '../common'
 import PlaylistFolderCreateButton from './PlaylistFolderCreateButton'
 
 const PlaylistListActions = ({ className, ...rest }) => {
   const isNotSmall = useMediaQuery((theme) => theme.breakpoints.up('sm'))
+  const resource = useResourceContext() || 'folder'
 
   return (
     <TopToolbar className={className} {...sanitizeListRestProps(rest)}>
       {rest.filters ? cloneElement(rest.filters, { context: 'button' }) : null}
-      <PlaylistFolderCreateButton recordId={rest?.filterValues?.parent_id} />
-      {isNotSmall && <ToggleFieldsMenu resource="folder" />}
+      <PlaylistFolderCreateButton
+        recordId={rest?.filterValues?.parent_id}
+        resource={resource}
+      />
+      {isNotSmall && <ToggleFieldsMenu resource={resource} />}
     </TopToolbar>
   )
 }

--- a/ui/src/playlist_folder/TypeAwareEditButton.jsx
+++ b/ui/src/playlist_folder/TypeAwareEditButton.jsx
@@ -13,7 +13,7 @@ const TypeAwareEditButton = () => {
 
   let target = `/${record.type}/${record.id}`
   if (record.type === 'folder') {
-    target = `${resource === 'discoveryFolder' ? '/discovery/folder' : '/folder'}/${record.id}`
+    target = `${resource === 'discoveryFolder' ? '/discoveryFolder' : '/folder'}/${record.id}`
   } else if (record.type === 'discovery') {
     target = `/discovery/${record.id}`
   }

--- a/ui/src/playlist_folder/TypeAwareEditButton.jsx
+++ b/ui/src/playlist_folder/TypeAwareEditButton.jsx
@@ -1,19 +1,27 @@
 import { useCallback } from 'react'
-import { Button, useRecordContext } from 'react-admin'
+import { Button, useRecordContext, useResourceContext } from 'react-admin'
 import EditIcon from '@material-ui/icons/Edit'
 import { Link } from 'react-router-dom'
 
 const TypeAwareEditButton = () => {
   const record = useRecordContext()
+  const resource = useResourceContext() || 'folder'
 
   const stop = useCallback((e) => e.stopPropagation(), [])
 
   if (!record) return null
 
+  let target = `/${record.type}/${record.id}`
+  if (record.type === 'folder') {
+    target = `${resource === 'discoveryFolder' ? '/discovery/folder' : '/folder'}/${record.id}`
+  } else if (record.type === 'discovery') {
+    target = `/discovery/${record.id}`
+  }
+
   return (
-   <Button
+    <Button
       component={Link}
-      to={`/${record.type}/${record.id}`}
+      to={target}
       label="ra.action.edit"
       onClick={stop}
       size="small"


### PR DESCRIPTION
## Summary
- add a Discovery submenu component mirroring the playlist sidebar structure
- wire the new menu into the sidebar navigation and expose a translation label

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e02b5494d48330a3500b2c7c785109