### PR TITLE
Add discovery feature and embed placeholders

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -67,8 +67,9 @@ func runScanner(ctx context.Context) {
 	defer db.Db().Close()
 	ds := persistence.New(sqlDB)
 	pls := core.NewPlaylists(ds)
+	disc := core.NewDiscoveries(ds)
 
-	progress, err := scanner.CallScan(ctx, ds, pls, fullScan)
+	progress, err := scanner.CallScan(ctx, ds, pls, disc, fullScan)
 	if err != nil {
 		log.Fatal(ctx, "Failed to scan", err)
 	}

--- a/cmd/wire_gen.go
+++ b/cmd/wire_gen.go
@@ -59,6 +59,7 @@ func CreateNativeAPIRouter(ctx context.Context) *nativeapi.Router {
 	dataStore := persistence.New(sqlDB)
 	share := core.NewShare(dataStore)
 	playlists := core.NewPlaylists(dataStore)
+	discoveries := core.NewDiscoveries(dataStore)
 	metricsMetrics := metrics.GetPrometheusInstance(dataStore)
 	manager := plugins.GetManager(dataStore, metricsMetrics)
 	insights := metrics.GetInstance(dataStore, manager)
@@ -69,7 +70,7 @@ func CreateNativeAPIRouter(ctx context.Context) *nativeapi.Router {
 	artworkArtwork := artwork.NewArtwork(dataStore, fileCache, fFmpeg, provider)
 	cacheWarmer := artwork.NewCacheWarmer(artworkArtwork, fileCache)
 	broker := events.GetBroker()
-	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, metricsMetrics)
+	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, discoveries, metricsMetrics)
 	watcher := scanner.GetWatcher(dataStore, scannerScanner)
 	library := core.NewLibrary(dataStore, scannerScanner, watcher, broker)
 	router := nativeapi.New(dataStore, share, playlists, insights, library)
@@ -94,7 +95,8 @@ func CreateSubsonicAPIRouter(ctx context.Context) *subsonic.Router {
 	cacheWarmer := artwork.NewCacheWarmer(artworkArtwork, fileCache)
 	broker := events.GetBroker()
 	playlists := core.NewPlaylists(dataStore)
-	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, metricsMetrics)
+	discoveries := core.NewDiscoveries(dataStore)
+	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, discoveries, metricsMetrics)
 	playTracker := scrobbler.GetPlayTracker(dataStore, broker, manager)
 	playbackServer := playback.GetInstance(dataStore)
 	router := subsonic.New(dataStore, artworkArtwork, mediaStreamer, archiver, players, provider, scannerScanner, broker, playlists, playTracker, share, playbackServer, metricsMetrics)
@@ -162,7 +164,8 @@ func CreateScanner(ctx context.Context) scanner.Scanner {
 	cacheWarmer := artwork.NewCacheWarmer(artworkArtwork, fileCache)
 	broker := events.GetBroker()
 	playlists := core.NewPlaylists(dataStore)
-	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, metricsMetrics)
+	discoveries := core.NewDiscoveries(dataStore)
+	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, discoveries, metricsMetrics)
 	return scannerScanner
 }
 
@@ -179,7 +182,8 @@ func CreateScanWatcher(ctx context.Context) scanner.Watcher {
 	cacheWarmer := artwork.NewCacheWarmer(artworkArtwork, fileCache)
 	broker := events.GetBroker()
 	playlists := core.NewPlaylists(dataStore)
-	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, metricsMetrics)
+	discoveries := core.NewDiscoveries(dataStore)
+	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, discoveries, metricsMetrics)
 	watcher := scanner.GetWatcher(dataStore, scannerScanner)
 	return watcher
 }

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -52,6 +52,7 @@ type configOptions struct {
 	AutoImportPlaylists             bool
 	DefaultPlaylistPublicVisibility bool
 	PlaylistsPath                   string
+	DiscoveryPath                   string
 	SyncFolder                      string
 	SmartPlaylistRefreshDelay       time.Duration
 	AutoTranscodeDownload           bool
@@ -310,6 +311,7 @@ func Load(noConfigDump bool) {
 		validateScanSchedule,
 		validateBackupSchedule,
 		validatePlaylistsPath,
+		validateDiscoveryPath,
 		validatePurgeMissingOption,
 	)
 	if err != nil {
@@ -417,6 +419,19 @@ func validatePlaylistsPath() error {
 	return nil
 }
 
+func validateDiscoveryPath() error {
+	if Server.DiscoveryPath == "" {
+		return nil
+	}
+	if _, err := os.Stat(Server.DiscoveryPath); err != nil {
+		if !os.IsNotExist(err) {
+			log.Error("Invalid DiscoveryPath", "path", Server.DiscoveryPath, err)
+			return err
+		}
+	}
+	return nil
+}
+
 func validatePurgeMissingOption() error {
 	allowedValues := []string{consts.PurgeMissingNever, consts.PurgeMissingAlways, consts.PurgeMissingFull}
 	valid := false
@@ -498,6 +513,7 @@ func setViperDefaults() {
 	viper.SetDefault("autoimportplaylists", true)
 	viper.SetDefault("defaultplaylistpublicvisibility", false)
 	viper.SetDefault("playlistspath", "")
+	viper.SetDefault("discoverypath", "")
 	viper.SetDefault("smartPlaylistRefreshDelay", 5*time.Second)
 	viper.SetDefault("enabledownloads", true)
 	viper.SetDefault("enableexternalservices", true)
@@ -520,7 +536,7 @@ func setViperDefaults() {
 	viper.SetDefault("enablefavourites", true)
 	viper.SetDefault("enablestarrating", true)
 	viper.SetDefault("enableuserediting", true)
-       viper.SetDefault("defaulttheme", "Music Matters")
+	viper.SetDefault("defaulttheme", "Music Matters")
 	viper.SetDefault("defaultlanguage", "")
 	viper.SetDefault("defaultuivolume", consts.DefaultUIVolume)
 	viper.SetDefault("enablereplaygain", true)

--- a/core/discoveries.go
+++ b/core/discoveries.go
@@ -2,17 +2,19 @@ package core
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/core/storage"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
+	modelmetadata "github.com/navidrome/navidrome/model/metadata"
 	"github.com/navidrome/navidrome/model/request"
 )
 
@@ -92,17 +94,17 @@ func (d *discoveries) Sync(ctx context.Context) error {
 }
 
 func (d *discoveries) importDirectory(ctx context.Context, repo model.DiscoveryRepository, current model.Discovery, absPath, name string) error {
-	mediaFiles, err := d.collectMediaFiles(ctx, absPath)
+	tracks, err := d.collectTracks(ctx, absPath)
 	if err != nil {
 		return err
 	}
-	if len(mediaFiles) == 0 {
+	if len(tracks) == 0 {
 		return nil
 	}
 
 	usr, ok := request.UserFrom(ctx)
 	if !ok {
-		return errors.New("discovery sync requires authenticated user")
+		return fmt.Errorf("discovery sync requires authenticated user")
 	}
 
 	disc := &model.Discovery{}
@@ -113,25 +115,51 @@ func (d *discoveries) importDirectory(ctx context.Context, repo model.DiscoveryR
 	disc.OwnerID = usr.ID
 	disc.Path = absPath
 	disc.Comment = current.Comment
-	disc.AddMediaFiles(mediaFiles)
+	var totalDuration float32
+	var totalSize int64
+	for _, track := range tracks {
+		totalDuration += track.Duration
+		totalSize += track.Size
+	}
+	disc.Duration = totalDuration
+	disc.Size = totalSize
+	disc.SongCount = len(tracks)
 
 	if err := repo.Put(disc); err != nil {
 		return err
 	}
 
-	ids := make([]string, len(mediaFiles))
-	for i, mf := range mediaFiles {
-		ids[i] = mf.ID
-	}
-	if err := repo.ReplaceTracks(disc.ID, ids); err != nil {
+	if err := repo.ReplaceTracks(disc.ID, tracks); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (d *discoveries) collectMediaFiles(ctx context.Context, root string) (model.MediaFiles, error) {
-	var files []string
-	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+type fileInfoWithBirth struct {
+	fs.FileInfo
+}
+
+func (f fileInfoWithBirth) BirthTime() time.Time {
+	return f.ModTime()
+}
+
+type trackCandidate struct {
+	abs string
+	rel string
+}
+
+func (d *discoveries) collectTracks(ctx context.Context, root string) (model.DiscoveryTracks, error) {
+	store, err := storage.For(root)
+	if err != nil {
+		return nil, err
+	}
+	musicFS, err := store.FS()
+	if err != nil {
+		return nil, err
+	}
+
+	var candidates []trackCandidate
+	err = filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -144,74 +172,73 @@ func (d *discoveries) collectMediaFiles(ctx context.Context, root string) (model
 		if !model.IsAudioFile(entry.Name()) {
 			return nil
 		}
-		files = append(files, path)
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		candidates = append(candidates, trackCandidate{
+			abs: filepath.Clean(path),
+			rel: filepath.ToSlash(rel),
+		})
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	sort.Strings(files)
-	return d.lookupMediaFiles(ctx, files)
-}
-
-func (d *discoveries) lookupMediaFiles(ctx context.Context, files []string) (model.MediaFiles, error) {
-	if len(files) == 0 {
+	if len(candidates) == 0 {
 		return nil, nil
 	}
-	libs, err := d.ds.Library(ctx).GetAll()
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].abs < candidates[j].abs
+	})
+
+	relPaths := make([]string, len(candidates))
+	absPaths := make([]string, len(candidates))
+	for i, cand := range candidates {
+		relPaths[i] = cand.rel
+		absPaths[i] = cand.abs
+	}
+
+	tagResults, err := musicFS.ReadTags(relPaths...)
 	if err != nil {
-		return nil, err
+		log.Warn(ctx, "Discovery: unable to read tags", "path", root, err)
 	}
-	mfRepo := d.ds.MediaFile(ctx)
-	ordered := make(model.MediaFiles, 0, len(files))
-	for _, file := range files {
-		candidates := []string{filepath.Clean(file)}
-		if resolved, err := filepath.EvalSymlinks(file); err == nil {
-			resolved = filepath.Clean(resolved)
-			if resolved != candidates[0] {
-				candidates = append([]string{resolved}, candidates...)
+
+	tracks := make(model.DiscoveryTracks, 0, len(absPaths))
+	for idx, absPath := range absPaths {
+		relPath := relPaths[idx]
+		info, ok := tagResults[relPath]
+		if !ok {
+			info = modelmetadata.Info{}
+		}
+		if info.FileInfo == nil {
+			if stat, statErr := os.Stat(absPath); statErr == nil {
+				info.FileInfo = fileInfoWithBirth{FileInfo: stat}
 			}
-		} else if !errors.Is(err, fs.ErrNotExist) {
-			log.Warn(ctx, "Discovery: unable to resolve symlink", "path", file, err)
+		}
+		md := modelmetadata.New(absPath, info)
+		title := md.String(model.TagTitle)
+		if title == "" {
+			base := filepath.Base(absPath)
+			title = strings.TrimSuffix(base, filepath.Ext(base))
+		}
+		artist := md.String(model.TagArtist)
+		album := md.String(model.TagAlbum)
+		size := int64(0)
+		if info.FileInfo != nil {
+			size = info.FileInfo.Size()
 		}
 
-		var matched bool
-		for _, candidate := range candidates {
-			rels := possibleRelatives(libs, candidate)
-			if len(rels) == 0 {
-				continue
-			}
-			mfs, err := mfRepo.FindByPaths(rels)
-			if err != nil {
-				return nil, err
-			}
-			if len(mfs) == 0 {
-				continue
-			}
-			ordered = append(ordered, mfs[0])
-			matched = true
-			break
-		}
-		if !matched {
-			log.Warn(ctx, "Discovery: media file not found", "path", file)
-		}
+		tracks = append(tracks, model.DiscoveryTrack{
+			Path:     absPath,
+			Title:    title,
+			Artist:   artist,
+			Album:    album,
+			Duration: md.Length(),
+			Size:     size,
+		})
 	}
-	return ordered, nil
-}
-
-func possibleRelatives(libs model.Libraries, path string) []string {
-	rels := []string{}
-	for _, lib := range libs {
-		rel, err := filepath.Rel(lib.Path, path)
-		if err != nil {
-			continue
-		}
-		if strings.HasPrefix(rel, "..") {
-			continue
-		}
-		rels = append(rels, filepath.ToSlash(rel))
-	}
-	return rels
+	return tracks, nil
 }
 
 func ensureDir(path string) error {

--- a/core/discoveries.go
+++ b/core/discoveries.go
@@ -37,6 +37,12 @@ func (d *discoveries) Sync(ctx context.Context) error {
 		return err
 	}
 
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	root = absRoot
+
 	entries, err := os.ReadDir(root)
 	if err != nil {
 		return err
@@ -50,7 +56,13 @@ func (d *discoveries) Sync(ctx context.Context) error {
 
 	existingByPath := map[string]model.Discovery{}
 	for _, disc := range existing {
-		existingByPath[filepath.Clean(disc.Path)] = disc
+		path := filepath.Clean(disc.Path)
+		if !filepath.IsAbs(path) {
+			if absPath, err := filepath.Abs(path); err == nil {
+				path = absPath
+			}
+		}
+		existingByPath[path] = disc
 	}
 
 	seen := map[string]struct{}{}
@@ -153,20 +165,36 @@ func (d *discoveries) lookupMediaFiles(ctx context.Context, files []string) (mod
 	mfRepo := d.ds.MediaFile(ctx)
 	ordered := make(model.MediaFiles, 0, len(files))
 	for _, file := range files {
-		rels := possibleRelatives(libs, file)
-		if len(rels) == 0 {
-			log.Warn(ctx, "Discovery: skipping file outside libraries", "path", file)
-			continue
+		candidates := []string{filepath.Clean(file)}
+		if resolved, err := filepath.EvalSymlinks(file); err == nil {
+			resolved = filepath.Clean(resolved)
+			if resolved != candidates[0] {
+				candidates = append([]string{resolved}, candidates...)
+			}
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			log.Warn(ctx, "Discovery: unable to resolve symlink", "path", file, err)
 		}
-		mfs, err := mfRepo.FindByPaths(rels)
-		if err != nil {
-			return nil, err
+
+		var matched bool
+		for _, candidate := range candidates {
+			rels := possibleRelatives(libs, candidate)
+			if len(rels) == 0 {
+				continue
+			}
+			mfs, err := mfRepo.FindByPaths(rels)
+			if err != nil {
+				return nil, err
+			}
+			if len(mfs) == 0 {
+				continue
+			}
+			ordered = append(ordered, mfs[0])
+			matched = true
+			break
 		}
-		if len(mfs) == 0 {
+		if !matched {
 			log.Warn(ctx, "Discovery: media file not found", "path", file)
-			continue
 		}
-		ordered = append(ordered, mfs[0])
 	}
 	return ordered, nil
 }

--- a/core/discoveries.go
+++ b/core/discoveries.go
@@ -222,7 +222,7 @@ func (d *discoveries) collectTracks(ctx context.Context, root string) (model.Dis
 			base := filepath.Base(absPath)
 			title = strings.TrimSuffix(base, filepath.Ext(base))
 		}
-		artist := md.String(model.TagArtist)
+               artist := md.String(model.TagTrackArtist)
 		album := md.String(model.TagAlbum)
 		size := int64(0)
 		if info.FileInfo != nil {

--- a/core/discoveries.go
+++ b/core/discoveries.go
@@ -1,0 +1,201 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+)
+
+type Discoveries interface {
+	Sync(ctx context.Context) error
+}
+
+type discoveries struct {
+	ds model.DataStore
+}
+
+func NewDiscoveries(ds model.DataStore) Discoveries {
+	return &discoveries{ds: ds}
+}
+
+func (d *discoveries) Sync(ctx context.Context) error {
+	root := conf.Server.DiscoveryPath
+	if root == "" {
+		return nil
+	}
+	if err := ensureDir(root); err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return err
+	}
+
+	repo := d.ds.Discovery(ctx)
+	existing, err := repo.GetAll()
+	if err != nil {
+		return err
+	}
+
+	existingByPath := map[string]model.Discovery{}
+	for _, disc := range existing {
+		existingByPath[filepath.Clean(disc.Path)] = disc
+	}
+
+	seen := map[string]struct{}{}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		absPath := filepath.Join(root, entry.Name())
+		seen[filepath.Clean(absPath)] = struct{}{}
+		if err := d.importDirectory(ctx, repo, existingByPath[filepath.Clean(absPath)], absPath, entry.Name()); err != nil {
+			log.Error(ctx, "Discovery: error importing folder", "path", absPath, err)
+		}
+	}
+
+	for path, disc := range existingByPath {
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		if err := repo.Delete(disc.ID); err != nil {
+			log.Error(ctx, "Discovery: error removing missing discovery", "path", path, err)
+		}
+	}
+	return nil
+}
+
+func (d *discoveries) importDirectory(ctx context.Context, repo model.DiscoveryRepository, current model.Discovery, absPath, name string) error {
+	mediaFiles, err := d.collectMediaFiles(ctx, absPath)
+	if err != nil {
+		return err
+	}
+	if len(mediaFiles) == 0 {
+		return nil
+	}
+
+	usr, ok := request.UserFrom(ctx)
+	if !ok {
+		return errors.New("discovery sync requires authenticated user")
+	}
+
+	disc := &model.Discovery{}
+	if current.ID != "" {
+		disc.ID = current.ID
+	}
+	disc.Name = name
+	disc.OwnerID = usr.ID
+	disc.Path = absPath
+	disc.Comment = current.Comment
+	disc.AddMediaFiles(mediaFiles)
+
+	if err := repo.Put(disc); err != nil {
+		return err
+	}
+
+	ids := make([]string, len(mediaFiles))
+	for i, mf := range mediaFiles {
+		ids[i] = mf.ID
+	}
+	if err := repo.ReplaceTracks(disc.ID, ids); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *discoveries) collectMediaFiles(ctx context.Context, root string) (model.MediaFiles, error) {
+	var files []string
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if strings.HasPrefix(entry.Name(), ".") && path != root {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !model.IsAudioFile(entry.Name()) {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(files)
+	return d.lookupMediaFiles(ctx, files)
+}
+
+func (d *discoveries) lookupMediaFiles(ctx context.Context, files []string) (model.MediaFiles, error) {
+	if len(files) == 0 {
+		return nil, nil
+	}
+	libs, err := d.ds.Library(ctx).GetAll()
+	if err != nil {
+		return nil, err
+	}
+	mfRepo := d.ds.MediaFile(ctx)
+	ordered := make(model.MediaFiles, 0, len(files))
+	for _, file := range files {
+		rels := possibleRelatives(libs, file)
+		if len(rels) == 0 {
+			log.Warn(ctx, "Discovery: skipping file outside libraries", "path", file)
+			continue
+		}
+		mfs, err := mfRepo.FindByPaths(rels)
+		if err != nil {
+			return nil, err
+		}
+		if len(mfs) == 0 {
+			log.Warn(ctx, "Discovery: media file not found", "path", file)
+			continue
+		}
+		ordered = append(ordered, mfs[0])
+	}
+	return ordered, nil
+}
+
+func possibleRelatives(libs model.Libraries, path string) []string {
+	rels := []string{}
+	for _, lib := range libs {
+		rel, err := filepath.Rel(lib.Path, path)
+		if err != nil {
+			continue
+		}
+		if strings.HasPrefix(rel, "..") {
+			continue
+		}
+		rels = append(rels, filepath.ToSlash(rel))
+	}
+	return rels
+}
+
+func ensureDir(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return os.MkdirAll(path, 0o755)
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", path)
+	}
+	return nil
+}

--- a/core/wire_providers.go
+++ b/core/wire_providers.go
@@ -11,13 +11,14 @@ import (
 )
 
 var Set = wire.NewSet(
-	NewMediaStreamer,
-	GetTranscodingCache,
-	NewArchiver,
-	NewPlayers,
-	NewShare,
-	NewPlaylists,
-	NewLibrary,
+        NewMediaStreamer,
+        GetTranscodingCache,
+        NewArchiver,
+        NewPlayers,
+        NewShare,
+        NewPlaylists,
+        NewDiscoveries,
+        NewLibrary,
 	agents.GetAgents,
 	external.NewProvider,
 	wire.Bind(new(external.Agents), new(*agents.Agents)),

--- a/db/migrations/20250816074434_create_discovery_tables.go
+++ b/db/migrations/20250816074434_create_discovery_tables.go
@@ -1,0 +1,56 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upCreateDiscoveryTables, downCreateDiscoveryTables)
+}
+
+func upCreateDiscoveryTables(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+                CREATE TABLE IF NOT EXISTS discovery (
+                        id         VARCHAR NOT NULL PRIMARY KEY,
+                        name       VARCHAR NOT NULL CHECK (length(trim(name)) > 0),
+                        comment    VARCHAR NOT NULL DEFAULT '',
+                        duration   REAL NOT NULL DEFAULT 0,
+                        size       INTEGER NOT NULL DEFAULT 0,
+                        song_count INTEGER NOT NULL DEFAULT 0,
+                        owner_id   VARCHAR NOT NULL REFERENCES user(id) ON UPDATE CASCADE ON DELETE CASCADE,
+                        path       TEXT NOT NULL,
+                        created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+                        updated_at DATETIME NOT NULL DEFAULT (datetime('now'))
+                );
+
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_discovery_owner_name ON discovery(owner_id, lower(name));
+                CREATE INDEX IF NOT EXISTS idx_discovery_owner ON discovery(owner_id);
+                CREATE INDEX IF NOT EXISTS idx_discovery_path ON discovery(path);
+
+                CREATE TABLE IF NOT EXISTS discovery_tracks (
+                        id            INTEGER NOT NULL,
+                        discovery_id  VARCHAR NOT NULL REFERENCES discovery(id) ON DELETE CASCADE,
+                        media_file_id VARCHAR NOT NULL REFERENCES media_file(id) ON DELETE CASCADE,
+                        PRIMARY KEY (discovery_id, id)
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_discovery_tracks_media ON discovery_tracks(media_file_id);
+        `)
+	return err
+}
+
+func downCreateDiscoveryTables(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+                DROP INDEX IF EXISTS idx_discovery_tracks_media;
+                DROP TABLE IF EXISTS discovery_tracks;
+
+                DROP INDEX IF EXISTS idx_discovery_owner_name;
+                DROP INDEX IF EXISTS idx_discovery_owner;
+                DROP INDEX IF EXISTS idx_discovery_path;
+                DROP TABLE IF EXISTS discovery;
+        `)
+	return err
+}

--- a/db/migrations/20250816074434_create_discovery_tables.go
+++ b/db/migrations/20250816074434_create_discovery_tables.go
@@ -30,21 +30,26 @@ func upCreateDiscoveryTables(ctx context.Context, tx *sql.Tx) error {
                 CREATE INDEX IF NOT EXISTS idx_discovery_owner ON discovery(owner_id);
                 CREATE INDEX IF NOT EXISTS idx_discovery_path ON discovery(path);
 
-                CREATE TABLE IF NOT EXISTS discovery_tracks (
-                        id            INTEGER NOT NULL,
-                        discovery_id  VARCHAR NOT NULL REFERENCES discovery(id) ON DELETE CASCADE,
-                        media_file_id VARCHAR NOT NULL REFERENCES media_file(id) ON DELETE CASCADE,
-                        PRIMARY KEY (discovery_id, id)
-                );
+               CREATE TABLE IF NOT EXISTS discovery_tracks (
+                       id            INTEGER NOT NULL,
+                       discovery_id  VARCHAR NOT NULL REFERENCES discovery(id) ON DELETE CASCADE,
+                       path          TEXT    NOT NULL,
+                       title         TEXT    NOT NULL DEFAULT '',
+                       artist        TEXT    NOT NULL DEFAULT '',
+                       album         TEXT    NOT NULL DEFAULT '',
+                       duration      REAL    NOT NULL DEFAULT 0,
+                       size          INTEGER NOT NULL DEFAULT 0,
+                       PRIMARY KEY (discovery_id, id)
+               );
 
-                CREATE INDEX IF NOT EXISTS idx_discovery_tracks_media ON discovery_tracks(media_file_id);
+               CREATE INDEX IF NOT EXISTS idx_discovery_tracks_path ON discovery_tracks(path);
         `)
 	return err
 }
 
 func downCreateDiscoveryTables(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.ExecContext(ctx, `
-                DROP INDEX IF EXISTS idx_discovery_tracks_media;
+                DROP INDEX IF EXISTS idx_discovery_tracks_path;
                 DROP TABLE IF EXISTS discovery_tracks;
 
                 DROP INDEX IF EXISTS idx_discovery_owner_name;

--- a/model/datastore.go
+++ b/model/datastore.go
@@ -1,48 +1,49 @@
-	package model
+package model
 
-	import (
-		"context"
+import (
+	"context"
 
-		"github.com/Masterminds/squirrel"
-		"github.com/deluan/rest"
-	)
+	"github.com/Masterminds/squirrel"
+	"github.com/deluan/rest"
+)
 
-	type QueryOptions struct {
-		Sort    string
-		Order   string
-		Max     int
-		Offset  int
-		Filters squirrel.Sqlizer
-		Seed    string // for random sorting
-	}
+type QueryOptions struct {
+	Sort    string
+	Order   string
+	Max     int
+	Offset  int
+	Filters squirrel.Sqlizer
+	Seed    string // for random sorting
+}
 
-	type ResourceRepository interface {
-		rest.Repository
-	}
+type ResourceRepository interface {
+	rest.Repository
+}
 
-	type DataStore interface {
-		Library(ctx context.Context) LibraryRepository
-		Folder(ctx context.Context) FolderRepository
-		Album(ctx context.Context) AlbumRepository
-		Artist(ctx context.Context) ArtistRepository
-		MediaFile(ctx context.Context) MediaFileRepository
-		Genre(ctx context.Context) GenreRepository
-		Tag(ctx context.Context) TagRepository
-		Playlist(ctx context.Context) PlaylistRepository
-		PlaylistFolder(ctx context.Context) PlaylistFolderRepository
-		PlayQueue(ctx context.Context) PlayQueueRepository
-		Transcoding(ctx context.Context) TranscodingRepository
-		Player(ctx context.Context) PlayerRepository
-		Radio(ctx context.Context) RadioRepository
-		Share(ctx context.Context) ShareRepository
-		Property(ctx context.Context) PropertyRepository
-		User(ctx context.Context) UserRepository
-		UserProps(ctx context.Context) UserPropsRepository
-		ScrobbleBuffer(ctx context.Context) ScrobbleBufferRepository
+type DataStore interface {
+	Library(ctx context.Context) LibraryRepository
+	Folder(ctx context.Context) FolderRepository
+	Album(ctx context.Context) AlbumRepository
+	Artist(ctx context.Context) ArtistRepository
+	MediaFile(ctx context.Context) MediaFileRepository
+	Genre(ctx context.Context) GenreRepository
+	Tag(ctx context.Context) TagRepository
+	Playlist(ctx context.Context) PlaylistRepository
+	Discovery(ctx context.Context) DiscoveryRepository
+	PlaylistFolder(ctx context.Context) PlaylistFolderRepository
+	PlayQueue(ctx context.Context) PlayQueueRepository
+	Transcoding(ctx context.Context) TranscodingRepository
+	Player(ctx context.Context) PlayerRepository
+	Radio(ctx context.Context) RadioRepository
+	Share(ctx context.Context) ShareRepository
+	Property(ctx context.Context) PropertyRepository
+	User(ctx context.Context) UserRepository
+	UserProps(ctx context.Context) UserPropsRepository
+	ScrobbleBuffer(ctx context.Context) ScrobbleBufferRepository
 
-		Resource(ctx context.Context, model interface{}) ResourceRepository
+	Resource(ctx context.Context, model interface{}) ResourceRepository
 
-		WithTx(block func(tx DataStore) error, scope ...string) error
-		WithTxImmediate(block func(tx DataStore) error, scope ...string) error
-		GC(ctx context.Context) error
-	}
+	WithTx(block func(tx DataStore) error, scope ...string) error
+	WithTxImmediate(block func(tx DataStore) error, scope ...string) error
+	GC(ctx context.Context) error
+}

--- a/model/discovery.go
+++ b/model/discovery.go
@@ -1,9 +1,6 @@
 package model
 
-import (
-	"strconv"
-	"time"
-)
+import "time"
 
 type Discovery struct {
 	ID        string          `structs:"id" json:"id"`
@@ -26,28 +23,13 @@ func (d *Discovery) refreshStats() {
 	d.Duration = 0
 	d.Size = 0
 	for _, t := range d.Tracks {
-		d.Duration += t.MediaFile.Duration
-		d.Size += t.MediaFile.Size
+		d.Duration += t.Duration
+		d.Size += t.Size
 	}
 }
 
 func (d *Discovery) SetTracks(tracks DiscoveryTracks) {
 	d.Tracks = tracks
-	d.refreshStats()
-}
-
-func (d *Discovery) AddMediaFiles(mfs MediaFiles) {
-	pos := len(d.Tracks)
-	for _, mf := range mfs {
-		pos++
-		t := DiscoveryTrack{
-			ID:          strconv.Itoa(pos),
-			MediaFileID: mf.ID,
-			DiscoveryID: d.ID,
-			MediaFile:   mf,
-		}
-		d.Tracks = append(d.Tracks, t)
-	}
 	d.refreshStats()
 }
 
@@ -65,14 +47,18 @@ type DiscoveryRepository interface {
 	Delete(id string) error
 	Tracks(discoveryID string) DiscoveryTrackRepository
 	GetDiscoveries(mediaFileId string) (Discoveries, error)
-	ReplaceTracks(id string, mediaFileIDs []string) error
+	ReplaceTracks(id string, tracks DiscoveryTracks) error
 }
 
 type DiscoveryTrack struct {
-	ID          string `json:"id"`
-	MediaFileID string `json:"mediaFileId"`
-	DiscoveryID string `json:"discoveryId"`
-	MediaFile
+	ID          string  `json:"id"`
+	DiscoveryID string  `json:"discoveryId"`
+	Path        string  `json:"path"`
+	Title       string  `json:"title"`
+	Artist      string  `json:"artist"`
+	Album       string  `json:"album"`
+	Duration    float32 `json:"duration"`
+	Size        int64   `json:"size"`
 }
 
 type DiscoveryTracks []DiscoveryTrack

--- a/model/discovery.go
+++ b/model/discovery.go
@@ -1,0 +1,85 @@
+package model
+
+import (
+	"strconv"
+	"time"
+)
+
+type Discovery struct {
+	ID        string          `structs:"id" json:"id"`
+	Name      string          `structs:"name" json:"name"`
+	Comment   string          `structs:"comment" json:"comment"`
+	Duration  float32         `structs:"duration" json:"duration"`
+	Size      int64           `structs:"size" json:"size"`
+	SongCount int             `structs:"song_count" json:"songCount"`
+	OwnerName string          `structs:"-" json:"ownerName"`
+	OwnerID   string          `structs:"owner_id" json:"ownerId"`
+	Path      string          `structs:"path" json:"path"`
+	CreatedAt time.Time       `structs:"created_at" json:"createdAt"`
+	UpdatedAt time.Time       `structs:"updated_at" json:"updatedAt"`
+	Tracks    DiscoveryTracks `structs:"-" json:"tracks,omitempty"`
+	Type      string          `structs:"-" json:"type,omitempty"`
+}
+
+func (d *Discovery) refreshStats() {
+	d.SongCount = len(d.Tracks)
+	d.Duration = 0
+	d.Size = 0
+	for _, t := range d.Tracks {
+		d.Duration += t.MediaFile.Duration
+		d.Size += t.MediaFile.Size
+	}
+}
+
+func (d *Discovery) SetTracks(tracks DiscoveryTracks) {
+	d.Tracks = tracks
+	d.refreshStats()
+}
+
+func (d *Discovery) AddMediaFiles(mfs MediaFiles) {
+	pos := len(d.Tracks)
+	for _, mf := range mfs {
+		pos++
+		t := DiscoveryTrack{
+			ID:          strconv.Itoa(pos),
+			MediaFileID: mf.ID,
+			DiscoveryID: d.ID,
+			MediaFile:   mf,
+		}
+		d.Tracks = append(d.Tracks, t)
+	}
+	d.refreshStats()
+}
+
+type Discoveries []Discovery
+
+type DiscoveryRepository interface {
+	ResourceRepository
+	CountAll(options ...QueryOptions) (int64, error)
+	Exists(id string) (bool, error)
+	Put(d *Discovery) error
+	Get(id string) (*Discovery, error)
+	GetWithTracks(id string) (*Discovery, error)
+	GetAll(options ...QueryOptions) (Discoveries, error)
+	FindByPath(path string) (*Discovery, error)
+	Delete(id string) error
+	Tracks(discoveryID string) DiscoveryTrackRepository
+	GetDiscoveries(mediaFileId string) (Discoveries, error)
+	ReplaceTracks(id string, mediaFileIDs []string) error
+}
+
+type DiscoveryTrack struct {
+	ID          string `json:"id"`
+	MediaFileID string `json:"mediaFileId"`
+	DiscoveryID string `json:"discoveryId"`
+	MediaFile
+}
+
+type DiscoveryTracks []DiscoveryTrack
+
+type DiscoveryTrackRepository interface {
+	ResourceRepository
+	GetAll(options ...QueryOptions) (DiscoveryTracks, error)
+	Delete(id ...string) error
+	DeleteAll() error
+}

--- a/persistence/discovery_repository.go
+++ b/persistence/discovery_repository.go
@@ -261,7 +261,7 @@ func (r *discoveryRepository) findBy(cond Sqlizer) (*model.Discovery, error) {
 
 func (r *discoveryRepository) selectDiscovery(options ...model.QueryOptions) SelectBuilder {
 	sel := r.newSelect(options...).
-		Columns("discovery.*", "owner.username as owner_name").
+		Columns("discovery.*", "owner.user_name as owner_name").
 		From("discovery").
 		LeftJoin("user owner on owner.id = discovery.owner_id")
 	return sel

--- a/persistence/discovery_repository.go
+++ b/persistence/discovery_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	. "github.com/Masterminds/squirrel"
@@ -17,17 +18,27 @@ type discoveryRepository struct {
 }
 
 type dbDiscoveryTrack struct {
-	dbMediaFile
-	*model.DiscoveryTrack `structs:",flatten"`
+	ID          int     `db:"id"`
+	DiscoveryID string  `db:"discovery_id"`
+	Path        string  `db:"path"`
+	Title       string  `db:"title"`
+	Artist      string  `db:"artist"`
+	Album       string  `db:"album"`
+	Duration    float64 `db:"duration"`
+	Size        int64   `db:"size"`
 }
 
-func (t *dbDiscoveryTrack) PostScan() error {
-	if err := t.dbMediaFile.PostScan(); err != nil {
-		return err
+func (t dbDiscoveryTrack) toModel() model.DiscoveryTrack {
+	return model.DiscoveryTrack{
+		ID:          strconv.Itoa(t.ID),
+		DiscoveryID: t.DiscoveryID,
+		Path:        t.Path,
+		Title:       t.Title,
+		Artist:      t.Artist,
+		Album:       t.Album,
+		Duration:    float32(t.Duration),
+		Size:        t.Size,
 	}
-	t.DiscoveryTrack.MediaFile = *t.dbMediaFile.MediaFile
-	t.DiscoveryTrack.MediaFile.ID = t.MediaFileID
-	return nil
 }
 
 type dbDiscoveryTracks []dbDiscoveryTrack
@@ -35,7 +46,7 @@ type dbDiscoveryTracks []dbDiscoveryTrack
 func (t dbDiscoveryTracks) toModels() model.DiscoveryTracks {
 	tracks := make(model.DiscoveryTracks, len(t))
 	for i := range t {
-		tracks[i] = *t[i].DiscoveryTrack
+		tracks[i] = t[i].toModel()
 	}
 	return tracks
 }
@@ -109,10 +120,7 @@ func (r *discoveryRepository) GetWithTracks(id string) (*model.Discovery, error)
 	if err != nil {
 		return nil, err
 	}
-	tracks, err := r.loadTracks(
-		r.newSelect().Columns("discovery_tracks.*").Where(Eq{"discovery_tracks.discovery_id": id}),
-		id,
-	)
+	tracks, err := r.loadTracks(r.newSelect(), id)
 	if err != nil {
 		return nil, fmt.Errorf("loading discovery tracks: %w", err)
 	}
@@ -169,34 +177,14 @@ func (r *discoveryRepository) Tracks(discoveryID string) model.DiscoveryTrackRep
 	return repo
 }
 
-func (r *discoveryRepository) GetDiscoveries(mediaFileId string) (model.Discoveries, error) {
-	sel := r.selectDiscovery().
-		Join("discovery_tracks on discovery.id = discovery_tracks.discovery_id").
-		Where(And{Eq{"discovery_tracks.media_file_id": mediaFileId}, r.userFilter()})
-	var res []struct {
-		model.Discovery
-		OwnerName string `db:"owner_name"`
-	}
-	if err := r.queryAll(sel, &res); err != nil {
-		return nil, err
-	}
-	out := make(model.Discoveries, len(res))
-	for i := range res {
-		res[i].Discovery.OwnerName = res[i].OwnerName
-		res[i].Discovery.Type = "discovery"
-		out[i] = res[i].Discovery
-	}
-	return out, nil
+func (r *discoveryRepository) GetDiscoveries(string) (model.Discoveries, error) {
+	return model.Discoveries{}, nil
 }
 
 func (r *discoveryRepository) loadTracks(sel SelectBuilder, id string) (model.DiscoveryTracks, error) {
 	sel = sel.
-		Columns(
-			"discovery_tracks.*",
-			"f.*",
-		).
+		Columns("discovery_tracks.*").
 		From("discovery_tracks").
-		Join("media_file f on f.id = discovery_tracks.media_file_id").
 		Where(Eq{"discovery_tracks.discovery_id": id}).
 		OrderBy("discovery_tracks.id")
 	rows := dbDiscoveryTracks{}
@@ -206,35 +194,30 @@ func (r *discoveryRepository) loadTracks(sel SelectBuilder, id string) (model.Di
 	return rows.toModels(), nil
 }
 
-func (r *discoveryRepository) ReplaceTracks(id string, mediaFileIDs []string) error {
+func (r *discoveryRepository) ReplaceTracks(id string, tracks model.DiscoveryTracks) error {
 	del := Delete("discovery_tracks").Where(Eq{"discovery_id": id})
 	if _, err := r.executeSQL(del); err != nil {
 		return err
 	}
-	if len(mediaFileIDs) == 0 {
-		return r.refreshCounters(id)
-	}
-	builder := Insert("discovery_tracks").Columns("id", "discovery_id", "media_file_id")
-	for idx, mfID := range mediaFileIDs {
-		builder = builder.Values(idx+1, id, mfID)
-	}
-	if _, err := r.executeSQL(builder); err != nil {
-		return err
-	}
-	return r.refreshCounters(id)
-}
 
-func (r *discoveryRepository) refreshCounters(id string) error {
+	var totalDuration float64
+	var totalSize int64
+	if len(tracks) > 0 {
+		builder := Insert("discovery_tracks").Columns("id", "discovery_id", "path", "title", "artist", "album", "duration", "size")
+		for idx, track := range tracks {
+			builder = builder.Values(idx+1, id, track.Path, track.Title, track.Artist, track.Album, track.Duration, track.Size)
+			totalDuration += float64(track.Duration)
+			totalSize += track.Size
+		}
+		if _, err := r.executeSQL(builder); err != nil {
+			return err
+		}
+	}
+
 	upd := Update("discovery").
-		Set("song_count", Select("count(*)").From("discovery_tracks").Where(Eq{"discovery_id": id})).
-		Set("duration", Select("ifnull(sum(m.duration),0)").
-			From("discovery_tracks dt").
-			Join("media_file m on m.id = dt.media_file_id").
-			Where(Eq{"dt.discovery_id": id})).
-		Set("size", Select("ifnull(sum(m.size),0)").
-			From("discovery_tracks dt").
-			Join("media_file m on m.id = dt.media_file_id").
-			Where(Eq{"dt.discovery_id": id})).
+		Set("song_count", len(tracks)).
+		Set("duration", totalDuration).
+		Set("size", totalSize).
 		Set("updated_at", time.Now()).
 		Where(Eq{"id": id})
 	_, err := r.executeSQL(upd)

--- a/persistence/discovery_repository.go
+++ b/persistence/discovery_repository.go
@@ -70,6 +70,10 @@ func (r *discoveryRepository) CountAll(options ...model.QueryOptions) (int64, er
 	return r.count(sel, options...)
 }
 
+func (r *discoveryRepository) Count(options ...rest.QueryOptions) (int64, error) {
+	return r.CountAll(r.parseRestOptions(r.ctx, options...))
+}
+
 func (r *discoveryRepository) Exists(id string) (bool, error) {
 	return r.exists(And{Eq{"discovery.id": id}, r.userFilter()})
 }
@@ -94,6 +98,10 @@ func (r *discoveryRepository) Put(d *model.Discovery) error {
 
 func (r *discoveryRepository) Get(id string) (*model.Discovery, error) {
 	return r.findBy(And{Eq{"discovery.id": id}, r.userFilter()})
+}
+
+func (r *discoveryRepository) Read(id string) (interface{}, error) {
+	return r.Get(id)
 }
 
 func (r *discoveryRepository) GetWithTracks(id string) (*model.Discovery, error) {
@@ -128,6 +136,10 @@ func (r *discoveryRepository) GetAll(options ...model.QueryOptions) (model.Disco
 		out[i] = res[i].Discovery
 	}
 	return out, nil
+}
+
+func (r *discoveryRepository) ReadAll(options ...rest.QueryOptions) (interface{}, error) {
+	return r.GetAll(r.parseRestOptions(r.ctx, options...))
 }
 
 func (r *discoveryRepository) FindByPath(path string) (*model.Discovery, error) {

--- a/persistence/discovery_repository.go
+++ b/persistence/discovery_repository.go
@@ -1,0 +1,278 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	. "github.com/Masterminds/squirrel"
+	"github.com/deluan/rest"
+	"github.com/navidrome/navidrome/model"
+	"github.com/pocketbase/dbx"
+)
+
+type discoveryRepository struct {
+	sqlRepository
+}
+
+type dbDiscoveryTrack struct {
+	dbMediaFile
+	*model.DiscoveryTrack `structs:",flatten"`
+}
+
+func (t *dbDiscoveryTrack) PostScan() error {
+	if err := t.dbMediaFile.PostScan(); err != nil {
+		return err
+	}
+	t.DiscoveryTrack.MediaFile = *t.dbMediaFile.MediaFile
+	t.DiscoveryTrack.MediaFile.ID = t.MediaFileID
+	return nil
+}
+
+type dbDiscoveryTracks []dbDiscoveryTrack
+
+func (t dbDiscoveryTracks) toModels() model.DiscoveryTracks {
+	tracks := make(model.DiscoveryTracks, len(t))
+	for i := range t {
+		tracks[i] = *t[i].DiscoveryTrack
+	}
+	return tracks
+}
+
+func NewDiscoveryRepository(ctx context.Context, db dbx.Builder) model.DiscoveryRepository {
+	r := &discoveryRepository{}
+	r.ctx = ctx
+	r.db = db
+	r.registerModel(&model.Discovery{}, map[string]filterFunc{
+		"q": discoveryFilter,
+	})
+	r.setSortMappings(map[string]string{
+		"owner_name": "owner_name",
+	})
+	return r
+}
+
+func discoveryFilter(_ string, value any) Sqlizer {
+	return substringFilter("discovery.name", value)
+}
+
+func (r *discoveryRepository) userFilter() Sqlizer {
+	user := loggedUser(r.ctx)
+	if user.IsAdmin {
+		return And{}
+	}
+	return Eq{"owner_id": user.ID}
+}
+
+func (r *discoveryRepository) CountAll(options ...model.QueryOptions) (int64, error) {
+	sel := Select().Where(r.userFilter())
+	return r.count(sel, options...)
+}
+
+func (r *discoveryRepository) Exists(id string) (bool, error) {
+	return r.exists(And{Eq{"discovery.id": id}, r.userFilter()})
+}
+
+func (r *discoveryRepository) Put(d *model.Discovery) error {
+	usr := loggedUser(r.ctx)
+	if !usr.IsAdmin && usr.ID != d.OwnerID {
+		return rest.ErrPermissionDenied
+	}
+	if d.ID == "" {
+		d.CreatedAt = time.Now()
+	}
+	d.UpdatedAt = time.Now()
+	id, err := r.put(d.ID, d)
+	if err != nil {
+		return err
+	}
+	d.ID = id
+	d.Type = "discovery"
+	return nil
+}
+
+func (r *discoveryRepository) Get(id string) (*model.Discovery, error) {
+	return r.findBy(And{Eq{"discovery.id": id}, r.userFilter()})
+}
+
+func (r *discoveryRepository) GetWithTracks(id string) (*model.Discovery, error) {
+	disc, err := r.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	tracks, err := r.loadTracks(
+		r.newSelect().Columns("discovery_tracks.*").Where(Eq{"discovery_tracks.discovery_id": id}),
+		id,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("loading discovery tracks: %w", err)
+	}
+	disc.SetTracks(tracks)
+	return disc, nil
+}
+
+func (r *discoveryRepository) GetAll(options ...model.QueryOptions) (model.Discoveries, error) {
+	sel := r.selectDiscovery(options...).Where(r.userFilter())
+	var res []struct {
+		model.Discovery
+		OwnerName string `db:"owner_name"`
+	}
+	if err := r.queryAll(sel, &res); err != nil {
+		return nil, err
+	}
+	out := make(model.Discoveries, len(res))
+	for i := range res {
+		res[i].Discovery.OwnerName = res[i].OwnerName
+		res[i].Discovery.Type = "discovery"
+		out[i] = res[i].Discovery
+	}
+	return out, nil
+}
+
+func (r *discoveryRepository) FindByPath(path string) (*model.Discovery, error) {
+	return r.findBy(And{Eq{"discovery.path": path}, r.userFilter()})
+}
+
+func (r *discoveryRepository) Delete(id string) error {
+	disc, err := r.Get(id)
+	if err != nil {
+		return err
+	}
+	usr := loggedUser(r.ctx)
+	if !usr.IsAdmin && disc.OwnerID != usr.ID {
+		return rest.ErrPermissionDenied
+	}
+	return r.delete(And{Eq{"discovery.id": id}, r.userFilter()})
+}
+
+func (r *discoveryRepository) Tracks(discoveryID string) model.DiscoveryTrackRepository {
+	repo := &discoveryTrackRepository{}
+	repo.ctx = r.ctx
+	repo.db = r.db
+	repo.discoveryID = discoveryID
+	repo.discoveryRepo = r
+	repo.registerModel(&model.DiscoveryTrack{}, nil)
+	repo.tableName = "discovery_tracks"
+	return repo
+}
+
+func (r *discoveryRepository) GetDiscoveries(mediaFileId string) (model.Discoveries, error) {
+	sel := r.selectDiscovery().
+		Join("discovery_tracks on discovery.id = discovery_tracks.discovery_id").
+		Where(And{Eq{"discovery_tracks.media_file_id": mediaFileId}, r.userFilter()})
+	var res []struct {
+		model.Discovery
+		OwnerName string `db:"owner_name"`
+	}
+	if err := r.queryAll(sel, &res); err != nil {
+		return nil, err
+	}
+	out := make(model.Discoveries, len(res))
+	for i := range res {
+		res[i].Discovery.OwnerName = res[i].OwnerName
+		res[i].Discovery.Type = "discovery"
+		out[i] = res[i].Discovery
+	}
+	return out, nil
+}
+
+func (r *discoveryRepository) loadTracks(sel SelectBuilder, id string) (model.DiscoveryTracks, error) {
+	sel = sel.
+		Columns(
+			"discovery_tracks.*",
+			"f.*",
+		).
+		From("discovery_tracks").
+		Join("media_file f on f.id = discovery_tracks.media_file_id").
+		Where(Eq{"discovery_tracks.discovery_id": id}).
+		OrderBy("discovery_tracks.id")
+	rows := dbDiscoveryTracks{}
+	if err := r.queryAll(sel, &rows); err != nil {
+		return nil, err
+	}
+	return rows.toModels(), nil
+}
+
+func (r *discoveryRepository) ReplaceTracks(id string, mediaFileIDs []string) error {
+	del := Delete("discovery_tracks").Where(Eq{"discovery_id": id})
+	if _, err := r.executeSQL(del); err != nil {
+		return err
+	}
+	if len(mediaFileIDs) == 0 {
+		return r.refreshCounters(id)
+	}
+	builder := Insert("discovery_tracks").Columns("id", "discovery_id", "media_file_id")
+	for idx, mfID := range mediaFileIDs {
+		builder = builder.Values(idx+1, id, mfID)
+	}
+	if _, err := r.executeSQL(builder); err != nil {
+		return err
+	}
+	return r.refreshCounters(id)
+}
+
+func (r *discoveryRepository) refreshCounters(id string) error {
+	upd := Update("discovery").
+		Set("song_count", Select("count(*)").From("discovery_tracks").Where(Eq{"discovery_id": id})).
+		Set("duration", Select("ifnull(sum(m.duration),0)").
+			From("discovery_tracks dt").
+			Join("media_file m on m.id = dt.media_file_id").
+			Where(Eq{"dt.discovery_id": id})).
+		Set("size", Select("ifnull(sum(m.size),0)").
+			From("discovery_tracks dt").
+			Join("media_file m on m.id = dt.media_file_id").
+			Where(Eq{"dt.discovery_id": id})).
+		Set("updated_at", time.Now()).
+		Where(Eq{"id": id})
+	_, err := r.executeSQL(upd)
+	return err
+}
+
+func (r *discoveryRepository) findBy(cond Sqlizer) (*model.Discovery, error) {
+	sel := r.selectDiscovery().Where(cond)
+	var res struct {
+		model.Discovery
+		OwnerName string `db:"owner_name"`
+	}
+	err := r.queryOne(sel, &res)
+	if errors.Is(err, rest.ErrNotFound) {
+		return nil, err
+	}
+	if err != nil {
+		return nil, err
+	}
+	res.Discovery.OwnerName = res.OwnerName
+	res.Discovery.Type = "discovery"
+	return &res.Discovery, nil
+}
+
+func (r *discoveryRepository) selectDiscovery(options ...model.QueryOptions) SelectBuilder {
+	sel := r.newSelect(options...).
+		Columns("discovery.*", "owner.username as owner_name").
+		From("discovery").
+		LeftJoin("user owner on owner.id = discovery.owner_id")
+	return sel
+}
+
+func (r *discoveryRepository) EntityName() string { return "discovery" }
+
+func (r *discoveryRepository) NewInstance() interface{} { return &model.Discovery{} }
+
+func (r *discoveryRepository) Save(entity interface{}) (string, error) {
+	disc := entity.(*model.Discovery)
+	if err := r.Put(disc); err != nil {
+		return "", err
+	}
+	return disc.ID, nil
+}
+
+func (r *discoveryRepository) Update(id string, entity interface{}, cols ...string) error {
+	disc := entity.(*model.Discovery)
+	disc.ID = id
+	return r.Put(disc)
+}
+
+var _ model.DiscoveryRepository = (*discoveryRepository)(nil)
+var _ rest.Repository = (*discoveryRepository)(nil)
+var _ rest.Persistable = (*discoveryRepository)(nil)

--- a/persistence/discovery_repository.go
+++ b/persistence/discovery_repository.go
@@ -17,6 +17,8 @@ type discoveryRepository struct {
 	sqlRepository
 }
 
+func ignoreDiscoveryFilter(string, any) Sqlizer { return nil }
+
 type dbDiscoveryTrack struct {
 	ID          int     `db:"id"`
 	DiscoveryID string  `db:"discovery_id"`
@@ -172,7 +174,10 @@ func (r *discoveryRepository) Tracks(discoveryID string) model.DiscoveryTrackRep
 	repo.db = r.db
 	repo.discoveryID = discoveryID
 	repo.discoveryRepo = r
-	repo.registerModel(&model.DiscoveryTrack{}, nil)
+	repo.registerModel(&model.DiscoveryTrack{}, map[string]filterFunc{
+		":discoveryid": ignoreDiscoveryFilter,
+		"discovery_id": ignoreDiscoveryFilter,
+	})
 	repo.tableName = "discovery_tracks"
 	return repo
 }

--- a/persistence/discovery_track_repository.go
+++ b/persistence/discovery_track_repository.go
@@ -37,19 +37,11 @@ func (r *discoveryTrackRepository) EntityName() string { return "discovery_track
 
 func (r *discoveryTrackRepository) NewInstance() interface{} { return &model.DiscoveryTrack{} }
 
-func (r *discoveryTrackRepository) Save(entity interface{}) (string, error) {
-	return "", rest.ErrNotImplemented
-}
-
-func (r *discoveryTrackRepository) Update(id string, entity interface{}, cols ...string) error {
-	return rest.ErrNotImplemented
-}
-
 func (r *discoveryTrackRepository) GetAll(options ...model.QueryOptions) (model.DiscoveryTracks, error) {
 	sel := r.newSelect(options...).
 		Columns("discovery_tracks.*").
 		Where(Eq{"discovery_tracks.discovery_id": r.discoveryID})
-	tracks, err := r.discoveryRepo.loadTracks(sel)
+	tracks, err := r.discoveryRepo.loadTracks(sel, r.discoveryID)
 	if err != nil {
 		return nil, err
 	}
@@ -57,11 +49,11 @@ func (r *discoveryTrackRepository) GetAll(options ...model.QueryOptions) (model.
 }
 
 func (r *discoveryTrackRepository) Delete(id ...string) error {
-	return rest.ErrNotImplemented
+	return rest.ErrPermissionDenied
 }
 
 func (r *discoveryTrackRepository) DeleteAll() error {
-	return rest.ErrNotImplemented
+	return rest.ErrPermissionDenied
 }
 
 var _ model.DiscoveryTrackRepository = (*discoveryTrackRepository)(nil)

--- a/persistence/discovery_track_repository.go
+++ b/persistence/discovery_track_repository.go
@@ -1,0 +1,68 @@
+package persistence
+
+import (
+	. "github.com/Masterminds/squirrel"
+	"github.com/deluan/rest"
+	"github.com/navidrome/navidrome/model"
+)
+
+type discoveryTrackRepository struct {
+	sqlRepository
+	discoveryID   string
+	discoveryRepo *discoveryRepository
+}
+
+func (r *discoveryTrackRepository) Count(options ...rest.QueryOptions) (int64, error) {
+	qo := r.parseRestOptions(r.ctx, options...)
+	sel := Select().Where(Eq{"discovery_tracks.discovery_id": r.discoveryID})
+	return r.count(sel, qo)
+}
+
+func (r *discoveryTrackRepository) Read(id string) (interface{}, error) {
+	sel := r.newSelect().
+		Columns("discovery_tracks.*").
+		Where(And{Eq{"discovery_tracks.discovery_id": r.discoveryID}, Eq{"discovery_tracks.id": id}})
+	var track model.DiscoveryTrack
+	err := r.queryOne(sel, &track)
+	return track, err
+}
+
+func (r *discoveryTrackRepository) ReadAll(options ...rest.QueryOptions) (interface{}, error) {
+	qo := r.parseRestOptions(r.ctx, options...)
+	tracks, err := r.GetAll(qo)
+	return tracks, err
+}
+
+func (r *discoveryTrackRepository) EntityName() string { return "discovery_tracks" }
+
+func (r *discoveryTrackRepository) NewInstance() interface{} { return &model.DiscoveryTrack{} }
+
+func (r *discoveryTrackRepository) Save(entity interface{}) (string, error) {
+	return "", rest.ErrNotImplemented
+}
+
+func (r *discoveryTrackRepository) Update(id string, entity interface{}, cols ...string) error {
+	return rest.ErrNotImplemented
+}
+
+func (r *discoveryTrackRepository) GetAll(options ...model.QueryOptions) (model.DiscoveryTracks, error) {
+	sel := r.newSelect(options...).
+		Columns("discovery_tracks.*").
+		Where(Eq{"discovery_tracks.discovery_id": r.discoveryID})
+	tracks, err := r.discoveryRepo.loadTracks(sel)
+	if err != nil {
+		return nil, err
+	}
+	return tracks, nil
+}
+
+func (r *discoveryTrackRepository) Delete(id ...string) error {
+	return rest.ErrNotImplemented
+}
+
+func (r *discoveryTrackRepository) DeleteAll() error {
+	return rest.ErrNotImplemented
+}
+
+var _ model.DiscoveryTrackRepository = (*discoveryTrackRepository)(nil)
+var _ rest.Repository = (*discoveryTrackRepository)(nil)

--- a/persistence/discovery_track_repository.go
+++ b/persistence/discovery_track_repository.go
@@ -21,10 +21,15 @@ func (r *discoveryTrackRepository) Count(options ...rest.QueryOptions) (int64, e
 func (r *discoveryTrackRepository) Read(id string) (interface{}, error) {
 	sel := r.newSelect().
 		Columns("discovery_tracks.*").
-		Where(And{Eq{"discovery_tracks.discovery_id": r.discoveryID}, Eq{"discovery_tracks.id": id}})
-	var track model.DiscoveryTrack
-	err := r.queryOne(sel, &track)
-	return track, err
+		Where(Eq{"discovery_tracks.id": id})
+	tracks, err := r.discoveryRepo.loadTracks(sel, r.discoveryID)
+	if err != nil {
+		return nil, err
+	}
+	if len(tracks) == 0 {
+		return nil, rest.ErrNotFound
+	}
+	return tracks[0], nil
 }
 
 func (r *discoveryTrackRepository) ReadAll(options ...rest.QueryOptions) (interface{}, error) {

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -57,8 +57,12 @@ func (s *SQLStore) Playlist(ctx context.Context) model.PlaylistRepository {
 	return NewPlaylistRepository(ctx, s.getDBXBuilder())
 }
 
+func (s *SQLStore) Discovery(ctx context.Context) model.DiscoveryRepository {
+	return NewDiscoveryRepository(ctx, s.getDBXBuilder())
+}
+
 func (s *SQLStore) PlaylistFolder(ctx context.Context) model.PlaylistFolderRepository {
-    return NewPlaylistFolderRepository(ctx, s.getDBXBuilder())
+	return NewPlaylistFolderRepository(ctx, s.getDBXBuilder())
 }
 
 func (s *SQLStore) Property(ctx context.Context) model.PropertyRepository {
@@ -111,6 +115,8 @@ func (s *SQLStore) Resource(ctx context.Context, m interface{}) model.ResourceRe
 		return s.Genre(ctx).(model.ResourceRepository)
 	case model.Playlist:
 		return s.Playlist(ctx).(model.ResourceRepository)
+	case model.Discovery:
+		return s.Discovery(ctx).(model.ResourceRepository)
 	case model.PlaylistFolder:
 		return s.PlaylistFolder(ctx).(model.ResourceRepository)
 	case model.Radio:

--- a/scanner/controller.go
+++ b/scanner/controller.go
@@ -43,13 +43,14 @@ type StatusInfo struct {
 }
 
 func New(rootCtx context.Context, ds model.DataStore, cw artwork.CacheWarmer, broker events.Broker,
-	pls core.Playlists, m metrics.Metrics) Scanner {
+	pls core.Playlists, disc core.Discoveries, m metrics.Metrics) Scanner {
 	c := &controller{
 		rootCtx: rootCtx,
 		ds:      ds,
 		cw:      cw,
 		broker:  broker,
 		pls:     pls,
+		disc:    disc,
 		metrics: m,
 	}
 	if !conf.Server.DevExternalScanner {
@@ -62,12 +63,12 @@ func (s *controller) getScanner() scanner {
 	if conf.Server.DevExternalScanner {
 		return &scannerExternal{}
 	}
-	return &scannerImpl{ds: s.ds, cw: s.cw, pls: s.pls}
+	return &scannerImpl{ds: s.ds, cw: s.cw, pls: s.pls, disc: s.disc}
 }
 
 // CallScan starts an in-process scan of the music library.
 // This is meant to be called from the command line (see cmd/scan.go).
-func CallScan(ctx context.Context, ds model.DataStore, pls core.Playlists, fullScan bool) (<-chan *ProgressInfo, error) {
+func CallScan(ctx context.Context, ds model.DataStore, pls core.Playlists, disc core.Discoveries, fullScan bool) (<-chan *ProgressInfo, error) {
 	release, err := lockScan(ctx)
 	if err != nil {
 		return nil, err
@@ -78,7 +79,7 @@ func CallScan(ctx context.Context, ds model.DataStore, pls core.Playlists, fullS
 	progress := make(chan *ProgressInfo, 100)
 	go func() {
 		defer close(progress)
-		scanner := &scannerImpl{ds: ds, cw: artwork.NoopCacheWarmer(), pls: pls}
+		scanner := &scannerImpl{ds: ds, cw: artwork.NoopCacheWarmer(), pls: pls, disc: disc}
 		scanner.scanAll(ctx, fullScan, progress)
 	}()
 	return progress, nil
@@ -110,6 +111,7 @@ type controller struct {
 	broker          events.Broker
 	metrics         metrics.Metrics
 	pls             core.Playlists
+	disc            core.Discoveries
 	limiter         *rate.Sometimes
 	count           atomic.Uint32
 	folderCount     atomic.Uint32

--- a/scanner/controller_test.go
+++ b/scanner/controller_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Controller", func() {
 			DeferCleanup(configtest.SetupConfig())
 			ds = &tests.MockDataStore{RealDS: persistence.New(db.Db())}
 			ds.MockedProperty = &tests.MockedPropertyRepo{}
-			ctrl = scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(), core.NewPlaylists(ds), metrics.NewNoopInstance())
+                        ctrl = scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(), core.NewPlaylists(ds), core.NewDiscoveries(ds), metrics.NewNoopInstance())
 		})
 
 		It("includes last scan error", func() {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -18,9 +18,10 @@ import (
 )
 
 type scannerImpl struct {
-	ds  model.DataStore
-	cw  artwork.CacheWarmer
-	pls core.Playlists
+	ds   model.DataStore
+	cw   artwork.CacheWarmer
+	pls  core.Playlists
+	disc core.Discoveries
 }
 
 // scanState holds the state of an in-progress scan, to be passed to the various phases
@@ -102,6 +103,9 @@ func (s *scannerImpl) scanAll(ctx context.Context, fullScan bool, progress chan<
 
 			// Phase 4: Import/update playlists
 			runPhase[*model.Folder](ctx, 4, createPhasePlaylists(ctx, &state, s.ds, s.pls, s.cw)),
+
+			// Phase 5: Sync discovery directories
+			func() error { return s.disc.Sync(ctx) },
 		),
 
 		// Final Steps (cannot be parallelized):

--- a/scanner/scanner_benchmark_test.go
+++ b/scanner/scanner_benchmark_test.go
@@ -39,8 +39,8 @@ func BenchmarkScan(b *testing.B) {
 
 	ds := persistence.New(db.Db())
 	conf.Server.DevExternalScanner = false
-	s := scanner.New(context.Background(), ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
-		core.NewPlaylists(ds), metrics.NewNoopInstance())
+        s := scanner.New(context.Background(), ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
+                core.NewPlaylists(ds), core.NewDiscoveries(ds), metrics.NewNoopInstance())
 
 	fs := storagetest.FakeFS{}
 	storagetest.Register("fake", &fs)

--- a/scanner/scanner_multilibrary_test.go
+++ b/scanner/scanner_multilibrary_test.go
@@ -70,8 +70,8 @@ var _ = Describe("Scanner - Multi-Library", Ordered, func() {
 		}
 		Expect(ds.User(ctx).Put(&adminUser)).To(Succeed())
 
-		s = scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
-			core.NewPlaylists(ds), metrics.NewNoopInstance())
+                s = scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
+                        core.NewPlaylists(ds), core.NewDiscoveries(ds), metrics.NewNoopInstance())
 
 		// Create two test libraries (let DB auto-assign IDs)
 		lib1 = model.Library{Name: "Rock Collection", Path: "rock:///music"}

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -83,8 +83,8 @@ var _ = Describe("Scanner", Ordered, func() {
 		}
 		Expect(ds.User(ctx).Put(&adminUser)).To(Succeed())
 
-		s = scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
-			core.NewPlaylists(ds), metrics.NewNoopInstance())
+                s = scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
+                        core.NewPlaylists(ds), core.NewDiscoveries(ds), metrics.NewNoopInstance())
 
 		lib = model.Library{ID: 1, Name: "Fake Library", Path: "fake:///music"}
 		Expect(ds.Library(ctx).Put(&lib)).To(Succeed())

--- a/server/nativeapi/discovery.go
+++ b/server/nativeapi/discovery.go
@@ -1,12 +1,12 @@
 package nativeapi
 
 import (
-        "net/http"
+	"net/http"
 
-        "github.com/deluan/rest"
-        "github.com/go-chi/chi/v5"
-        "github.com/navidrome/navidrome/log"
-        "github.com/navidrome/navidrome/model"
+	"github.com/deluan/rest"
+	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
 )
 
 func getDiscovery(ds model.DataStore) http.HandlerFunc {
@@ -25,12 +25,8 @@ func getDiscoveryTracks(ds model.DataStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		discID := chi.URLParam(r, "discoveryId")
 		repo := ds.Discovery(r.Context()).Tracks(discID)
-		tracks, err := repo.GetAll()
-		if err != nil {
-			http.Error(w, err.Error(), statusFor(err))
-			return
-		}
-		rest.RespondWithJSON(w, http.StatusOK, tracks)
+		controller := rest.Controller{Repository: repo}
+		controller.GetAll(w, r)
 	}
 }
 

--- a/server/nativeapi/discovery.go
+++ b/server/nativeapi/discovery.go
@@ -1,0 +1,48 @@
+package nativeapi
+
+import (
+        "net/http"
+
+        "github.com/deluan/rest"
+        "github.com/go-chi/chi/v5"
+        "github.com/navidrome/navidrome/log"
+        "github.com/navidrome/navidrome/model"
+)
+
+func getDiscovery(ds model.DataStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		disc, err := ds.Discovery(r.Context()).GetWithTracks(id)
+		if err != nil {
+			http.Error(w, err.Error(), statusFor(err))
+			return
+		}
+		rest.RespondWithJSON(w, http.StatusOK, disc)
+	}
+}
+
+func getDiscoveryTracks(ds model.DataStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		discID := chi.URLParam(r, "discoveryId")
+		repo := ds.Discovery(r.Context()).Tracks(discID)
+		tracks, err := repo.GetAll()
+		if err != nil {
+			http.Error(w, err.Error(), statusFor(err))
+			return
+		}
+		rest.RespondWithJSON(w, http.StatusOK, tracks)
+	}
+}
+
+func getSongDiscoveries(ds model.DataStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		trackID := chi.URLParam(r, "id")
+		discs, err := ds.Discovery(r.Context()).GetDiscoveries(trackID)
+		if err != nil {
+			log.Error(r.Context(), "Error getting song discoveries", "songId", trackID, err)
+			http.Error(w, err.Error(), statusFor(err))
+			return
+		}
+		rest.RespondWithJSON(w, http.StatusOK, discs)
+	}
+}

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -63,7 +63,10 @@ func (n *Router) routes() http.Handler {
 		n.addPlaylistRoute(r)
 		n.addPlaylistFolderRoute(r)
 		n.addPlaylistTrackRoute(r)
+		n.addDiscoveryRoute(r)
+		n.addDiscoveryTrackRoute(r)
 		n.addSongPlaylistsRoute(r)
+		n.addSongDiscoveriesRoute(r)
 		n.addQueueRoute(r)
 		n.addMissingFilesRoute(r)
 		n.addKeepAliveRoute(r)
@@ -203,9 +206,36 @@ func (n *Router) addPlaylistTrackRoute(r chi.Router) {
 	})
 }
 
+func (n *Router) addDiscoveryRoute(r chi.Router) {
+	constructor := func(ctx context.Context) rest.Repository {
+		return n.ds.Resource(ctx, model.Discovery{})
+	}
+
+	r.Route("/discovery", func(r chi.Router) {
+		r.Get("/", rest.GetAll(constructor))
+		r.Route("/{id}", func(r chi.Router) {
+			r.Use(server.URLParamsMiddleware)
+			r.Get("/", getDiscovery(n.ds))
+		})
+	})
+}
+
+func (n *Router) addDiscoveryTrackRoute(r chi.Router) {
+	r.Route("/discovery/{discoveryId}/tracks", func(r chi.Router) {
+		r.Use(server.URLParamsMiddleware)
+		r.Get("/", getDiscoveryTracks(n.ds))
+	})
+}
+
 func (n *Router) addSongPlaylistsRoute(r chi.Router) {
 	r.With(server.URLParamsMiddleware).Get("/song/{id}/playlists", func(w http.ResponseWriter, r *http.Request) {
 		getSongPlaylists(n.ds)(w, r)
+	})
+}
+
+func (n *Router) addSongDiscoveriesRoute(r chi.Router) {
+	r.With(server.URLParamsMiddleware).Get("/song/{id}/discoveries", func(w http.ResponseWriter, r *http.Request) {
+		getSongDiscoveries(n.ds)(w, r)
 	})
 }
 

--- a/tests/mock_data_store.go
+++ b/tests/mock_data_store.go
@@ -8,27 +8,28 @@ import (
 )
 
 type MockDataStore struct {
-	RealDS               		model.DataStore
-	MockedLibrary        		model.LibraryRepository
-	MockedFolder         		model.FolderRepository
-	MockedGenre          		model.GenreRepository
-	MockedAlbum          		model.AlbumRepository
-	MockedArtist         		model.ArtistRepository
-	MockedMediaFile      		model.MediaFileRepository
-	MockedTag            		model.TagRepository
-	MockedUser           		model.UserRepository
-	MockedProperty       		model.PropertyRepository
-	MockedPlayer         		model.PlayerRepository
-	MockedPlaylist       		model.PlaylistRepository
-	MockedPlaylistFolder 		model.PlaylistFolderRepository
-	MockedPlayQueue      		model.PlayQueueRepository
-	MockedShare          		model.ShareRepository
-	MockedTranscoding    		model.TranscodingRepository
-	MockedUserProps      		model.UserPropsRepository
-	MockedScrobbleBuffer 		model.ScrobbleBufferRepository
-	MockedRadio          		model.RadioRepository
-	scrobbleBufferMu     		sync.Mutex
-	repoMu               		sync.Mutex
+	RealDS               model.DataStore
+	MockedLibrary        model.LibraryRepository
+	MockedFolder         model.FolderRepository
+	MockedGenre          model.GenreRepository
+	MockedAlbum          model.AlbumRepository
+	MockedArtist         model.ArtistRepository
+	MockedMediaFile      model.MediaFileRepository
+	MockedTag            model.TagRepository
+	MockedUser           model.UserRepository
+	MockedProperty       model.PropertyRepository
+	MockedPlayer         model.PlayerRepository
+	MockedPlaylist       model.PlaylistRepository
+	MockedDiscovery      model.DiscoveryRepository
+	MockedPlaylistFolder model.PlaylistFolderRepository
+	MockedPlayQueue      model.PlayQueueRepository
+	MockedShare          model.ShareRepository
+	MockedTranscoding    model.TranscodingRepository
+	MockedUserProps      model.UserPropsRepository
+	MockedScrobbleBuffer model.ScrobbleBufferRepository
+	MockedRadio          model.RadioRepository
+	scrobbleBufferMu     sync.Mutex
+	repoMu               sync.Mutex
 }
 
 func (db *MockDataStore) Library(ctx context.Context) model.LibraryRepository {
@@ -119,6 +120,17 @@ func (db *MockDataStore) Playlist(ctx context.Context) model.PlaylistRepository 
 		}
 	}
 	return db.MockedPlaylist
+}
+
+func (db *MockDataStore) Discovery(ctx context.Context) model.DiscoveryRepository {
+	if db.MockedDiscovery == nil {
+		if db.RealDS != nil {
+			db.MockedDiscovery = db.RealDS.Discovery(ctx)
+		} else {
+			db.MockedDiscovery = struct{ model.DiscoveryRepository }{}
+		}
+	}
+	return db.MockedDiscovery
 }
 
 func (db *MockDataStore) PlaylistFolder(ctx context.Context) model.PlaylistFolderRepository {

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -3,5 +3,7 @@ node_modules
 
 build/*
 !build/.gitkeep
+!build/3rdparty/
+!build/3rdparty/placeholder.txt
 /coverage/
 public/3rdparty/workbox

--- a/ui/build/3rdparty/placeholder.txt
+++ b/ui/build/3rdparty/placeholder.txt
@@ -1,0 +1,1 @@
+This placeholder file ensures the build/3rdparty directory contains at least one embeddable asset during development builds.

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -14,6 +14,7 @@ import album from './album'
 import artist from './artist'
 import playlist from './playlist'
 import playlist_folder from './playlist_folder'
+import discovery from './discovery'
 import radio from './radio'
 import share from './share'
 import library from './library'
@@ -115,6 +116,7 @@ const Admin = (props) => {
           show={PlaylistShow}
           edit={PlaylistEdit}
         />,
+        <Resource name="discovery" {...discovery} />,
         <Resource
           {...playlist_folder}
           name="folder"
@@ -154,6 +156,7 @@ const Admin = (props) => {
         <Resource name="genre" />,
         <Resource name="tag" />,
         <Resource name="playlistTrack" />,
+        <Resource name="discoveryTrack" />,
         <Resource name="keepalive" />,
         <Resource name="insights" />,
         <Resource name="config" />,

--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -21,7 +21,14 @@ const getSelectedLibraries = () => {
 // Function to apply library filtering to appropriate resources
 const applyLibraryFilter = (resource, params) => {
   // Content resources that should be filtered by selected libraries
-  const filteredResources = ['album', 'song', 'artist', 'playlistTrack', 'tag']
+  const filteredResources = [
+    'album',
+    'song',
+    'artist',
+    'playlistTrack',
+    'discoveryTrack',
+    'tag',
+  ]
 
   // Get selected libraries from localStorage
   const selectedLibraries = getSelectedLibraries()
@@ -51,6 +58,14 @@ const mapResource = (resource, params) => {
       params = applyLibraryFilter(resource, params)
 
       return [`playlist/${plsId}/tracks`, params]
+    }
+    case 'discoveryTrack': {
+      params.filter = params.filter || {}
+
+      const discoveryId = params.filter.discovery_id
+      params = applyLibraryFilter(resource, params)
+
+      return [`discovery/${discoveryId}/tracks`, params]
     }
     case 'album':
     case 'song':

--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -26,7 +26,6 @@ const applyLibraryFilter = (resource, params) => {
     'song',
     'artist',
     'playlistTrack',
-    'discoveryTrack',
     'tag',
   ]
 

--- a/ui/src/discovery/DiscoveryActions.jsx
+++ b/ui/src/discovery/DiscoveryActions.jsx
@@ -1,0 +1,110 @@
+import React from 'react'
+import {
+  Button,
+  sanitizeListRestProps,
+  TopToolbar,
+  useTranslate,
+  useDataProvider,
+  useNotify,
+} from 'react-admin'
+import { useDispatch } from 'react-redux'
+import { useMediaQuery, makeStyles } from '@material-ui/core'
+import PlayArrowIcon from '@material-ui/icons/PlayArrow'
+import ShuffleIcon from '@material-ui/icons/Shuffle'
+import { RiPlayListAddFill, RiPlayList2Fill } from 'react-icons/ri'
+import { ToggleFieldsMenu } from '../common'
+import { addTracks, playNext, playTracks, shuffleTracks } from '../actions'
+
+const useStyles = makeStyles({
+  toolbar: { display: 'flex', justifyContent: 'space-between', width: '100%' },
+})
+
+const DiscoveryActions = ({ className, ids, data, record, ...rest }) => {
+  const dispatch = useDispatch()
+  const translate = useTranslate()
+  const classes = useStyles()
+  const dataProvider = useDataProvider()
+  const notify = useNotify()
+  const isNotSmall = useMediaQuery((theme) => theme.breakpoints.up('sm'))
+
+  const getAllTracks = React.useCallback(
+    (action) => {
+      if (!record) {
+        return
+      }
+      if (ids?.length && record.songCount && ids.length >= record.songCount) {
+        dispatch(action(data, ids))
+        return
+      }
+      dataProvider
+        .getList('discoveryTrack', {
+          pagination: { page: 1, perPage: 0 },
+          sort: { field: 'id', order: 'ASC' },
+          filter: { discovery_id: record.id },
+        })
+        .then((response) => {
+          const trackMap = response.data.reduce(
+            (acc, track) => ({ ...acc, [track.id]: track }),
+            {},
+          )
+          dispatch(action(trackMap))
+        })
+        .catch(() => {
+          notify('ra.page.error', 'warning')
+        })
+    },
+    [record, ids, data, dataProvider, dispatch, notify],
+  )
+
+  const handlePlay = React.useCallback(() => {
+    getAllTracks(playTracks)
+  }, [getAllTracks])
+
+  const handlePlayNext = React.useCallback(() => {
+    getAllTracks(playNext)
+  }, [getAllTracks])
+
+  const handlePlayLater = React.useCallback(() => {
+    getAllTracks(addTracks)
+  }, [getAllTracks])
+
+  const handleShuffle = React.useCallback(() => {
+    getAllTracks(shuffleTracks)
+  }, [getAllTracks])
+
+  return (
+    <TopToolbar className={className} {...sanitizeListRestProps(rest)}>
+      <div className={classes.toolbar}>
+        <div>
+          <Button
+            onClick={handlePlay}
+            label={translate('resources.album.actions.playAll')}
+          >
+            <PlayArrowIcon />
+          </Button>
+          <Button
+            onClick={handleShuffle}
+            label={translate('resources.album.actions.shuffle')}
+          >
+            <ShuffleIcon />
+          </Button>
+          <Button
+            onClick={handlePlayNext}
+            label={translate('resources.album.actions.playNext')}
+          >
+            <RiPlayList2Fill />
+          </Button>
+          <Button
+            onClick={handlePlayLater}
+            label={translate('resources.album.actions.addToQueue')}
+          >
+            <RiPlayListAddFill />
+          </Button>
+        </div>
+        <div>{isNotSmall && <ToggleFieldsMenu resource="discoveryTrack" />}</div>
+      </div>
+    </TopToolbar>
+  )
+}
+
+export default DiscoveryActions

--- a/ui/src/discovery/DiscoveryList.jsx
+++ b/ui/src/discovery/DiscoveryList.jsx
@@ -1,7 +1,27 @@
 import React, { useMemo } from 'react'
-import { List, Datagrid, TextField, NumberField, DateField } from 'react-admin'
+import {
+  Datagrid,
+  DateField,
+  Filter,
+  NumberField,
+  SearchInput,
+  TextField,
+} from 'react-admin'
 import { useMediaQuery } from '@material-ui/core'
-import { DurationField, useSelectedFields, useResourceRefresh } from '../common'
+import {
+  DurationField,
+  List,
+  SizeField,
+  useSelectedFields,
+  useResourceRefresh,
+} from '../common'
+import DiscoveryListActions from './DiscoveryListActions'
+
+const DiscoveryFilter = (props) => (
+  <Filter {...props} variant="outlined">
+    <SearchInput source="q" alwaysOn />
+  </Filter>
+)
 
 const DiscoveryList = (props) => {
   const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
@@ -13,9 +33,10 @@ const DiscoveryList = (props) => {
       ownerName: isDesktop && <TextField source="ownerName" />,
       songCount: !isXsmall && <NumberField source="songCount" />,
       duration: <DurationField source="duration" />,
+      size: isDesktop && <SizeField source="size" />, 
       updatedAt: isDesktop && <DateField source="updatedAt" showTime />, 
-      createdAt: <DateField source="createdAt" showTime />,
-      comment: <TextField source="comment" />,
+      createdAt: <DateField source="createdAt" showTime />, 
+      comment: <TextField source="comment" />, 
     }),
     [isDesktop, isXsmall],
   )
@@ -27,7 +48,13 @@ const DiscoveryList = (props) => {
   })
 
   return (
-    <List {...props} exporter={false} actions={false}>
+    <List
+      {...props}
+      exporter={false}
+      filters={<DiscoveryFilter />}
+      actions={<DiscoveryListActions />}
+      bulkActionButtons={false}
+    >
       <Datagrid rowClick="show">
         <TextField source="name" />
         {columns}

--- a/ui/src/discovery/DiscoveryList.jsx
+++ b/ui/src/discovery/DiscoveryList.jsx
@@ -1,0 +1,39 @@
+import React, { useMemo } from 'react'
+import { List, Datagrid, TextField, NumberField, DateField } from 'react-admin'
+import { useMediaQuery } from '@material-ui/core'
+import { DurationField, useSelectedFields, useResourceRefresh } from '../common'
+
+const DiscoveryList = (props) => {
+  const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
+  const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
+  useResourceRefresh('discovery')
+
+  const toggleableFields = useMemo(
+    () => ({
+      ownerName: isDesktop && <TextField source="ownerName" />,
+      songCount: !isXsmall && <NumberField source="songCount" />,
+      duration: <DurationField source="duration" />,
+      updatedAt: isDesktop && <DateField source="updatedAt" showTime />, 
+      createdAt: <DateField source="createdAt" showTime />,
+      comment: <TextField source="comment" />,
+    }),
+    [isDesktop, isXsmall],
+  )
+
+  const columns = useSelectedFields({
+    resource: 'discovery',
+    columns: toggleableFields,
+    defaultOff: ['comment'],
+  })
+
+  return (
+    <List {...props} exporter={false} actions={false}>
+      <Datagrid rowClick="show">
+        <TextField source="name" />
+        {columns}
+      </Datagrid>
+    </List>
+  )
+}
+
+export default DiscoveryList

--- a/ui/src/discovery/DiscoveryListActions.jsx
+++ b/ui/src/discovery/DiscoveryListActions.jsx
@@ -1,0 +1,23 @@
+import React, { cloneElement } from 'react'
+import {
+  sanitizeListRestProps,
+  TopToolbar,
+  useTranslate,
+} from 'react-admin'
+import { useMediaQuery } from '@material-ui/core'
+import { ToggleFieldsMenu } from '../common'
+
+const DiscoveryListActions = ({ className, filters, ...rest }) => {
+  const isNotSmall = useMediaQuery((theme) => theme.breakpoints.up('sm'))
+  const translate = useTranslate()
+
+  return (
+    <TopToolbar className={className} {...sanitizeListRestProps(rest)}>
+      {filters && cloneElement(filters, { context: 'button' })}
+      <span className="ra-top-toolbar__label">{translate('resources.discovery.name')}</span>
+      {isNotSmall && <ToggleFieldsMenu resource="discovery" />}
+    </TopToolbar>
+  )
+}
+
+export default DiscoveryListActions

--- a/ui/src/discovery/DiscoveryShow.jsx
+++ b/ui/src/discovery/DiscoveryShow.jsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import {
+  Show,
+  SimpleShowLayout,
+  TextField,
+  NumberField,
+  DateField,
+  ReferenceManyField,
+  useShowController,
+  ShowContextProvider,
+} from 'react-admin'
+import { Card, CardContent, Typography } from '@material-ui/core'
+import { DurationField, Title, useResourceRefresh } from '../common'
+import DiscoverySongs from './DiscoverySongs'
+
+const DiscoveryDetails = ({ record }) => {
+  useResourceRefresh('song')
+  if (!record) {
+    return null
+  }
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="h5">{record.name}</Typography>
+        <Typography variant="body2" color="textSecondary">
+          {record.comment}
+        </Typography>
+      </CardContent>
+    </Card>
+  )
+}
+
+const DiscoveryShowLayout = (props) => {
+  const { record } = props
+  return (
+    <>
+      {record && <Title subTitle={record.name} />}
+      <DiscoveryDetails record={record} />
+      <SimpleShowLayout {...props}>
+        <TextField source="name" />
+        <TextField source="ownerName" />
+        <NumberField source="songCount" />
+        <DurationField source="duration" />
+        <DateField source="createdAt" showTime />
+        <DateField source="updatedAt" showTime />
+      </SimpleShowLayout>
+      {record && (
+        <ReferenceManyField
+          reference="discoveryTrack"
+          target="discovery_id"
+          sort={{ field: 'id', order: 'ASC' }}
+          perPage={100}
+          addLabel={false}
+        >
+          <DiscoverySongs discoveryId={record.id} />
+        </ReferenceManyField>
+      )}
+    </>
+  )
+}
+
+const DiscoveryShow = (props) => {
+  const controllerProps = useShowController(props)
+  return (
+    <ShowContextProvider value={controllerProps}>
+      <Show {...props} component="div">
+        <DiscoveryShowLayout {...controllerProps} {...props} />
+      </Show>
+    </ShowContextProvider>
+  )
+}
+
+export default DiscoveryShow

--- a/ui/src/discovery/DiscoveryShow.jsx
+++ b/ui/src/discovery/DiscoveryShow.jsx
@@ -1,59 +1,68 @@
-import React from 'react'
+import React, { useState, useCallback } from 'react'
 import {
-  Show,
-  SimpleShowLayout,
-  TextField,
-  NumberField,
-  DateField,
+  Filter,
+  Pagination,
   ReferenceManyField,
-  useShowController,
+  SearchInput,
   ShowContextProvider,
+  Title as RaTitle,
+  useShowContext,
+  useShowController,
 } from 'react-admin'
-import { Card, CardContent, Typography } from '@material-ui/core'
-import { DurationField, Title, useResourceRefresh } from '../common'
+import { Title, useResourceRefresh } from '../common'
+import PlaylistDetails from '../playlist/PlaylistDetails'
 import DiscoverySongs from './DiscoverySongs'
-
-const DiscoveryDetails = ({ record }) => {
-  useResourceRefresh('song')
-  if (!record) {
-    return null
-  }
-  return (
-    <Card>
-      <CardContent>
-        <Typography variant="h5">{record.name}</Typography>
-        <Typography variant="body2" color="textSecondary">
-          {record.comment}
-        </Typography>
-      </CardContent>
-    </Card>
-  )
-}
+import DiscoveryActions from './DiscoveryActions'
 
 const DiscoveryShowLayout = (props) => {
-  const { record } = props
+  const { loading, ...context } = useShowContext(props)
+  const { record } = context
+  const [searchTerm, setSearchTerm] = useState('')
+  useResourceRefresh('discovery')
+
+  const handleSearchChange = useCallback((event) => {
+    setSearchTerm(event.target.value)
+  }, [])
+
+  if (loading) {
+    return null
+  }
+
   return (
     <>
-      {record && <Title subTitle={record.name} />}
-      <DiscoveryDetails record={record} />
-      <SimpleShowLayout {...props}>
-        <TextField source="name" />
-        <TextField source="ownerName" />
-        <NumberField source="songCount" />
-        <DurationField source="duration" />
-        <DateField source="createdAt" showTime />
-        <DateField source="updatedAt" showTime />
-      </SimpleShowLayout>
+      {record && <RaTitle title={<Title subTitle={record.name} />} />}
+      {record && <PlaylistDetails {...context} />}
       {record && (
-        <ReferenceManyField
-          reference="discoveryTrack"
-          target="discovery_id"
-          sort={{ field: 'id', order: 'ASC' }}
-          perPage={100}
-          addLabel={false}
-        >
-          <DiscoverySongs discoveryId={record.id} />
-        </ReferenceManyField>
+        <>
+          <Filter variant="outlined">
+            <SearchInput
+              id="search"
+              source="q"
+              alwaysOn
+              value={searchTerm}
+              onChange={handleSearchChange}
+            />
+          </Filter>
+          <ReferenceManyField
+            {...context}
+            addLabel={false}
+            reference="discoveryTrack"
+            target="discovery_id"
+            sort={{ field: 'id', order: 'ASC' }}
+            perPage={50}
+            filter={{ discovery_id: props.id, q: searchTerm }}
+          >
+            <DiscoverySongs
+              discoveryId={record.id}
+              searchTerm={searchTerm}
+              title={<Title subTitle={record.name} />}
+              actions={<DiscoveryActions record={record} />}
+              pagination={
+                <Pagination rowsPerPageOptions={[25, 50, 100, 200]} perPage={50} />
+              }
+            />
+          </ReferenceManyField>
+        </>
       )}
     </>
   )
@@ -63,9 +72,7 @@ const DiscoveryShow = (props) => {
   const controllerProps = useShowController(props)
   return (
     <ShowContextProvider value={controllerProps}>
-      <Show {...props} component="div">
-        <DiscoveryShowLayout {...controllerProps} {...props} />
-      </Show>
+      <DiscoveryShowLayout {...props} {...controllerProps} />
     </ShowContextProvider>
   )
 }

--- a/ui/src/discovery/DiscoverySongs.jsx
+++ b/ui/src/discovery/DiscoverySongs.jsx
@@ -1,23 +1,99 @@
-import React from 'react'
-import { Datagrid, ListContextProvider, TextField, useListContext } from 'react-admin'
-import { Card, CardContent } from '@material-ui/core'
-import { DurationField } from '../common'
+import React, { useEffect, useMemo } from 'react'
+import {
+  Datagrid,
+  ListContextProvider,
+  ListToolbar,
+  TextField,
+  useListContext,
+  useVersion,
+} from 'react-admin'
+import { Card, useMediaQuery } from '@material-ui/core'
+import { makeStyles } from '@material-ui/core/styles'
+import clsx from 'clsx'
+import {
+  DurationField,
+  PathField,
+  SizeField,
+  useSelectedFields,
+  useResourceRefresh,
+} from '../common'
 
-const DiscoverySongs = (props) => {
+const useStyles = makeStyles(
+  (theme) => ({
+    main: {
+      display: 'flex',
+    },
+    content: {
+      marginTop: 0,
+      transition: theme.transitions.create('margin-top'),
+      position: 'relative',
+      flex: '1 1 auto',
+      [theme.breakpoints.down('xs')]: {
+        boxShadow: 'none',
+      },
+    },
+    toolbar: {
+      justifyContent: 'flex-start',
+    },
+    bulkActionsDisplayed: {
+      marginTop: -theme.spacing(8),
+      transition: theme.transitions.create('margin-top'),
+    },
+  }),
+  { name: 'NDDiscoverySongs' },
+)
+
+const DiscoverySongs = ({ actions, pagination, discoveryId, searchTerm }) => {
   const listContext = useListContext()
+  const version = useVersion()
+  const { setPage, selectedIds } = listContext
+  const classes = useStyles()
+  const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
+  useResourceRefresh('discoveryTrack', 'discovery')
+
+  useEffect(() => {
+    setPage(1)
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [discoveryId, searchTerm, setPage])
+
+  const toggleableFields = useMemo(
+    () => ({
+      title: <TextField source="title" label="resources.song.fields.title" />,
+      artist: isDesktop && (
+        <TextField source="artist" label="resources.song.fields.artist" />
+      ),
+      album: isDesktop && (
+        <TextField source="album" label="resources.song.fields.album" />
+      ),
+      duration: <DurationField source="duration" />, 
+      size: isDesktop && <SizeField source="size" />, 
+      path: <PathField source="path" label="resources.song.fields.path" />, 
+    }),
+    [isDesktop],
+  )
+
+  const columns = useSelectedFields({
+    resource: 'discoveryTrack',
+    columns: toggleableFields,
+    defaultOff: ['path'],
+  })
+
   return (
     <ListContextProvider value={listContext}>
-      <Card variant="outlined">
-        <CardContent>
-          <Datagrid rowClick="show" {...props} bulkActionButtons={false}>
-            <TextField source="title" label="resources.song.fields.title" />
-            <TextField source="artist" label="resources.song.fields.artist" />
-            <TextField source="album" label="resources.song.fields.album" />
-            <DurationField source="duration" />
-            <TextField source="path" label="resources.song.fields.path" />
+      <ListToolbar classes={{ toolbar: classes.toolbar }} actions={actions} />
+      <div className={classes.main}>
+        <Card
+          className={clsx(classes.content, {
+            [classes.bulkActionsDisplayed]: selectedIds?.length > 0,
+          })}
+          key={version}
+        >
+          <Datagrid {...listContext} rowClick={false} bulkActionButtons={false}>
+            {columns}
           </Datagrid>
-        </CardContent>
-      </Card>
+        </Card>
+      </div>
+      {pagination && React.cloneElement(pagination, listContext)}
     </ListContextProvider>
   )
 }

--- a/ui/src/discovery/DiscoverySongs.jsx
+++ b/ui/src/discovery/DiscoverySongs.jsx
@@ -1,12 +1,7 @@
 import React from 'react'
-import {
-  Datagrid,
-  FunctionField,
-  ListContextProvider,
-  useListContext,
-} from 'react-admin'
+import { Datagrid, ListContextProvider, TextField, useListContext } from 'react-admin'
 import { Card, CardContent } from '@material-ui/core'
-import { DurationField, SongContextMenu } from '../common'
+import { DurationField } from '../common'
 
 const DiscoverySongs = (props) => {
   const listContext = useListContext()
@@ -15,28 +10,11 @@ const DiscoverySongs = (props) => {
       <Card variant="outlined">
         <CardContent>
           <Datagrid rowClick="show" {...props} bulkActionButtons={false}>
-            <FunctionField
-              label="resources.song.fields.title"
-              render={(record) => record?.mediaFile?.title || ''}
-            />
-            <FunctionField
-              label="resources.song.fields.artist"
-              render={(record) => record?.mediaFile?.artist || ''}
-            />
-            <FunctionField
-              label="resources.song.fields.album"
-              render={(record) => record?.mediaFile?.album || ''}
-            />
-            <DurationField source="mediaFile.duration" />
-            <FunctionField
-              label="resources.song.fields.actions"
-              render={(record) => (
-                <SongContextMenu
-                  resource="song"
-                  record={{ ...record.mediaFile, playlistId: null }}
-                />
-              )}
-            />
+            <TextField source="title" label="resources.song.fields.title" />
+            <TextField source="artist" label="resources.song.fields.artist" />
+            <TextField source="album" label="resources.song.fields.album" />
+            <DurationField source="duration" />
+            <TextField source="path" label="resources.song.fields.path" />
           </Datagrid>
         </CardContent>
       </Card>

--- a/ui/src/discovery/DiscoverySongs.jsx
+++ b/ui/src/discovery/DiscoverySongs.jsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import {
+  Datagrid,
+  FunctionField,
+  ListContextProvider,
+  useListContext,
+} from 'react-admin'
+import { Card, CardContent } from '@material-ui/core'
+import { DurationField, SongContextMenu } from '../common'
+
+const DiscoverySongs = (props) => {
+  const listContext = useListContext()
+  return (
+    <ListContextProvider value={listContext}>
+      <Card variant="outlined">
+        <CardContent>
+          <Datagrid rowClick="show" {...props} bulkActionButtons={false}>
+            <FunctionField
+              label="resources.song.fields.title"
+              render={(record) => record?.mediaFile?.title || ''}
+            />
+            <FunctionField
+              label="resources.song.fields.artist"
+              render={(record) => record?.mediaFile?.artist || ''}
+            />
+            <FunctionField
+              label="resources.song.fields.album"
+              render={(record) => record?.mediaFile?.album || ''}
+            />
+            <DurationField source="mediaFile.duration" />
+            <FunctionField
+              label="resources.song.fields.actions"
+              render={(record) => (
+                <SongContextMenu
+                  resource="song"
+                  record={{ ...record.mediaFile, playlistId: null }}
+                />
+              )}
+            />
+          </Datagrid>
+        </CardContent>
+      </Card>
+    </ListContextProvider>
+  )
+}
+
+export default DiscoverySongs

--- a/ui/src/discovery/index.jsx
+++ b/ui/src/discovery/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import TravelExploreOutlinedIcon from '@material-ui/icons/TravelExplore'
-import TravelExploreIcon from '@material-ui/icons/TravelExplore'
+import ExploreOutlinedIcon from '@material-ui/icons/ExploreOutlined'
+import ExploreIcon from '@material-ui/icons/Explore'
 import DynamicMenuIcon from '../layout/DynamicMenuIcon'
 import DiscoveryList from './DiscoveryList'
 import DiscoveryShow from './DiscoveryShow'
@@ -11,8 +11,8 @@ export default {
   icon: (
     <DynamicMenuIcon
       path={'discovery'}
-      icon={TravelExploreOutlinedIcon}
-      activeIcon={TravelExploreIcon}
+      icon={ExploreOutlinedIcon}
+      activeIcon={ExploreIcon}
     />
   ),
 }

--- a/ui/src/discovery/index.jsx
+++ b/ui/src/discovery/index.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import TravelExploreOutlinedIcon from '@material-ui/icons/TravelExplore'
+import TravelExploreIcon from '@material-ui/icons/TravelExplore'
+import DynamicMenuIcon from '../layout/DynamicMenuIcon'
+import DiscoveryList from './DiscoveryList'
+import DiscoveryShow from './DiscoveryShow'
+
+export default {
+  list: DiscoveryList,
+  show: DiscoveryShow,
+  icon: (
+    <DynamicMenuIcon
+      path={'discovery'}
+      icon={TravelExploreOutlinedIcon}
+      activeIcon={TravelExploreIcon}
+    />
+  ),
+}

--- a/ui/src/i18n/provider.js
+++ b/ui/src/i18n/provider.js
@@ -45,6 +45,10 @@ const prepareLanguage = (lang) => {
   // Make "albumSong" and "playlistTrack" resource use the same translations as "song"
   lang.resources.albumSong = lang.resources.song
   lang.resources.playlistTrack = lang.resources.song
+  lang.resources.discoveryTrack = lang.resources.song
+  if (lang.resources.playlist) {
+    lang.resources.discovery = lang.resources.playlist
+  }
   // ra.boolean.null should always be empty
   lang.ra.boolean.null = ''
   // Fallback to english translations


### PR DESCRIPTION
## Summary
- add a Discovery domain with dedicated models, repositories, migration, and service wiring
- integrate discovery sync into the scanner/CLI and expose read-only Native API endpoints
- surface discovery resources in the React admin UI and keep UI embeds building via tracked placeholders

## Testing
- `go test ./...` *(fails: missing taglib pkg-config dependency in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1936791908330a21add857bd8c447