### PR TITLE
Add discovery playlists feature

### DIFF
--- a/cmd/wire_gen.go
+++ b/cmd/wire_gen.go
@@ -59,6 +59,7 @@ func CreateNativeAPIRouter(ctx context.Context) *nativeapi.Router {
 	dataStore := persistence.New(sqlDB)
 	share := core.NewShare(dataStore)
 	playlists := core.NewPlaylists(dataStore)
+	discovery := core.NewDiscovery(dataStore)
 	metricsMetrics := metrics.GetPrometheusInstance(dataStore)
 	manager := plugins.GetManager(dataStore, metricsMetrics)
 	insights := metrics.GetInstance(dataStore, manager)
@@ -72,7 +73,7 @@ func CreateNativeAPIRouter(ctx context.Context) *nativeapi.Router {
 	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, metricsMetrics)
 	watcher := scanner.GetWatcher(dataStore, scannerScanner)
 	library := core.NewLibrary(dataStore, scannerScanner, watcher, broker)
-	router := nativeapi.New(dataStore, share, playlists, insights, library)
+	router := nativeapi.New(dataStore, share, playlists, discovery, insights, library)
 	return router
 }
 

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -52,6 +52,7 @@ type configOptions struct {
 	AutoImportPlaylists             bool
 	DefaultPlaylistPublicVisibility bool
 	PlaylistsPath                   string
+	DiscoveryPath                   string
 	SyncFolder                      string
 	SmartPlaylistRefreshDelay       time.Duration
 	AutoTranscodeDownload           bool
@@ -278,6 +279,14 @@ func Load(noConfigDump bool) {
 		}
 	}
 
+	if Server.DiscoveryPath != "" {
+		err = os.MkdirAll(Server.DiscoveryPath, os.ModePerm)
+		if err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, "FATAL: Error creating discovery path:", err)
+			os.Exit(1)
+		}
+	}
+
 	Server.ConfigFile = viper.GetViper().ConfigFileUsed()
 	if Server.DbPath == "" {
 		Server.DbPath = filepath.Join(Server.DataFolder, consts.DefaultDbPath)
@@ -310,6 +319,7 @@ func Load(noConfigDump bool) {
 		validateScanSchedule,
 		validateBackupSchedule,
 		validatePlaylistsPath,
+		validateDiscoveryPath,
 		validatePurgeMissingOption,
 	)
 	if err != nil {
@@ -417,6 +427,23 @@ func validatePlaylistsPath() error {
 	return nil
 }
 
+func validateDiscoveryPath() error {
+	if Server.DiscoveryPath == "" {
+		return nil
+	}
+	info, err := os.Stat(Server.DiscoveryPath)
+	if err != nil {
+		log.Error("Invalid DiscoveryPath", "path", Server.DiscoveryPath, err)
+		return err
+	}
+	if !info.IsDir() {
+		err = fmt.Errorf("DiscoveryPath is not a directory: %s", Server.DiscoveryPath)
+		log.Error(err.Error())
+		return err
+	}
+	return nil
+}
+
 func validatePurgeMissingOption() error {
 	allowedValues := []string{consts.PurgeMissingNever, consts.PurgeMissingAlways, consts.PurgeMissingFull}
 	valid := false
@@ -520,7 +547,7 @@ func setViperDefaults() {
 	viper.SetDefault("enablefavourites", true)
 	viper.SetDefault("enablestarrating", true)
 	viper.SetDefault("enableuserediting", true)
-       viper.SetDefault("defaulttheme", "Music Matters")
+	viper.SetDefault("defaulttheme", "Music Matters")
 	viper.SetDefault("defaultlanguage", "")
 	viper.SetDefault("defaultuivolume", consts.DefaultUIVolume)
 	viper.SetDefault("enablereplaygain", true)

--- a/core/discovery.go
+++ b/core/discovery.go
@@ -33,6 +33,50 @@ func NewDiscovery(ds model.DataStore) Discovery {
 	return &discovery{ds: ds}
 }
 
+type discoveryTrackEntry struct {
+	display  string
+	absolute string
+}
+
+func (d *discovery) collectTrackEntries(folder string) ([]discoveryTrackEntry, error) {
+	entries := make([]discoveryTrackEntry, 0)
+	err := filepath.WalkDir(folder, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !model.IsAudioFile(path) {
+			return nil
+		}
+		absolute := filepath.Clean(path)
+		display := absolute
+		musicRoot := conf.Server.MusicFolder
+		if musicRoot != "" {
+			if absRoot, absErr := filepath.Abs(musicRoot); absErr == nil {
+				musicRoot = absRoot
+			}
+			if rel, relErr := filepath.Rel(musicRoot, absolute); relErr == nil && !strings.HasPrefix(rel, "..") {
+				display = rel
+			}
+		}
+		display = filepath.ToSlash(display)
+		entries = append(entries, discoveryTrackEntry{
+			display:  display,
+			absolute: absolute,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].display < entries[j].display
+	})
+	return entries, nil
+}
+
 func (d *discovery) List(ctx context.Context, refresh bool) (model.DiscoveryPlaylists, error) {
 	if refresh {
 		return d.Refresh(ctx)
@@ -131,66 +175,150 @@ func (d *discovery) Export(ctx context.Context, id string, w io.Writer) error {
 }
 
 func (d *discovery) collectTrackPaths(folder string) ([]string, error) {
-	var tracks []string
-	err := filepath.WalkDir(folder, func(path string, entry os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if entry.IsDir() {
-			return nil
-		}
-		if !model.IsAudioFile(path) {
-			return nil
-		}
-		rel := path
-		if conf.Server.MusicFolder != "" {
-			if r, relErr := filepath.Rel(conf.Server.MusicFolder, path); relErr == nil && !strings.HasPrefix(r, "..") {
-				rel = r
-			}
-		}
-		rel = filepath.ToSlash(rel)
-		tracks = append(tracks, rel)
-		return nil
-	})
+	entries, err := d.collectTrackEntries(folder)
 	if err != nil {
 		return nil, err
 	}
-	sort.Strings(tracks)
+	tracks := make([]string, len(entries))
+	for i, entry := range entries {
+		tracks[i] = entry.display
+	}
 	return tracks, nil
 }
 
+func (d *discovery) libraryRoots(ctx context.Context) []string {
+	libraries, err := d.ds.Library(ctx).GetAll()
+	if err != nil {
+		log.Warn(ctx, "Failed to list libraries for discovery matching", err)
+		return nil
+	}
+	roots := make([]string, 0, len(libraries))
+	for _, lib := range libraries {
+		if lib.Path == "" {
+			continue
+		}
+		root := lib.Path
+		if abs, absErr := filepath.Abs(root); absErr == nil {
+			root = abs
+		}
+		roots = append(roots, filepath.Clean(root))
+	}
+	return roots
+}
+
+func (d *discovery) discoveryPathVariants(displayPath, absolutePath string, libraryRoots []string) []string {
+	seen := make(map[string]struct{}, len(libraryRoots)+2)
+	variants := make([]string, 0, len(libraryRoots)+2)
+	add := func(candidate string) {
+		if candidate == "" {
+			return
+		}
+		cleaned := filepath.Clean(candidate)
+		cleaned = filepath.ToSlash(cleaned)
+		if cleaned == "." {
+			return
+		}
+		if _, ok := seen[cleaned]; ok {
+			return
+		}
+		seen[cleaned] = struct{}{}
+		variants = append(variants, cleaned)
+	}
+
+	add(displayPath)
+	if absolutePath != "" {
+		add(absolutePath)
+	}
+	for _, root := range libraryRoots {
+		absRoot := root
+		if !filepath.IsAbs(absRoot) {
+			if resolved, err := filepath.Abs(absRoot); err == nil {
+				absRoot = resolved
+			}
+		}
+		if absolutePath == "" {
+			continue
+		}
+		rel, relErr := filepath.Rel(absRoot, absolutePath)
+		if relErr != nil {
+			continue
+		}
+		if strings.HasPrefix(rel, "..") {
+			continue
+		}
+		add(rel)
+	}
+	return variants
+}
+
 func (d *discovery) buildTracks(ctx context.Context, entry *model.DiscoveryPlaylist) (model.DiscoveryTracks, error) {
-	paths, err := d.collectTrackPaths(entry.FolderPath)
+	entries, err := d.collectTrackEntries(entry.FolderPath)
 	if err != nil {
 		return nil, err
 	}
-	if len(paths) == 0 {
+	if len(entries) == 0 {
 		return nil, nil
 	}
 	repo := d.ds.MediaFile(ctx)
-	mediaFiles, err := repo.FindByPaths(paths)
+	libraryRoots := d.libraryRoots(ctx)
+	variantByPath := make(map[string][]string, len(entries))
+	lookupSet := make(map[string]struct{}, len(entries)*2)
+	lookup := make([]string, 0, len(entries)*2)
+	for _, entryPath := range entries {
+		normalized := entryPath.display
+		variants := d.discoveryPathVariants(entryPath.display, entryPath.absolute, libraryRoots)
+		variantByPath[normalized] = variants
+		for _, candidate := range variants {
+			if _, ok := lookupSet[candidate]; ok {
+				continue
+			}
+			lookupSet[candidate] = struct{}{}
+			lookup = append(lookup, candidate)
+		}
+	}
+	mediaFiles, err := repo.FindByPaths(lookup)
 	if err != nil {
 		return nil, err
 	}
-	mfByPath := make(map[string]model.MediaFile, len(mediaFiles))
+	mfByPath := make(map[string]model.MediaFile, len(mediaFiles)*2)
 	for _, mf := range mediaFiles {
-		mfByPath[strings.ToLower(filepath.ToSlash(mf.Path))] = mf
+		key := strings.ToLower(filepath.ToSlash(filepath.Clean(mf.Path)))
+		mfByPath[key] = mf
+		if absPath := mf.AbsolutePath(); absPath != "" {
+			absKey := strings.ToLower(filepath.ToSlash(filepath.Clean(absPath)))
+			mfByPath[absKey] = mf
+		}
 	}
-	tracks := make(model.DiscoveryTracks, 0, len(paths))
-	for idx, path := range paths {
-		key := strings.ToLower(path)
-		mediaFile, ok := mfByPath[key]
-		if !ok {
+	tracks := make(model.DiscoveryTracks, 0, len(entries))
+	for idx, entryPath := range entries {
+		normalized := entryPath.display
+		variants := variantByPath[normalized]
+		var (
+			mediaFile model.MediaFile
+			found     bool
+		)
+		for _, candidate := range variants {
+			if mf, ok := mfByPath[strings.ToLower(candidate)]; ok {
+				mediaFile = mf
+				found = true
+				break
+			}
+		}
+		if !found {
+			fallback := normalized
+			if len(variants) > 0 {
+				fallback = variants[0]
+			}
 			mediaFile = model.MediaFile{
-				ID:      id.NewHash(entry.ID + path),
-				Path:    path,
-				Title:   filepath.Base(path),
+				ID:      id.NewHash(entry.ID + fallback),
+				Path:    fallback,
+				Title:   filepath.Base(fallback),
 				Missing: true,
 			}
 		}
 		trackID := mediaFile.ID
 		if trackID == "" {
-			trackID = id.NewHash(entry.ID + path + "#" + strconv.Itoa(idx))
+			trackID = id.NewHash(entry.ID + normalized + "#" + strconv.Itoa(idx))
 		}
 		tracks = append(tracks, model.DiscoveryTrack{
 			ID:          trackID,

--- a/core/discovery.go
+++ b/core/discovery.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -21,6 +22,7 @@ type Discovery interface {
 	Get(ctx context.Context, id string) (*model.DiscoveryPlaylist, error)
 	Export(ctx context.Context, id string, w io.Writer) error
 	Refresh(ctx context.Context) (model.DiscoveryPlaylists, error)
+	Tracks(ctx context.Context, id string) (model.DiscoveryTracks, error)
 }
 
 type discovery struct {
@@ -62,19 +64,19 @@ func (d *discovery) Refresh(ctx context.Context) (model.DiscoveryPlaylists, erro
 			continue
 		}
 		folderPath := filepath.Join(root, entry.Name())
-		tracks, err := d.collectTracks(folderPath)
+		trackPaths, err := d.collectTrackPaths(folderPath)
 		if err != nil {
 			log.Error(ctx, "Error collecting discovery playlist tracks", "folder", folderPath, err)
 			continue
 		}
-		if len(tracks) == 0 {
+		if len(trackPaths) == 0 {
 			continue
 		}
 		playlists = append(playlists, model.DiscoveryPlaylist{
 			ID:         id.NewHash(folderPath),
 			Name:       entry.Name(),
 			FolderPath: folderPath,
-			SongCount:  len(tracks),
+			SongCount:  len(trackPaths),
 			UpdatedAt:  now,
 		})
 	}
@@ -92,24 +94,35 @@ func (d *discovery) Get(ctx context.Context, id string) (*model.DiscoveryPlaylis
 	if err != nil {
 		return nil, err
 	}
-	tracks, err := d.collectTracks(entry.FolderPath)
+	tracks, err := d.buildTracks(ctx, entry)
 	if err != nil {
 		return nil, err
 	}
 	entry.Tracks = tracks
 	entry.SongCount = len(tracks)
+	entry.Sync = false
+	entry.Duration = 0
+	entry.Size = 0
+	for _, track := range tracks {
+		entry.Duration += track.MediaFile.Duration
+		entry.Size += track.MediaFile.Size
+	}
 	return entry, nil
 }
 
 func (d *discovery) Export(ctx context.Context, id string, w io.Writer) error {
-	entry, err := d.Get(ctx, id)
+	entry, err := d.ds.DiscoveryPlaylist(ctx).Get(id)
 	if err != nil {
 		return err
 	}
 	builder := &strings.Builder{}
 	builder.WriteString("#EXTM3U\n")
 	builder.WriteString("#PLAYLIST:" + entry.Name + "\n")
-	for _, track := range entry.Tracks {
+	trackPaths, err := d.collectTrackPaths(entry.FolderPath)
+	if err != nil {
+		return err
+	}
+	for _, track := range trackPaths {
 		builder.WriteString(track)
 		builder.WriteString("\n")
 	}
@@ -117,7 +130,7 @@ func (d *discovery) Export(ctx context.Context, id string, w io.Writer) error {
 	return err
 }
 
-func (d *discovery) collectTracks(folder string) ([]string, error) {
+func (d *discovery) collectTrackPaths(folder string) ([]string, error) {
 	var tracks []string
 	err := filepath.WalkDir(folder, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -144,4 +157,56 @@ func (d *discovery) collectTracks(folder string) ([]string, error) {
 	}
 	sort.Strings(tracks)
 	return tracks, nil
+}
+
+func (d *discovery) buildTracks(ctx context.Context, entry *model.DiscoveryPlaylist) (model.DiscoveryTracks, error) {
+	paths, err := d.collectTrackPaths(entry.FolderPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	repo := d.ds.MediaFile(ctx)
+	mediaFiles, err := repo.FindByPaths(paths)
+	if err != nil {
+		return nil, err
+	}
+	mfByPath := make(map[string]model.MediaFile, len(mediaFiles))
+	for _, mf := range mediaFiles {
+		mfByPath[strings.ToLower(filepath.ToSlash(mf.Path))] = mf
+	}
+	tracks := make(model.DiscoveryTracks, 0, len(paths))
+	for idx, path := range paths {
+		key := strings.ToLower(path)
+		mediaFile, ok := mfByPath[key]
+		if !ok {
+			mediaFile = model.MediaFile{
+				ID:      id.NewHash(entry.ID + path),
+				Path:    path,
+				Title:   filepath.Base(path),
+				Missing: true,
+			}
+		}
+		trackID := mediaFile.ID
+		if trackID == "" {
+			trackID = id.NewHash(entry.ID + path + "#" + strconv.Itoa(idx))
+		}
+		tracks = append(tracks, model.DiscoveryTrack{
+			ID:          trackID,
+			DiscoveryID: entry.ID,
+			MediaFileID: mediaFile.ID,
+			Position:    idx + 1,
+			MediaFile:   mediaFile,
+		})
+	}
+	return tracks, nil
+}
+
+func (d *discovery) Tracks(ctx context.Context, id string) (model.DiscoveryTracks, error) {
+	entry, err := d.ds.DiscoveryPlaylist(ctx).Get(id)
+	if err != nil {
+		return nil, err
+	}
+	return d.buildTracks(ctx, entry)
 }

--- a/core/discovery.go
+++ b/core/discovery.go
@@ -36,6 +36,7 @@ func NewDiscovery(ds model.DataStore) Discovery {
 type discoveryTrackEntry struct {
 	display  string
 	absolute string
+	resolved string
 }
 
 func (d *discovery) collectTrackEntries(folder string) ([]discoveryTrackEntry, error) {
@@ -51,6 +52,10 @@ func (d *discovery) collectTrackEntries(folder string) ([]discoveryTrackEntry, e
 			return nil
 		}
 		absolute := filepath.Clean(path)
+		resolved := absolute
+		if linkTarget, err := filepath.EvalSymlinks(absolute); err == nil && linkTarget != "" {
+			resolved = filepath.Clean(linkTarget)
+		}
 		display := absolute
 		musicRoot := conf.Server.MusicFolder
 		if musicRoot != "" {
@@ -65,6 +70,7 @@ func (d *discovery) collectTrackEntries(folder string) ([]discoveryTrackEntry, e
 		entries = append(entries, discoveryTrackEntry{
 			display:  display,
 			absolute: absolute,
+			resolved: resolved,
 		})
 		return nil
 	})
@@ -206,7 +212,7 @@ func (d *discovery) libraryRoots(ctx context.Context) []string {
 	return roots
 }
 
-func (d *discovery) discoveryPathVariants(displayPath, absolutePath string, libraryRoots []string) []string {
+func (d *discovery) discoveryPathVariants(displayPath, absolutePath, resolvedPath string, libraryRoots []string) []string {
 	seen := make(map[string]struct{}, len(libraryRoots)+2)
 	variants := make([]string, 0, len(libraryRoots)+2)
 	add := func(candidate string) {
@@ -229,6 +235,13 @@ func (d *discovery) discoveryPathVariants(displayPath, absolutePath string, libr
 	if absolutePath != "" {
 		add(absolutePath)
 	}
+	if resolvedPath != "" {
+		add(resolvedPath)
+	}
+	basePath := resolvedPath
+	if basePath == "" {
+		basePath = absolutePath
+	}
 	for _, root := range libraryRoots {
 		absRoot := root
 		if !filepath.IsAbs(absRoot) {
@@ -236,10 +249,10 @@ func (d *discovery) discoveryPathVariants(displayPath, absolutePath string, libr
 				absRoot = resolved
 			}
 		}
-		if absolutePath == "" {
+		if basePath == "" {
 			continue
 		}
-		rel, relErr := filepath.Rel(absRoot, absolutePath)
+		rel, relErr := filepath.Rel(absRoot, basePath)
 		if relErr != nil {
 			continue
 		}
@@ -266,7 +279,7 @@ func (d *discovery) buildTracks(ctx context.Context, entry *model.DiscoveryPlayl
 	lookup := make([]string, 0, len(entries)*2)
 	for _, entryPath := range entries {
 		normalized := entryPath.display
-		variants := d.discoveryPathVariants(entryPath.display, entryPath.absolute, libraryRoots)
+		variants := d.discoveryPathVariants(entryPath.display, entryPath.absolute, entryPath.resolved, libraryRoots)
 		variantByPath[normalized] = variants
 		for _, candidate := range variants {
 			if _, ok := lookupSet[candidate]; ok {

--- a/core/discovery.go
+++ b/core/discovery.go
@@ -15,6 +15,7 @@ import (
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/id"
+	"golang.org/x/text/unicode/norm"
 )
 
 type Discovery interface {
@@ -218,16 +219,20 @@ func (d *discovery) discoveryPathVariants(displayPath, absolutePath string, libr
 		if candidate == "" {
 			return
 		}
-		cleaned := filepath.Clean(candidate)
-		cleaned = filepath.ToSlash(cleaned)
+		cleaned := filepath.ToSlash(filepath.Clean(candidate))
 		if cleaned == "." {
 			return
 		}
-		if _, ok := seen[cleaned]; ok {
-			return
+		for _, normalized := range []string{cleaned, norm.NFC.String(cleaned), norm.NFD.String(cleaned)} {
+			if normalized == "." {
+				continue
+			}
+			if _, ok := seen[normalized]; ok {
+				continue
+			}
+			seen[normalized] = struct{}{}
+			variants = append(variants, normalized)
 		}
-		seen[cleaned] = struct{}{}
-		variants = append(variants, cleaned)
 	}
 
 	add(displayPath)

--- a/core/discovery.go
+++ b/core/discovery.go
@@ -36,7 +36,6 @@ func NewDiscovery(ds model.DataStore) Discovery {
 type discoveryTrackEntry struct {
 	display  string
 	absolute string
-	resolved string
 }
 
 func (d *discovery) collectTrackEntries(folder string) ([]discoveryTrackEntry, error) {
@@ -52,9 +51,10 @@ func (d *discovery) collectTrackEntries(folder string) ([]discoveryTrackEntry, e
 			return nil
 		}
 		absolute := filepath.Clean(path)
-		resolved := absolute
-		if linkTarget, err := filepath.EvalSymlinks(absolute); err == nil && linkTarget != "" {
-			resolved = filepath.Clean(linkTarget)
+		if !filepath.IsAbs(absolute) {
+			if absPath, err := filepath.Abs(absolute); err == nil {
+				absolute = absPath
+			}
 		}
 		display := absolute
 		musicRoot := conf.Server.MusicFolder
@@ -70,7 +70,6 @@ func (d *discovery) collectTrackEntries(folder string) ([]discoveryTrackEntry, e
 		entries = append(entries, discoveryTrackEntry{
 			display:  display,
 			absolute: absolute,
-			resolved: resolved,
 		})
 		return nil
 	})
@@ -212,7 +211,7 @@ func (d *discovery) libraryRoots(ctx context.Context) []string {
 	return roots
 }
 
-func (d *discovery) discoveryPathVariants(displayPath, absolutePath, resolvedPath string, libraryRoots []string) []string {
+func (d *discovery) discoveryPathVariants(displayPath, absolutePath string, libraryRoots []string) []string {
 	seen := make(map[string]struct{}, len(libraryRoots)+2)
 	variants := make([]string, 0, len(libraryRoots)+2)
 	add := func(candidate string) {
@@ -235,13 +234,7 @@ func (d *discovery) discoveryPathVariants(displayPath, absolutePath, resolvedPat
 	if absolutePath != "" {
 		add(absolutePath)
 	}
-	if resolvedPath != "" {
-		add(resolvedPath)
-	}
-	basePath := resolvedPath
-	if basePath == "" {
-		basePath = absolutePath
-	}
+	basePath := absolutePath
 	for _, root := range libraryRoots {
 		absRoot := root
 		if !filepath.IsAbs(absRoot) {
@@ -279,7 +272,7 @@ func (d *discovery) buildTracks(ctx context.Context, entry *model.DiscoveryPlayl
 	lookup := make([]string, 0, len(entries)*2)
 	for _, entryPath := range entries {
 		normalized := entryPath.display
-		variants := d.discoveryPathVariants(entryPath.display, entryPath.absolute, entryPath.resolved, libraryRoots)
+		variants := d.discoveryPathVariants(entryPath.display, entryPath.absolute, libraryRoots)
 		variantByPath[normalized] = variants
 		for _, candidate := range variants {
 			if _, ok := lookupSet[candidate]; ok {

--- a/core/discovery.go
+++ b/core/discovery.go
@@ -1,0 +1,147 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/id"
+)
+
+type Discovery interface {
+	List(ctx context.Context, refresh bool) (model.DiscoveryPlaylists, error)
+	Get(ctx context.Context, id string) (*model.DiscoveryPlaylist, error)
+	Export(ctx context.Context, id string, w io.Writer) error
+	Refresh(ctx context.Context) (model.DiscoveryPlaylists, error)
+}
+
+type discovery struct {
+	ds model.DataStore
+}
+
+func NewDiscovery(ds model.DataStore) Discovery {
+	return &discovery{ds: ds}
+}
+
+func (d *discovery) List(ctx context.Context, refresh bool) (model.DiscoveryPlaylists, error) {
+	if refresh {
+		return d.Refresh(ctx)
+	}
+	repo := d.ds.DiscoveryPlaylist(ctx)
+	playlists, err := repo.GetAll()
+	if err != nil {
+		return nil, err
+	}
+	if len(playlists) == 0 && conf.Server.DiscoveryPath != "" {
+		return d.Refresh(ctx)
+	}
+	return playlists, nil
+}
+
+func (d *discovery) Refresh(ctx context.Context) (model.DiscoveryPlaylists, error) {
+	root := conf.Server.DiscoveryPath
+	if root == "" {
+		return nil, errors.New("discovery directory not configured")
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+	var playlists model.DiscoveryPlaylists
+	now := time.Now().UTC()
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		folderPath := filepath.Join(root, entry.Name())
+		tracks, err := d.collectTracks(folderPath)
+		if err != nil {
+			log.Error(ctx, "Error collecting discovery playlist tracks", "folder", folderPath, err)
+			continue
+		}
+		if len(tracks) == 0 {
+			continue
+		}
+		playlists = append(playlists, model.DiscoveryPlaylist{
+			ID:         id.NewHash(folderPath),
+			Name:       entry.Name(),
+			FolderPath: folderPath,
+			SongCount:  len(tracks),
+			UpdatedAt:  now,
+		})
+	}
+	sort.SliceStable(playlists, func(i, j int) bool {
+		return strings.ToLower(playlists[i].Name) < strings.ToLower(playlists[j].Name)
+	})
+	if err := d.ds.DiscoveryPlaylist(ctx).ReplaceAll(playlists); err != nil {
+		return nil, err
+	}
+	return playlists, nil
+}
+
+func (d *discovery) Get(ctx context.Context, id string) (*model.DiscoveryPlaylist, error) {
+	entry, err := d.ds.DiscoveryPlaylist(ctx).Get(id)
+	if err != nil {
+		return nil, err
+	}
+	tracks, err := d.collectTracks(entry.FolderPath)
+	if err != nil {
+		return nil, err
+	}
+	entry.Tracks = tracks
+	entry.SongCount = len(tracks)
+	return entry, nil
+}
+
+func (d *discovery) Export(ctx context.Context, id string, w io.Writer) error {
+	entry, err := d.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	builder := &strings.Builder{}
+	builder.WriteString("#EXTM3U\n")
+	builder.WriteString("#PLAYLIST:" + entry.Name + "\n")
+	for _, track := range entry.Tracks {
+		builder.WriteString(track)
+		builder.WriteString("\n")
+	}
+	_, err = io.Copy(w, strings.NewReader(builder.String()))
+	return err
+}
+
+func (d *discovery) collectTracks(folder string) ([]string, error) {
+	var tracks []string
+	err := filepath.WalkDir(folder, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !model.IsAudioFile(path) {
+			return nil
+		}
+		rel := path
+		if conf.Server.MusicFolder != "" {
+			if r, relErr := filepath.Rel(conf.Server.MusicFolder, path); relErr == nil && !strings.HasPrefix(r, "..") {
+				rel = r
+			}
+		}
+		rel = filepath.ToSlash(rel)
+		tracks = append(tracks, rel)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(tracks)
+	return tracks, nil
+}

--- a/core/wire_providers.go
+++ b/core/wire_providers.go
@@ -17,6 +17,7 @@ var Set = wire.NewSet(
 	NewPlayers,
 	NewShare,
 	NewPlaylists,
+	NewDiscovery,
 	NewLibrary,
 	agents.GetAgents,
 	external.NewProvider,

--- a/db/migrations/20250819010109_create_discovery_playlists.go
+++ b/db/migrations/20250819010109_create_discovery_playlists.go
@@ -1,0 +1,32 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(Up20250819010109, Down20250819010109)
+}
+
+func Up20250819010109(_ context.Context, tx *sql.Tx) error {
+	_, err := tx.Exec(`
+create table if not exists discovery_playlists (
+    id varchar(255) not null primary key,
+    name varchar(255) not null,
+    folder_path text not null unique,
+    song_count integer not null default 0,
+    updated_at datetime not null
+);
+
+create index if not exists discovery_playlists_name on discovery_playlists(name);
+`)
+	return err
+}
+
+func Down20250819010109(_ context.Context, tx *sql.Tx) error {
+	_, err := tx.Exec(`drop table if exists discovery_playlists;`)
+	return err
+}

--- a/model/datastore.go
+++ b/model/datastore.go
@@ -1,48 +1,49 @@
-	package model
+package model
 
-	import (
-		"context"
+import (
+	"context"
 
-		"github.com/Masterminds/squirrel"
-		"github.com/deluan/rest"
-	)
+	"github.com/Masterminds/squirrel"
+	"github.com/deluan/rest"
+)
 
-	type QueryOptions struct {
-		Sort    string
-		Order   string
-		Max     int
-		Offset  int
-		Filters squirrel.Sqlizer
-		Seed    string // for random sorting
-	}
+type QueryOptions struct {
+	Sort    string
+	Order   string
+	Max     int
+	Offset  int
+	Filters squirrel.Sqlizer
+	Seed    string // for random sorting
+}
 
-	type ResourceRepository interface {
-		rest.Repository
-	}
+type ResourceRepository interface {
+	rest.Repository
+}
 
-	type DataStore interface {
-		Library(ctx context.Context) LibraryRepository
-		Folder(ctx context.Context) FolderRepository
-		Album(ctx context.Context) AlbumRepository
-		Artist(ctx context.Context) ArtistRepository
-		MediaFile(ctx context.Context) MediaFileRepository
-		Genre(ctx context.Context) GenreRepository
-		Tag(ctx context.Context) TagRepository
-		Playlist(ctx context.Context) PlaylistRepository
-		PlaylistFolder(ctx context.Context) PlaylistFolderRepository
-		PlayQueue(ctx context.Context) PlayQueueRepository
-		Transcoding(ctx context.Context) TranscodingRepository
-		Player(ctx context.Context) PlayerRepository
-		Radio(ctx context.Context) RadioRepository
-		Share(ctx context.Context) ShareRepository
-		Property(ctx context.Context) PropertyRepository
-		User(ctx context.Context) UserRepository
-		UserProps(ctx context.Context) UserPropsRepository
-		ScrobbleBuffer(ctx context.Context) ScrobbleBufferRepository
+type DataStore interface {
+	Library(ctx context.Context) LibraryRepository
+	Folder(ctx context.Context) FolderRepository
+	Album(ctx context.Context) AlbumRepository
+	Artist(ctx context.Context) ArtistRepository
+	MediaFile(ctx context.Context) MediaFileRepository
+	Genre(ctx context.Context) GenreRepository
+	Tag(ctx context.Context) TagRepository
+	Playlist(ctx context.Context) PlaylistRepository
+	PlaylistFolder(ctx context.Context) PlaylistFolderRepository
+	DiscoveryPlaylist(ctx context.Context) DiscoveryPlaylistRepository
+	PlayQueue(ctx context.Context) PlayQueueRepository
+	Transcoding(ctx context.Context) TranscodingRepository
+	Player(ctx context.Context) PlayerRepository
+	Radio(ctx context.Context) RadioRepository
+	Share(ctx context.Context) ShareRepository
+	Property(ctx context.Context) PropertyRepository
+	User(ctx context.Context) UserRepository
+	UserProps(ctx context.Context) UserPropsRepository
+	ScrobbleBuffer(ctx context.Context) ScrobbleBufferRepository
 
-		Resource(ctx context.Context, model interface{}) ResourceRepository
+	Resource(ctx context.Context, model interface{}) ResourceRepository
 
-		WithTx(block func(tx DataStore) error, scope ...string) error
-		WithTxImmediate(block func(tx DataStore) error, scope ...string) error
-		GC(ctx context.Context) error
-	}
+	WithTx(block func(tx DataStore) error, scope ...string) error
+	WithTxImmediate(block func(tx DataStore) error, scope ...string) error
+	GC(ctx context.Context) error
+}

--- a/model/discovery_playlist.go
+++ b/model/discovery_playlist.go
@@ -1,0 +1,20 @@
+package model
+
+import "time"
+
+type DiscoveryPlaylist struct {
+	ID         string    `structs:"id" json:"id"`
+	Name       string    `structs:"name" json:"name"`
+	FolderPath string    `structs:"folder_path" json:"folderPath"`
+	SongCount  int       `structs:"song_count" json:"songCount"`
+	UpdatedAt  time.Time `structs:"updated_at" json:"updatedAt"`
+	Tracks     []string  `structs:"-" json:"tracks,omitempty"`
+}
+
+type DiscoveryPlaylists []DiscoveryPlaylist
+
+type DiscoveryPlaylistRepository interface {
+	GetAll(options ...QueryOptions) (DiscoveryPlaylists, error)
+	Get(id string) (*DiscoveryPlaylist, error)
+	ReplaceAll(playlists DiscoveryPlaylists) error
+}

--- a/model/discovery_playlist.go
+++ b/model/discovery_playlist.go
@@ -3,15 +3,28 @@ package model
 import "time"
 
 type DiscoveryPlaylist struct {
-	ID         string    `structs:"id" json:"id"`
-	Name       string    `structs:"name" json:"name"`
-	FolderPath string    `structs:"folder_path" json:"folderPath"`
-	SongCount  int       `structs:"song_count" json:"songCount"`
-	UpdatedAt  time.Time `structs:"updated_at" json:"updatedAt"`
-	Tracks     []string  `structs:"-" json:"tracks,omitempty"`
+	ID         string          `structs:"id" json:"id"`
+	Name       string          `structs:"name" json:"name"`
+	FolderPath string          `structs:"folder_path" json:"folderPath"`
+	SongCount  int             `structs:"song_count" json:"songCount"`
+	UpdatedAt  time.Time       `structs:"updated_at" json:"updatedAt"`
+	Duration   float32         `structs:"-" json:"duration"`
+	Size       int64           `structs:"-" json:"size"`
+	Sync       bool            `structs:"-" json:"sync"`
+	Tracks     DiscoveryTracks `structs:"-" json:"tracks,omitempty"`
 }
 
 type DiscoveryPlaylists []DiscoveryPlaylist
+
+type DiscoveryTrack struct {
+	ID          string `json:"id"`
+	DiscoveryID string `json:"discoveryId"`
+	MediaFileID string `json:"mediaFileId"`
+	Position    int    `json:"position"`
+	MediaFile
+}
+
+type DiscoveryTracks []DiscoveryTrack
 
 type DiscoveryPlaylistRepository interface {
 	GetAll(options ...QueryOptions) (DiscoveryPlaylists, error)

--- a/persistence/discovery_repository.go
+++ b/persistence/discovery_repository.go
@@ -33,7 +33,7 @@ func (r *discoveryPlaylistRepository) Get(id string) (*model.DiscoveryPlaylist, 
 }
 
 func (r *discoveryPlaylistRepository) ReplaceAll(playlists model.DiscoveryPlaylists) error {
-	if _, err := r.db.Delete("discovery_playlists").Execute(); err != nil {
+	if _, err := r.db.NewQuery("delete from discovery_playlists").Execute(); err != nil {
 		return err
 	}
 	for _, pls := range playlists {

--- a/persistence/discovery_repository.go
+++ b/persistence/discovery_repository.go
@@ -1,0 +1,53 @@
+package persistence
+
+import (
+	"context"
+
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/pocketbase/dbx"
+)
+
+type discoveryPlaylistRepository struct {
+	ctx context.Context
+	db  dbx.Builder
+}
+
+func NewDiscoveryPlaylistRepository(ctx context.Context, db dbx.Builder) model.DiscoveryPlaylistRepository {
+	return &discoveryPlaylistRepository{ctx: ctx, db: db}
+}
+
+func (r *discoveryPlaylistRepository) GetAll(_ ...model.QueryOptions) (model.DiscoveryPlaylists, error) {
+	var entries model.DiscoveryPlaylists
+	err := r.db.Select("*").From("discovery_playlists").OrderBy("name asc").All(&entries)
+	return entries, err
+}
+
+func (r *discoveryPlaylistRepository) Get(id string) (*model.DiscoveryPlaylist, error) {
+	var entry model.DiscoveryPlaylist
+	err := r.db.Select("*").From("discovery_playlists").Where(dbx.HashExp{"id": id}).One(&entry)
+	if err != nil {
+		return nil, err
+	}
+	return &entry, nil
+}
+
+func (r *discoveryPlaylistRepository) ReplaceAll(playlists model.DiscoveryPlaylists) error {
+	if _, err := r.db.Delete("discovery_playlists").Execute(); err != nil {
+		return err
+	}
+	for _, pls := range playlists {
+		params := dbx.Params{
+			"id":          pls.ID,
+			"name":        pls.Name,
+			"folder_path": pls.FolderPath,
+			"song_count":  pls.SongCount,
+			"updated_at":  pls.UpdatedAt,
+		}
+		if _, err := r.db.Insert("discovery_playlists", params).Execute(); err != nil {
+			log.Error(r.ctx, "Error persisting discovery playlist", "name", pls.Name, err)
+			return err
+		}
+	}
+	return nil
+}

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -58,7 +58,11 @@ func (s *SQLStore) Playlist(ctx context.Context) model.PlaylistRepository {
 }
 
 func (s *SQLStore) PlaylistFolder(ctx context.Context) model.PlaylistFolderRepository {
-    return NewPlaylistFolderRepository(ctx, s.getDBXBuilder())
+	return NewPlaylistFolderRepository(ctx, s.getDBXBuilder())
+}
+
+func (s *SQLStore) DiscoveryPlaylist(ctx context.Context) model.DiscoveryPlaylistRepository {
+	return NewDiscoveryPlaylistRepository(ctx, s.getDBXBuilder())
 }
 
 func (s *SQLStore) Property(ctx context.Context) model.PropertyRepository {

--- a/server/nativeapi/discovery.go
+++ b/server/nativeapi/discovery.go
@@ -19,6 +19,7 @@ func (n *Router) addDiscoveryRoute(r chi.Router) {
 		r.Route("/{id}", func(r chi.Router) {
 			r.Use(server.URLParamsMiddleware)
 			r.Get("/", n.getDiscovery())
+			r.Get("/tracks", n.getDiscoveryTracks())
 			r.Get("/export", n.exportDiscovery())
 		})
 	})
@@ -61,6 +62,23 @@ func (n *Router) getDiscovery() http.HandlerFunc {
 			return
 		}
 		rest.RespondWithJSON(w, http.StatusOK, entry)
+	}
+}
+
+func (n *Router) getDiscoveryTracks() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		tracks, err := n.discovery.Tracks(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, rest.ErrNotFound) || errors.Is(err, sql.ErrNoRows) {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			log.Error(r.Context(), "Error retrieving discovery playlist tracks", "id", id, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		rest.RespondWithJSON(w, http.StatusOK, tracks)
 	}
 }
 

--- a/server/nativeapi/discovery.go
+++ b/server/nativeapi/discovery.go
@@ -1,0 +1,92 @@
+package nativeapi
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/deluan/rest"
+	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/server"
+)
+
+func (n *Router) addDiscoveryRoute(r chi.Router) {
+	r.Route("/discovery", func(r chi.Router) {
+		r.Get("/", n.listDiscovery())
+		r.Post("/refresh", n.refreshDiscovery())
+		r.Route("/{id}", func(r chi.Router) {
+			r.Use(server.URLParamsMiddleware)
+			r.Get("/", n.getDiscovery())
+			r.Get("/export", n.exportDiscovery())
+		})
+	})
+}
+
+func (n *Router) listDiscovery() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		refresh := strings.EqualFold(r.URL.Query().Get("refresh"), "true")
+		playlists, err := n.discovery.List(r.Context(), refresh)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		rest.RespondWithJSON(w, http.StatusOK, playlists)
+	}
+}
+
+func (n *Router) refreshDiscovery() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		playlists, err := n.discovery.Refresh(r.Context())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		rest.RespondWithJSON(w, http.StatusOK, playlists)
+	}
+}
+
+func (n *Router) getDiscovery() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		entry, err := n.discovery.Get(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, rest.ErrNotFound) || errors.Is(err, sql.ErrNoRows) {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			log.Error(r.Context(), "Error retrieving discovery playlist", "id", id, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		rest.RespondWithJSON(w, http.StatusOK, entry)
+	}
+}
+
+func (n *Router) exportDiscovery() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		entry, err := n.discovery.Get(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, rest.ErrNotFound) || errors.Is(err, sql.ErrNoRows) {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			log.Error(r.Context(), "Error retrieving discovery playlist for export", "id", id, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "audio/x-mpegurl")
+		filename := entry.Name
+		if filename == "" {
+			filename = "discovery-" + id
+		}
+		w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+".m3u\"")
+		if err := n.discovery.Export(r.Context(), id, w); err != nil {
+			log.Error(r.Context(), "Error exporting discovery playlist", "id", id, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+}

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -26,12 +26,13 @@ type Router struct {
 	ds        model.DataStore
 	share     core.Share
 	playlists core.Playlists
+	discovery core.Discovery
 	insights  metrics.Insights
 	libs      core.Library
 }
 
-func New(ds model.DataStore, share core.Share, playlists core.Playlists, insights metrics.Insights, libraryService core.Library) *Router {
-	r := &Router{ds: ds, share: share, playlists: playlists, insights: insights, libs: libraryService}
+func New(ds model.DataStore, share core.Share, playlists core.Playlists, discovery core.Discovery, insights metrics.Insights, libraryService core.Library) *Router {
+	r := &Router{ds: ds, share: share, playlists: playlists, discovery: discovery, insights: insights, libs: libraryService}
 	r.Handler = r.routes()
 	return r
 }
@@ -63,6 +64,7 @@ func (n *Router) routes() http.Handler {
 		n.addPlaylistRoute(r)
 		n.addPlaylistFolderRoute(r)
 		n.addPlaylistTrackRoute(r)
+		n.addDiscoveryRoute(r)
 		n.addSongPlaylistsRoute(r)
 		n.addQueueRoute(r)
 		n.addMissingFilesRoute(r)

--- a/tests/mock_data_store.go
+++ b/tests/mock_data_store.go
@@ -8,27 +8,28 @@ import (
 )
 
 type MockDataStore struct {
-	RealDS               		model.DataStore
-	MockedLibrary        		model.LibraryRepository
-	MockedFolder         		model.FolderRepository
-	MockedGenre          		model.GenreRepository
-	MockedAlbum          		model.AlbumRepository
-	MockedArtist         		model.ArtistRepository
-	MockedMediaFile      		model.MediaFileRepository
-	MockedTag            		model.TagRepository
-	MockedUser           		model.UserRepository
-	MockedProperty       		model.PropertyRepository
-	MockedPlayer         		model.PlayerRepository
-	MockedPlaylist       		model.PlaylistRepository
-	MockedPlaylistFolder 		model.PlaylistFolderRepository
-	MockedPlayQueue      		model.PlayQueueRepository
-	MockedShare          		model.ShareRepository
-	MockedTranscoding    		model.TranscodingRepository
-	MockedUserProps      		model.UserPropsRepository
-	MockedScrobbleBuffer 		model.ScrobbleBufferRepository
-	MockedRadio          		model.RadioRepository
-	scrobbleBufferMu     		sync.Mutex
-	repoMu               		sync.Mutex
+	RealDS                  model.DataStore
+	MockedLibrary           model.LibraryRepository
+	MockedFolder            model.FolderRepository
+	MockedGenre             model.GenreRepository
+	MockedAlbum             model.AlbumRepository
+	MockedArtist            model.ArtistRepository
+	MockedMediaFile         model.MediaFileRepository
+	MockedTag               model.TagRepository
+	MockedUser              model.UserRepository
+	MockedProperty          model.PropertyRepository
+	MockedPlayer            model.PlayerRepository
+	MockedPlaylist          model.PlaylistRepository
+	MockedDiscoveryPlaylist model.DiscoveryPlaylistRepository
+	MockedPlaylistFolder    model.PlaylistFolderRepository
+	MockedPlayQueue         model.PlayQueueRepository
+	MockedShare             model.ShareRepository
+	MockedTranscoding       model.TranscodingRepository
+	MockedUserProps         model.UserPropsRepository
+	MockedScrobbleBuffer    model.ScrobbleBufferRepository
+	MockedRadio             model.RadioRepository
+	scrobbleBufferMu        sync.Mutex
+	repoMu                  sync.Mutex
 }
 
 func (db *MockDataStore) Library(ctx context.Context) model.LibraryRepository {
@@ -119,6 +120,19 @@ func (db *MockDataStore) Playlist(ctx context.Context) model.PlaylistRepository 
 		}
 	}
 	return db.MockedPlaylist
+}
+
+func (db *MockDataStore) DiscoveryPlaylist(ctx context.Context) model.DiscoveryPlaylistRepository {
+	if db.MockedDiscoveryPlaylist == nil {
+		if db.RealDS != nil {
+			db.MockedDiscoveryPlaylist = db.RealDS.DiscoveryPlaylist(ctx)
+		} else {
+			db.MockedDiscoveryPlaylist = struct {
+				model.DiscoveryPlaylistRepository
+			}{}
+		}
+	}
+	return db.MockedDiscoveryPlaylist
 }
 
 func (db *MockDataStore) PlaylistFolder(ctx context.Context) model.PlaylistFolderRepository {

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -13,6 +13,7 @@ import song from './song'
 import album from './album'
 import artist from './artist'
 import playlist from './playlist'
+import discovery from './discovery'
 import playlist_folder from './playlist_folder'
 import radio from './radio'
 import share from './share'
@@ -114,6 +115,11 @@ const Admin = (props) => {
           create={PlaylistCreate}
           show={PlaylistShow}
           edit={PlaylistEdit}
+        />,
+        <Resource
+          name="discovery"
+          {...discovery}
+          options={{ subMenu: 'playlist' }}
         />,
         <Resource
           {...playlist_folder}

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -160,6 +160,7 @@ const Admin = (props) => {
         <Resource name="genre" />,
         <Resource name="tag" />,
         <Resource name="playlistTrack" />,
+        <Resource name="discoveryTrack" />,
         <Resource name="keepalive" />,
         <Resource name="insights" />,
         <Resource name="config" />,

--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -84,14 +84,71 @@ const handleUserLibraryAssociation = async (userId, libraryIds) => {
   }
 
   try {
-  await httpClient(`${REST_URL}/user/${userId}/library`, {
-    method: 'PUT',
-    body: JSON.stringify({ libraryIds }),
-  })
+    await httpClient(`${REST_URL}/user/${userId}/library`, {
+      method: 'PUT',
+      body: JSON.stringify({ libraryIds }),
+    })
   } catch (error) {
     console.error('Error setting user libraries:', error) //eslint-disable-line no-console
     throw error
   }
+}
+
+const sortDiscoveryRecords = (records, sort) => {
+  if (!sort?.field) return [...records]
+  const { field, order } = sort
+  const direction = order === 'DESC' ? -1 : 1
+  return [...records].sort((a, b) => {
+    const aValue = a?.[field]
+    const bValue = b?.[field]
+    if (aValue === undefined || aValue === null) {
+      return bValue === undefined || bValue === null ? 0 : -1 * direction
+    }
+    if (bValue === undefined || bValue === null) {
+      return 1 * direction
+    }
+    if (typeof aValue === 'number' && typeof bValue === 'number') {
+      return (aValue - bValue) * direction
+    }
+    if (typeof aValue === 'string' && typeof bValue === 'string') {
+      return aValue.localeCompare(bValue) * direction
+    }
+    const aText = `${aValue}`
+    const bText = `${bValue}`
+    const aNumber = Number(aText)
+    const bNumber = Number(bText)
+    if (!Number.isNaN(aNumber) && !Number.isNaN(bNumber)) {
+      return (aNumber - bNumber) * direction
+    }
+    return aText.localeCompare(bText) * direction
+  })
+}
+
+const applyDiscoveryFilter = (records, filter) => {
+  if (!filter?.q) return [...records]
+  const query = String(filter.q).trim().toLowerCase()
+  if (!query) return [...records]
+  return records.filter((record) =>
+    (record?.name || '').toLowerCase().includes(query)
+  )
+}
+
+const getDiscoveryList = async (params = {}) => {
+  const { pagination = {}, sort, filter } = params
+  const { json } = await httpClient(`${REST_URL}/discovery`)
+  const records = Array.isArray(json) ? json : []
+  const filtered = applyDiscoveryFilter(records, filter)
+  const sorted = sortDiscoveryRecords(filtered, sort)
+  const page = Math.max(1, pagination.page || 1)
+  const perPage = Math.max(1, pagination.perPage || (sorted.length || 1))
+  const start = (page - 1) * perPage
+  const paginated = sorted.slice(start, start + perPage)
+  return { data: paginated, total: sorted.length }
+}
+
+const getDiscoveryOne = async (id) => {
+  const { json } = await httpClient(`${REST_URL}/discovery/${id}`)
+  return { data: json }
 }
 
 // Enhanced user creation that handles library associations
@@ -142,10 +199,16 @@ const emitFoldersChanged = (detail) => {
 const wrapperDataProvider = {
   ...dataProvider,
   getList: (resource, params) => {
+    if (resource === 'discovery') {
+      return getDiscoveryList(params)
+    }
     const [r, p] = mapResource(resource, params)
     return dataProvider.getList(r, p)
   },
   getOne: (resource, params) => {
+    if (resource === 'discovery') {
+      return getDiscoveryOne(params.id)
+    }
     const [r, p] = mapResource(resource, params)
     const response = dataProvider.getOne(r, p)
 
@@ -162,10 +225,19 @@ const wrapperDataProvider = {
     return response
   },
   getMany: (resource, params) => {
+    if (resource === 'discovery') {
+      const ids = params.ids || []
+      return Promise.all(ids.map((id) => getDiscoveryOne(id))).then((results) => ({
+        data: results.map((item) => item.data),
+      }))
+    }
     const [r, p] = mapResource(resource, params)
     return dataProvider.getMany(r, p)
   },
   getManyReference: (resource, params) => {
+    if (resource === 'discovery') {
+      return getDiscoveryList(params)
+    }
     const [r, p] = mapResource(resource, params)
     return dataProvider.getManyReference(r, p)
   },
@@ -282,6 +354,11 @@ const wrapperDataProvider = {
       }
       return { data: json }
     })
+  },
+  refreshDiscovery: () => {
+    return httpClient(`${REST_URL}/discovery/refresh`, {
+      method: 'POST',
+    }).then(({ json }) => ({ data: json }))
   },
 }
 

--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -133,22 +133,127 @@ const applyDiscoveryFilter = (records, filter) => {
   )
 }
 
+const applyDiscoveryTrackFilter = (records, filter = {}) => {
+  const query = String(filter.q || '').trim().toLowerCase()
+  if (!query) {
+    return [...records]
+  }
+  return records.filter((track) => {
+    const candidates = [
+      track?.title,
+      track?.album,
+      track?.artist,
+      track?.albumArtist,
+      track?.path,
+    ]
+    return candidates.some((value) =>
+      String(value || '')
+        .toLowerCase()
+        .includes(query),
+    )
+  })
+}
+
 const getDiscoveryList = async (params = {}) => {
   const { pagination = {}, sort, filter } = params
   const { json } = await httpClient(`${REST_URL}/discovery`)
   const records = Array.isArray(json) ? json : []
   const filtered = applyDiscoveryFilter(records, filter)
   const sorted = sortDiscoveryRecords(filtered, sort)
+  const perPageRaw = pagination.perPage
+  const perPage =
+    perPageRaw === 0
+      ? sorted.length || 1
+      : Math.max(1, perPageRaw || (sorted.length || 1))
   const page = Math.max(1, pagination.page || 1)
-  const perPage = Math.max(1, pagination.perPage || (sorted.length || 1))
   const start = (page - 1) * perPage
-  const paginated = sorted.slice(start, start + perPage)
+  const end = perPageRaw === 0 ? sorted.length : start + perPage
+  const paginated = sorted.slice(start, end)
   return { data: paginated, total: sorted.length }
 }
 
 const getDiscoveryOne = async (id) => {
   const { json } = await httpClient(`${REST_URL}/discovery/${id}`)
   return { data: json }
+}
+
+const findDiscoveryTrack = async (trackId, discoveryId) => {
+  if (!trackId) {
+    return null
+  }
+
+  const searchWithin = async (id) => {
+    if (!id) {
+      return null
+    }
+    const res = await getDiscoveryTracks({
+      filter: { discovery_id: id },
+      pagination: { page: 1, perPage: 0 },
+    })
+    return res.data.find((item) => item.id === trackId) || null
+  }
+
+  const direct = await searchWithin(discoveryId)
+  if (direct) {
+    return direct
+  }
+
+  const all = await getDiscoveryList({
+    pagination: { page: 1, perPage: 0 },
+  })
+
+  for (const playlist of all.data) {
+    const found = await searchWithin(playlist.id)
+    if (found) {
+      return found
+    }
+  }
+
+  return null
+}
+
+const sortDiscoveryTracks = (records, sort) => {
+  if (!sort?.field) {
+    return [...records]
+  }
+  const { field, order } = sort
+  const direction = order === 'DESC' ? -1 : 1
+  return [...records].sort((a, b) => {
+    const aValue = a?.[field]
+    const bValue = b?.[field]
+    if (typeof aValue === 'number' && typeof bValue === 'number') {
+      return (aValue - bValue) * direction
+    }
+    const aText = String(aValue ?? '').toLowerCase()
+    const bText = String(bValue ?? '').toLowerCase()
+    return aText.localeCompare(bText) * direction
+  })
+}
+
+const getDiscoveryTracks = async (params = {}) => {
+  const { pagination = {}, sort, filter = {} } = params
+  const discoveryId =
+    filter.discovery_id || filter.discoveryId || filter.id || ''
+  if (!discoveryId) {
+    return { data: [], total: 0 }
+  }
+  const { json } = await httpClient(
+    `${REST_URL}/discovery/${discoveryId}/tracks`,
+  )
+  const records = Array.isArray(json) ? json : []
+  const filtered = applyDiscoveryTrackFilter(records, filter)
+  const sorted = sortDiscoveryTracks(filtered, sort)
+  const total = sorted.length
+  const perPageRaw = pagination.perPage
+  const perPage =
+    perPageRaw === 0
+      ? total || 1
+      : Math.max(1, perPageRaw || (sorted.length || 1))
+  const page = Math.max(1, pagination.page || 1)
+  const start = (page - 1) * perPage
+  const end = perPageRaw === 0 ? sorted.length : start + perPage
+  const paginated = sorted.slice(start, end)
+  return { data: paginated, total }
 }
 
 // Enhanced user creation that handles library associations
@@ -202,12 +307,20 @@ const wrapperDataProvider = {
     if (resource === 'discovery') {
       return getDiscoveryList(params)
     }
+    if (resource === 'discoveryTrack') {
+      return getDiscoveryTracks(params)
+    }
     const [r, p] = mapResource(resource, params)
     return dataProvider.getList(r, p)
   },
   getOne: (resource, params) => {
     if (resource === 'discovery') {
       return getDiscoveryOne(params.id)
+    }
+    if (resource === 'discoveryTrack') {
+      return findDiscoveryTrack(params.id, params?.filter?.discovery_id).then(
+        (track) => ({ data: track }),
+      )
     }
     const [r, p] = mapResource(resource, params)
     const response = dataProvider.getOne(r, p)
@@ -231,12 +344,24 @@ const wrapperDataProvider = {
         data: results.map((item) => item.data),
       }))
     }
+    if (resource === 'discoveryTrack') {
+      const filter = params?.filter || {}
+      return getDiscoveryTracks({
+        filter,
+        pagination: { page: 1, perPage: 0 },
+      }).then((res) => ({
+        data: res.data.filter((track) => params.ids.includes(track.id)),
+      }))
+    }
     const [r, p] = mapResource(resource, params)
     return dataProvider.getMany(r, p)
   },
   getManyReference: (resource, params) => {
     if (resource === 'discovery') {
       return getDiscoveryList(params)
+    }
+    if (resource === 'discoveryTrack') {
+      return getDiscoveryTracks(params)
     }
     const [r, p] = mapResource(resource, params)
     return dataProvider.getManyReference(r, p)

--- a/ui/src/discovery/DiscoveryActions.jsx
+++ b/ui/src/discovery/DiscoveryActions.jsx
@@ -1,0 +1,172 @@
+import React from 'react'
+import { useDispatch } from 'react-redux'
+import {
+  Button,
+  sanitizeListRestProps,
+  TopToolbar,
+  useTranslate,
+  useDataProvider,
+  useNotify,
+} from 'react-admin'
+import { useMediaQuery, makeStyles } from '@material-ui/core'
+import PlayArrowIcon from '@material-ui/icons/PlayArrow'
+import ShuffleIcon from '@material-ui/icons/Shuffle'
+import CloudDownloadOutlinedIcon from '@material-ui/icons/CloudDownloadOutlined'
+import { RiPlayListAddFill, RiPlayList2Fill } from 'react-icons/ri'
+import QueueMusicIcon from '@material-ui/icons/QueueMusic'
+import ShareIcon from '@material-ui/icons/Share'
+import {
+  playNext,
+  addTracks,
+  playTracks,
+  shuffleTracks,
+  openDownloadMenu,
+  DOWNLOAD_MENU_PLAY,
+  openShareMenu,
+} from '../actions'
+import httpClient from '../dataProvider/httpClient'
+import { M3U_MIME_TYPE, REST_URL } from '../consts'
+import { formatBytes } from '../utils'
+import config from '../config'
+import { ToggleFieldsMenu } from '../common'
+
+const useStyles = makeStyles({
+  toolbar: { display: 'flex', justifyContent: 'space-between', width: '100%' },
+})
+
+const DiscoveryActions = ({ className, ids, data, record, ...rest }) => {
+  const dispatch = useDispatch()
+  const translate = useTranslate()
+  const classes = useStyles()
+  const dataProvider = useDataProvider()
+  const notify = useNotify()
+  const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
+  const isNotSmall = useMediaQuery((theme) => theme.breakpoints.up('sm'))
+
+  const getAllSongsAndDispatch = React.useCallback(
+    (action) => {
+      if (ids?.length === record.songCount) {
+        return dispatch(action(data, ids))
+      }
+
+      dataProvider
+        .getList('discoveryTrack', {
+          pagination: { page: 1, perPage: 0 },
+          sort: { field: 'position', order: 'ASC' },
+          filter: { discovery_id: record.id },
+        })
+        .then((res) => {
+          const mapped = res.data.reduce(
+            (acc, curr) => ({ ...acc, [curr.id]: curr }),
+            {},
+          )
+          dispatch(action(mapped))
+        })
+        .catch(() => {
+          notify('ra.page.error', 'warning')
+        })
+    },
+    [dataProvider, dispatch, record, data, ids, notify],
+  )
+
+  const handlePlay = React.useCallback(() => {
+    getAllSongsAndDispatch(playTracks)
+  }, [getAllSongsAndDispatch])
+
+  const handlePlayNext = React.useCallback(() => {
+    getAllSongsAndDispatch(playNext)
+  }, [getAllSongsAndDispatch])
+
+  const handlePlayLater = React.useCallback(() => {
+    getAllSongsAndDispatch(addTracks)
+  }, [getAllSongsAndDispatch])
+
+  const handleShuffle = React.useCallback(() => {
+    getAllSongsAndDispatch(shuffleTracks)
+  }, [getAllSongsAndDispatch])
+
+  const handleShare = React.useCallback(() => {
+    dispatch(openShareMenu([record.id], 'discovery', record.name))
+  }, [dispatch, record])
+
+  const handleDownload = React.useCallback(() => {
+    dispatch(openDownloadMenu(record, DOWNLOAD_MENU_PLAY))
+  }, [dispatch, record])
+
+  const handleExport = React.useCallback(() => {
+    return httpClient(`${REST_URL}/discovery/${record.id}/export`, {
+      headers: new Headers({ Accept: M3U_MIME_TYPE }),
+    })
+      .then((res) => {
+        const blob = new Blob([res.body], { type: M3U_MIME_TYPE })
+        const url = window.URL.createObjectURL(blob)
+        const link = document.createElement('a')
+        link.href = url
+        link.download = `${record.name}.m3u`
+        document.body.appendChild(link)
+        link.click()
+        link.parentNode.removeChild(link)
+      })
+      .catch(() => {
+        notify('ra.page.error', 'warning')
+      })
+  }, [record, notify])
+
+  return (
+    <TopToolbar className={className} {...sanitizeListRestProps(rest)}>
+      <div className={classes.toolbar}>
+        <div>
+          <Button
+            onClick={handlePlay}
+            label={translate('resources.album.actions.playAll')}
+          >
+            <PlayArrowIcon />
+          </Button>
+          <Button
+            onClick={handleShuffle}
+            label={translate('resources.album.actions.shuffle')}
+          >
+            <ShuffleIcon />
+          </Button>
+          <Button
+            onClick={handlePlayNext}
+            label={translate('resources.album.actions.playNext')}
+          >
+            <RiPlayList2Fill />
+          </Button>
+          <Button
+            onClick={handlePlayLater}
+            label={translate('resources.album.actions.addToQueue')}
+          >
+            <RiPlayListAddFill />
+          </Button>
+          {config.enableSharing && (
+            <Button onClick={handleShare} label={translate('ra.action.share')}>
+              <ShareIcon />
+            </Button>
+          )}
+          {config.enableDownloads && (
+            <Button
+              onClick={handleDownload}
+              label={
+                translate('ra.action.download') +
+                (isDesktop ? ` (${formatBytes(record.size)})` : '')
+              }
+            >
+              <CloudDownloadOutlinedIcon />
+            </Button>
+          )}
+          <Button
+            onClick={handleExport}
+            label={translate('resources.playlist.actions.export')}
+          >
+            <QueueMusicIcon />
+          </Button>
+        </div>
+        <div>{isNotSmall && <ToggleFieldsMenu resource="discoveryTrack" />}</div>
+      </div>
+    </TopToolbar>
+  )
+}
+
+export default DiscoveryActions

--- a/ui/src/discovery/DiscoveryDetails.jsx
+++ b/ui/src/discovery/DiscoveryDetails.jsx
@@ -1,0 +1,16 @@
+import React, { useMemo } from 'react'
+import PlaylistDetails from '../playlist/PlaylistDetails'
+
+const DiscoveryDetails = (props) => {
+  const { record, ...rest } = props
+  const playlistRecord = useMemo(() => {
+    if (!record) {
+      return record
+    }
+    return { ...record, sync: false }
+  }, [record])
+
+  return <PlaylistDetails {...rest} record={playlistRecord} />
+}
+
+export default DiscoveryDetails

--- a/ui/src/discovery/DiscoveryList.jsx
+++ b/ui/src/discovery/DiscoveryList.jsx
@@ -1,0 +1,117 @@
+import React, { cloneElement, useCallback, useMemo, useState } from 'react'
+import {
+  Button,
+  Datagrid,
+  DateField,
+  Filter,
+  NumberField,
+  SearchInput,
+  TextField,
+  TopToolbar,
+  List,
+  sanitizeListRestProps,
+  useDataProvider,
+  useNotify,
+  useRefresh,
+  useTranslate,
+} from 'react-admin'
+import { makeStyles, CircularProgress } from '@material-ui/core'
+import RefreshIcon from '@material-ui/icons/Refresh'
+
+const useActionStyles = makeStyles(
+  (theme) => ({
+    toolbar: {
+      gap: theme.spacing(1),
+    },
+    spinner: {
+      marginRight: theme.spacing(1),
+    },
+  }),
+  { name: 'NDDiscoveryListActions' }
+)
+
+const DiscoveryFilter = (props) => (
+  <Filter {...props} variant="outlined">
+    <SearchInput source="q" alwaysOn />
+  </Filter>
+)
+
+const DiscoveryListActions = ({ className, ...rest }) => {
+  const classes = useActionStyles()
+  const dataProvider = useDataProvider()
+  const notify = useNotify()
+  const refresh = useRefresh()
+  const translate = useTranslate()
+  const [loading, setLoading] = useState(false)
+
+  const handleRefresh = useCallback(async () => {
+    if (loading) return
+    setLoading(true)
+    try {
+      await dataProvider.refreshDiscovery()
+      refresh()
+      notify('resources.discovery.messages.refreshed', 'info', {
+        _: translate('resources.discovery.messages.refreshed'),
+      })
+    } catch (error) {
+      notify('ra.page.error', 'warning')
+    } finally {
+      setLoading(false)
+    }
+  }, [dataProvider, loading, notify, refresh, translate])
+
+  return (
+    <TopToolbar
+      className={`${className || ''} ${classes.toolbar}`.trim()}
+      {...sanitizeListRestProps(rest)}
+    >
+      {rest.filters && cloneElement(rest.filters, { context: 'button' })}
+      <Button
+        label={translate('resources.discovery.actions.refresh')}
+        onClick={handleRefresh}
+        disabled={loading}
+      >
+        {loading ? <CircularProgress size={18} className={classes.spinner} /> : <RefreshIcon />}
+      </Button>
+    </TopToolbar>
+  )
+}
+
+const rowClick = (id) => `/discovery/${id}`
+
+const DiscoveryList = (props) => {
+  const translate = useTranslate()
+  const defaultSort = useMemo(() => ({ field: 'name', order: 'ASC' }), [])
+  const title = useMemo(
+    () => translate('resources.discovery.name', { smart_count: 2 }),
+    [translate]
+  )
+
+  return (
+    <List
+      {...props}
+      exporter={false}
+      filters={<DiscoveryFilter />}
+      actions={<DiscoveryListActions />}
+      bulkActionButtons={false}
+      perPage={50}
+      sort={defaultSort}
+      title={title}
+    >
+      <Datagrid rowClick={rowClick} optimized>
+        <TextField source="name" />
+        <NumberField
+          source="songCount"
+          label="resources.discovery.fields.songCount"
+        />
+        <DateField
+          source="updatedAt"
+          showTime
+          label="resources.discovery.fields.updatedAt"
+        />
+      </Datagrid>
+    </List>
+  )
+}
+
+export default DiscoveryList

--- a/ui/src/discovery/DiscoveryShow.jsx
+++ b/ui/src/discovery/DiscoveryShow.jsx
@@ -79,7 +79,6 @@ const DiscoveryShowLayout = (props) => {
               record={record}
             />
           }
-          filters={filters}
           discoveryId={record.id}
           pagination={
             <Pagination

--- a/ui/src/discovery/DiscoveryShow.jsx
+++ b/ui/src/discovery/DiscoveryShow.jsx
@@ -12,7 +12,7 @@ import {
 } from '@material-ui/core'
 import RefreshIcon from '@material-ui/icons/Refresh'
 import QueueMusicIcon from '@material-ui/icons/QueueMusic'
-import { Button, RaTitle, TopToolbar, useNotify, useTranslate } from 'react-admin'
+import { Button, Title as RaTitle, TopToolbar, useNotify, useTranslate } from 'react-admin'
 import { useParams } from 'react-router-dom'
 import httpClient from '../dataProvider/httpClient'
 import { M3U_MIME_TYPE, REST_URL } from '../consts'

--- a/ui/src/discovery/DiscoveryShow.jsx
+++ b/ui/src/discovery/DiscoveryShow.jsx
@@ -1,31 +1,22 @@
-import React, { useCallback, useEffect, useState } from 'react'
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  Typography,
-  List,
-  ListItem,
-  ListItemText,
-  Button,
-  CircularProgress,
-  makeStyles,
-} from '@material-ui/core'
-import CloudDownloadIcon from '@material-ui/icons/CloudDownload'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { Card, CardContent, CardHeader, CircularProgress, List, ListItem, ListItemText, Typography, makeStyles } from '@material-ui/core'
 import RefreshIcon from '@material-ui/icons/Refresh'
-import { useNotify, useTranslate } from 'react-admin'
+import QueueMusicIcon from '@material-ui/icons/QueueMusic'
+import { Button, RaRecordContext, RaTitle, TopToolbar, useNotify, useTranslate } from 'react-admin'
 import { useParams } from 'react-router-dom'
 import httpClient from '../dataProvider/httpClient'
-import { REST_URL } from '../consts'
+import { M3U_MIME_TYPE, REST_URL } from '../consts'
+import { Title } from '../common'
 
 const useStyles = makeStyles((theme) => ({
   root: {
     maxWidth: 960,
     margin: '24px auto',
   },
-  actions: {
+  actionsToolbar: {
     display: 'flex',
-    gap: theme.spacing(1),
+    justifyContent: 'space-between',
+    width: '100%',
     marginBottom: theme.spacing(2),
   },
   list: {
@@ -34,6 +25,32 @@ const useStyles = makeStyles((theme) => ({
   },
 }))
 
+const DiscoveryActions = ({ onRefresh, onExport, refreshing, exporting }) => {
+  const translate = useTranslate()
+  const classes = useStyles()
+
+  return (
+    <TopToolbar className={classes.actionsToolbar}>
+      <div>
+        <Button
+          onClick={onRefresh}
+          label={translate('action.refresh', { _: translate('ra.action.refresh') })}
+          disabled={refreshing || exporting}
+        >
+          <RefreshIcon />
+        </Button>
+        <Button
+          onClick={onExport}
+          label={translate('resources.playlist.actions.export')}
+          disabled={refreshing || exporting}
+        >
+          <QueueMusicIcon />
+        </Button>
+      </div>
+    </TopToolbar>
+  )
+}
+
 const DiscoveryShow = () => {
   const classes = useStyles()
   const notify = useNotify()
@@ -41,6 +58,7 @@ const DiscoveryShow = () => {
   const { id } = useParams()
   const [record, setRecord] = useState(null)
   const [loading, setLoading] = useState(false)
+  const [exporting, setExporting] = useState(false)
 
   const fetchRecord = useCallback(async () => {
     if (!id) return
@@ -59,13 +77,43 @@ const DiscoveryShow = () => {
     fetchRecord()
   }, [fetchRecord])
 
-  const handleExport = () => {
-    window.open(`${REST_URL}/discovery/${id}/export`, '_blank')
-  }
+  const playlistSubtitle = useMemo(() => {
+    if (!record) {
+      return null
+    }
+    return translate('resources.playlist.fields.songCount', {
+      smart_count: record.songCount || 0,
+    })
+  }, [record, translate])
 
-  const handleRefresh = () => {
+  const handleExport = useCallback(() => {
+    if (!id) return
+    setExporting(true)
+    httpClient(`${REST_URL}/discovery/${id}/export`, {
+      headers: new Headers({ Accept: M3U_MIME_TYPE }),
+    })
+      .then((res) => {
+        const blob = new Blob([res.body], { type: M3U_MIME_TYPE })
+        const url = window.URL.createObjectURL(blob)
+        const link = document.createElement('a')
+        link.href = url
+        link.download = `${record?.name || 'discovery'}.m3u`
+        document.body.appendChild(link)
+        link.click()
+        link.parentNode.removeChild(link)
+        window.URL.revokeObjectURL(url)
+      })
+      .catch(() => {
+        notify('ra.page.error', 'warning')
+      })
+      .finally(() => {
+        setExporting(false)
+      })
+  }, [id, notify, record])
+
+  const handleRefresh = useCallback(() => {
     fetchRecord()
-  }
+  }, [fetchRecord])
 
   if (loading && !record) {
     return (
@@ -91,27 +139,28 @@ const DiscoveryShow = () => {
   }
 
   return (
-    <Card className={classes.root}>
-      <CardHeader title={record.name} subheader={translate('resources.playlist.fields.songCount', { smart_count: record.songCount || 0 })} />
-      <CardContent>
-        <div className={classes.actions}>
-          <Button startIcon={<RefreshIcon />} onClick={handleRefresh} disabled={loading} variant="outlined">
-            {translate('action.refresh', { _: translate('ra.action.refresh') })}
-          </Button>
-          <Button startIcon={<CloudDownloadIcon />} onClick={handleExport} variant="contained" color="primary">
-            {translate('action.export', { _: translate('ra.action.export') })}
-          </Button>
-        </div>
-        {loading ? <CircularProgress size={24} /> : null}
-        <List className={classes.list} dense>
-          {(record.tracks || []).map((track, index) => (
-            <ListItem key={`${track}-${index}`}>
-              <ListItemText primary={track} secondary={`#${index + 1}`} />
-            </ListItem>
-          ))}
-        </List>
-      </CardContent>
-    </Card>
+    <RaRecordContext.Provider value={record}>
+      {record && <RaTitle title={<Title subTitle={record.name} />} />}
+      <Card className={classes.root}>
+        <CardHeader title={record.name} subheader={playlistSubtitle} />
+        <CardContent>
+          <DiscoveryActions
+            onRefresh={handleRefresh}
+            onExport={handleExport}
+            refreshing={loading}
+            exporting={exporting}
+          />
+          {loading ? <CircularProgress size={24} /> : null}
+          <List className={classes.list} dense>
+            {(record.tracks || []).map((track, index) => (
+              <ListItem key={`${track}-${index}`} divider>
+                <ListItemText primary={track} secondary={`#${index + 1}`} />
+              </ListItem>
+            ))}
+          </List>
+        </CardContent>
+      </Card>
+    </RaRecordContext.Provider>
   )
 }
 

--- a/ui/src/discovery/DiscoveryShow.jsx
+++ b/ui/src/discovery/DiscoveryShow.jsx
@@ -1,37 +1,58 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { Card, CardContent, CardHeader, CircularProgress, List, ListItem, ListItemText, Typography, makeStyles } from '@material-ui/core'
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CircularProgress,
+  List,
+  ListItem,
+  ListItemText,
+  Typography,
+  makeStyles,
+} from '@material-ui/core'
 import RefreshIcon from '@material-ui/icons/Refresh'
 import QueueMusicIcon from '@material-ui/icons/QueueMusic'
-import { Button, RaRecordContext, RaTitle, TopToolbar, useNotify, useTranslate } from 'react-admin'
+import { Button, RaTitle, TopToolbar, useNotify, useTranslate } from 'react-admin'
 import { useParams } from 'react-router-dom'
 import httpClient from '../dataProvider/httpClient'
 import { M3U_MIME_TYPE, REST_URL } from '../consts'
 import { Title } from '../common'
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    maxWidth: 960,
-    margin: '24px auto',
-  },
-  actionsToolbar: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    width: '100%',
-    marginBottom: theme.spacing(2),
-  },
-  list: {
-    backgroundColor: theme.palette.background.paper,
-    borderRadius: theme.shape.borderRadius,
-  },
-}))
+const useStyles = makeStyles(
+  (theme) => ({
+    root: {
+      maxWidth: 960,
+      margin: '24px auto',
+    },
+    toolbar: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      width: '100%',
+      marginBottom: theme.spacing(2),
+    },
+    list: {
+      backgroundColor: theme.palette.background.paper,
+      borderRadius: theme.shape.borderRadius,
+    },
+    actionsGroup: {
+      '& > *': {
+        marginRight: theme.spacing(1),
+      },
+      '& > *:last-child': {
+        marginRight: 0,
+      },
+    },
+  }),
+  { name: 'NDDiscoveryShow' },
+)
 
 const DiscoveryActions = ({ onRefresh, onExport, refreshing, exporting }) => {
   const translate = useTranslate()
   const classes = useStyles()
 
   return (
-    <TopToolbar className={classes.actionsToolbar}>
-      <div>
+    <TopToolbar className={classes.toolbar}>
+      <div className={classes.actionsGroup}>
         <Button
           onClick={onRefresh}
           label={translate('action.refresh', { _: translate('ra.action.refresh') })}
@@ -47,6 +68,7 @@ const DiscoveryActions = ({ onRefresh, onExport, refreshing, exporting }) => {
           <QueueMusicIcon />
         </Button>
       </div>
+      <div />
     </TopToolbar>
   )
 }
@@ -139,7 +161,7 @@ const DiscoveryShow = () => {
   }
 
   return (
-    <RaRecordContext.Provider value={record}>
+    <>
       {record && <RaTitle title={<Title subTitle={record.name} />} />}
       <Card className={classes.root}>
         <CardHeader title={record.name} subheader={playlistSubtitle} />
@@ -160,7 +182,7 @@ const DiscoveryShow = () => {
           </List>
         </CardContent>
       </Card>
-    </RaRecordContext.Provider>
+    </>
   )
 }
 

--- a/ui/src/discovery/DiscoveryShow.jsx
+++ b/ui/src/discovery/DiscoveryShow.jsx
@@ -1,0 +1,118 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  Button,
+  CircularProgress,
+  makeStyles,
+} from '@material-ui/core'
+import CloudDownloadIcon from '@material-ui/icons/CloudDownload'
+import RefreshIcon from '@material-ui/icons/Refresh'
+import { useNotify, useTranslate } from 'react-admin'
+import { useParams } from 'react-router-dom'
+import httpClient from '../dataProvider/httpClient'
+import { REST_URL } from '../consts'
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    maxWidth: 960,
+    margin: '24px auto',
+  },
+  actions: {
+    display: 'flex',
+    gap: theme.spacing(1),
+    marginBottom: theme.spacing(2),
+  },
+  list: {
+    backgroundColor: theme.palette.background.paper,
+    borderRadius: theme.shape.borderRadius,
+  },
+}))
+
+const DiscoveryShow = () => {
+  const classes = useStyles()
+  const notify = useNotify()
+  const translate = useTranslate()
+  const { id } = useParams()
+  const [record, setRecord] = useState(null)
+  const [loading, setLoading] = useState(false)
+
+  const fetchRecord = useCallback(async () => {
+    if (!id) return
+    setLoading(true)
+    try {
+      const res = await httpClient(`${REST_URL}/discovery/${id}`)
+      setRecord(res?.json || null)
+    } catch (error) {
+      notify('ra.page.error', 'warning')
+    } finally {
+      setLoading(false)
+    }
+  }, [id, notify])
+
+  useEffect(() => {
+    fetchRecord()
+  }, [fetchRecord])
+
+  const handleExport = () => {
+    window.open(`${REST_URL}/discovery/${id}/export`, '_blank')
+  }
+
+  const handleRefresh = () => {
+    fetchRecord()
+  }
+
+  if (loading && !record) {
+    return (
+      <Card className={classes.root}>
+        <CardContent>
+          <CircularProgress />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (!record) {
+    return (
+      <Card className={classes.root}>
+        <CardHeader title={translate('menu.discovery')} />
+        <CardContent>
+          <Typography color="textSecondary">
+            {translate('menu.discovery_empty', { _: translate('ra.message.no_results') })}
+          </Typography>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className={classes.root}>
+      <CardHeader title={record.name} subheader={translate('resources.playlist.fields.songCount', { smart_count: record.songCount || 0 })} />
+      <CardContent>
+        <div className={classes.actions}>
+          <Button startIcon={<RefreshIcon />} onClick={handleRefresh} disabled={loading} variant="outlined">
+            {translate('action.refresh', { _: translate('ra.action.refresh') })}
+          </Button>
+          <Button startIcon={<CloudDownloadIcon />} onClick={handleExport} variant="contained" color="primary">
+            {translate('action.export', { _: translate('ra.action.export') })}
+          </Button>
+        </div>
+        {loading ? <CircularProgress size={24} /> : null}
+        <List className={classes.list} dense>
+          {(record.tracks || []).map((track, index) => (
+            <ListItem key={`${track}-${index}`}>
+              <ListItemText primary={track} secondary={`#${index + 1}`} />
+            </ListItem>
+          ))}
+        </List>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default DiscoveryShow

--- a/ui/src/discovery/DiscoveryShow.jsx
+++ b/ui/src/discovery/DiscoveryShow.jsx
@@ -1,188 +1,104 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import {
-  Card,
-  CardContent,
-  CardHeader,
-  CircularProgress,
-  List,
-  ListItem,
-  ListItemText,
-  Typography,
-  makeStyles,
-} from '@material-ui/core'
-import RefreshIcon from '@material-ui/icons/Refresh'
-import QueueMusicIcon from '@material-ui/icons/QueueMusic'
-import { Button, Title as RaTitle, TopToolbar, useNotify, useTranslate } from 'react-admin'
-import { useParams } from 'react-router-dom'
-import httpClient from '../dataProvider/httpClient'
-import { M3U_MIME_TYPE, REST_URL } from '../consts'
-import { Title } from '../common'
+  Filter,
+  Pagination,
+  ReferenceManyField,
+  SearchInput,
+  ShowContextProvider,
+  Title as RaTitle,
+  useShowContext,
+  useShowController,
+} from 'react-admin'
+import { makeStyles } from '@material-ui/core/styles'
+import DiscoveryDetails from './DiscoveryDetails'
+import DiscoverySongs from './DiscoverySongs'
+import DiscoveryActions from './DiscoveryActions'
+import { Title, useResourceRefresh } from '../common'
 
 const useStyles = makeStyles(
-  (theme) => ({
-    root: {
-      maxWidth: 960,
-      margin: '24px auto',
-    },
-    toolbar: {
-      display: 'flex',
-      justifyContent: 'space-between',
+  () => ({
+    discoveryActions: {
       width: '100%',
-      marginBottom: theme.spacing(2),
-    },
-    list: {
-      backgroundColor: theme.palette.background.paper,
-      borderRadius: theme.shape.borderRadius,
-    },
-    actionsGroup: {
-      '& > *': {
-        marginRight: theme.spacing(1),
-      },
-      '& > *:last-child': {
-        marginRight: 0,
-      },
     },
   }),
   { name: 'NDDiscoveryShow' },
 )
 
-const DiscoveryActions = ({ onRefresh, onExport, refreshing, exporting }) => {
-  const translate = useTranslate()
-  const classes = useStyles()
+const DiscoveryFilter = ({ value, onChange }) => (
+  <Filter variant="outlined">
+    <SearchInput
+      id="search"
+      source="q"
+      alwaysOn
+      value={value}
+      onChange={onChange}
+    />
+  </Filter>
+)
 
-  return (
-    <TopToolbar className={classes.toolbar}>
-      <div className={classes.actionsGroup}>
-        <Button
-          onClick={onRefresh}
-          label={translate('action.refresh', { _: translate('ra.action.refresh') })}
-          disabled={refreshing || exporting}
-        >
-          <RefreshIcon />
-        </Button>
-        <Button
-          onClick={onExport}
-          label={translate('resources.playlist.actions.export')}
-          disabled={refreshing || exporting}
-        >
-          <QueueMusicIcon />
-        </Button>
-      </div>
-      <div />
-    </TopToolbar>
+const DiscoveryShowLayout = (props) => {
+  const context = useShowContext(props)
+  const { record } = context
+  const classes = useStyles()
+  useResourceRefresh('song')
+  const [searchTerm, setSearchTerm] = useState('')
+
+  const handleSearchChange = useCallback((event) => {
+    setSearchTerm(event.target.value)
+  }, [])
+
+  const filters = useMemo(
+    () => (
+      <DiscoveryFilter value={searchTerm} onChange={handleSearchChange} />
+    ),
+    [handleSearchChange, searchTerm],
   )
-}
-
-const DiscoveryShow = () => {
-  const classes = useStyles()
-  const notify = useNotify()
-  const translate = useTranslate()
-  const { id } = useParams()
-  const [record, setRecord] = useState(null)
-  const [loading, setLoading] = useState(false)
-  const [exporting, setExporting] = useState(false)
-
-  const fetchRecord = useCallback(async () => {
-    if (!id) return
-    setLoading(true)
-    try {
-      const res = await httpClient(`${REST_URL}/discovery/${id}`)
-      setRecord(res?.json || null)
-    } catch (error) {
-      notify('ra.page.error', 'warning')
-    } finally {
-      setLoading(false)
-    }
-  }, [id, notify])
-
-  useEffect(() => {
-    fetchRecord()
-  }, [fetchRecord])
-
-  const playlistSubtitle = useMemo(() => {
-    if (!record) {
-      return null
-    }
-    return translate('resources.playlist.fields.songCount', {
-      smart_count: record.songCount || 0,
-    })
-  }, [record, translate])
-
-  const handleExport = useCallback(() => {
-    if (!id) return
-    setExporting(true)
-    httpClient(`${REST_URL}/discovery/${id}/export`, {
-      headers: new Headers({ Accept: M3U_MIME_TYPE }),
-    })
-      .then((res) => {
-        const blob = new Blob([res.body], { type: M3U_MIME_TYPE })
-        const url = window.URL.createObjectURL(blob)
-        const link = document.createElement('a')
-        link.href = url
-        link.download = `${record?.name || 'discovery'}.m3u`
-        document.body.appendChild(link)
-        link.click()
-        link.parentNode.removeChild(link)
-        window.URL.revokeObjectURL(url)
-      })
-      .catch(() => {
-        notify('ra.page.error', 'warning')
-      })
-      .finally(() => {
-        setExporting(false)
-      })
-  }, [id, notify, record])
-
-  const handleRefresh = useCallback(() => {
-    fetchRecord()
-  }, [fetchRecord])
-
-  if (loading && !record) {
-    return (
-      <Card className={classes.root}>
-        <CardContent>
-          <CircularProgress />
-        </CardContent>
-      </Card>
-    )
-  }
 
   if (!record) {
-    return (
-      <Card className={classes.root}>
-        <CardHeader title={translate('menu.discovery')} />
-        <CardContent>
-          <Typography color="textSecondary">
-            {translate('menu.discovery_empty', { _: translate('ra.message.no_results') })}
-          </Typography>
-        </CardContent>
-      </Card>
-    )
+    return null
   }
 
   return (
     <>
       {record && <RaTitle title={<Title subTitle={record.name} />} />}
-      <Card className={classes.root}>
-        <CardHeader title={record.name} subheader={playlistSubtitle} />
-        <CardContent>
-          <DiscoveryActions
-            onRefresh={handleRefresh}
-            onExport={handleExport}
-            refreshing={loading}
-            exporting={exporting}
-          />
-          {loading ? <CircularProgress size={24} /> : null}
-          <List className={classes.list} dense>
-            {(record.tracks || []).map((track, index) => (
-              <ListItem key={`${track}-${index}`} divider>
-                <ListItemText primary={track} secondary={`#${index + 1}`} />
-              </ListItem>
-            ))}
-          </List>
-        </CardContent>
-      </Card>
+      <DiscoveryDetails {...context} />
+      {filters}
+      <ReferenceManyField
+        {...context}
+        addLabel={false}
+        reference="discoveryTrack"
+        target="discovery_id"
+        sort={{ field: 'position', order: 'ASC' }}
+        perPage={50}
+        filter={{ discovery_id: record.id, q: searchTerm }}
+      >
+        <DiscoverySongs
+          actions={
+            <DiscoveryActions
+              className={classes.discoveryActions}
+              record={record}
+            />
+          }
+          filters={filters}
+          discoveryId={record.id}
+          pagination={
+            <Pagination
+              rowsPerPageOptions={[25, 50, 100, 200]}
+              perPage={50}
+            />
+          }
+        />
+      </ReferenceManyField>
     </>
+  )
+}
+
+const DiscoveryShow = (props) => {
+  const controllerProps = useShowController(props)
+  return (
+    <ShowContextProvider value={controllerProps}>
+      <DiscoveryShowLayout {...props} {...controllerProps} />
+    </ShowContextProvider>
   )
 }
 

--- a/ui/src/discovery/DiscoverySongs.jsx
+++ b/ui/src/discovery/DiscoverySongs.jsx
@@ -1,0 +1,206 @@
+import React, { useCallback, useEffect, useMemo } from 'react'
+import {
+  ListToolbar,
+  NumberField,
+  TextField,
+  useListContext,
+  useVersion,
+} from 'react-admin'
+import clsx from 'clsx'
+import { useDispatch } from 'react-redux'
+import { Card, useMediaQuery } from '@material-ui/core'
+import { makeStyles } from '@material-ui/core/styles'
+import {
+  DurationField,
+  SongInfo,
+  SongContextMenu,
+  SongDatagrid,
+  SongTitleField,
+  QualityInfo,
+  useSelectedFields,
+  useResourceRefresh,
+  DateField,
+  ArtistLinkField,
+  PathField,
+  RatingField,
+} from '../common'
+import { AlbumLinkField } from '../song/AlbumLinkField'
+import { playTracks } from '../actions'
+import ExpandInfoDialog from '../dialogs/ExpandInfoDialog'
+import config from '../config'
+
+const useStyles = makeStyles(
+  (theme) => ({
+    main: {
+      display: 'flex',
+    },
+    content: {
+      marginTop: 0,
+      transition: theme.transitions.create('margin-top'),
+      position: 'relative',
+      flex: '1 1 auto',
+      [theme.breakpoints.down('xs')]: {
+        boxShadow: 'none',
+      },
+    },
+    actions: {
+      zIndex: 2,
+      display: 'flex',
+      justifyContent: 'flex-end',
+      flexWrap: 'wrap',
+    },
+    toolbar: {
+      justifyContent: 'flex-start',
+    },
+    row: {
+      '&:hover': {
+        '& $contextMenu': {
+          visibility: 'visible',
+        },
+        '& $ratingField': {
+          visibility: 'visible',
+        },
+      },
+    },
+    contextMenu: {
+      visibility: (props) => (props.isDesktop ? 'hidden' : 'visible'),
+    },
+    ratingField: {
+      visibility: 'hidden',
+    },
+  }),
+  { name: 'NDDiscoverySongs' },
+)
+
+const DiscoverySongs = ({ actions, pagination, filters, discoveryId }) => {
+  const listContext = useListContext()
+  const { data, ids, selectedIds, setPage } = listContext
+  const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
+  const classes = useStyles({ isDesktop })
+  const dispatch = useDispatch()
+  const version = useVersion()
+  useResourceRefresh('song')
+
+  useEffect(() => {
+    setPage(1)
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [discoveryId, setPage])
+
+  const handleRowClick = useCallback(
+    (id) => {
+      if (!ids || ids.length === 0) {
+        dispatch(playTracks(data, ids, id))
+        return
+      }
+
+      const startIndex = ids.indexOf(id)
+      if (startIndex === -1) {
+        dispatch(playTracks(data, ids, id))
+        return
+      }
+
+      const orderedIds = [
+        ...ids.slice(startIndex),
+        ...ids.slice(0, startIndex),
+      ]
+
+      dispatch(playTracks(data, orderedIds, id))
+    },
+    [dispatch, data, ids],
+  )
+
+  const toggleableFields = useMemo(() => {
+    return {
+      position: isDesktop && <TextField source="position" label={'#'} />,
+      title: <SongTitleField source="title" showTrackNumbers={false} />,
+      album: isDesktop && <AlbumLinkField source="album" />,
+      artist: isDesktop && <ArtistLinkField source="artist" />,
+      albumArtist: isDesktop && <ArtistLinkField source="albumArtist" />,
+      duration: <DurationField source="duration" />, 
+      year: isDesktop && (
+        <NumberField source="year" sortByOrder={'DESC'} />
+      ),
+      playCount: isDesktop && (
+        <NumberField source="playCount" sortByOrder={'DESC'} />
+      ),
+      playDate: isDesktop && (
+        <DateField source="playDate" sortByOrder={'DESC'} showTime />
+      ),
+      createdAt: (
+        <DateField source="createdAt" showTime sortable={false} />
+      ),
+      quality: isDesktop && <QualityInfo source="quality" sortable={false} />,
+      channels: isDesktop && <NumberField source="channels" />,
+      bpm: isDesktop && <NumberField source="bpm" />,
+      genre: <TextField source="genre" />,
+      comment: <TextField source="comment" />,
+      path: <PathField source="path" />,
+      rating: config.enableStarRating && (
+        <RatingField
+          source="rating"
+          sortByOrder={'DESC'}
+          resource={'song'}
+          className={classes.ratingField}
+        />
+      ),
+    }
+  }, [isDesktop, classes.ratingField])
+
+  const columns = useSelectedFields({
+    resource: 'discoveryTrack',
+    columns: toggleableFields,
+    defaultOff: [
+      'channels',
+      'bpm',
+      'year',
+      'playCount',
+      'comment',
+      'playDate',
+      'createdAt',
+      'albumArtist',
+      'rating',
+    ],
+  })
+
+  const toolbarActions = useMemo(() => {
+    if (!actions) {
+      return null
+    }
+    return React.cloneElement(actions, {
+      ids,
+      data,
+      selectedIds,
+    })
+  }, [actions, ids, data, selectedIds])
+
+  return (
+    <>
+      <ListToolbar
+        classes={{ toolbar: classes.toolbar }}
+        filters={filters}
+        actions={toolbarActions}
+      />
+      <div className={classes.main}>
+        <Card className={clsx(classes.content)} key={version}>
+          <SongDatagrid
+            rowClick={handleRowClick}
+            {...listContext}
+            hasBulkActions={false}
+            contextAlwaysVisible={!isDesktop}
+            classes={{ row: classes.row }}
+          >
+            {columns}
+            <SongContextMenu
+              showLove={true}
+              className={classes.contextMenu}
+            />
+          </SongDatagrid>
+        </Card>
+      </div>
+      <ExpandInfoDialog content={<SongInfo />} />
+      {pagination && React.cloneElement(pagination, listContext)}
+    </>
+  )
+}
+
+export default DiscoverySongs

--- a/ui/src/discovery/index.jsx
+++ b/ui/src/discovery/index.jsx
@@ -1,0 +1,17 @@
+import QueueMusicOutlinedIcon from '@material-ui/icons/QueueMusicOutlined'
+import QueueMusicIcon from '@material-ui/icons/QueueMusic'
+import DynamicMenuIcon from '../layout/DynamicMenuIcon'
+import DiscoveryList from './DiscoveryList'
+import DiscoveryShow from './DiscoveryShow'
+
+export default {
+  list: DiscoveryList,
+  show: DiscoveryShow,
+  icon: (
+    <DynamicMenuIcon
+      path={'discovery'}
+      icon={QueueMusicOutlinedIcon}
+      activeIcon={QueueMusicIcon}
+    />
+  ),
+}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -530,6 +530,8 @@
   },
   "menu": {
     "library": "Library",
+    "discovery": "Discovery",
+    "discovery_empty": "No discovery playlists available",
     "librarySelector": {
       "allLibraries": "All Libraries (%{count})",
       "multipleLibraries": "%{selected} of %{total} Libraries",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -240,6 +240,20 @@
         "updatedAt": "Updated at"
       }
     },
+    "discovery": {
+      "name": "Discovery Folder |||| Discovery Folders",
+      "fields": {
+        "name": "Name",
+        "songCount": "Songs",
+        "updatedAt": "Updated at"
+      },
+      "actions": {
+        "refresh": "Refresh"
+      },
+      "messages": {
+        "refreshed": "Discovery folders refreshed"
+      }
+    },
     "radio": {
       "name": "Radio |||| Radios",
       "fields": {

--- a/ui/src/layout/DiscoverySubMenu.jsx
+++ b/ui/src/layout/DiscoverySubMenu.jsx
@@ -1,0 +1,127 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import {
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  IconButton,
+  CircularProgress,
+  makeStyles,
+} from '@material-ui/core'
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
+import QueueMusicIcon from '@material-ui/icons/QueueMusic'
+import RefreshIcon from '@material-ui/icons/Refresh'
+import CloudDownloadIcon from '@material-ui/icons/CloudDownload'
+import { useHistory } from 'react-router-dom'
+import { useNotify, useTranslate } from 'react-admin'
+import SubMenu from './SubMenu'
+import httpClient from '../dataProvider/httpClient'
+import { REST_URL } from '../consts'
+
+const useStyles = makeStyles((theme) => ({
+  item: {
+    borderRadius: 6,
+    marginRight: 4,
+    paddingTop: 1,
+    paddingBottom: 1,
+    '&:hover': { backgroundColor: theme.palette.action.hover },
+  },
+  icon: { minWidth: 28 },
+  placeholder: { padding: theme.spacing(1, 2) },
+  spinner: { marginLeft: theme.spacing(1) },
+}))
+
+const DiscoverySubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
+  const classes = useStyles()
+  const notify = useNotify()
+  const translate = useTranslate()
+  const history = useHistory()
+  const [items, setItems] = useState([])
+  const [loading, setLoading] = useState(false)
+
+  const fetchDiscovery = useCallback(
+    async (refresh = false) => {
+      setLoading(true)
+      try {
+        const suffix = refresh ? '?refresh=true' : ''
+        const res = await httpClient(`${REST_URL}/discovery${suffix}`)
+        const list = Array.isArray(res?.json) ? res.json : []
+        setItems(list)
+      } catch (error) {
+        notify('ra.page.error', 'warning')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [notify]
+  )
+
+  useEffect(() => {
+    fetchDiscovery(false)
+  }, [fetchDiscovery])
+
+  const handleToggle = () => {
+    setState((prev) => ({ ...prev, menuDiscovery: !prev.menuDiscovery }))
+  }
+
+  const handleNavigate = (item) => {
+    history.push(`/discovery/${item.id}`)
+  }
+
+  const handleExport = (item) => {
+    window.open(`${REST_URL}/discovery/${item.id}/export`, '_blank')
+  }
+
+  const songCountLabel = (item) => {
+    if (typeof item.songCount !== 'number') return ''
+    return translate('resources.playlist.fields.songCount', {
+      smart_count: item.songCount,
+      _: translate('ra.page.items', { smart_count: item.songCount }),
+    })
+  }
+
+  const handleRefresh = () => {
+    if (!loading) {
+      fetchDiscovery(true)
+    }
+  }
+
+  return (
+    <SubMenu
+      handleToggle={handleToggle}
+      isOpen={state.menuDiscovery}
+      sidebarIsOpen={sidebarIsOpen}
+      name="menu.discovery"
+      icon={<QueueMusicIcon />}
+      dense={dense}
+      onAction={handleRefresh}
+      actionIcon={loading ? <CircularProgress size={16} className={classes.spinner} /> : <RefreshIcon fontSize="small" />}
+    >
+      {items.length === 0 && !loading ? (
+        <ListItem disabled className={classes.placeholder}>
+          <ListItemText primary={translate('menu.discovery_empty', { _: translate('ra.message.no_results') })} />
+        </ListItem>
+      ) : null}
+      {items.map((item) => (
+        <ListItem
+          button
+          dense={dense}
+          key={item.id}
+          onClick={() => handleNavigate(item)}
+          className={classes.item}
+        >
+          <ListItemIcon className={classes.icon}>
+            <QueueMusicIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText primary={item.name} secondary={songCountLabel(item)} />
+          <ListItemSecondaryAction>
+            <IconButton edge="end" size="small" onClick={() => handleExport(item)} aria-label={translate('action.export')}>
+              <CloudDownloadIcon fontSize="small" />
+            </IconButton>
+          </ListItemSecondaryAction>
+        </ListItem>
+      ))}
+    </SubMenu>
+  )
+}
+
+export default DiscoverySubMenu

--- a/ui/src/layout/DiscoverySubMenu.jsx
+++ b/ui/src/layout/DiscoverySubMenu.jsx
@@ -15,7 +15,7 @@ import { useHistory } from 'react-router-dom'
 import { useNotify, useTranslate } from 'react-admin'
 import SubMenu from './SubMenu'
 import httpClient from '../dataProvider/httpClient'
-import { REST_URL } from '../consts'
+import { M3U_MIME_TYPE, REST_URL } from '../consts'
 
 const useStyles = makeStyles((theme) => ({
   item: {
@@ -37,6 +37,7 @@ const DiscoverySubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
   const history = useHistory()
   const [items, setItems] = useState([])
   const [loading, setLoading] = useState(false)
+  const [exportingId, setExportingId] = useState(null)
 
   const fetchDiscovery = useCallback(
     async (refresh = false) => {
@@ -67,8 +68,27 @@ const DiscoverySubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
     history.push(`/discovery/${item.id}`)
   }
 
-  const handleExport = (item) => {
-    window.open(`${REST_URL}/discovery/${item.id}/export`, '_blank')
+  const handleExport = async (item) => {
+    if (!item?.id || exportingId === item.id) return
+    setExportingId(item.id)
+    try {
+      const res = await httpClient(`${REST_URL}/discovery/${item.id}/export`, {
+        headers: new Headers({ Accept: M3U_MIME_TYPE }),
+      })
+      const blob = new Blob([res.body], { type: M3U_MIME_TYPE })
+      const url = window.URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = url
+      link.download = `${item.name || 'discovery'}.m3u`
+      document.body.appendChild(link)
+      link.click()
+      link.parentNode.removeChild(link)
+      window.URL.revokeObjectURL(url)
+    } catch (error) {
+      notify('ra.page.error', 'warning')
+    } finally {
+      setExportingId(null)
+    }
   }
 
   const songCountLabel = (item) => {
@@ -114,7 +134,13 @@ const DiscoverySubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
           </ListItemIcon>
           <ListItemText primary={item.name} secondary={songCountLabel(item)} />
           <ListItemSecondaryAction>
-            <IconButton edge="end" size="small" onClick={() => handleExport(item)} aria-label={translate('action.export')}>
+            <IconButton
+              edge="end"
+              size="small"
+              onClick={() => handleExport(item)}
+              aria-label={translate('action.export')}
+              disabled={exportingId === item.id}
+            >
               <CloudDownloadIcon fontSize="small" />
             </IconButton>
           </ListItemSecondaryAction>

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -9,6 +9,7 @@ import SubMenu from './SubMenu'
 import { humanize, pluralize } from 'inflection'
 import albumLists from '../album/albumLists'
 import PlaylistsSubMenu from './PlaylistsSubMenu'
+import DiscoverySubMenu from './DiscoverySubMenu'
 import LibrarySelector from '../common/LibrarySelector'
 import config from '../config'
 
@@ -60,6 +61,7 @@ const Menu = ({ dense = false }) => {
     menuAlbumList: true,
     menuPlaylists: true,
     menuSharedPlaylists: true,
+    menuDiscovery: true,
   })
 
   const handleToggle = (menu) => {
@@ -131,6 +133,12 @@ const Menu = ({ dense = false }) => {
       {config.devSidebarPlaylists && open ? (
         <>
           <Divider />
+          <DiscoverySubMenu
+            state={state}
+            setState={setState}
+            sidebarIsOpen={open}
+            dense={dense}
+          />
           <PlaylistsSubMenu
             state={state}
             setState={setState}
@@ -139,7 +147,15 @@ const Menu = ({ dense = false }) => {
           />
         </>
       ) : (
-        resources.filter(subItems('playlist')).map(renderResourceMenuItemLink)
+        <>
+          <DiscoverySubMenu
+            state={state}
+            setState={setState}
+            sidebarIsOpen={open}
+            dense={dense}
+          />
+          {resources.filter(subItems('playlist')).map(renderResourceMenuItemLink)}
+        </>
       )}
     </div>
   )

--- a/ui/src/routes.jsx
+++ b/ui/src/routes.jsx
@@ -5,7 +5,19 @@ import DiscoveryShow from './discovery/DiscoveryShow'
 
 const routes = [
   <Route exact path="/personal" render={() => <Personal />} key={'personal'} />,
-  <Route exact path="/discovery/:id" render={() => <DiscoveryShow />} key={'discovery-show'} />,
+  <Route
+    exact
+    path="/discovery/:id"
+    render={(routeProps) => (
+      <DiscoveryShow
+        {...routeProps}
+        resource="discovery"
+        basePath="/discovery"
+        id={routeProps.match.params.id}
+      />
+    )}
+    key={'discovery-show'}
+  />,
 ]
 
 export default routes

--- a/ui/src/routes.jsx
+++ b/ui/src/routes.jsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { Route } from 'react-router-dom'
 import Personal from './personal/Personal'
+import DiscoveryShow from './discovery/DiscoveryShow'
 
 const routes = [
   <Route exact path="/personal" render={() => <Personal />} key={'personal'} />,
+  <Route exact path="/discovery/:id" render={() => <DiscoveryShow />} key={'discovery-show'} />,
 ]
 
 export default routes


### PR DESCRIPTION
## Summary
- add discovery playlist model, datastore wiring, and migration for storing folder-backed discovery playlists
- implement discovery service and native API routes for listing, refreshing, and exporting playlists from a configured directory
- surface discovery playlists in the UI with a sidebar section and detail page tied to the new endpoints

## Testing
- go test ./... *(fails: ui/embed.go references build assets missing in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e18e3f58c083308bc5a1617ff56d63