### PR TITLE
Align discovery UI with playlist layout

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -67,8 +67,9 @@ func runScanner(ctx context.Context) {
 	defer db.Db().Close()
 	ds := persistence.New(sqlDB)
 	pls := core.NewPlaylists(ds)
+	disc := core.NewDiscoveries(ds)
 
-	progress, err := scanner.CallScan(ctx, ds, pls, fullScan)
+	progress, err := scanner.CallScan(ctx, ds, pls, disc, fullScan)
 	if err != nil {
 		log.Fatal(ctx, "Failed to scan", err)
 	}

--- a/cmd/wire_gen.go
+++ b/cmd/wire_gen.go
@@ -59,6 +59,7 @@ func CreateNativeAPIRouter(ctx context.Context) *nativeapi.Router {
 	dataStore := persistence.New(sqlDB)
 	share := core.NewShare(dataStore)
 	playlists := core.NewPlaylists(dataStore)
+	discoveries := core.NewDiscoveries(dataStore)
 	metricsMetrics := metrics.GetPrometheusInstance(dataStore)
 	manager := plugins.GetManager(dataStore, metricsMetrics)
 	insights := metrics.GetInstance(dataStore, manager)
@@ -69,7 +70,7 @@ func CreateNativeAPIRouter(ctx context.Context) *nativeapi.Router {
 	artworkArtwork := artwork.NewArtwork(dataStore, fileCache, fFmpeg, provider)
 	cacheWarmer := artwork.NewCacheWarmer(artworkArtwork, fileCache)
 	broker := events.GetBroker()
-	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, metricsMetrics)
+	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, discoveries, metricsMetrics)
 	watcher := scanner.GetWatcher(dataStore, scannerScanner)
 	library := core.NewLibrary(dataStore, scannerScanner, watcher, broker)
 	router := nativeapi.New(dataStore, share, playlists, insights, library)
@@ -94,7 +95,8 @@ func CreateSubsonicAPIRouter(ctx context.Context) *subsonic.Router {
 	cacheWarmer := artwork.NewCacheWarmer(artworkArtwork, fileCache)
 	broker := events.GetBroker()
 	playlists := core.NewPlaylists(dataStore)
-	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, metricsMetrics)
+	discoveries := core.NewDiscoveries(dataStore)
+	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, discoveries, metricsMetrics)
 	playTracker := scrobbler.GetPlayTracker(dataStore, broker, manager)
 	playbackServer := playback.GetInstance(dataStore)
 	router := subsonic.New(dataStore, artworkArtwork, mediaStreamer, archiver, players, provider, scannerScanner, broker, playlists, playTracker, share, playbackServer, metricsMetrics)
@@ -162,7 +164,8 @@ func CreateScanner(ctx context.Context) scanner.Scanner {
 	cacheWarmer := artwork.NewCacheWarmer(artworkArtwork, fileCache)
 	broker := events.GetBroker()
 	playlists := core.NewPlaylists(dataStore)
-	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, metricsMetrics)
+	discoveries := core.NewDiscoveries(dataStore)
+	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, discoveries, metricsMetrics)
 	return scannerScanner
 }
 
@@ -179,7 +182,8 @@ func CreateScanWatcher(ctx context.Context) scanner.Watcher {
 	cacheWarmer := artwork.NewCacheWarmer(artworkArtwork, fileCache)
 	broker := events.GetBroker()
 	playlists := core.NewPlaylists(dataStore)
-	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, metricsMetrics)
+	discoveries := core.NewDiscoveries(dataStore)
+	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, discoveries, metricsMetrics)
 	watcher := scanner.GetWatcher(dataStore, scannerScanner)
 	return watcher
 }

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -52,6 +52,7 @@ type configOptions struct {
 	AutoImportPlaylists             bool
 	DefaultPlaylistPublicVisibility bool
 	PlaylistsPath                   string
+	DiscoveryPath                   string
 	SyncFolder                      string
 	SmartPlaylistRefreshDelay       time.Duration
 	AutoTranscodeDownload           bool
@@ -310,6 +311,7 @@ func Load(noConfigDump bool) {
 		validateScanSchedule,
 		validateBackupSchedule,
 		validatePlaylistsPath,
+		validateDiscoveryPath,
 		validatePurgeMissingOption,
 	)
 	if err != nil {
@@ -417,6 +419,19 @@ func validatePlaylistsPath() error {
 	return nil
 }
 
+func validateDiscoveryPath() error {
+	if Server.DiscoveryPath == "" {
+		return nil
+	}
+	if _, err := os.Stat(Server.DiscoveryPath); err != nil {
+		if !os.IsNotExist(err) {
+			log.Error("Invalid DiscoveryPath", "path", Server.DiscoveryPath, err)
+			return err
+		}
+	}
+	return nil
+}
+
 func validatePurgeMissingOption() error {
 	allowedValues := []string{consts.PurgeMissingNever, consts.PurgeMissingAlways, consts.PurgeMissingFull}
 	valid := false
@@ -498,6 +513,7 @@ func setViperDefaults() {
 	viper.SetDefault("autoimportplaylists", true)
 	viper.SetDefault("defaultplaylistpublicvisibility", false)
 	viper.SetDefault("playlistspath", "")
+	viper.SetDefault("discoverypath", "")
 	viper.SetDefault("smartPlaylistRefreshDelay", 5*time.Second)
 	viper.SetDefault("enabledownloads", true)
 	viper.SetDefault("enableexternalservices", true)
@@ -520,7 +536,7 @@ func setViperDefaults() {
 	viper.SetDefault("enablefavourites", true)
 	viper.SetDefault("enablestarrating", true)
 	viper.SetDefault("enableuserediting", true)
-       viper.SetDefault("defaulttheme", "Music Matters")
+	viper.SetDefault("defaulttheme", "Music Matters")
 	viper.SetDefault("defaultlanguage", "")
 	viper.SetDefault("defaultuivolume", consts.DefaultUIVolume)
 	viper.SetDefault("enablereplaygain", true)

--- a/core/artwork/artwork.go
+++ b/core/artwork/artwork.go
@@ -129,6 +129,8 @@ func (a *artwork) getArtworkReader(ctx context.Context, artID model.ArtworkID, s
 			artReader, err = newMediafileArtworkReader(ctx, a, artID)
 		case model.KindPlaylistArtwork:
 			artReader, err = newPlaylistArtworkReader(ctx, a, artID)
+		case model.KindDiscoveryArtwork:
+			artReader, err = newDiscoveryArtworkReader(ctx, a, artID)
 		default:
 			return nil, ErrUnavailable
 		}

--- a/core/artwork/reader_discovery.go
+++ b/core/artwork/reader_discovery.go
@@ -1,0 +1,59 @@
+package artwork
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/navidrome/navidrome/model"
+)
+
+type discoveryArtworkReader struct {
+	cacheKey
+	a         *artwork
+	discovery model.Discovery
+	leadTrack *model.DiscoveryTrack
+}
+
+func newDiscoveryArtworkReader(ctx context.Context, artwork *artwork, artID model.ArtworkID) (*discoveryArtworkReader, error) {
+	disc, err := artwork.ds.Discovery(ctx).Get(artID.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	tracksRepo := artwork.ds.Discovery(ctx).Tracks(disc.ID)
+	tracks, err := tracksRepo.GetAll(model.QueryOptions{Max: 1})
+	if err != nil {
+		return nil, err
+	}
+	if len(tracks) == 0 {
+		return nil, ErrUnavailable
+	}
+
+	reader := &discoveryArtworkReader{
+		a:         artwork,
+		discovery: *disc,
+		leadTrack: &tracks[0],
+	}
+	reader.cacheKey.artID = artID
+	reader.cacheKey.lastUpdate = disc.UpdatedAt
+	return reader, nil
+}
+
+func (d *discoveryArtworkReader) LastUpdated() time.Time {
+	return d.lastUpdate
+}
+
+func (d *discoveryArtworkReader) Reader(ctx context.Context) (io.ReadCloser, string, error) {
+	if d.leadTrack == nil {
+		return nil, "", ErrUnavailable
+	}
+
+	ff := []sourceFunc{
+		fromTag(ctx, d.leadTrack.Path),
+		fromFFmpegTag(ctx, d.a.ffmpeg, d.leadTrack.Path),
+		fromAlbumPlaceholder(),
+	}
+
+	return selectImageReader(ctx, d.artID, ff...)
+}

--- a/core/discoveries.go
+++ b/core/discoveries.go
@@ -1,0 +1,256 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/core/storage"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	modelmetadata "github.com/navidrome/navidrome/model/metadata"
+	"github.com/navidrome/navidrome/model/request"
+)
+
+type Discoveries interface {
+	Sync(ctx context.Context) error
+}
+
+type discoveries struct {
+	ds model.DataStore
+}
+
+func NewDiscoveries(ds model.DataStore) Discoveries {
+	return &discoveries{ds: ds}
+}
+
+func (d *discoveries) Sync(ctx context.Context) error {
+	root := conf.Server.DiscoveryPath
+	if root == "" {
+		return nil
+	}
+	if err := ensureDir(root); err != nil {
+		return err
+	}
+
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	root = absRoot
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return err
+	}
+
+	repo := d.ds.Discovery(ctx)
+	existing, err := repo.GetAll()
+	if err != nil {
+		return err
+	}
+
+	existingByPath := map[string]model.Discovery{}
+	for _, disc := range existing {
+		path := filepath.Clean(disc.Path)
+		if !filepath.IsAbs(path) {
+			if absPath, err := filepath.Abs(path); err == nil {
+				path = absPath
+			}
+		}
+		existingByPath[path] = disc
+	}
+
+	seen := map[string]struct{}{}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		absPath := filepath.Join(root, entry.Name())
+		seen[filepath.Clean(absPath)] = struct{}{}
+		if err := d.importDirectory(ctx, repo, existingByPath[filepath.Clean(absPath)], absPath, entry.Name()); err != nil {
+			log.Error(ctx, "Discovery: error importing folder", "path", absPath, err)
+		}
+	}
+
+	for path, disc := range existingByPath {
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		if err := repo.Delete(disc.ID); err != nil {
+			log.Error(ctx, "Discovery: error removing missing discovery", "path", path, err)
+		}
+	}
+	return nil
+}
+
+func (d *discoveries) importDirectory(ctx context.Context, repo model.DiscoveryRepository, current model.Discovery, absPath, name string) error {
+	tracks, err := d.collectTracks(ctx, absPath)
+	if err != nil {
+		return err
+	}
+	if len(tracks) == 0 {
+		return nil
+	}
+
+	usr, ok := request.UserFrom(ctx)
+	if !ok {
+		return fmt.Errorf("discovery sync requires authenticated user")
+	}
+
+	disc := &model.Discovery{}
+	if current.ID != "" {
+		disc.ID = current.ID
+	}
+	disc.Name = name
+	disc.OwnerID = usr.ID
+	disc.Path = absPath
+	disc.Comment = current.Comment
+	var totalDuration float32
+	var totalSize int64
+	for _, track := range tracks {
+		totalDuration += track.Duration
+		totalSize += track.Size
+	}
+	disc.Duration = totalDuration
+	disc.Size = totalSize
+	disc.SongCount = len(tracks)
+
+	if err := repo.Put(disc); err != nil {
+		return err
+	}
+
+	if err := repo.ReplaceTracks(disc.ID, tracks); err != nil {
+		return err
+	}
+	return nil
+}
+
+type fileInfoWithBirth struct {
+	fs.FileInfo
+}
+
+func (f fileInfoWithBirth) BirthTime() time.Time {
+	return f.ModTime()
+}
+
+type trackCandidate struct {
+	abs string
+	rel string
+}
+
+func (d *discoveries) collectTracks(ctx context.Context, root string) (model.DiscoveryTracks, error) {
+	store, err := storage.For(root)
+	if err != nil {
+		return nil, err
+	}
+	musicFS, err := store.FS()
+	if err != nil {
+		return nil, err
+	}
+
+	var candidates []trackCandidate
+	err = filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if strings.HasPrefix(entry.Name(), ".") && path != root {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !model.IsAudioFile(entry.Name()) {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		candidates = append(candidates, trackCandidate{
+			abs: filepath.Clean(path),
+			rel: filepath.ToSlash(rel),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].abs < candidates[j].abs
+	})
+
+	relPaths := make([]string, len(candidates))
+	absPaths := make([]string, len(candidates))
+	for i, cand := range candidates {
+		relPaths[i] = cand.rel
+		absPaths[i] = cand.abs
+	}
+
+	tagResults, err := musicFS.ReadTags(relPaths...)
+	if err != nil {
+		log.Warn(ctx, "Discovery: unable to read tags", "path", root, err)
+	}
+
+	tracks := make(model.DiscoveryTracks, 0, len(absPaths))
+	for idx, absPath := range absPaths {
+		relPath := relPaths[idx]
+		info, ok := tagResults[relPath]
+		if !ok {
+			info = modelmetadata.Info{}
+		}
+		if info.FileInfo == nil {
+			if stat, statErr := os.Stat(absPath); statErr == nil {
+				info.FileInfo = fileInfoWithBirth{FileInfo: stat}
+			}
+		}
+		md := modelmetadata.New(absPath, info)
+		title := md.String(model.TagTitle)
+		if title == "" {
+			base := filepath.Base(absPath)
+			title = strings.TrimSuffix(base, filepath.Ext(base))
+		}
+               artist := md.String(model.TagTrackArtist)
+		album := md.String(model.TagAlbum)
+		size := int64(0)
+		if info.FileInfo != nil {
+			size = info.FileInfo.Size()
+		}
+
+		tracks = append(tracks, model.DiscoveryTrack{
+			Path:     absPath,
+			Title:    title,
+			Artist:   artist,
+			Album:    album,
+			Duration: md.Length(),
+			Size:     size,
+		})
+	}
+	return tracks, nil
+}
+
+func ensureDir(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return os.MkdirAll(path, 0o755)
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", path)
+	}
+	return nil
+}

--- a/core/discoveries.go
+++ b/core/discoveries.go
@@ -2,7 +2,9 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -20,6 +22,7 @@ import (
 
 type Discoveries interface {
 	Sync(ctx context.Context) error
+	Publish(ctx context.Context, discoveryID string) error
 }
 
 type discoveries struct {
@@ -91,6 +94,76 @@ func (d *discoveries) Sync(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func (d *discoveries) Publish(ctx context.Context, discoveryID string) error {
+	repo := d.ds.Discovery(ctx)
+	disc, err := repo.GetWithTracks(discoveryID)
+	if err != nil {
+		return err
+	}
+	if conf.Server.SyncFolder == "" {
+		return fmt.Errorf("sync folder not configured")
+	}
+	if disc.Path == "" {
+		return fmt.Errorf("discovery path is empty")
+	}
+
+	srcPath, err := filepath.Abs(disc.Path)
+	if err != nil {
+		return err
+	}
+	if err := ensureDir(filepath.Dir(srcPath)); err != nil {
+		return err
+	}
+	if _, err := os.Stat(srcPath); err != nil {
+		return err
+	}
+
+	m3uName := disc.Name
+	if strings.TrimSpace(m3uName) == "" {
+		m3uName = filepath.Base(srcPath)
+	}
+	m3uName = sanitizeDiscoveryName(m3uName)
+	if err := writeDiscoveryM3U(filepath.Join(srcPath, m3uName+".m3u"), disc.Tracks); err != nil {
+		return err
+	}
+
+	syncRoot := conf.Server.SyncFolder
+	if abs, err := filepath.Abs(syncRoot); err == nil {
+		syncRoot = abs
+	}
+	if err := ensureDir(syncRoot); err != nil {
+		return err
+	}
+
+	rel := filepath.Base(srcPath)
+	if conf.Server.DiscoveryPath != "" {
+		if absRoot, err := filepath.Abs(conf.Server.DiscoveryPath); err == nil {
+			if r, err := filepath.Rel(absRoot, srcPath); err == nil && !strings.HasPrefix(r, "..") {
+				rel = r
+			}
+		}
+	}
+
+	destPath := filepath.Join(syncRoot, rel)
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(destPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	if err := os.Rename(srcPath, destPath); err != nil {
+		if copyErr := copyDiscoveryDir(srcPath, destPath); copyErr != nil {
+			return copyErr
+		}
+		if removeErr := os.RemoveAll(srcPath); removeErr != nil {
+			return removeErr
+		}
+	}
+
+	return d.Sync(ctx)
 }
 
 func (d *discoveries) importDirectory(ctx context.Context, repo model.DiscoveryRepository, current model.Discovery, absPath, name string) error {
@@ -222,7 +295,7 @@ func (d *discoveries) collectTracks(ctx context.Context, root string) (model.Dis
 			base := filepath.Base(absPath)
 			title = strings.TrimSuffix(base, filepath.Ext(base))
 		}
-               artist := md.String(model.TagTrackArtist)
+		artist := md.String(model.TagTrackArtist)
 		album := md.String(model.TagAlbum)
 		size := int64(0)
 		if info.FileInfo != nil {
@@ -253,4 +326,74 @@ func ensureDir(path string) error {
 		return fmt.Errorf("%s is not a directory", path)
 	}
 	return nil
+}
+
+func sanitizeDiscoveryName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "discovery"
+	}
+	replacer := strings.NewReplacer("/", "_", "\\", "_")
+	return replacer.Replace(name)
+}
+
+func writeDiscoveryM3U(path string, tracks model.DiscoveryTracks) error {
+	lines := make([]string, 0, len(tracks))
+	for _, track := range tracks {
+		title := strings.TrimSpace(track.Title)
+		if title == "" && track.Path != "" {
+			title = strings.TrimSuffix(filepath.Base(track.Path), filepath.Ext(track.Path))
+		}
+		artist := strings.TrimSpace(track.Artist)
+		ext := strings.ToLower(filepath.Ext(track.Path))
+		if ext == "" {
+			ext = ".mp3"
+		}
+		if artist != "" {
+			lines = append(lines, fmt.Sprintf("%s - %s%s", artist, title, ext))
+		} else {
+			lines = append(lines, fmt.Sprintf("%s%s", title, ext))
+		}
+	}
+
+	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o644)
+}
+
+func copyDiscoveryDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+
+		in, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer in.Close()
+
+		out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(out, in); err != nil {
+			out.Close()
+			return err
+		}
+		if err := out.Close(); err != nil {
+			return err
+		}
+		return nil
+	})
 }

--- a/core/media_streamer.go
+++ b/core/media_streamer.go
@@ -49,6 +49,23 @@ func (j *streamJob) Key() string {
 }
 
 func (ms *mediaStreamer) NewStream(ctx context.Context, id string, reqFormat string, reqBitRate int, reqOffset int) (*Stream, error) {
+	if discID, trackID, ok := model.ParseDiscoveryStreamID(id); ok {
+		repo := ms.ds.Discovery(ctx).Tracks(discID)
+		entry, err := repo.Read(trackID)
+		if err != nil {
+			return nil, err
+		}
+		track, ok := entry.(model.DiscoveryTrack)
+		if !ok {
+			return nil, fmt.Errorf("unexpected discovery track type %T", entry)
+		}
+		mf, err := track.ToMediaFile()
+		if err != nil {
+			return nil, err
+		}
+		return ms.DoStream(ctx, mf, reqFormat, reqBitRate, reqOffset)
+	}
+
 	mf, err := ms.ds.MediaFile(ctx).Get(id)
 	if err != nil {
 		return nil, err

--- a/core/wire_providers.go
+++ b/core/wire_providers.go
@@ -11,13 +11,14 @@ import (
 )
 
 var Set = wire.NewSet(
-	NewMediaStreamer,
-	GetTranscodingCache,
-	NewArchiver,
-	NewPlayers,
-	NewShare,
-	NewPlaylists,
-	NewLibrary,
+        NewMediaStreamer,
+        GetTranscodingCache,
+        NewArchiver,
+        NewPlayers,
+        NewShare,
+        NewPlaylists,
+        NewDiscoveries,
+        NewLibrary,
 	agents.GetAgents,
 	external.NewProvider,
 	wire.Bind(new(external.Agents), new(*agents.Agents)),

--- a/db/migrations/20250816074434_create_discovery_tables.go
+++ b/db/migrations/20250816074434_create_discovery_tables.go
@@ -1,0 +1,61 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upCreateDiscoveryTables, downCreateDiscoveryTables)
+}
+
+func upCreateDiscoveryTables(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+                CREATE TABLE IF NOT EXISTS discovery (
+                        id         VARCHAR NOT NULL PRIMARY KEY,
+                        name       VARCHAR NOT NULL CHECK (length(trim(name)) > 0),
+                        comment    VARCHAR NOT NULL DEFAULT '',
+                        duration   REAL NOT NULL DEFAULT 0,
+                        size       INTEGER NOT NULL DEFAULT 0,
+                        song_count INTEGER NOT NULL DEFAULT 0,
+                        owner_id   VARCHAR NOT NULL REFERENCES user(id) ON UPDATE CASCADE ON DELETE CASCADE,
+                        path       TEXT NOT NULL,
+                        created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+                        updated_at DATETIME NOT NULL DEFAULT (datetime('now'))
+                );
+
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_discovery_owner_name ON discovery(owner_id, lower(name));
+                CREATE INDEX IF NOT EXISTS idx_discovery_owner ON discovery(owner_id);
+                CREATE INDEX IF NOT EXISTS idx_discovery_path ON discovery(path);
+
+               CREATE TABLE IF NOT EXISTS discovery_tracks (
+                       id            INTEGER NOT NULL,
+                       discovery_id  VARCHAR NOT NULL REFERENCES discovery(id) ON DELETE CASCADE,
+                       path          TEXT    NOT NULL,
+                       title         TEXT    NOT NULL DEFAULT '',
+                       artist        TEXT    NOT NULL DEFAULT '',
+                       album         TEXT    NOT NULL DEFAULT '',
+                       duration      REAL    NOT NULL DEFAULT 0,
+                       size          INTEGER NOT NULL DEFAULT 0,
+                       PRIMARY KEY (discovery_id, id)
+               );
+
+               CREATE INDEX IF NOT EXISTS idx_discovery_tracks_path ON discovery_tracks(path);
+        `)
+	return err
+}
+
+func downCreateDiscoveryTables(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+                DROP INDEX IF EXISTS idx_discovery_tracks_path;
+                DROP TABLE IF EXISTS discovery_tracks;
+
+                DROP INDEX IF EXISTS idx_discovery_owner_name;
+                DROP INDEX IF EXISTS idx_discovery_owner;
+                DROP INDEX IF EXISTS idx_discovery_path;
+                DROP TABLE IF EXISTS discovery;
+        `)
+	return err
+}

--- a/model/artwork_id.go
+++ b/model/artwork_id.go
@@ -22,6 +22,7 @@ var (
 	KindArtistArtwork    = Kind{"ar", "artist"}
 	KindAlbumArtwork     = Kind{"al", "album"}
 	KindPlaylistArtwork  = Kind{"pl", "playlist"}
+	KindDiscoveryArtwork = Kind{"dc", "discovery"}
 )
 
 var artworkKindMap = map[string]Kind{
@@ -29,6 +30,7 @@ var artworkKindMap = map[string]Kind{
 	KindArtistArtwork.prefix:    KindArtistArtwork,
 	KindAlbumArtwork.prefix:     KindAlbumArtwork,
 	KindPlaylistArtwork.prefix:  KindPlaylistArtwork,
+	KindDiscoveryArtwork.prefix: KindDiscoveryArtwork,
 }
 
 type ArtworkID struct {

--- a/model/datastore.go
+++ b/model/datastore.go
@@ -1,48 +1,49 @@
-	package model
+package model
 
-	import (
-		"context"
+import (
+	"context"
 
-		"github.com/Masterminds/squirrel"
-		"github.com/deluan/rest"
-	)
+	"github.com/Masterminds/squirrel"
+	"github.com/deluan/rest"
+)
 
-	type QueryOptions struct {
-		Sort    string
-		Order   string
-		Max     int
-		Offset  int
-		Filters squirrel.Sqlizer
-		Seed    string // for random sorting
-	}
+type QueryOptions struct {
+	Sort    string
+	Order   string
+	Max     int
+	Offset  int
+	Filters squirrel.Sqlizer
+	Seed    string // for random sorting
+}
 
-	type ResourceRepository interface {
-		rest.Repository
-	}
+type ResourceRepository interface {
+	rest.Repository
+}
 
-	type DataStore interface {
-		Library(ctx context.Context) LibraryRepository
-		Folder(ctx context.Context) FolderRepository
-		Album(ctx context.Context) AlbumRepository
-		Artist(ctx context.Context) ArtistRepository
-		MediaFile(ctx context.Context) MediaFileRepository
-		Genre(ctx context.Context) GenreRepository
-		Tag(ctx context.Context) TagRepository
-		Playlist(ctx context.Context) PlaylistRepository
-		PlaylistFolder(ctx context.Context) PlaylistFolderRepository
-		PlayQueue(ctx context.Context) PlayQueueRepository
-		Transcoding(ctx context.Context) TranscodingRepository
-		Player(ctx context.Context) PlayerRepository
-		Radio(ctx context.Context) RadioRepository
-		Share(ctx context.Context) ShareRepository
-		Property(ctx context.Context) PropertyRepository
-		User(ctx context.Context) UserRepository
-		UserProps(ctx context.Context) UserPropsRepository
-		ScrobbleBuffer(ctx context.Context) ScrobbleBufferRepository
+type DataStore interface {
+	Library(ctx context.Context) LibraryRepository
+	Folder(ctx context.Context) FolderRepository
+	Album(ctx context.Context) AlbumRepository
+	Artist(ctx context.Context) ArtistRepository
+	MediaFile(ctx context.Context) MediaFileRepository
+	Genre(ctx context.Context) GenreRepository
+	Tag(ctx context.Context) TagRepository
+	Playlist(ctx context.Context) PlaylistRepository
+	Discovery(ctx context.Context) DiscoveryRepository
+	PlaylistFolder(ctx context.Context) PlaylistFolderRepository
+	PlayQueue(ctx context.Context) PlayQueueRepository
+	Transcoding(ctx context.Context) TranscodingRepository
+	Player(ctx context.Context) PlayerRepository
+	Radio(ctx context.Context) RadioRepository
+	Share(ctx context.Context) ShareRepository
+	Property(ctx context.Context) PropertyRepository
+	User(ctx context.Context) UserRepository
+	UserProps(ctx context.Context) UserPropsRepository
+	ScrobbleBuffer(ctx context.Context) ScrobbleBufferRepository
 
-		Resource(ctx context.Context, model interface{}) ResourceRepository
+	Resource(ctx context.Context, model interface{}) ResourceRepository
 
-		WithTx(block func(tx DataStore) error, scope ...string) error
-		WithTxImmediate(block func(tx DataStore) error, scope ...string) error
-		GC(ctx context.Context) error
-	}
+	WithTx(block func(tx DataStore) error, scope ...string) error
+	WithTxImmediate(block func(tx DataStore) error, scope ...string) error
+	GC(ctx context.Context) error
+}

--- a/model/discovery.go
+++ b/model/discovery.go
@@ -1,0 +1,75 @@
+package model
+
+import "time"
+
+type Discovery struct {
+	ID        string          `structs:"id" json:"id"`
+	Name      string          `structs:"name" json:"name"`
+	Comment   string          `structs:"comment" json:"comment"`
+	Duration  float32         `structs:"duration" json:"duration"`
+	Size      int64           `structs:"size" json:"size"`
+	SongCount int             `structs:"song_count" json:"songCount"`
+	OwnerName string          `structs:"-" json:"ownerName"`
+	OwnerID   string          `structs:"owner_id" json:"ownerId"`
+	Path      string          `structs:"path" json:"path"`
+	CreatedAt time.Time       `structs:"created_at" json:"createdAt"`
+	UpdatedAt time.Time       `structs:"updated_at" json:"updatedAt"`
+	Tracks    DiscoveryTracks `structs:"-" json:"tracks,omitempty"`
+	Type      string          `structs:"-" json:"type,omitempty"`
+}
+
+func (d *Discovery) refreshStats() {
+	d.SongCount = len(d.Tracks)
+	d.Duration = 0
+	d.Size = 0
+	for _, t := range d.Tracks {
+		d.Duration += t.Duration
+		d.Size += t.Size
+	}
+}
+
+func (d *Discovery) SetTracks(tracks DiscoveryTracks) {
+	d.Tracks = tracks
+	d.refreshStats()
+}
+
+func (d Discovery) CoverArtID() ArtworkID {
+	return NewArtworkID(KindDiscoveryArtwork, d.ID, &d.UpdatedAt)
+}
+
+type Discoveries []Discovery
+
+type DiscoveryRepository interface {
+	ResourceRepository
+	CountAll(options ...QueryOptions) (int64, error)
+	Exists(id string) (bool, error)
+	Put(d *Discovery) error
+	Get(id string) (*Discovery, error)
+	GetWithTracks(id string) (*Discovery, error)
+	GetAll(options ...QueryOptions) (Discoveries, error)
+	FindByPath(path string) (*Discovery, error)
+	Delete(id string) error
+	Tracks(discoveryID string) DiscoveryTrackRepository
+	GetDiscoveries(mediaFileId string) (Discoveries, error)
+	ReplaceTracks(id string, tracks DiscoveryTracks) error
+}
+
+type DiscoveryTrack struct {
+	ID          string  `json:"id"`
+	DiscoveryID string  `json:"discoveryId"`
+	Path        string  `json:"path"`
+	Title       string  `json:"title"`
+	Artist      string  `json:"artist"`
+	Album       string  `json:"album"`
+	Duration    float32 `json:"duration"`
+	Size        int64   `json:"size"`
+}
+
+type DiscoveryTracks []DiscoveryTrack
+
+type DiscoveryTrackRepository interface {
+	ResourceRepository
+	GetAll(options ...QueryOptions) (DiscoveryTracks, error)
+	Delete(id ...string) error
+	DeleteAll() error
+}

--- a/model/discovery.go
+++ b/model/discovery.go
@@ -1,6 +1,12 @@
 package model
 
-import "time"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
 
 type Discovery struct {
 	ID        string          `structs:"id" json:"id"`
@@ -63,6 +69,7 @@ type DiscoveryTrack struct {
 	Album       string  `json:"album"`
 	Duration    float32 `json:"duration"`
 	Size        int64   `json:"size"`
+	MediaFileID string  `json:"mediaFileId"`
 }
 
 type DiscoveryTracks []DiscoveryTrack
@@ -72,4 +79,63 @@ type DiscoveryTrackRepository interface {
 	GetAll(options ...QueryOptions) (DiscoveryTracks, error)
 	Delete(id ...string) error
 	DeleteAll() error
+}
+
+const discoveryStreamPrefix = "disc"
+
+func DiscoveryStreamID(discoveryID, trackID string) string {
+	if discoveryID == "" || trackID == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s:%s:%s", discoveryStreamPrefix, discoveryID, trackID)
+}
+
+func ParseDiscoveryStreamID(value string) (string, string, bool) {
+	if !strings.HasPrefix(value, discoveryStreamPrefix+":") {
+		return "", "", false
+	}
+	parts := strings.SplitN(value, ":", 3)
+	if len(parts) != 3 || parts[1] == "" || parts[2] == "" {
+		return "", "", false
+	}
+	return parts[1], parts[2], true
+}
+
+func (t DiscoveryTrack) StreamID() string {
+	if t.MediaFileID != "" {
+		return t.MediaFileID
+	}
+	return DiscoveryStreamID(t.DiscoveryID, t.ID)
+}
+
+func (t DiscoveryTrack) ToMediaFile() (*MediaFile, error) {
+	if t.Path == "" {
+		return nil, fmt.Errorf("discovery track missing path")
+	}
+
+	info, err := os.Stat(t.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	suffix := strings.TrimPrefix(strings.ToLower(filepath.Ext(t.Path)), ".")
+	mf := &MediaFile{
+		ID:          t.StreamID(),
+		Path:        t.Path,
+		Title:       t.Title,
+		Artist:      t.Artist,
+		Album:       t.Album,
+		Duration:    t.Duration,
+		Size:        info.Size(),
+		Suffix:      suffix,
+		UpdatedAt:   info.ModTime(),
+		CreatedAt:   info.ModTime(),
+		BirthTime:   info.ModTime(),
+		Missing:     false,
+		LibraryPath: "",
+	}
+	if mf.ID == "" {
+		mf.ID = DiscoveryStreamID(t.DiscoveryID, t.ID)
+	}
+	return mf, nil
 }

--- a/model/get_entity.go
+++ b/model/get_entity.go
@@ -14,6 +14,10 @@ func GetEntityByID(ctx context.Context, ds DataStore, id string) (interface{}, e
 	if err == nil {
 		return al, nil
 	}
+	disc, err := ds.Discovery(ctx).Get(id)
+	if err == nil {
+		return disc, nil
+	}
 	pls, err := ds.Playlist(ctx).Get(id)
 	if err == nil {
 		return pls, nil

--- a/model/get_entity.go
+++ b/model/get_entity.go
@@ -2,10 +2,23 @@ package model
 
 import (
 	"context"
+	"fmt"
 )
 
 // TODO: Should the type be encoded in the ID?
 func GetEntityByID(ctx context.Context, ds DataStore, id string) (interface{}, error) {
+	if discID, trackID, ok := ParseDiscoveryStreamID(id); ok {
+		entry, err := ds.Discovery(ctx).Tracks(discID).Read(trackID)
+		if err != nil {
+			return nil, err
+		}
+		track, ok := entry.(DiscoveryTrack)
+		if !ok {
+			return nil, fmt.Errorf("unexpected discovery track type %T", entry)
+		}
+		return track.ToMediaFile()
+	}
+
 	ar, err := ds.Artist(ctx).Get(id)
 	if err == nil {
 		return ar, nil

--- a/persistence/discovery_repository.go
+++ b/persistence/discovery_repository.go
@@ -1,0 +1,278 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	. "github.com/Masterminds/squirrel"
+	"github.com/deluan/rest"
+	"github.com/navidrome/navidrome/model"
+	"github.com/pocketbase/dbx"
+)
+
+type discoveryRepository struct {
+	sqlRepository
+}
+
+func ignoreDiscoveryFilter(string, any) Sqlizer { return nil }
+
+type dbDiscoveryTrack struct {
+	ID          int     `db:"id"`
+	DiscoveryID string  `db:"discovery_id"`
+	Path        string  `db:"path"`
+	Title       string  `db:"title"`
+	Artist      string  `db:"artist"`
+	Album       string  `db:"album"`
+	Duration    float64 `db:"duration"`
+	Size        int64   `db:"size"`
+}
+
+func (t dbDiscoveryTrack) toModel() model.DiscoveryTrack {
+	return model.DiscoveryTrack{
+		ID:          strconv.Itoa(t.ID),
+		DiscoveryID: t.DiscoveryID,
+		Path:        t.Path,
+		Title:       t.Title,
+		Artist:      t.Artist,
+		Album:       t.Album,
+		Duration:    float32(t.Duration),
+		Size:        t.Size,
+	}
+}
+
+type dbDiscoveryTracks []dbDiscoveryTrack
+
+func (t dbDiscoveryTracks) toModels() model.DiscoveryTracks {
+	tracks := make(model.DiscoveryTracks, len(t))
+	for i := range t {
+		tracks[i] = t[i].toModel()
+	}
+	return tracks
+}
+
+func NewDiscoveryRepository(ctx context.Context, db dbx.Builder) model.DiscoveryRepository {
+	r := &discoveryRepository{}
+	r.ctx = ctx
+	r.db = db
+	r.registerModel(&model.Discovery{}, map[string]filterFunc{
+		"q": discoveryFilter,
+	})
+	r.setSortMappings(map[string]string{
+		"owner_name": "owner_name",
+	})
+	return r
+}
+
+func discoveryFilter(_ string, value any) Sqlizer {
+	return substringFilter("discovery.name", value)
+}
+
+func (r *discoveryRepository) userFilter() Sqlizer {
+	user := loggedUser(r.ctx)
+	if user.IsAdmin {
+		return And{}
+	}
+	return Eq{"owner_id": user.ID}
+}
+
+func (r *discoveryRepository) CountAll(options ...model.QueryOptions) (int64, error) {
+	sel := Select().Where(r.userFilter())
+	return r.count(sel, options...)
+}
+
+func (r *discoveryRepository) Count(options ...rest.QueryOptions) (int64, error) {
+	return r.CountAll(r.parseRestOptions(r.ctx, options...))
+}
+
+func (r *discoveryRepository) Exists(id string) (bool, error) {
+	return r.exists(And{Eq{"discovery.id": id}, r.userFilter()})
+}
+
+func (r *discoveryRepository) Put(d *model.Discovery) error {
+	usr := loggedUser(r.ctx)
+	if !usr.IsAdmin && usr.ID != d.OwnerID {
+		return rest.ErrPermissionDenied
+	}
+	if d.ID == "" {
+		d.CreatedAt = time.Now()
+	}
+	d.UpdatedAt = time.Now()
+	id, err := r.put(d.ID, d)
+	if err != nil {
+		return err
+	}
+	d.ID = id
+	d.Type = "discovery"
+	return nil
+}
+
+func (r *discoveryRepository) Get(id string) (*model.Discovery, error) {
+	return r.findBy(And{Eq{"discovery.id": id}, r.userFilter()})
+}
+
+func (r *discoveryRepository) Read(id string) (interface{}, error) {
+	return r.Get(id)
+}
+
+func (r *discoveryRepository) GetWithTracks(id string) (*model.Discovery, error) {
+	disc, err := r.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	tracks, err := r.loadTracks(r.newSelect(), id)
+	if err != nil {
+		return nil, fmt.Errorf("loading discovery tracks: %w", err)
+	}
+	disc.SetTracks(tracks)
+	return disc, nil
+}
+
+func (r *discoveryRepository) GetAll(options ...model.QueryOptions) (model.Discoveries, error) {
+	sel := r.selectDiscovery(options...).Where(r.userFilter())
+	var res []struct {
+		model.Discovery
+		OwnerName string `db:"owner_name"`
+	}
+	if err := r.queryAll(sel, &res); err != nil {
+		return nil, err
+	}
+	out := make(model.Discoveries, len(res))
+	for i := range res {
+		res[i].Discovery.OwnerName = res[i].OwnerName
+		res[i].Discovery.Type = "discovery"
+		out[i] = res[i].Discovery
+	}
+	return out, nil
+}
+
+func (r *discoveryRepository) ReadAll(options ...rest.QueryOptions) (interface{}, error) {
+	return r.GetAll(r.parseRestOptions(r.ctx, options...))
+}
+
+func (r *discoveryRepository) FindByPath(path string) (*model.Discovery, error) {
+	return r.findBy(And{Eq{"discovery.path": path}, r.userFilter()})
+}
+
+func (r *discoveryRepository) Delete(id string) error {
+	disc, err := r.Get(id)
+	if err != nil {
+		return err
+	}
+	usr := loggedUser(r.ctx)
+	if !usr.IsAdmin && disc.OwnerID != usr.ID {
+		return rest.ErrPermissionDenied
+	}
+	return r.delete(And{Eq{"discovery.id": id}, r.userFilter()})
+}
+
+func (r *discoveryRepository) Tracks(discoveryID string) model.DiscoveryTrackRepository {
+	repo := &discoveryTrackRepository{}
+	repo.ctx = r.ctx
+	repo.db = r.db
+	repo.discoveryID = discoveryID
+	repo.discoveryRepo = r
+	repo.registerModel(&model.DiscoveryTrack{}, map[string]filterFunc{
+		":discoveryid": ignoreDiscoveryFilter,
+		"discovery_id": ignoreDiscoveryFilter,
+	})
+	repo.tableName = "discovery_tracks"
+	return repo
+}
+
+func (r *discoveryRepository) GetDiscoveries(string) (model.Discoveries, error) {
+	return model.Discoveries{}, nil
+}
+
+func (r *discoveryRepository) loadTracks(sel SelectBuilder, id string) (model.DiscoveryTracks, error) {
+	sel = sel.
+		Columns("discovery_tracks.*").
+		From("discovery_tracks").
+		Where(Eq{"discovery_tracks.discovery_id": id}).
+		OrderBy("discovery_tracks.id")
+	rows := dbDiscoveryTracks{}
+	if err := r.queryAll(sel, &rows); err != nil {
+		return nil, err
+	}
+	return rows.toModels(), nil
+}
+
+func (r *discoveryRepository) ReplaceTracks(id string, tracks model.DiscoveryTracks) error {
+	del := Delete("discovery_tracks").Where(Eq{"discovery_id": id})
+	if _, err := r.executeSQL(del); err != nil {
+		return err
+	}
+
+	var totalDuration float64
+	var totalSize int64
+	if len(tracks) > 0 {
+		builder := Insert("discovery_tracks").Columns("id", "discovery_id", "path", "title", "artist", "album", "duration", "size")
+		for idx, track := range tracks {
+			builder = builder.Values(idx+1, id, track.Path, track.Title, track.Artist, track.Album, track.Duration, track.Size)
+			totalDuration += float64(track.Duration)
+			totalSize += track.Size
+		}
+		if _, err := r.executeSQL(builder); err != nil {
+			return err
+		}
+	}
+
+	upd := Update("discovery").
+		Set("song_count", len(tracks)).
+		Set("duration", totalDuration).
+		Set("size", totalSize).
+		Set("updated_at", time.Now()).
+		Where(Eq{"id": id})
+	_, err := r.executeSQL(upd)
+	return err
+}
+
+func (r *discoveryRepository) findBy(cond Sqlizer) (*model.Discovery, error) {
+	sel := r.selectDiscovery().Where(cond)
+	var res struct {
+		model.Discovery
+		OwnerName string `db:"owner_name"`
+	}
+	err := r.queryOne(sel, &res)
+	if errors.Is(err, rest.ErrNotFound) {
+		return nil, err
+	}
+	if err != nil {
+		return nil, err
+	}
+	res.Discovery.OwnerName = res.OwnerName
+	res.Discovery.Type = "discovery"
+	return &res.Discovery, nil
+}
+
+func (r *discoveryRepository) selectDiscovery(options ...model.QueryOptions) SelectBuilder {
+	sel := r.newSelect(options...).
+		Columns("discovery.*", "owner.user_name as owner_name").
+		From("discovery").
+		LeftJoin("user owner on owner.id = discovery.owner_id")
+	return sel
+}
+
+func (r *discoveryRepository) EntityName() string { return "discovery" }
+
+func (r *discoveryRepository) NewInstance() interface{} { return &model.Discovery{} }
+
+func (r *discoveryRepository) Save(entity interface{}) (string, error) {
+	disc := entity.(*model.Discovery)
+	if err := r.Put(disc); err != nil {
+		return "", err
+	}
+	return disc.ID, nil
+}
+
+func (r *discoveryRepository) Update(id string, entity interface{}, cols ...string) error {
+	disc := entity.(*model.Discovery)
+	disc.ID = id
+	return r.Put(disc)
+}
+
+var _ model.DiscoveryRepository = (*discoveryRepository)(nil)
+var _ rest.Repository = (*discoveryRepository)(nil)
+var _ rest.Persistable = (*discoveryRepository)(nil)

--- a/persistence/discovery_repository.go
+++ b/persistence/discovery_repository.go
@@ -40,6 +40,7 @@ func (t dbDiscoveryTrack) toModel() model.DiscoveryTrack {
 		Album:       t.Album,
 		Duration:    float32(t.Duration),
 		Size:        t.Size,
+		MediaFileID: model.DiscoveryStreamID(t.DiscoveryID, strconv.Itoa(t.ID)),
 	}
 }
 

--- a/persistence/discovery_track_repository.go
+++ b/persistence/discovery_track_repository.go
@@ -1,0 +1,65 @@
+package persistence
+
+import (
+	. "github.com/Masterminds/squirrel"
+	"github.com/deluan/rest"
+	"github.com/navidrome/navidrome/model"
+)
+
+type discoveryTrackRepository struct {
+	sqlRepository
+	discoveryID   string
+	discoveryRepo *discoveryRepository
+}
+
+func (r *discoveryTrackRepository) Count(options ...rest.QueryOptions) (int64, error) {
+	qo := r.parseRestOptions(r.ctx, options...)
+	sel := Select().Where(Eq{"discovery_tracks.discovery_id": r.discoveryID})
+	return r.count(sel, qo)
+}
+
+func (r *discoveryTrackRepository) Read(id string) (interface{}, error) {
+	sel := r.newSelect().
+		Columns("discovery_tracks.*").
+		Where(Eq{"discovery_tracks.id": id})
+	tracks, err := r.discoveryRepo.loadTracks(sel, r.discoveryID)
+	if err != nil {
+		return nil, err
+	}
+	if len(tracks) == 0 {
+		return nil, rest.ErrNotFound
+	}
+	return tracks[0], nil
+}
+
+func (r *discoveryTrackRepository) ReadAll(options ...rest.QueryOptions) (interface{}, error) {
+	qo := r.parseRestOptions(r.ctx, options...)
+	tracks, err := r.GetAll(qo)
+	return tracks, err
+}
+
+func (r *discoveryTrackRepository) EntityName() string { return "discovery_tracks" }
+
+func (r *discoveryTrackRepository) NewInstance() interface{} { return &model.DiscoveryTrack{} }
+
+func (r *discoveryTrackRepository) GetAll(options ...model.QueryOptions) (model.DiscoveryTracks, error) {
+	sel := r.newSelect(options...).
+		Columns("discovery_tracks.*").
+		Where(Eq{"discovery_tracks.discovery_id": r.discoveryID})
+	tracks, err := r.discoveryRepo.loadTracks(sel, r.discoveryID)
+	if err != nil {
+		return nil, err
+	}
+	return tracks, nil
+}
+
+func (r *discoveryTrackRepository) Delete(id ...string) error {
+	return rest.ErrPermissionDenied
+}
+
+func (r *discoveryTrackRepository) DeleteAll() error {
+	return rest.ErrPermissionDenied
+}
+
+var _ model.DiscoveryTrackRepository = (*discoveryTrackRepository)(nil)
+var _ rest.Repository = (*discoveryTrackRepository)(nil)

--- a/persistence/discovery_track_repository.go
+++ b/persistence/discovery_track_repository.go
@@ -1,8 +1,15 @@
 package persistence
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
 	. "github.com/Masterminds/squirrel"
 	"github.com/deluan/rest"
+	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 )
 
@@ -54,7 +61,83 @@ func (r *discoveryTrackRepository) GetAll(options ...model.QueryOptions) (model.
 }
 
 func (r *discoveryTrackRepository) Delete(id ...string) error {
-	return rest.ErrPermissionDenied
+	if len(id) == 0 {
+		return nil
+	}
+
+	disc, err := r.discoveryRepo.Get(r.discoveryID)
+	if err != nil {
+		return err
+	}
+	usr := loggedUser(r.ctx)
+	if !usr.IsAdmin && disc.OwnerID != usr.ID {
+		return rest.ErrPermissionDenied
+	}
+
+	sel := Select().Where(Eq{"discovery_tracks.id": id})
+	tracks, err := r.discoveryRepo.loadTracks(sel, r.discoveryID)
+	if err != nil {
+		return err
+	}
+	if len(tracks) == 0 {
+		return model.ErrNotFound
+	}
+
+	basePath := disc.Path
+	if abs, err := filepath.Abs(basePath); err == nil {
+		basePath = abs
+	}
+
+	for _, track := range tracks {
+		if track.Path == "" {
+			continue
+		}
+		target := track.Path
+		if abs, err := filepath.Abs(target); err == nil {
+			target = abs
+		}
+		if basePath != "" {
+			if rel, err := filepath.Rel(basePath, target); err != nil || strings.HasPrefix(rel, "..") {
+				continue
+			}
+		}
+		if err := os.Remove(target); err != nil && !errors.Is(err, os.ErrNotExist) {
+			log.Warn(r.ctx, "Discovery: unable to remove track file", "path", target, err)
+		}
+	}
+
+	del := Delete("discovery_tracks").
+		Where(Eq{"discovery_id": r.discoveryID}).
+		Where(Eq{"id": id})
+	if _, err := r.executeSQL(del); err != nil {
+		return err
+	}
+
+	var stats struct {
+		Count    int     `db:"count"`
+		Duration float64 `db:"duration"`
+		Size     int64   `db:"size"`
+	}
+	selStats := Select("COUNT(*) as count", "COALESCE(SUM(duration),0) as duration", "COALESCE(SUM(size),0) as size").
+		From("discovery_tracks").
+		Where(Eq{"discovery_id": r.discoveryID})
+	if err := r.discoveryRepo.queryOne(selStats, &stats); err != nil {
+		if !errors.Is(err, model.ErrNotFound) {
+			return err
+		}
+		stats.Count = 0
+		stats.Duration = 0
+		stats.Size = 0
+	}
+
+	upd := Update("discovery").
+		Set("song_count", stats.Count).
+		Set("duration", stats.Duration).
+		Set("size", stats.Size).
+		Set("updated_at", time.Now()).
+		Where(Eq{"id": r.discoveryID})
+	_, err = r.discoveryRepo.executeSQL(upd)
+	return err
 }
 
 func (r *discoveryTrackRepository) DeleteAll() error {

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -57,8 +57,12 @@ func (s *SQLStore) Playlist(ctx context.Context) model.PlaylistRepository {
 	return NewPlaylistRepository(ctx, s.getDBXBuilder())
 }
 
+func (s *SQLStore) Discovery(ctx context.Context) model.DiscoveryRepository {
+	return NewDiscoveryRepository(ctx, s.getDBXBuilder())
+}
+
 func (s *SQLStore) PlaylistFolder(ctx context.Context) model.PlaylistFolderRepository {
-    return NewPlaylistFolderRepository(ctx, s.getDBXBuilder())
+	return NewPlaylistFolderRepository(ctx, s.getDBXBuilder())
 }
 
 func (s *SQLStore) Property(ctx context.Context) model.PropertyRepository {
@@ -111,6 +115,8 @@ func (s *SQLStore) Resource(ctx context.Context, m interface{}) model.ResourceRe
 		return s.Genre(ctx).(model.ResourceRepository)
 	case model.Playlist:
 		return s.Playlist(ctx).(model.ResourceRepository)
+	case model.Discovery:
+		return s.Discovery(ctx).(model.ResourceRepository)
 	case model.PlaylistFolder:
 		return s.PlaylistFolder(ctx).(model.ResourceRepository)
 	case model.Radio:

--- a/scanner/controller.go
+++ b/scanner/controller.go
@@ -43,13 +43,14 @@ type StatusInfo struct {
 }
 
 func New(rootCtx context.Context, ds model.DataStore, cw artwork.CacheWarmer, broker events.Broker,
-	pls core.Playlists, m metrics.Metrics) Scanner {
+	pls core.Playlists, disc core.Discoveries, m metrics.Metrics) Scanner {
 	c := &controller{
 		rootCtx: rootCtx,
 		ds:      ds,
 		cw:      cw,
 		broker:  broker,
 		pls:     pls,
+		disc:    disc,
 		metrics: m,
 	}
 	if !conf.Server.DevExternalScanner {
@@ -62,12 +63,12 @@ func (s *controller) getScanner() scanner {
 	if conf.Server.DevExternalScanner {
 		return &scannerExternal{}
 	}
-	return &scannerImpl{ds: s.ds, cw: s.cw, pls: s.pls}
+	return &scannerImpl{ds: s.ds, cw: s.cw, pls: s.pls, disc: s.disc}
 }
 
 // CallScan starts an in-process scan of the music library.
 // This is meant to be called from the command line (see cmd/scan.go).
-func CallScan(ctx context.Context, ds model.DataStore, pls core.Playlists, fullScan bool) (<-chan *ProgressInfo, error) {
+func CallScan(ctx context.Context, ds model.DataStore, pls core.Playlists, disc core.Discoveries, fullScan bool) (<-chan *ProgressInfo, error) {
 	release, err := lockScan(ctx)
 	if err != nil {
 		return nil, err
@@ -78,7 +79,7 @@ func CallScan(ctx context.Context, ds model.DataStore, pls core.Playlists, fullS
 	progress := make(chan *ProgressInfo, 100)
 	go func() {
 		defer close(progress)
-		scanner := &scannerImpl{ds: ds, cw: artwork.NoopCacheWarmer(), pls: pls}
+		scanner := &scannerImpl{ds: ds, cw: artwork.NoopCacheWarmer(), pls: pls, disc: disc}
 		scanner.scanAll(ctx, fullScan, progress)
 	}()
 	return progress, nil
@@ -110,6 +111,7 @@ type controller struct {
 	broker          events.Broker
 	metrics         metrics.Metrics
 	pls             core.Playlists
+	disc            core.Discoveries
 	limiter         *rate.Sometimes
 	count           atomic.Uint32
 	folderCount     atomic.Uint32

--- a/scanner/controller_test.go
+++ b/scanner/controller_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Controller", func() {
 			DeferCleanup(configtest.SetupConfig())
 			ds = &tests.MockDataStore{RealDS: persistence.New(db.Db())}
 			ds.MockedProperty = &tests.MockedPropertyRepo{}
-			ctrl = scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(), core.NewPlaylists(ds), metrics.NewNoopInstance())
+                        ctrl = scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(), core.NewPlaylists(ds), core.NewDiscoveries(ds), metrics.NewNoopInstance())
 		})
 
 		It("includes last scan error", func() {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -18,9 +18,10 @@ import (
 )
 
 type scannerImpl struct {
-	ds  model.DataStore
-	cw  artwork.CacheWarmer
-	pls core.Playlists
+	ds   model.DataStore
+	cw   artwork.CacheWarmer
+	pls  core.Playlists
+	disc core.Discoveries
 }
 
 // scanState holds the state of an in-progress scan, to be passed to the various phases
@@ -102,6 +103,9 @@ func (s *scannerImpl) scanAll(ctx context.Context, fullScan bool, progress chan<
 
 			// Phase 4: Import/update playlists
 			runPhase[*model.Folder](ctx, 4, createPhasePlaylists(ctx, &state, s.ds, s.pls, s.cw)),
+
+			// Phase 5: Sync discovery directories
+			func() error { return s.disc.Sync(ctx) },
 		),
 
 		// Final Steps (cannot be parallelized):

--- a/scanner/scanner_benchmark_test.go
+++ b/scanner/scanner_benchmark_test.go
@@ -39,8 +39,8 @@ func BenchmarkScan(b *testing.B) {
 
 	ds := persistence.New(db.Db())
 	conf.Server.DevExternalScanner = false
-	s := scanner.New(context.Background(), ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
-		core.NewPlaylists(ds), metrics.NewNoopInstance())
+        s := scanner.New(context.Background(), ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
+                core.NewPlaylists(ds), core.NewDiscoveries(ds), metrics.NewNoopInstance())
 
 	fs := storagetest.FakeFS{}
 	storagetest.Register("fake", &fs)

--- a/scanner/scanner_multilibrary_test.go
+++ b/scanner/scanner_multilibrary_test.go
@@ -70,8 +70,8 @@ var _ = Describe("Scanner - Multi-Library", Ordered, func() {
 		}
 		Expect(ds.User(ctx).Put(&adminUser)).To(Succeed())
 
-		s = scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
-			core.NewPlaylists(ds), metrics.NewNoopInstance())
+                s = scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
+                        core.NewPlaylists(ds), core.NewDiscoveries(ds), metrics.NewNoopInstance())
 
 		// Create two test libraries (let DB auto-assign IDs)
 		lib1 = model.Library{Name: "Rock Collection", Path: "rock:///music"}

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -83,8 +83,8 @@ var _ = Describe("Scanner", Ordered, func() {
 		}
 		Expect(ds.User(ctx).Put(&adminUser)).To(Succeed())
 
-		s = scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
-			core.NewPlaylists(ds), metrics.NewNoopInstance())
+                s = scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
+                        core.NewPlaylists(ds), core.NewDiscoveries(ds), metrics.NewNoopInstance())
 
 		lib = model.Library{ID: 1, Name: "Fake Library", Path: "fake:///music"}
 		Expect(ds.Library(ctx).Put(&lib)).To(Succeed())

--- a/server/nativeapi/discovery.go
+++ b/server/nativeapi/discovery.go
@@ -1,0 +1,117 @@
+package nativeapi
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/deluan/rest"
+	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/core"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+)
+
+func getDiscovery(ds model.DataStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		disc, err := ds.Discovery(r.Context()).GetWithTracks(id)
+		if err != nil {
+			http.Error(w, err.Error(), statusFor(err))
+			return
+		}
+		rest.RespondWithJSON(w, http.StatusOK, disc)
+	}
+}
+
+func getDiscoveryTracks(ds model.DataStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if strings.EqualFold(r.Header.Get("accept"), "audio/x-mpegurl") {
+			exportDiscovery(ds)(w, r)
+			return
+		}
+		discID := chi.URLParam(r, "discoveryId")
+		if discID == "" {
+			discID = chi.URLParam(r, "id")
+		}
+		repo := ds.Discovery(r.Context()).Tracks(discID)
+		controller := rest.Controller{Repository: repo}
+		controller.GetAll(w, r)
+	}
+}
+
+func getSongDiscoveries(ds model.DataStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		trackID := chi.URLParam(r, "id")
+		discs, err := ds.Discovery(r.Context()).GetDiscoveries(trackID)
+		if err != nil {
+			log.Error(r.Context(), "Error getting song discoveries", "songId", trackID, err)
+			http.Error(w, err.Error(), statusFor(err))
+			return
+		}
+		rest.RespondWithJSON(w, http.StatusOK, discs)
+	}
+}
+
+func exportDiscovery(ds model.DataStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		discID := chi.URLParam(r, "discoveryId")
+		if discID == "" {
+			discID = chi.URLParam(r, "id")
+		}
+		disc, err := ds.Discovery(ctx).GetWithTracks(discID)
+		if errors.Is(err, model.ErrNotFound) {
+			log.Warn(ctx, "Discovery not found", "id", discID)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		if err != nil {
+			log.Error(ctx, "Error retrieving discovery", "id", discID, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "audio/x-mpegurl")
+		disposition := fmt.Sprintf("attachment; filename=\"%s.m3u\"", disc.Name)
+		w.Header().Set("Content-Disposition", disposition)
+
+		var builder strings.Builder
+		builder.WriteString("#EXTM3U\n")
+		for _, track := range disc.Tracks {
+			title := track.Title
+			if track.Artist != "" {
+				title = fmt.Sprintf("%s - %s", track.Artist, track.Title)
+			}
+			builder.WriteString(fmt.Sprintf("#EXTINF:%d,%s\n", int(track.Duration+0.5), title))
+			builder.WriteString(track.Path)
+			builder.WriteString("\n")
+		}
+
+		if _, err := w.Write([]byte(builder.String())); err != nil {
+			log.Error(ctx, "Error exporting discovery", "id", discID, err)
+		}
+	}
+}
+
+func publishDiscovery(ds model.DataStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		discID := chi.URLParam(r, "id")
+		repo := ds.Discovery(ctx)
+		if _, err := repo.Get(discID); err != nil {
+			if errors.Is(err, model.ErrNotFound) {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			http.Error(w, err.Error(), statusFor(err))
+			return
+		}
+		if err := core.NewDiscoveries(ds).Sync(ctx); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/server/nativeapi/discovery.go
+++ b/server/nativeapi/discovery.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/deluan/rest"
@@ -11,6 +12,7 @@ import (
 	"github.com/navidrome/navidrome/core"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/utils/req"
 )
 
 func getDiscovery(ds model.DataStore) http.HandlerFunc {
@@ -102,19 +104,55 @@ func publishDiscovery(ds model.DataStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		discID := chi.URLParam(r, "id")
-		repo := ds.Discovery(ctx)
-		if _, err := repo.Get(discID); err != nil {
-			if errors.Is(err, model.ErrNotFound) {
-				http.Error(w, "not found", http.StatusNotFound)
-				return
-			}
-			http.Error(w, err.Error(), statusFor(err))
-			return
+		if discID == "" {
+			discID = chi.URLParam(r, "discoveryId")
 		}
-		if err := core.NewDiscoveries(ds).Sync(ctx); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+		discoveries := core.NewDiscoveries(ds)
+		if err := discoveries.Publish(ctx, discID); err != nil {
+			switch {
+			case errors.Is(err, model.ErrNotFound):
+				http.Error(w, "not found", http.StatusNotFound)
+			case errors.Is(err, os.ErrNotExist):
+				http.Error(w, "not found", http.StatusNotFound)
+			default:
+				http.Error(w, err.Error(), statusFor(err))
+			}
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func deleteDiscoveryTracks(ds model.DataStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		params := req.Params(r)
+		discID, _ := params.String(":discoveryId")
+		if discID == "" {
+			discID = chi.URLParam(r, "discoveryId")
+		}
+		if discID == "" {
+			discID = chi.URLParam(r, "id")
+		}
+		ids, _ := params.Strings("id")
+		if len(ids) == 0 {
+			http.Error(w, "no tracks selected", http.StatusBadRequest)
+			return
+		}
+
+		err := ds.WithTxImmediate(func(tx model.DataStore) error {
+			repo := tx.Discovery(ctx).Tracks(discID)
+			return repo.Delete(ids...)
+		})
+		if len(ids) == 1 && errors.Is(err, model.ErrNotFound) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		if err != nil {
+			log.Error(ctx, "Error deleting discovery tracks", "id", discID, "trackIds", ids, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeDeleteManyResponse(w, r, ids)
 	}
 }

--- a/server/nativeapi/discovery.go
+++ b/server/nativeapi/discovery.go
@@ -15,7 +15,10 @@ import (
 
 func getDiscovery(ds model.DataStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		id := chi.URLParam(r, "id")
+		id := chi.URLParam(r, "discoveryId")
+		if id == "" {
+			id = chi.URLParam(r, "id")
+		}
 		disc, err := ds.Discovery(r.Context()).GetWithTracks(id)
 		if err != nil {
 			http.Error(w, err.Error(), statusFor(err))

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -212,6 +212,7 @@ func (n *Router) addDiscoveryRoute(r chi.Router) {
 
 	r.Route("/discovery", func(r chi.Router) {
 		r.Get("/", rest.GetAll(constructor))
+		r.With(server.URLParamsMiddleware).Get("/{discoveryId}", getDiscovery(n.ds))
 		r.Route("/{discoveryId}", func(r chi.Router) {
 			r.Use(server.URLParamsMiddleware)
 			r.Get("/", getDiscovery(n.ds))

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -63,7 +63,9 @@ func (n *Router) routes() http.Handler {
 		n.addPlaylistRoute(r)
 		n.addPlaylistFolderRoute(r)
 		n.addPlaylistTrackRoute(r)
+		n.addDiscoveryRoute(r)
 		n.addSongPlaylistsRoute(r)
+		n.addSongDiscoveriesRoute(r)
 		n.addQueueRoute(r)
 		n.addMissingFilesRoute(r)
 		n.addKeepAliveRoute(r)
@@ -203,9 +205,31 @@ func (n *Router) addPlaylistTrackRoute(r chi.Router) {
 	})
 }
 
+func (n *Router) addDiscoveryRoute(r chi.Router) {
+	constructor := func(ctx context.Context) rest.Repository {
+		return n.ds.Resource(ctx, model.Discovery{})
+	}
+
+	r.Route("/discovery", func(r chi.Router) {
+		r.Get("/", rest.GetAll(constructor))
+		r.Route("/{discoveryId}", func(r chi.Router) {
+			r.Use(server.URLParamsMiddleware)
+			r.Get("/", getDiscovery(n.ds))
+			r.Post("/publish", publishDiscovery(n.ds))
+			r.Get("/tracks", getDiscoveryTracks(n.ds))
+		})
+	})
+}
+
 func (n *Router) addSongPlaylistsRoute(r chi.Router) {
 	r.With(server.URLParamsMiddleware).Get("/song/{id}/playlists", func(w http.ResponseWriter, r *http.Request) {
 		getSongPlaylists(n.ds)(w, r)
+	})
+}
+
+func (n *Router) addSongDiscoveriesRoute(r chi.Router) {
+	r.With(server.URLParamsMiddleware).Get("/song/{id}/discoveries", func(w http.ResponseWriter, r *http.Request) {
+		getSongDiscoveries(n.ds)(w, r)
 	})
 }
 

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -218,6 +218,7 @@ func (n *Router) addDiscoveryRoute(r chi.Router) {
 			r.Get("/", getDiscovery(n.ds))
 			r.Post("/publish", publishDiscovery(n.ds))
 			r.Get("/tracks", getDiscoveryTracks(n.ds))
+			r.Delete("/tracks", deleteDiscoveryTracks(n.ds))
 		})
 	})
 }

--- a/tests/mock_data_store.go
+++ b/tests/mock_data_store.go
@@ -8,27 +8,28 @@ import (
 )
 
 type MockDataStore struct {
-	RealDS               		model.DataStore
-	MockedLibrary        		model.LibraryRepository
-	MockedFolder         		model.FolderRepository
-	MockedGenre          		model.GenreRepository
-	MockedAlbum          		model.AlbumRepository
-	MockedArtist         		model.ArtistRepository
-	MockedMediaFile      		model.MediaFileRepository
-	MockedTag            		model.TagRepository
-	MockedUser           		model.UserRepository
-	MockedProperty       		model.PropertyRepository
-	MockedPlayer         		model.PlayerRepository
-	MockedPlaylist       		model.PlaylistRepository
-	MockedPlaylistFolder 		model.PlaylistFolderRepository
-	MockedPlayQueue      		model.PlayQueueRepository
-	MockedShare          		model.ShareRepository
-	MockedTranscoding    		model.TranscodingRepository
-	MockedUserProps      		model.UserPropsRepository
-	MockedScrobbleBuffer 		model.ScrobbleBufferRepository
-	MockedRadio          		model.RadioRepository
-	scrobbleBufferMu     		sync.Mutex
-	repoMu               		sync.Mutex
+	RealDS               model.DataStore
+	MockedLibrary        model.LibraryRepository
+	MockedFolder         model.FolderRepository
+	MockedGenre          model.GenreRepository
+	MockedAlbum          model.AlbumRepository
+	MockedArtist         model.ArtistRepository
+	MockedMediaFile      model.MediaFileRepository
+	MockedTag            model.TagRepository
+	MockedUser           model.UserRepository
+	MockedProperty       model.PropertyRepository
+	MockedPlayer         model.PlayerRepository
+	MockedPlaylist       model.PlaylistRepository
+	MockedDiscovery      model.DiscoveryRepository
+	MockedPlaylistFolder model.PlaylistFolderRepository
+	MockedPlayQueue      model.PlayQueueRepository
+	MockedShare          model.ShareRepository
+	MockedTranscoding    model.TranscodingRepository
+	MockedUserProps      model.UserPropsRepository
+	MockedScrobbleBuffer model.ScrobbleBufferRepository
+	MockedRadio          model.RadioRepository
+	scrobbleBufferMu     sync.Mutex
+	repoMu               sync.Mutex
 }
 
 func (db *MockDataStore) Library(ctx context.Context) model.LibraryRepository {
@@ -119,6 +120,17 @@ func (db *MockDataStore) Playlist(ctx context.Context) model.PlaylistRepository 
 		}
 	}
 	return db.MockedPlaylist
+}
+
+func (db *MockDataStore) Discovery(ctx context.Context) model.DiscoveryRepository {
+	if db.MockedDiscovery == nil {
+		if db.RealDS != nil {
+			db.MockedDiscovery = db.RealDS.Discovery(ctx)
+		} else {
+			db.MockedDiscovery = struct{ model.DiscoveryRepository }{}
+		}
+	}
+	return db.MockedDiscovery
 }
 
 func (db *MockDataStore) PlaylistFolder(ctx context.Context) model.PlaylistFolderRepository {

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -3,5 +3,7 @@ node_modules
 
 build/*
 !build/.gitkeep
+!build/3rdparty/
+!build/3rdparty/placeholder.txt
 /coverage/
 public/3rdparty/workbox

--- a/ui/build/3rdparty/placeholder.txt
+++ b/ui/build/3rdparty/placeholder.txt
@@ -1,0 +1,1 @@
+This placeholder file ensures the build/3rdparty directory contains at least one embeddable asset during development builds.

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -14,6 +14,7 @@ import album from './album'
 import artist from './artist'
 import playlist from './playlist'
 import playlist_folder from './playlist_folder'
+import discovery from './discovery'
 import radio from './radio'
 import share from './share'
 import library from './library'
@@ -115,6 +116,7 @@ const Admin = (props) => {
           show={PlaylistShow}
           edit={PlaylistEdit}
         />,
+        <Resource name="discovery" {...discovery} />,
         <Resource
           {...playlist_folder}
           name="folder"
@@ -154,6 +156,7 @@ const Admin = (props) => {
         <Resource name="genre" />,
         <Resource name="tag" />,
         <Resource name="playlistTrack" />,
+        <Resource name="discoveryTrack" />,
         <Resource name="keepalive" />,
         <Resource name="insights" />,
         <Resource name="config" />,

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -116,7 +116,7 @@ const Admin = (props) => {
           show={PlaylistShow}
           edit={PlaylistEdit}
         />,
-        <Resource name="discovery" {...discovery} />,
+        <Resource name="discovery" {...discovery} options={{ subMenu: 'discovery' }} />,
         <Resource
           {...playlist_folder}
           name="folder"

--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -21,7 +21,13 @@ const getSelectedLibraries = () => {
 // Function to apply library filtering to appropriate resources
 const applyLibraryFilter = (resource, params) => {
   // Content resources that should be filtered by selected libraries
-  const filteredResources = ['album', 'song', 'artist', 'playlistTrack', 'tag']
+  const filteredResources = [
+    'album',
+    'song',
+    'artist',
+    'playlistTrack',
+    'tag',
+  ]
 
   // Get selected libraries from localStorage
   const selectedLibraries = getSelectedLibraries()
@@ -51,6 +57,14 @@ const mapResource = (resource, params) => {
       params = applyLibraryFilter(resource, params)
 
       return [`playlist/${plsId}/tracks`, params]
+    }
+    case 'discoveryTrack': {
+      params.filter = params.filter || {}
+
+      const discoveryId = params.filter.discovery_id
+      params = applyLibraryFilter(resource, params)
+
+      return [`discovery/${discoveryId}/tracks`, params]
     }
     case 'album':
     case 'song':

--- a/ui/src/discovery/DiscoveryActions.jsx
+++ b/ui/src/discovery/DiscoveryActions.jsx
@@ -31,6 +31,11 @@ import PublishDiscoveryButton from './PublishDiscoveryButton'
 
 const useStyles = makeStyles({
   toolbar: { display: 'flex', justifyContent: 'space-between', width: '100%' },
+  columnPicker: {
+    marginLeft: 'auto',
+    display: 'flex',
+    alignItems: 'center',
+  },
 })
 
 const DiscoveryActions = ({ className, ids, data, record, ...rest }) => {
@@ -162,7 +167,9 @@ const DiscoveryActions = ({ className, ids, data, record, ...rest }) => {
           </Button>
           <PublishDiscoveryButton record={record} />
         </div>
-        <div>{isNotSmall && <ToggleFieldsMenu resource="discoveryTrack" />}</div>
+        <div className={classes.columnPicker}>
+          {isNotSmall && <ToggleFieldsMenu resource="discoveryTrack" />}
+        </div>
       </div>
     </TopToolbar>
   )

--- a/ui/src/discovery/DiscoveryActions.jsx
+++ b/ui/src/discovery/DiscoveryActions.jsx
@@ -1,0 +1,171 @@
+import React from 'react'
+import {
+  Button,
+  sanitizeListRestProps,
+  TopToolbar,
+  useTranslate,
+  useDataProvider,
+  useNotify,
+} from 'react-admin'
+import { useDispatch } from 'react-redux'
+import { useMediaQuery, makeStyles } from '@material-ui/core'
+import PlayArrowIcon from '@material-ui/icons/PlayArrow'
+import ShuffleIcon from '@material-ui/icons/Shuffle'
+import CloudDownloadOutlinedIcon from '@material-ui/icons/CloudDownloadOutlined'
+import QueueMusicIcon from '@material-ui/icons/QueueMusic'
+import { RiPlayListAddFill, RiPlayList2Fill } from 'react-icons/ri'
+import { ToggleFieldsMenu } from '../common'
+import {
+  addTracks,
+  playNext,
+  playTracks,
+  shuffleTracks,
+  openDownloadMenu,
+  DOWNLOAD_MENU_PLAY,
+} from '../actions'
+import { httpClient } from '../dataProvider'
+import { REST_URL } from '../consts'
+import config from '../config'
+import { formatBytes } from '../utils'
+import PublishDiscoveryButton from './PublishDiscoveryButton'
+
+const useStyles = makeStyles({
+  toolbar: { display: 'flex', justifyContent: 'space-between', width: '100%' },
+})
+
+const DiscoveryActions = ({ className, ids, data, record, ...rest }) => {
+  const dispatch = useDispatch()
+  const translate = useTranslate()
+  const classes = useStyles()
+  const dataProvider = useDataProvider()
+  const notify = useNotify()
+  const isNotSmall = useMediaQuery((theme) => theme.breakpoints.up('sm'))
+
+  const getAllTracks = React.useCallback(
+    (action) => {
+      if (!record) {
+        return
+      }
+      if (ids?.length && record.songCount && ids.length >= record.songCount) {
+        dispatch(action(data, ids))
+        return
+      }
+      dataProvider
+        .getList('discoveryTrack', {
+          pagination: { page: 1, perPage: 0 },
+          sort: { field: 'id', order: 'ASC' },
+          filter: { discovery_id: record.id },
+        })
+        .then((response) => {
+          const trackMap = response.data.reduce(
+            (acc, track) => ({ ...acc, [track.id]: track }),
+            {},
+          )
+          dispatch(action(trackMap))
+        })
+        .catch(() => {
+          notify('ra.page.error', 'warning')
+        })
+    },
+    [record, ids, data, dataProvider, dispatch, notify],
+  )
+
+  const handlePlay = React.useCallback(() => {
+    getAllTracks(playTracks)
+  }, [getAllTracks])
+
+  const handlePlayNext = React.useCallback(() => {
+    getAllTracks(playNext)
+  }, [getAllTracks])
+
+  const handlePlayLater = React.useCallback(() => {
+    getAllTracks(addTracks)
+  }, [getAllTracks])
+
+  const handleShuffle = React.useCallback(() => {
+    getAllTracks(shuffleTracks)
+  }, [getAllTracks])
+
+  const handleDownload = React.useCallback(() => {
+    if (!record) {
+      return
+    }
+    dispatch(openDownloadMenu(record, DOWNLOAD_MENU_PLAY))
+  }, [dispatch, record])
+
+  const handleExport = React.useCallback(() => {
+    if (!record) {
+      return
+    }
+    httpClient(`${REST_URL}/discovery/${record.id}/tracks`, {
+      headers: new Headers({ Accept: 'audio/x-mpegurl' }),
+    })
+      .then((res) => {
+        const blob = new Blob([res.body], { type: 'audio/x-mpegurl' })
+        const url = window.URL.createObjectURL(blob)
+        const link = document.createElement('a')
+        link.href = url
+        link.download = `${record.name}.m3u`
+        document.body.appendChild(link)
+        link.click()
+        link.parentNode.removeChild(link)
+      })
+      .catch(() => {
+        notify('ra.page.error', 'warning')
+      })
+  }, [notify, record])
+
+  return (
+    <TopToolbar className={className} {...sanitizeListRestProps(rest)}>
+      <div className={classes.toolbar}>
+        <div>
+          <Button
+            onClick={handlePlay}
+            label={translate('resources.album.actions.playAll')}
+          >
+            <PlayArrowIcon />
+          </Button>
+          <Button
+            onClick={handleShuffle}
+            label={translate('resources.album.actions.shuffle')}
+          >
+            <ShuffleIcon />
+          </Button>
+          <Button
+            onClick={handlePlayNext}
+            label={translate('resources.album.actions.playNext')}
+          >
+            <RiPlayList2Fill />
+          </Button>
+          <Button
+            onClick={handlePlayLater}
+            label={translate('resources.album.actions.addToQueue')}
+          >
+            <RiPlayListAddFill />
+          </Button>
+          {config.enableDownloads && (
+            <Button
+              onClick={handleDownload}
+              label={
+                translate('ra.action.download') +
+                (isNotSmall ? ` (${formatBytes(record?.size)})` : '')
+              }
+            >
+              <CloudDownloadOutlinedIcon />
+            </Button>
+          )}
+          <Button
+            onClick={handleExport}
+            label={translate('resources.playlist.actions.export')}
+          >
+            <QueueMusicIcon />
+          </Button>
+          <PublishDiscoveryButton record={record} />
+        </div>
+        <div>{isNotSmall && <ToggleFieldsMenu resource="discoveryTrack" />}</div>
+      </div>
+    </TopToolbar>
+  )
+}
+
+export default DiscoveryActions

--- a/ui/src/discovery/DiscoveryList.jsx
+++ b/ui/src/discovery/DiscoveryList.jsx
@@ -1,0 +1,66 @@
+import React, { useMemo } from 'react'
+import {
+  Datagrid,
+  DateField,
+  Filter,
+  NumberField,
+  SearchInput,
+  TextField,
+} from 'react-admin'
+import { useMediaQuery } from '@material-ui/core'
+import {
+  DurationField,
+  List,
+  SizeField,
+  useSelectedFields,
+  useResourceRefresh,
+} from '../common'
+import DiscoveryListActions from './DiscoveryListActions'
+
+const DiscoveryFilter = (props) => (
+  <Filter {...props} variant="outlined">
+    <SearchInput source="q" alwaysOn />
+  </Filter>
+)
+
+const DiscoveryList = (props) => {
+  const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
+  const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
+  useResourceRefresh('discovery')
+
+  const toggleableFields = useMemo(
+    () => ({
+      ownerName: isDesktop && <TextField source="ownerName" />,
+      songCount: !isXsmall && <NumberField source="songCount" />,
+      duration: <DurationField source="duration" />,
+      size: isDesktop && <SizeField source="size" />, 
+      updatedAt: isDesktop && <DateField source="updatedAt" showTime />, 
+      createdAt: <DateField source="createdAt" showTime />, 
+      comment: <TextField source="comment" />, 
+    }),
+    [isDesktop, isXsmall],
+  )
+
+  const columns = useSelectedFields({
+    resource: 'discovery',
+    columns: toggleableFields,
+    defaultOff: ['comment'],
+  })
+
+  return (
+    <List
+      {...props}
+      exporter={false}
+      filters={<DiscoveryFilter />}
+      actions={<DiscoveryListActions />}
+      bulkActionButtons={false}
+    >
+      <Datagrid rowClick="show">
+        <TextField source="name" />
+        {columns}
+      </Datagrid>
+    </List>
+  )
+}
+
+export default DiscoveryList

--- a/ui/src/discovery/DiscoveryListActions.jsx
+++ b/ui/src/discovery/DiscoveryListActions.jsx
@@ -1,0 +1,23 @@
+import React, { cloneElement } from 'react'
+import {
+  sanitizeListRestProps,
+  TopToolbar,
+  useTranslate,
+} from 'react-admin'
+import { useMediaQuery } from '@material-ui/core'
+import { ToggleFieldsMenu } from '../common'
+
+const DiscoveryListActions = ({ className, filters, ...rest }) => {
+  const isNotSmall = useMediaQuery((theme) => theme.breakpoints.up('sm'))
+  const translate = useTranslate()
+
+  return (
+    <TopToolbar className={className} {...sanitizeListRestProps(rest)}>
+      {filters && cloneElement(filters, { context: 'button' })}
+      <span className="ra-top-toolbar__label">{translate('resources.discovery.name')}</span>
+      {isNotSmall && <ToggleFieldsMenu resource="discovery" />}
+    </TopToolbar>
+  )
+}
+
+export default DiscoveryListActions

--- a/ui/src/discovery/DiscoveryListActions.jsx
+++ b/ui/src/discovery/DiscoveryListActions.jsx
@@ -15,6 +15,7 @@ const DiscoveryListActions = ({ className, filters, ...rest }) => {
     <TopToolbar className={className} {...sanitizeListRestProps(rest)}>
       {filters && cloneElement(filters, { context: 'button' })}
       <span className="ra-top-toolbar__label">{translate('resources.discovery.name')}</span>
+      <span style={{ flex: 1 }} />
       {isNotSmall && <ToggleFieldsMenu resource="discovery" />}
     </TopToolbar>
   )

--- a/ui/src/discovery/DiscoveryShow.jsx
+++ b/ui/src/discovery/DiscoveryShow.jsx
@@ -1,0 +1,80 @@
+import React, { useState, useCallback } from 'react'
+import {
+  Filter,
+  Pagination,
+  ReferenceManyField,
+  SearchInput,
+  ShowContextProvider,
+  Title as RaTitle,
+  useShowContext,
+  useShowController,
+} from 'react-admin'
+import { Title, useResourceRefresh } from '../common'
+import PlaylistDetails from '../playlist/PlaylistDetails'
+import DiscoverySongs from './DiscoverySongs'
+import DiscoveryActions from './DiscoveryActions'
+
+const DiscoveryShowLayout = (props) => {
+  const { loading, ...context } = useShowContext(props)
+  const { record } = context
+  const [searchTerm, setSearchTerm] = useState('')
+  useResourceRefresh('discovery')
+
+  const handleSearchChange = useCallback((event) => {
+    setSearchTerm(event.target.value)
+  }, [])
+
+  if (loading) {
+    return null
+  }
+
+  return (
+    <>
+      {record && <RaTitle title={<Title subTitle={record.name} />} />}
+      {record && <PlaylistDetails {...context} />}
+      {record && (
+        <>
+          <Filter variant="outlined">
+            <SearchInput
+              id="search"
+              source="q"
+              alwaysOn
+              value={searchTerm}
+              onChange={handleSearchChange}
+            />
+          </Filter>
+          <ReferenceManyField
+            {...context}
+            addLabel={false}
+            reference="discoveryTrack"
+            target="discovery_id"
+            sort={{ field: 'id', order: 'ASC' }}
+            perPage={50}
+            filter={{ discovery_id: props.id, q: searchTerm }}
+          >
+            <DiscoverySongs
+              discoveryId={record.id}
+              searchTerm={searchTerm}
+              title={<Title subTitle={record.name} />}
+              actions={<DiscoveryActions record={record} />}
+              pagination={
+                <Pagination rowsPerPageOptions={[25, 50, 100, 200]} perPage={50} />
+              }
+            />
+          </ReferenceManyField>
+        </>
+      )}
+    </>
+  )
+}
+
+const DiscoveryShow = (props) => {
+  const controllerProps = useShowController(props)
+  return (
+    <ShowContextProvider value={controllerProps}>
+      <DiscoveryShowLayout {...props} {...controllerProps} />
+    </ShowContextProvider>
+  )
+}
+
+export default DiscoveryShow

--- a/ui/src/discovery/DiscoverySongBulkActions.jsx
+++ b/ui/src/discovery/DiscoverySongBulkActions.jsx
@@ -1,14 +1,21 @@
 import React, { Fragment, useCallback } from 'react'
 import { useDispatch } from 'react-redux'
-import { Button, useListContext, useTranslate } from 'react-admin'
+import {
+  BulkDeleteButton,
+  Button,
+  ResourceContextProvider,
+  useListContext,
+  useTranslate,
+} from 'react-admin'
 import PlayArrowIcon from '@material-ui/icons/PlayArrow'
 import ShuffleIcon from '@material-ui/icons/Shuffle'
 import { RiPlayList2Fill, RiPlayListAddFill } from 'react-icons/ri'
+import { MdOutlinePlaylistRemove } from 'react-icons/md'
 import PropTypes from 'prop-types'
 
 import { addTracks, playNext, playTracks, shuffleTracks } from '../actions'
 
-const DiscoverySongBulkActions = ({ onUnselectItems }) => {
+const DiscoverySongBulkActions = ({ discoveryId, onUnselectItems }) => {
   const dispatch = useDispatch()
   const translate = useTranslate()
   const { data, selectedIds } = useListContext()
@@ -25,37 +32,49 @@ const DiscoverySongBulkActions = ({ onUnselectItems }) => {
     [dispatch, data, selectedIds, onUnselectItems],
   )
 
+  const mappedResource = `discovery/${discoveryId}/tracks`
+
   return (
-    <Fragment>
-      <Button
-        onClick={handleAction(playTracks, true)}
-        label={translate('resources.album.actions.playAll')}
-      >
-        <PlayArrowIcon />
-      </Button>
-      <Button
-        onClick={handleAction(shuffleTracks)}
-        label={translate('resources.album.actions.shuffle')}
-      >
-        <ShuffleIcon />
-      </Button>
-      <Button
-        onClick={handleAction(playNext)}
-        label={translate('resources.album.actions.playNext')}
-      >
-        <RiPlayList2Fill />
-      </Button>
-      <Button
-        onClick={handleAction(addTracks)}
-        label={translate('resources.album.actions.addToQueue')}
-      >
-        <RiPlayListAddFill />
-      </Button>
-    </Fragment>
+    <ResourceContextProvider value={mappedResource}>
+      <Fragment>
+        <Button
+          onClick={handleAction(playTracks, true)}
+          label={translate('resources.album.actions.playAll')}
+        >
+          <PlayArrowIcon />
+        </Button>
+        <Button
+          onClick={handleAction(shuffleTracks)}
+          label={translate('resources.album.actions.shuffle')}
+        >
+          <ShuffleIcon />
+        </Button>
+        <Button
+          onClick={handleAction(playNext)}
+          label={translate('resources.album.actions.playNext')}
+        >
+          <RiPlayList2Fill />
+        </Button>
+        <Button
+          onClick={handleAction(addTracks)}
+          label={translate('resources.album.actions.addToQueue')}
+        >
+          <RiPlayListAddFill />
+        </Button>
+        <BulkDeleteButton
+          label={translate('ra.action.remove')}
+          resource={mappedResource}
+          icon={<MdOutlinePlaylistRemove />}
+          onClick={onUnselectItems}
+        />
+      </Fragment>
+    </ResourceContextProvider>
   )
 }
 
 DiscoverySongBulkActions.propTypes = {
+  discoveryId: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    .isRequired,
   onUnselectItems: PropTypes.func,
 }
 

--- a/ui/src/discovery/DiscoverySongBulkActions.jsx
+++ b/ui/src/discovery/DiscoverySongBulkActions.jsx
@@ -1,0 +1,66 @@
+import React, { Fragment, useCallback } from 'react'
+import { useDispatch } from 'react-redux'
+import { Button, useListContext, useTranslate } from 'react-admin'
+import PlayArrowIcon from '@material-ui/icons/PlayArrow'
+import ShuffleIcon from '@material-ui/icons/Shuffle'
+import { RiPlayList2Fill, RiPlayListAddFill } from 'react-icons/ri'
+import PropTypes from 'prop-types'
+
+import { addTracks, playNext, playTracks, shuffleTracks } from '../actions'
+
+const DiscoverySongBulkActions = ({ onUnselectItems }) => {
+  const dispatch = useDispatch()
+  const translate = useTranslate()
+  const { data, selectedIds } = useListContext()
+
+  const handleAction = useCallback(
+    (action, includeSelectedId = false) => () => {
+      if (!selectedIds || selectedIds.length === 0) {
+        return
+      }
+      const selectedId = includeSelectedId ? selectedIds[0] : undefined
+      dispatch(action(data, selectedIds, selectedId))
+      onUnselectItems?.()
+    },
+    [dispatch, data, selectedIds, onUnselectItems],
+  )
+
+  return (
+    <Fragment>
+      <Button
+        onClick={handleAction(playTracks, true)}
+        label={translate('resources.album.actions.playAll')}
+      >
+        <PlayArrowIcon />
+      </Button>
+      <Button
+        onClick={handleAction(shuffleTracks)}
+        label={translate('resources.album.actions.shuffle')}
+      >
+        <ShuffleIcon />
+      </Button>
+      <Button
+        onClick={handleAction(playNext)}
+        label={translate('resources.album.actions.playNext')}
+      >
+        <RiPlayList2Fill />
+      </Button>
+      <Button
+        onClick={handleAction(addTracks)}
+        label={translate('resources.album.actions.addToQueue')}
+      >
+        <RiPlayListAddFill />
+      </Button>
+    </Fragment>
+  )
+}
+
+DiscoverySongBulkActions.propTypes = {
+  onUnselectItems: PropTypes.func,
+}
+
+DiscoverySongBulkActions.defaultProps = {
+  onUnselectItems: undefined,
+}
+
+export default DiscoverySongBulkActions

--- a/ui/src/discovery/DiscoverySongs.jsx
+++ b/ui/src/discovery/DiscoverySongs.jsx
@@ -1,0 +1,154 @@
+import React, { useCallback, useEffect, useMemo } from 'react'
+import {
+  BulkActionsToolbar,
+  ListContextProvider,
+  ListToolbar,
+  TextField,
+  useListContext,
+  useVersion,
+} from 'react-admin'
+import { useDispatch } from 'react-redux'
+import { Card, useMediaQuery } from '@material-ui/core'
+import { makeStyles } from '@material-ui/core/styles'
+import clsx from 'clsx'
+import {
+  DurationField,
+  PathField,
+  SizeField,
+  SongDatagrid,
+  SongTitleField,
+  SongContextMenu,
+  SongInfo,
+  useSelectedFields,
+  useResourceRefresh,
+} from '../common'
+import ExpandInfoDialog from '../dialogs/ExpandInfoDialog'
+import { playTracks } from '../actions'
+import DiscoverySongBulkActions from './DiscoverySongBulkActions'
+
+const useStyles = makeStyles(
+  (theme) => ({
+    main: {
+      display: 'flex',
+    },
+    content: {
+      marginTop: 0,
+      transition: theme.transitions.create('margin-top'),
+      position: 'relative',
+      flex: '1 1 auto',
+      [theme.breakpoints.down('xs')]: {
+        boxShadow: 'none',
+      },
+    },
+    toolbar: {
+      justifyContent: 'flex-start',
+    },
+    bulkActionsDisplayed: {
+      marginTop: -theme.spacing(8),
+      transition: theme.transitions.create('margin-top'),
+    },
+    row: {
+      '&:hover': {
+        '& $contextMenu': {
+          visibility: 'visible',
+        },
+      },
+    },
+    contextMenu: (props) => ({
+      visibility: props?.isDesktop ? 'hidden' : 'visible',
+    }),
+  }),
+  { name: 'NDDiscoverySongs' },
+)
+
+const DiscoverySongs = ({ actions, pagination, discoveryId, searchTerm }) => {
+  const listContext = useListContext()
+  const version = useVersion()
+  const dispatch = useDispatch()
+  const { setPage, selectedIds, data, ids, onUnselectItems } = listContext
+  const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
+  const classes = useStyles({ isDesktop })
+  useResourceRefresh('discoveryTrack', 'discovery')
+
+  useEffect(() => {
+    setPage(1)
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [discoveryId, searchTerm, setPage])
+
+  const toggleableFields = useMemo(
+    () => ({
+      title: <SongTitleField source="title" showTrackNumbers={false} />,
+      artist: isDesktop && (
+        <TextField source="artist" label="resources.song.fields.artist" />
+      ),
+      album: isDesktop && (
+        <TextField source="album" label="resources.song.fields.album" />
+      ),
+      duration: <DurationField source="duration" />, 
+      size: isDesktop && <SizeField source="size" />, 
+      path: <PathField source="path" label="resources.song.fields.path" />,
+    }),
+    [isDesktop],
+  )
+
+  const columns = useSelectedFields({
+    resource: 'discoveryTrack',
+    columns: toggleableFields,
+    defaultOff: ['path'],
+  })
+
+  const handleRowClick = useCallback(
+    (id) => {
+      if (!ids || ids.length === 0) {
+        dispatch(playTracks(data, ids, id))
+        return
+      }
+
+      const startIndex = ids.indexOf(id)
+      if (startIndex === -1) {
+        dispatch(playTracks(data, ids, id))
+        return
+      }
+
+      const orderedIds = [...ids.slice(startIndex), ...ids.slice(0, startIndex)]
+      dispatch(playTracks(data, orderedIds, id))
+    },
+    [dispatch, data, ids],
+  )
+
+  return (
+    <ListContextProvider value={listContext}>
+      <ListToolbar classes={{ toolbar: classes.toolbar }} actions={actions} />
+      <div className={classes.main}>
+        <Card
+          className={clsx(classes.content, {
+            [classes.bulkActionsDisplayed]: selectedIds?.length > 0,
+          })}
+          key={version}
+        >
+          <BulkActionsToolbar>
+            <DiscoverySongBulkActions onUnselectItems={onUnselectItems} />
+          </BulkActionsToolbar>
+          <SongDatagrid
+            {...listContext}
+            rowClick={handleRowClick}
+            hasBulkActions
+            contextAlwaysVisible={!isDesktop}
+            classes={{ row: classes.row }}
+          >
+            {columns}
+            <SongContextMenu
+              onAddToPlaylist={() => null}
+              showLove={false}
+              className={classes.contextMenu}
+            />
+          </SongDatagrid>
+        </Card>
+      </div>
+      <ExpandInfoDialog content={<SongInfo />} />
+      {pagination && React.cloneElement(pagination, listContext)}
+    </ListContextProvider>
+  )
+}
+
+export default DiscoverySongs

--- a/ui/src/discovery/DiscoverySongs.jsx
+++ b/ui/src/discovery/DiscoverySongs.jsx
@@ -127,7 +127,10 @@ const DiscoverySongs = ({ actions, pagination, discoveryId, searchTerm }) => {
           key={version}
         >
           <BulkActionsToolbar>
-            <DiscoverySongBulkActions onUnselectItems={onUnselectItems} />
+            <DiscoverySongBulkActions
+              discoveryId={discoveryId}
+              onUnselectItems={onUnselectItems}
+            />
           </BulkActionsToolbar>
           <SongDatagrid
             {...listContext}

--- a/ui/src/discovery/PublishDiscoveryButton.jsx
+++ b/ui/src/discovery/PublishDiscoveryButton.jsx
@@ -1,0 +1,155 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import PublishIcon from '@material-ui/icons/Publish'
+import {
+  Button as RaButton,
+  useNotify,
+  useTranslate,
+} from 'react-admin'
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@material-ui/core'
+import { makeStyles } from '@material-ui/core/styles'
+
+import { REST_URL } from '../consts'
+import { httpClient } from '../dataProvider'
+
+const useStyles = makeStyles((theme) => ({
+  dialogPaper: {
+    backgroundColor: theme.palette.background.default,
+    padding: theme.spacing(3, 4, 2, 4),
+  },
+  dialogTitle: {
+    color: theme.palette.text.primary,
+    fontSize: '1.25rem',
+    fontWeight: theme.typography.fontWeightMedium,
+    paddingBottom: theme.spacing(1),
+  },
+  dialogContentText: {
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.body1.fontSize,
+  },
+  cancelButton: {
+    color: theme.palette.text.secondary,
+    '&:hover': {
+      backgroundColor: theme.palette.grey[700],
+    },
+  },
+  confirmButton: {
+    backgroundColor: theme.palette.secondary.main,
+    color: theme.palette.getContrastText(theme.palette.secondary.main),
+    '&:hover': {
+      backgroundColor: theme.palette.grey[700],
+    },
+  },
+}))
+
+const PublishDiscoveryButton = ({ record }) => {
+  const translate = useTranslate()
+  const notify = useNotify()
+  const classes = useStyles()
+  const [open, setOpen] = React.useState(false)
+  const [loading, setLoading] = React.useState(false)
+
+  const handleDialogOpen = React.useCallback(() => {
+    setOpen(true)
+  }, [])
+
+  const handleDialogClose = React.useCallback(() => {
+    if (!loading) {
+      setOpen(false)
+    }
+  }, [loading])
+
+  const handlePublish = React.useCallback(() => {
+    if (!record?.id) {
+      setOpen(false)
+      return Promise.resolve()
+    }
+
+    setLoading(true)
+    return httpClient(`${REST_URL}/discovery/${record.id}/publish`, {
+      method: 'POST',
+    })
+      .then(() => {
+        notify('resources.discovery.notifications.published', 'info', {
+          smart_count: record.songCount,
+          name: record.name,
+        })
+        setOpen(false)
+      })
+      .catch(() => {
+        notify('ra.page.error', 'warning')
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+  }, [notify, record])
+
+  return (
+    <>
+      <RaButton
+        onClick={handleDialogOpen}
+        disabled={loading}
+        label={translate('resources.discovery.actions.publish')}
+      >
+        <PublishIcon />
+      </RaButton>
+      <Dialog
+        open={open}
+        onClose={handleDialogClose}
+        aria-labelledby="publish-discovery-dialog"
+        PaperProps={{ className: classes.dialogPaper }}
+      >
+        <DialogTitle
+          id="publish-discovery-dialog"
+          className={classes.dialogTitle}
+        >
+          {translate('resources.discovery.actions.publish')}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText className={classes.dialogContentText}>
+            {translate('resources.discovery.dialog.publish_confirmation', {
+              _: 'Are you sure you want to publish this discovery?',
+            })}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={handleDialogClose}
+            disabled={loading}
+            className={classes.cancelButton}
+          >
+            {translate('ra.action.no', { _: 'No' }).toUpperCase()}
+          </Button>
+          <Button
+            onClick={handlePublish}
+            disabled={loading}
+            className={classes.confirmButton}
+          >
+            {translate('ra.action.yes', { _: 'Yes' }).toUpperCase()}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  )
+}
+
+PublishDiscoveryButton.propTypes = {
+  record: PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    name: PropTypes.string,
+    songCount: PropTypes.number,
+  }),
+}
+
+PublishDiscoveryButton.defaultProps = {
+  record: null,
+}
+
+export default PublishDiscoveryButton

--- a/ui/src/discovery/index.jsx
+++ b/ui/src/discovery/index.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import ExploreOutlinedIcon from '@material-ui/icons/ExploreOutlined'
+import ExploreIcon from '@material-ui/icons/Explore'
+import DynamicMenuIcon from '../layout/DynamicMenuIcon'
+import DiscoveryList from './DiscoveryList'
+import DiscoveryShow from './DiscoveryShow'
+
+export default {
+  list: DiscoveryList,
+  show: DiscoveryShow,
+  icon: (
+    <DynamicMenuIcon
+      path={'discovery'}
+      icon={ExploreOutlinedIcon}
+      activeIcon={ExploreIcon}
+    />
+  ),
+}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -583,6 +583,7 @@
       }
     },
     "albumList": "Albums",
+    "discovery": "Discovery",
     "playlists": "Playlists",
     "sharedPlaylists": "Shared Playlists",
     "about": "About"

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -231,6 +231,30 @@
         "noPlaylists": "No playlists available"
       }
     },
+    "discovery": {
+      "name": "Discovery |||| Discoveries",
+      "fields": {
+        "name": "Name",
+        "duration": "Duration",
+        "ownerName": "Owner",
+        "public": "Public",
+        "updatedAt": "Updated at",
+        "createdAt": "Date added",
+        "songCount": "Songs",
+        "comment": "Comment",
+        "size": "File size",
+        "path": "Folder"
+      },
+      "actions": {
+        "publish": "Publish"
+      },
+      "notifications": {
+        "published": "%{smart_count} song from %{name} published to Sync folder |||| %{smart_count} songs from %{name} published to Sync folder"
+      },
+      "dialog": {
+        "publish_confirmation": "Are you sure you want to publish this discovery?"
+      }
+    },
     "folder": {
       "name": "Folder |||| Folders",
       "fields": {

--- a/ui/src/i18n/provider.js
+++ b/ui/src/i18n/provider.js
@@ -45,6 +45,10 @@ const prepareLanguage = (lang) => {
   // Make "albumSong" and "playlistTrack" resource use the same translations as "song"
   lang.resources.albumSong = lang.resources.song
   lang.resources.playlistTrack = lang.resources.song
+  lang.resources.discoveryTrack = lang.resources.song
+  if (lang.resources.playlist) {
+    lang.resources.discovery = lang.resources.playlist
+  }
   // ra.boolean.null should always be empty
   lang.ra.boolean.null = ''
   // Fallback to english translations

--- a/ui/src/layout/DiscoverySubMenu.jsx
+++ b/ui/src/layout/DiscoverySubMenu.jsx
@@ -1,0 +1,267 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { useDataProvider, useNotify } from 'react-admin'
+import { useHistory, useLocation } from 'react-router-dom'
+import {
+  Collapse,
+  CircularProgress,
+  IconButton,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Typography,
+  makeStyles,
+} from '@material-ui/core'
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
+import ChevronRightIcon from '@material-ui/icons/ChevronRight'
+import ExploreIcon from '@material-ui/icons/Explore'
+import FolderIcon from '@material-ui/icons/Folder'
+import SubMenu from './SubMenu'
+import config from '../config'
+import { useTheme } from '@material-ui/core/styles'
+
+const useStyles = makeStyles((theme) => ({
+  listItem: {
+    borderRadius: 6,
+    marginRight: 4,
+    paddingTop: 1,
+    paddingBottom: 1,
+    transition: 'all 0.2s ease-in-out',
+    '&:hover': { backgroundColor: theme.palette.action.hover, transform: 'translateX(2px)' },
+  },
+  nested: { paddingLeft: theme.spacing(2) },
+  listItemIcon: { minWidth: 28 },
+  spinner: { margin: theme.spacing(1, 0, 1, 1) },
+  active: { fontWeight: theme.typography.fontWeightMedium },
+}))
+
+const normalisePathSegments = (path) =>
+  (path || '')
+    .replace(/\\/g, '/')
+    .split('/')
+    .filter(Boolean)
+
+const buildTree = (discoveries) => {
+  if (!discoveries?.length) {
+    return new Map([['', { folders: [], discoveries: [] }]])
+  }
+
+  const segmentsList = discoveries.map((disc) => normalisePathSegments(disc.path))
+  let commonPrefix = segmentsList[0]
+  for (let i = 1; i < segmentsList.length; i += 1) {
+    const parts = segmentsList[i]
+    const len = Math.min(commonPrefix.length, parts.length)
+    const prefix = []
+    for (let j = 0; j < len; j += 1) {
+      if (commonPrefix[j] !== parts[j]) {
+        break
+      }
+      prefix.push(commonPrefix[j])
+    }
+    commonPrefix = prefix
+    if (commonPrefix.length === 0) {
+      break
+    }
+  }
+
+  const children = new Map()
+  const ensureParent = (id) => {
+    if (!children.has(id)) {
+      children.set(id, { folders: [], discoveries: [] })
+    }
+    return children.get(id)
+  }
+  ensureParent('')
+
+  const folderCache = new Map()
+
+  const sortByName = (a, b) =>
+    (a.name || '').localeCompare(b.name || '', undefined, { sensitivity: 'base', numeric: true })
+
+  discoveries.forEach((disc) => {
+    const parts = normalisePathSegments(disc.path)
+    const relSegments = parts.slice(commonPrefix.length)
+    const effectiveSegments = relSegments.length ? relSegments : [disc.name || disc.id]
+
+    let parentId = ''
+    effectiveSegments.forEach((segment, idx) => {
+      const isLeaf = idx === effectiveSegments.length - 1
+      if (isLeaf) {
+        const parentChildren = ensureParent(parentId)
+        parentChildren.discoveries.push({
+          ...disc,
+          type: 'discovery',
+          parent_id: parentId,
+        })
+        parentChildren.discoveries.sort(sortByName)
+      } else {
+        const folderId = parentId ? `${parentId}/${segment}` : segment
+        if (!folderCache.has(folderId)) {
+          const folder = { id: folderId, name: segment, parent_id: parentId }
+          folderCache.set(folderId, folder)
+          const parentChildren = ensureParent(parentId)
+          parentChildren.folders.push(folder)
+          parentChildren.folders.sort(sortByName)
+        }
+        parentId = folderId
+        ensureParent(parentId)
+      }
+    })
+  })
+
+  return children
+}
+
+const DiscoverySubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
+  const classes = useStyles()
+  const dataProvider = useDataProvider()
+  const notify = useNotify()
+  const history = useHistory()
+  const location = useLocation()
+  const theme = useTheme()
+
+  const [discoveries, setDiscoveries] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [openMap, setOpenMap] = useState({})
+
+  useEffect(() => {
+    let cancelled = false
+    const fetchDiscoveries = async () => {
+      setLoading(true)
+      try {
+        const res = await dataProvider.getList('discovery', {
+          pagination: { page: 1, perPage: config.maxSidebarPlaylists },
+          sort: { field: 'name', order: 'ASC' },
+          filter: {},
+        })
+        if (!cancelled) {
+          setDiscoveries(res?.data || [])
+        }
+      } catch {
+        if (!cancelled) {
+          notify('ra.page.error', 'warning')
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    fetchDiscoveries()
+    return () => {
+      cancelled = true
+    }
+  }, [dataProvider, notify])
+
+  const childrenMap = useMemo(() => buildTree(discoveries), [discoveries])
+
+  const handleToggle = useCallback(
+    (menu) => {
+      setState((prev) => ({ ...prev, [menu]: !prev[menu] }))
+    },
+    [setState]
+  )
+
+  const rootChildren = childrenMap.get('') || { folders: [], discoveries: [] }
+
+  const isActive = useCallback((id) => location.pathname.includes(`/discovery/${id}`), [location.pathname])
+
+  const renderDiscovery = useCallback(
+    (disc, depth) => (
+      <ListItem
+        button
+        key={disc.id}
+        onClick={() => history.push(`/discovery/${disc.id}/show`)}
+        className={classes.listItem}
+        style={{ paddingLeft: theme.spacing(2) + depth * theme.spacing(2) }}
+      >
+        <ListItemIcon className={classes.listItemIcon}>
+          <ExploreIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText
+          primary={
+            <Typography
+              variant="body2"
+              noWrap
+              className={isActive(disc.id) ? classes.active : undefined}
+            >
+              {disc.name}
+            </Typography>
+          }
+        />
+      </ListItem>
+    ),
+    [classes, history, isActive, theme]
+  )
+
+  const renderFolder = useCallback(
+    (folder, depth = 0) => {
+      const open = !!openMap[folder.id]
+      const childGroup = childrenMap.get(folder.id) || { folders: [], discoveries: [] }
+
+      const toggle = (event) => {
+        event.stopPropagation()
+        setOpenMap((prev) => ({ ...prev, [folder.id]: !open }))
+      }
+
+      return (
+        <React.Fragment key={folder.id}>
+          <ListItem
+            button
+            onClick={toggle}
+            className={classes.listItem}
+            style={{ paddingLeft: theme.spacing(2) + depth * theme.spacing(2) }}
+          >
+            <IconButton size="small" onClick={toggle}>
+              {open ? <ExpandMoreIcon fontSize="small" /> : <ChevronRightIcon fontSize="small" />}
+            </IconButton>
+            <ListItemIcon className={classes.listItemIcon}>
+              <FolderIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText
+              primary={
+                <Typography variant="body2" noWrap>
+                  {folder.name}
+                </Typography>
+              }
+            />
+          </ListItem>
+          <Collapse in={open} timeout="auto" unmountOnExit>
+            <List disablePadding className={classes.nested}>
+              {childGroup.folders.map((child) => renderFolder(child, depth + 1))}
+              {childGroup.discoveries.map((disc) => renderDiscovery(disc, depth + 1))}
+            </List>
+          </Collapse>
+        </React.Fragment>
+      )
+    },
+    [childrenMap, classes, openMap, renderDiscovery, theme]
+  )
+
+  return (
+    <SubMenu
+      handleToggle={() => handleToggle('menuDiscovery')}
+      isOpen={state.menuDiscovery}
+      sidebarIsOpen={sidebarIsOpen}
+      name="menu.discovery"
+      icon={<ExploreIcon />}
+      dense={dense}
+    >
+      <List disablePadding>
+        {loading ? (
+          <ListItem>
+            <CircularProgress size={16} className={classes.spinner} />
+          </ListItem>
+        ) : (
+          <>
+            {rootChildren.folders.map((folder) => renderFolder(folder, 0))}
+            {rootChildren.discoveries.map((disc) => renderDiscovery(disc, 0))}
+          </>
+        )}
+      </List>
+    </SubMenu>
+  )
+}
+
+export default DiscoverySubMenu

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -8,6 +8,7 @@ import AlbumIcon from '@material-ui/icons/Album'
 import SubMenu from './SubMenu'
 import { humanize, pluralize } from 'inflection'
 import albumLists from '../album/albumLists'
+import PlaylistsSubMenu from './PlaylistsSubMenu'
 import DiscoverySubMenu from './DiscoverySubMenu'
 import LibrarySelector from '../common/LibrarySelector'
 import config from '../config'
@@ -57,7 +58,8 @@ const Menu = ({ dense = false }) => {
 
   // TODO State is not persisted in mobile when you close the sidebar menu. Move to redux?
   const [state, setState] = useState({
-    menuAlbumList: true,
+    menuAlbumList: false,
+    menuPlaylists: true,
     menuDiscovery: true,
     menuSharedPlaylists: true,
   })
@@ -131,10 +133,25 @@ const Menu = ({ dense = false }) => {
       {config.devSidebarPlaylists && open ? (
         <>
           <Divider />
-          <DiscoverySubMenu state={state} setState={setState} sidebarIsOpen={open} dense={dense} />
+          <PlaylistsSubMenu
+            state={state}
+            setState={setState}
+            sidebarIsOpen={open}
+            dense={dense}
+          />
+          <Divider />
+          <DiscoverySubMenu
+            state={state}
+            setState={setState}
+            sidebarIsOpen={open}
+            dense={dense}
+          />
         </>
       ) : (
-        resources.filter(subItems('discovery')).map(renderResourceMenuItemLink)
+        <>
+          {resources.filter(subItems('playlist')).map(renderResourceMenuItemLink)}
+          {resources.filter(subItems('discovery')).map(renderResourceMenuItemLink)}
+        </>
       )}
     </div>
   )

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -8,7 +8,7 @@ import AlbumIcon from '@material-ui/icons/Album'
 import SubMenu from './SubMenu'
 import { humanize, pluralize } from 'inflection'
 import albumLists from '../album/albumLists'
-import PlaylistsSubMenu from './PlaylistsSubMenu'
+import DiscoverySubMenu from './DiscoverySubMenu'
 import LibrarySelector from '../common/LibrarySelector'
 import config from '../config'
 
@@ -58,7 +58,7 @@ const Menu = ({ dense = false }) => {
   // TODO State is not persisted in mobile when you close the sidebar menu. Move to redux?
   const [state, setState] = useState({
     menuAlbumList: true,
-    menuPlaylists: true,
+    menuDiscovery: true,
     menuSharedPlaylists: true,
   })
 
@@ -131,15 +131,10 @@ const Menu = ({ dense = false }) => {
       {config.devSidebarPlaylists && open ? (
         <>
           <Divider />
-          <PlaylistsSubMenu
-            state={state}
-            setState={setState}
-            sidebarIsOpen={open}
-            dense={dense}
-          />
+          <DiscoverySubMenu state={state} setState={setState} sidebarIsOpen={open} dense={dense} />
         </>
       ) : (
-        resources.filter(subItems('playlist')).map(renderResourceMenuItemLink)
+        resources.filter(subItems('discovery')).map(renderResourceMenuItemLink)
       )}
     </div>
   )

--- a/ui/src/subsonic/index.js
+++ b/ui/src/subsonic/index.js
@@ -73,7 +73,9 @@ const getCoverArtUrl = (record, size, square) => {
   }
 
   // TODO Move this logic to server
-  if (record.album) {
+  if (record.type === 'discovery') {
+    return baseUrl(url('getCoverArt', `dc-${record.id}`, options))
+  } else if (record.album) {
     return baseUrl(url('getCoverArt', 'mf-' + record.id, options))
   } else if (record.albumArtist) {
     return baseUrl(url('getCoverArt', 'al-' + record.id, options))


### PR DESCRIPTION
## Summary
- add discovery artwork support and expose publish/export endpoints alongside track retrieval updates
- refresh the discovery admin views to reuse playlist-style toolbars, bulk selection, and song grid interactions
- surface download, export, and publish actions with discovery-specific dialogs and cover art handling in the UI

## Testing
- `npm --prefix ui run lint`
- `go test ./server/nativeapi/...`


------
https://chatgpt.com/codex/tasks/task_e_68e1936791908330a21add857bd8c447