### PR TITLE
Store discovery tracks and metadata in dedicated table

### DIFF
--- a/cmd/wire_gen.go
+++ b/cmd/wire_gen.go
@@ -59,6 +59,7 @@ func CreateNativeAPIRouter(ctx context.Context) *nativeapi.Router {
 	dataStore := persistence.New(sqlDB)
 	share := core.NewShare(dataStore)
 	playlists := core.NewPlaylists(dataStore)
+	discovery := core.NewDiscovery(dataStore)
 	metricsMetrics := metrics.GetPrometheusInstance(dataStore)
 	manager := plugins.GetManager(dataStore, metricsMetrics)
 	insights := metrics.GetInstance(dataStore, manager)
@@ -72,7 +73,7 @@ func CreateNativeAPIRouter(ctx context.Context) *nativeapi.Router {
 	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, metricsMetrics)
 	watcher := scanner.GetWatcher(dataStore, scannerScanner)
 	library := core.NewLibrary(dataStore, scannerScanner, watcher, broker)
-	router := nativeapi.New(dataStore, share, playlists, insights, library)
+	router := nativeapi.New(dataStore, share, playlists, discovery, insights, library)
 	return router
 }
 

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -52,6 +52,7 @@ type configOptions struct {
 	AutoImportPlaylists             bool
 	DefaultPlaylistPublicVisibility bool
 	PlaylistsPath                   string
+	DiscoveryPath                   string
 	SyncFolder                      string
 	SmartPlaylistRefreshDelay       time.Duration
 	AutoTranscodeDownload           bool
@@ -278,6 +279,14 @@ func Load(noConfigDump bool) {
 		}
 	}
 
+	if Server.DiscoveryPath != "" {
+		err = os.MkdirAll(Server.DiscoveryPath, os.ModePerm)
+		if err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, "FATAL: Error creating discovery path:", err)
+			os.Exit(1)
+		}
+	}
+
 	Server.ConfigFile = viper.GetViper().ConfigFileUsed()
 	if Server.DbPath == "" {
 		Server.DbPath = filepath.Join(Server.DataFolder, consts.DefaultDbPath)
@@ -310,6 +319,7 @@ func Load(noConfigDump bool) {
 		validateScanSchedule,
 		validateBackupSchedule,
 		validatePlaylistsPath,
+		validateDiscoveryPath,
 		validatePurgeMissingOption,
 	)
 	if err != nil {
@@ -417,6 +427,23 @@ func validatePlaylistsPath() error {
 	return nil
 }
 
+func validateDiscoveryPath() error {
+	if Server.DiscoveryPath == "" {
+		return nil
+	}
+	info, err := os.Stat(Server.DiscoveryPath)
+	if err != nil {
+		log.Error("Invalid DiscoveryPath", "path", Server.DiscoveryPath, err)
+		return err
+	}
+	if !info.IsDir() {
+		err = fmt.Errorf("DiscoveryPath is not a directory: %s", Server.DiscoveryPath)
+		log.Error(err.Error())
+		return err
+	}
+	return nil
+}
+
 func validatePurgeMissingOption() error {
 	allowedValues := []string{consts.PurgeMissingNever, consts.PurgeMissingAlways, consts.PurgeMissingFull}
 	valid := false
@@ -520,7 +547,7 @@ func setViperDefaults() {
 	viper.SetDefault("enablefavourites", true)
 	viper.SetDefault("enablestarrating", true)
 	viper.SetDefault("enableuserediting", true)
-       viper.SetDefault("defaulttheme", "Music Matters")
+	viper.SetDefault("defaulttheme", "Music Matters")
 	viper.SetDefault("defaultlanguage", "")
 	viper.SetDefault("defaultuivolume", consts.DefaultUIVolume)
 	viper.SetDefault("enablereplaygain", true)

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -279,6 +279,9 @@ func Load(noConfigDump bool) {
 		}
 	}
 
+	if Server.DiscoveryPath == "" && !viper.IsSet("discoverypath") {
+		Server.DiscoveryPath = filepath.Join(Server.DataFolder, "discovery")
+	}
 	if Server.DiscoveryPath != "" {
 		err = os.MkdirAll(Server.DiscoveryPath, os.ModePerm)
 		if err != nil {

--- a/core/artwork/reader_playlist.go
+++ b/core/artwork/reader_playlist.go
@@ -76,17 +76,28 @@ func toAlbumArtworkIDs(albumIDs []string) []model.ArtworkID {
 }
 
 func (a *playlistArtworkReader) loadTiles(ctx context.Context) ([]image.Image, error) {
-	tracksRepo := a.a.ds.Playlist(ctx).Tracks(a.pl.ID, false)
-	albumIds, err := tracksRepo.GetAlbumIDs(model.QueryOptions{Max: 4, Sort: "random()"})
-	if err != nil {
-		log.Error(ctx, "Error getting album IDs for playlist", "id", a.pl.ID, "name", a.pl.Name, err)
-		return nil, err
+	var ids []model.ArtworkID
+
+	if tracksRepo := a.a.ds.Playlist(ctx).Tracks(a.pl.ID, false); tracksRepo != nil {
+		albumIds, err := tracksRepo.GetAlbumIDs(model.QueryOptions{Max: 4, Sort: "random()"})
+		if err != nil {
+			log.Error(ctx, "Error getting album IDs for playlist", "id", a.pl.ID, "name", a.pl.Name, err)
+		} else {
+			ids = toAlbumArtworkIDs(albumIds)
+		}
 	}
-	ids := toAlbumArtworkIDs(albumIds)
+
+	if len(ids) == 0 && len(a.pl.Tracks) > 0 {
+		ids = artworkIDsFromTracks(a.pl.Tracks)
+	}
+
+	if len(ids) == 0 {
+		return nil, errors.New("could not find any eligible cover")
+	}
 
 	var tiles []image.Image
 	for _, id := range ids {
-		r, _, err := fromAlbum(ctx, a.a, id)()
+		r, _, err := a.a.Get(ctx, id, 0, false)
 		if err == nil {
 			tile, err := a.createTile(ctx, r)
 			if err == nil {
@@ -151,6 +162,27 @@ func rect(pos int) image.Rectangle {
 	r.Max.X = r.Min.X + tileSize/2
 	r.Max.Y = r.Min.Y + tileSize/2
 	return r
+}
+
+func artworkIDsFromTracks(tracks model.PlaylistTracks) []model.ArtworkID {
+	unique := make([]model.ArtworkID, 0, 4)
+	seen := make(map[string]struct{}, len(tracks))
+	for _, track := range tracks {
+		artID := track.MediaFile.CoverArtID()
+		if artID.ID == "" {
+			continue
+		}
+		key := artID.Kind.String() + ":" + artID.ID
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		unique = append(unique, artID)
+		if len(unique) == 4 {
+			break
+		}
+	}
+	return unique
 }
 
 func discoveryPlaylistForArtwork(ctx context.Context, ds model.DataStore, id string) (*model.Playlist, error) {

--- a/core/artwork/reader_playlist.go
+++ b/core/artwork/reader_playlist.go
@@ -3,6 +3,7 @@ package artwork
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"errors"
 	"image"
 	"image/draw"
@@ -27,7 +28,13 @@ const tileSize = 600
 func newPlaylistArtworkReader(ctx context.Context, artwork *artwork, artID model.ArtworkID) (*playlistArtworkReader, error) {
 	pl, err := artwork.ds.Playlist(ctx).Get(artID.ID)
 	if err != nil {
-		return nil, err
+		if !errors.Is(err, model.ErrNotFound) && !errors.Is(err, sql.ErrNoRows) {
+			return nil, err
+		}
+		pl, err = discoveryPlaylistForArtwork(ctx, artwork.ds, artID.ID)
+		if err != nil {
+			return nil, err
+		}
 	}
 	a := &playlistArtworkReader{
 		a:  artwork,
@@ -144,4 +151,39 @@ func rect(pos int) image.Rectangle {
 	r.Max.X = r.Min.X + tileSize/2
 	r.Max.Y = r.Min.Y + tileSize/2
 	return r
+}
+
+func discoveryPlaylistForArtwork(ctx context.Context, ds model.DataStore, id string) (*model.Playlist, error) {
+	entry, err := ds.DiscoveryPlaylist(ctx).Get(id)
+	if err != nil {
+		return nil, err
+	}
+	tracks, err := ds.DiscoveryTrack(ctx).GetByDiscovery(id)
+	if err != nil {
+		return nil, err
+	}
+	playlist := &model.Playlist{
+		ID:        entry.ID,
+		Name:      entry.Name,
+		UpdatedAt: entry.UpdatedAt,
+	}
+	playlistTracks := make(model.PlaylistTracks, 0, len(tracks))
+	for _, track := range tracks {
+		media := track.MediaFile
+		if media.ID == "" {
+			media.ID = track.ID
+		}
+		plt := model.PlaylistTrack{
+			ID:          track.ID,
+			MediaFileID: track.MediaFileID,
+			PlaylistID:  entry.ID,
+			MediaFile:   media,
+		}
+		if plt.MediaFileID == "" {
+			plt.MediaFileID = media.ID
+		}
+		playlistTracks = append(playlistTracks, plt)
+	}
+	playlist.SetTracks(playlistTracks)
+	return playlist, nil
 }

--- a/core/discovery.go
+++ b/core/discovery.go
@@ -45,6 +45,12 @@ type discoveryTrackEntry struct {
 }
 
 func (d *discovery) collectTrackEntries(folder string) ([]discoveryTrackEntry, error) {
+	root := filepath.Clean(folder)
+	if !filepath.IsAbs(root) {
+		if absRoot, err := filepath.Abs(root); err == nil {
+			root = filepath.Clean(absRoot)
+		}
+	}
 	entries := make([]discoveryTrackEntry, 0)
 	err := filepath.WalkDir(folder, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -63,13 +69,21 @@ func (d *discovery) collectTrackEntries(folder string) ([]discoveryTrackEntry, e
 			}
 		}
 		display := absolute
-		musicRoot := conf.Server.MusicFolder
-		if musicRoot != "" {
-			if absRoot, absErr := filepath.Abs(musicRoot); absErr == nil {
-				musicRoot = absRoot
+		if relToFolder, relErr := filepath.Rel(root, absolute); relErr == nil {
+			relToFolder = filepath.Clean(relToFolder)
+			if relToFolder != "." && !strings.HasPrefix(relToFolder, "..") && !strings.HasPrefix(relToFolder, "..\\") {
+				display = relToFolder
 			}
-			if rel, relErr := filepath.Rel(musicRoot, absolute); relErr == nil && !strings.HasPrefix(rel, "..") {
-				display = rel
+		}
+		if display == absolute {
+			musicRoot := conf.Server.MusicFolder
+			if musicRoot != "" {
+				if absRoot, absErr := filepath.Abs(musicRoot); absErr == nil {
+					musicRoot = absRoot
+				}
+				if rel, relErr := filepath.Rel(musicRoot, absolute); relErr == nil && !strings.HasPrefix(rel, "..") {
+					display = rel
+				}
 			}
 		}
 		display = filepath.ToSlash(display)
@@ -364,7 +378,11 @@ func (d *discovery) loadMetadataForMissing(ctx context.Context, entry *model.Dis
 			mf.ID = id.NewHash(entry.ID + absolutePath)
 		}
 		mf.Missing = false
-		mf.LibraryPath = absolutePath
+		folderRoot := filepath.Clean(entry.FolderPath)
+		if folderRoot == "" {
+			folderRoot = filepath.Dir(absolutePath)
+		}
+		mf.LibraryPath = folderRoot
 		for _, idx := range indices {
 			entryPath := missing[idx]
 			clone := mf
@@ -377,8 +395,10 @@ func (d *discovery) loadMetadataForMissing(ctx context.Context, entry *model.Dis
 			if clone.Path == "" {
 				clone.Path = absolutePath
 			}
-			if entryPath.absolute != "" {
-				clone.LibraryPath = entryPath.absolute
+			if folderRoot != "" {
+				clone.LibraryPath = folderRoot
+			} else if entryPath.absolute != "" {
+				clone.LibraryPath = filepath.Dir(entryPath.absolute)
 			}
 			if clone.ID == "" {
 				clone.ID = id.NewHash(entry.ID + clone.Path)
@@ -448,10 +468,14 @@ func (d *discovery) scanTracks(ctx context.Context, ds model.DataStore, entry *m
 			if len(variants) > 0 {
 				fallback = variants[0]
 			}
+			libraryRoot := filepath.Clean(entry.FolderPath)
+			if libraryRoot == "" {
+				libraryRoot = filepath.Dir(entryPath.absolute)
+			}
 			mediaFile = model.MediaFile{
 				ID:          id.NewHash(entry.ID + fallback),
 				Path:        fallback,
-				LibraryPath: entryPath.absolute,
+				LibraryPath: libraryRoot,
 				Title:       filepath.Base(fallback),
 				Missing:     true,
 			}

--- a/core/discovery.go
+++ b/core/discovery.go
@@ -484,13 +484,21 @@ func (d *discovery) scanTracks(ctx context.Context, ds model.DataStore, entry *m
 		if mediaFile.Path == "" {
 			mediaFile.Path = normalized
 		}
-		uniqueKey := normalized
-		count := occurrences[normalized]
-		occurrences[normalized] = count + 1
-		if count > 0 {
-			uniqueKey = fmt.Sprintf("%s#%d", normalized, count+1)
+		canonical := entryPath.absolute
+		if canonical == "" {
+			canonical = normalized
 		}
-		trackID := id.NewHash(entry.ID + "#" + uniqueKey)
+		canonical = filepath.ToSlash(filepath.Clean(canonical))
+		if canonical == "." || canonical == "" {
+			canonical = fmt.Sprintf("%s@%d", normalized, idx+1)
+		}
+		count := occurrences[canonical]
+		occurrences[canonical] = count + 1
+		uniqueKey := canonical
+		if count > 0 {
+			uniqueKey = fmt.Sprintf("%s#%d", canonical, count+1)
+		}
+		trackID := id.NewHash(entry.ID, "#", uniqueKey)
 		tracks = append(tracks, model.DiscoveryTrack{
 			ID:          trackID,
 			DiscoveryID: entry.ID,

--- a/core/discovery.go
+++ b/core/discovery.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -449,6 +448,7 @@ func (d *discovery) scanTracks(ctx context.Context, ds model.DataStore, entry *m
 	}
 	tracks := make(model.DiscoveryTracks, 0, len(entries))
 	missing := make(map[int]discoveryTrackEntry)
+	occurrences := make(map[string]int, len(entries))
 	for idx, entryPath := range entries {
 		normalized := entryPath.display
 		variants := variantByPath[normalized]
@@ -484,10 +484,13 @@ func (d *discovery) scanTracks(ctx context.Context, ds model.DataStore, entry *m
 		if mediaFile.Path == "" {
 			mediaFile.Path = normalized
 		}
-		trackID := mediaFile.ID
-		if trackID == "" {
-			trackID = id.NewHash(entry.ID + normalized + "#" + strconv.Itoa(idx))
+		uniqueKey := normalized
+		count := occurrences[normalized]
+		occurrences[normalized] = count + 1
+		if count > 0 {
+			uniqueKey = fmt.Sprintf("%s#%d", normalized, count+1)
 		}
+		trackID := id.NewHash(entry.ID + "#" + uniqueKey)
 		tracks = append(tracks, model.DiscoveryTrack{
 			ID:          trackID,
 			DiscoveryID: entry.ID,

--- a/core/discovery.go
+++ b/core/discovery.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -26,6 +27,8 @@ type Discovery interface {
 	Export(ctx context.Context, id string, w io.Writer) error
 	Refresh(ctx context.Context) (model.DiscoveryPlaylists, error)
 	Tracks(ctx context.Context, id string) (model.DiscoveryTracks, error)
+	DeleteTracks(ctx context.Context, id string, trackIDs []string) error
+	Publish(ctx context.Context, id string) error
 }
 
 type discovery struct {
@@ -203,31 +206,20 @@ func (d *discovery) Export(ctx context.Context, id string, w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	builder := &strings.Builder{}
-	builder.WriteString("#EXTM3U\n")
-	builder.WriteString("#PLAYLIST:" + entry.Name + "\n")
-	trackPaths, err := d.collectTrackPaths(entry.FolderPath)
+	tracks, err := d.loadTracks(ctx, entry)
 	if err != nil {
 		return err
 	}
-	for _, track := range trackPaths {
-		builder.WriteString(track)
+	names := d.canonicalFilenames(tracks)
+	builder := &strings.Builder{}
+	builder.WriteString("#EXTM3U\n")
+	builder.WriteString("#PLAYLIST:" + entry.Name + "\n")
+	for _, name := range names {
+		builder.WriteString(name)
 		builder.WriteString("\n")
 	}
 	_, err = io.Copy(w, strings.NewReader(builder.String()))
 	return err
-}
-
-func (d *discovery) collectTrackPaths(folder string) ([]string, error) {
-	entries, err := d.collectTrackEntries(folder)
-	if err != nil {
-		return nil, err
-	}
-	tracks := make([]string, len(entries))
-	for i, entry := range entries {
-		tracks[i] = entry.display
-	}
-	return tracks, nil
 }
 
 func (d *discovery) libraryRoots(ctx context.Context, ds model.DataStore) []string {
@@ -477,6 +469,7 @@ func (d *discovery) scanTracks(ctx context.Context, ds model.DataStore, entry *m
 			DiscoveryID: entry.ID,
 			MediaFileID: mediaFile.ID,
 			Position:    idx + 1,
+			SourcePath:  entryPath.absolute,
 			MediaFile:   mediaFile,
 		})
 	}
@@ -519,6 +512,19 @@ func (d *discovery) rescanAndPersist(ctx context.Context, entry *model.Discovery
 		if err := tx.DiscoveryTrack(ctx).ReplaceForDiscovery(entry.ID, scanned); err != nil {
 			return err
 		}
+		updated := *entry
+		updated.SongCount = len(scanned)
+		updated.Duration = 0
+		updated.Size = 0
+		for _, track := range scanned {
+			updated.Duration += track.MediaFile.Duration
+			updated.Size += track.MediaFile.Size
+		}
+		updated.UpdatedAt = time.Now().UTC()
+		if err := tx.DiscoveryPlaylist(ctx).Put(&updated); err != nil {
+			return err
+		}
+		*entry = updated
 		tracks = scanned
 		return nil
 	})
@@ -534,4 +540,282 @@ func (d *discovery) Tracks(ctx context.Context, id string) (model.DiscoveryTrack
 		return nil, err
 	}
 	return d.loadTracks(ctx, entry)
+}
+
+func (d *discovery) DeleteTracks(ctx context.Context, id string, trackIDs []string) error {
+	if len(trackIDs) == 0 {
+		return nil
+	}
+	entry, err := d.ds.DiscoveryPlaylist(ctx).Get(id)
+	if err != nil {
+		return err
+	}
+	folderPath := filepath.Clean(entry.FolderPath)
+	if abs, absErr := filepath.Abs(folderPath); absErr == nil {
+		folderPath = filepath.Clean(abs)
+	}
+	tracks, err := d.ds.DiscoveryTrack(ctx).GetByIDs(id, trackIDs)
+	if err != nil {
+		return err
+	}
+	if len(tracks) == 0 {
+		return model.ErrNotFound
+	}
+	for _, track := range tracks {
+		source := track.SourcePath
+		if source == "" {
+			switch {
+			case track.MediaFile.LibraryPath != "":
+				source = track.MediaFile.LibraryPath
+			case track.MediaFile.Path != "":
+				source = filepath.Join(folderPath, filepath.Base(track.MediaFile.Path))
+			}
+		}
+		if source == "" {
+			continue
+		}
+		if !filepath.IsAbs(source) {
+			source = filepath.Join(folderPath, source)
+		}
+		source = filepath.Clean(source)
+		if !isWithinDir(folderPath, source) {
+			continue
+		}
+		if err := os.Remove(source); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	_, err = d.rescanAndPersist(ctx, entry)
+	return err
+}
+
+func (d *discovery) Publish(ctx context.Context, id string) error {
+	if conf.Server.SyncFolder == "" {
+		return errors.New("sync folder not configured")
+	}
+	entry, err := d.ds.DiscoveryPlaylist(ctx).Get(id)
+	if err != nil {
+		return err
+	}
+	folderPath := filepath.Clean(entry.FolderPath)
+	if abs, absErr := filepath.Abs(folderPath); absErr == nil {
+		folderPath = filepath.Clean(abs)
+	}
+	info, err := os.Stat(folderPath)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("discovery folder is not a directory: %s", folderPath)
+	}
+	tracks, err := d.loadTracks(ctx, entry)
+	if err != nil {
+		return err
+	}
+	if len(tracks) == 0 {
+		return errors.New("discovery playlist has no tracks")
+	}
+	names := d.canonicalFilenames(tracks)
+	for idx, track := range tracks {
+		source := track.SourcePath
+		if source == "" {
+			switch {
+			case track.MediaFile.LibraryPath != "":
+				source = track.MediaFile.LibraryPath
+			case track.MediaFile.Path != "":
+				source = filepath.Join(folderPath, filepath.Base(track.MediaFile.Path))
+			}
+		}
+		if source == "" {
+			continue
+		}
+		if !filepath.IsAbs(source) {
+			source = filepath.Join(folderPath, source)
+		}
+		source = filepath.Clean(source)
+		if !isWithinDir(folderPath, source) {
+			continue
+		}
+		target := filepath.Join(folderPath, names[idx])
+		if filepath.Clean(source) == filepath.Clean(target) {
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		if err := os.Remove(target); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if err := os.Rename(source, target); err != nil {
+			return err
+		}
+	}
+	playlistName := sanitizeFilenameComponent(entry.Name)
+	if playlistName == "" {
+		playlistName = "discovery"
+	}
+	playlistPath := filepath.Join(folderPath, playlistName+".m3u")
+	if err := os.Remove(playlistPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	builder := &strings.Builder{}
+	builder.WriteString("#EXTM3U\n")
+	builder.WriteString("#PLAYLIST:" + entry.Name + "\n")
+	for _, name := range names {
+		builder.WriteString(name)
+		builder.WriteString("\n")
+	}
+	if err := os.WriteFile(playlistPath, []byte(builder.String()), 0o644); err != nil {
+		return err
+	}
+	syncRoot := filepath.Clean(conf.Server.SyncFolder)
+	if abs, absErr := filepath.Abs(syncRoot); absErr == nil {
+		syncRoot = filepath.Clean(abs)
+	}
+	if err := os.MkdirAll(syncRoot, 0o755); err != nil {
+		return err
+	}
+	destination := filepath.Join(syncRoot, filepath.Base(folderPath))
+	if err := os.RemoveAll(destination); err != nil {
+		return err
+	}
+	if err := os.Rename(folderPath, destination); err != nil {
+		if copyErr := copyDirectory(folderPath, destination); copyErr != nil {
+			return copyErr
+		}
+		if err := os.RemoveAll(folderPath); err != nil {
+			return err
+		}
+	}
+	return d.ds.WithTx(func(tx model.DataStore) error {
+		return tx.DiscoveryPlaylist(ctx).Delete(id)
+	})
+}
+
+var fileNameSanitizer = strings.NewReplacer(
+	"\\", "_",
+	"/", "_",
+	":", " -",
+	"*", "_",
+	"?", "",
+	"\"", "'",
+	"<", "_",
+	">", "_",
+	"|", "_",
+)
+
+func sanitizeFilenameComponent(input string) string {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return "Unknown"
+	}
+	sanitized := fileNameSanitizer.Replace(trimmed)
+	sanitized = strings.Join(strings.Fields(sanitized), " ")
+	if sanitized == "" {
+		return "Unknown"
+	}
+	return sanitized
+}
+
+func (d *discovery) canonicalFilenames(tracks model.DiscoveryTracks) []string {
+	names := make([]string, len(tracks))
+	used := make(map[string]int, len(tracks))
+	for idx := range tracks {
+		names[idx] = canonicalFilename(&tracks[idx], idx, used)
+	}
+	return names
+}
+
+func canonicalFilename(track *model.DiscoveryTrack, index int, used map[string]int) string {
+	artist := track.MediaFile.Artist
+	if artist == "" {
+		artist = track.MediaFile.AlbumArtist
+	}
+	title := track.MediaFile.Title
+	if title == "" {
+		switch {
+		case track.SourcePath != "":
+			title = strings.TrimSuffix(filepath.Base(track.SourcePath), filepath.Ext(track.SourcePath))
+		case track.MediaFile.Path != "":
+			title = strings.TrimSuffix(filepath.Base(track.MediaFile.Path), filepath.Ext(track.MediaFile.Path))
+		default:
+			title = fmt.Sprintf("Track %02d", index+1)
+		}
+	}
+	artist = sanitizeFilenameComponent(artist)
+	title = sanitizeFilenameComponent(title)
+	ext := trackExtension(track)
+	base := fmt.Sprintf("%s - %s", artist, title)
+	key := strings.ToLower(base + "." + ext)
+	count := used[key]
+	used[key] = count + 1
+	name := base
+	if count > 0 {
+		name = fmt.Sprintf("%s (%d)", base, count+1)
+	}
+	return fmt.Sprintf("%s.%s", name, ext)
+}
+
+func trackExtension(track *model.DiscoveryTrack) string {
+	suffix := strings.TrimSpace(track.MediaFile.Suffix)
+	suffix = strings.TrimPrefix(suffix, ".")
+	if suffix == "" {
+		if track.SourcePath != "" {
+			suffix = strings.TrimPrefix(strings.ToLower(filepath.Ext(track.SourcePath)), ".")
+		} else if track.MediaFile.Path != "" {
+			suffix = strings.TrimPrefix(strings.ToLower(filepath.Ext(track.MediaFile.Path)), ".")
+		}
+	}
+	if suffix == "" {
+		suffix = "mp3"
+	}
+	return suffix
+}
+
+func isWithinDir(root, target string) bool {
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	if rel == ".." {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+}
+
+func copyDirectory(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(src, path)
+		if relErr != nil {
+			return relErr
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		return copyFile(path, target)
+	})
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
 }

--- a/core/discovery.go
+++ b/core/discovery.go
@@ -12,9 +12,11 @@ import (
 	"time"
 
 	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/core/storage"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/id"
+	"github.com/navidrome/navidrome/model/metadata"
 	"golang.org/x/text/unicode/norm"
 )
 
@@ -298,6 +300,90 @@ func (d *discovery) discoveryPathVariants(displayPath, absolutePath string, libr
 	return variants
 }
 
+func (d *discovery) loadMetadataForMissing(ctx context.Context, entry *model.DiscoveryPlaylist, missing map[int]discoveryTrackEntry) (map[int]model.MediaFile, error) {
+	if len(missing) == 0 {
+		return nil, nil
+	}
+	store, err := storage.For(entry.FolderPath)
+	if err != nil {
+		return nil, err
+	}
+	fs, err := store.FS()
+	if err != nil {
+		return nil, err
+	}
+	pathToIndices := make(map[string][]int, len(missing))
+	paths := make([]string, 0, len(missing))
+	for idx, entryPath := range missing {
+		key := entryPath.absolute
+		if key == "" {
+			key = entryPath.display
+		}
+		if key == "" {
+			continue
+		}
+		key = filepath.Clean(key)
+		if _, ok := pathToIndices[key]; !ok {
+			paths = append(paths, key)
+		}
+		pathToIndices[key] = append(pathToIndices[key], idx)
+	}
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	infoByPath, err := fs.ReadTags(paths...)
+	if err != nil {
+		return nil, err
+	}
+	resolved := make(map[int]model.MediaFile, len(missing))
+	for rawPath, indices := range pathToIndices {
+		info, ok := infoByPath[rawPath]
+		if !ok {
+			if alt, altOk := infoByPath[filepath.ToSlash(rawPath)]; altOk {
+				info = alt
+				ok = true
+			}
+		}
+		if !ok {
+			if rel, relErr := filepath.Rel(entry.FolderPath, rawPath); relErr == nil {
+				rel = filepath.ToSlash(rel)
+				if relInfo, relOk := infoByPath[rel]; relOk {
+					info = relInfo
+					ok = true
+				}
+			}
+		}
+		if !ok {
+			continue
+		}
+		md := metadata.New(rawPath, info)
+		mf := md.ToMediaFile(0, entry.ID)
+		if mf.ID == "" {
+			mf.ID = id.NewHash(entry.ID + rawPath)
+		}
+		mf.Missing = false
+		mf.LibraryPath = rawPath
+		for _, idx := range indices {
+			entryPath := missing[idx]
+			clone := mf
+			if entryPath.display != "" {
+				clone.Path = entryPath.display
+			}
+			if clone.Path == "" {
+				clone.Path = rawPath
+			}
+			if entryPath.absolute != "" {
+				clone.LibraryPath = entryPath.absolute
+			}
+			if clone.ID == "" {
+				clone.ID = id.NewHash(entry.ID + clone.Path)
+			}
+			resolved[idx] = clone
+		}
+	}
+	return resolved, nil
+}
+
 func (d *discovery) scanTracks(ctx context.Context, ds model.DataStore, entry *model.DiscoveryPlaylist) (model.DiscoveryTracks, error) {
 	entries, err := d.collectTrackEntries(entry.FolderPath)
 	if err != nil {
@@ -337,6 +423,7 @@ func (d *discovery) scanTracks(ctx context.Context, ds model.DataStore, entry *m
 		}
 	}
 	tracks := make(model.DiscoveryTracks, 0, len(entries))
+	missing := make(map[int]discoveryTrackEntry)
 	for idx, entryPath := range entries {
 		normalized := entryPath.display
 		variants := variantByPath[normalized]
@@ -357,11 +444,13 @@ func (d *discovery) scanTracks(ctx context.Context, ds model.DataStore, entry *m
 				fallback = variants[0]
 			}
 			mediaFile = model.MediaFile{
-				ID:      id.NewHash(entry.ID + fallback),
-				Path:    fallback,
-				Title:   filepath.Base(fallback),
-				Missing: true,
+				ID:          id.NewHash(entry.ID + fallback),
+				Path:        fallback,
+				LibraryPath: entryPath.absolute,
+				Title:       filepath.Base(fallback),
+				Missing:     true,
 			}
+			missing[idx] = entryPath
 		}
 		if mediaFile.Path == "" {
 			mediaFile.Path = normalized
@@ -377,6 +466,20 @@ func (d *discovery) scanTracks(ctx context.Context, ds model.DataStore, entry *m
 			Position:    idx + 1,
 			MediaFile:   mediaFile,
 		})
+	}
+	if len(missing) > 0 {
+		metadataByIndex, metaErr := d.loadMetadataForMissing(ctx, entry, missing)
+		if metaErr != nil {
+			log.Warn(ctx, "Discovery: Failed to extract metadata for tracks", metaErr)
+		}
+		for idx, mf := range metadataByIndex {
+			track := &tracks[idx]
+			track.MediaFile = mf
+			track.MediaFileID = mf.ID
+			if track.MediaFileID == "" {
+				track.MediaFileID = track.ID
+			}
+		}
 	}
 	return tracks, nil
 }

--- a/core/discovery.go
+++ b/core/discovery.go
@@ -315,18 +315,28 @@ func (d *discovery) loadMetadataForMissing(ctx context.Context, entry *model.Dis
 	pathToIndices := make(map[string][]int, len(missing))
 	paths := make([]string, 0, len(missing))
 	for idx, entryPath := range missing {
-		key := entryPath.absolute
-		if key == "" {
-			key = entryPath.display
+		raw := entryPath.absolute
+		if raw == "" {
+			raw = entryPath.display
 		}
-		if key == "" {
+		if raw == "" {
 			continue
 		}
-		key = filepath.Clean(key)
-		if _, ok := pathToIndices[key]; !ok {
-			paths = append(paths, key)
+		cleaned := filepath.Clean(raw)
+		rel := cleaned
+		if filepath.IsAbs(cleaned) {
+			if relPath, relErr := filepath.Rel(entry.FolderPath, cleaned); relErr == nil {
+				rel = filepath.Clean(relPath)
+			}
 		}
-		pathToIndices[key] = append(pathToIndices[key], idx)
+		rel = filepath.ToSlash(rel)
+		if rel == "." || strings.HasPrefix(rel, "../") || strings.HasPrefix(rel, "..\\") {
+			continue
+		}
+		if _, ok := pathToIndices[rel]; !ok {
+			paths = append(paths, rel)
+		}
+		pathToIndices[rel] = append(pathToIndices[rel], idx)
 	}
 	if len(paths) == 0 {
 		return nil, nil
@@ -336,33 +346,33 @@ func (d *discovery) loadMetadataForMissing(ctx context.Context, entry *model.Dis
 		return nil, err
 	}
 	resolved := make(map[int]model.MediaFile, len(missing))
-	for rawPath, indices := range pathToIndices {
-		info, ok := infoByPath[rawPath]
+	for relPath, indices := range pathToIndices {
+		info, ok := infoByPath[relPath]
 		if !ok {
-			if alt, altOk := infoByPath[filepath.ToSlash(rawPath)]; altOk {
+			if alt, altOk := infoByPath[filepath.ToSlash(relPath)]; altOk {
 				info = alt
 				ok = true
 			}
 		}
+		absolutePath := filepath.Clean(filepath.Join(entry.FolderPath, relPath))
 		if !ok {
-			if rel, relErr := filepath.Rel(entry.FolderPath, rawPath); relErr == nil {
-				rel = filepath.ToSlash(rel)
-				if relInfo, relOk := infoByPath[rel]; relOk {
-					info = relInfo
-					ok = true
-				}
+			// Some extractors may echo back OS-specific separators. Try the joined absolute path.
+			joined := filepath.ToSlash(absolutePath)
+			if altInfo, altOk := infoByPath[joined]; altOk {
+				info = altInfo
+				ok = true
 			}
 		}
 		if !ok {
 			continue
 		}
-		md := metadata.New(rawPath, info)
+		md := metadata.New(absolutePath, info)
 		mf := md.ToMediaFile(0, entry.ID)
 		if mf.ID == "" {
-			mf.ID = id.NewHash(entry.ID + rawPath)
+			mf.ID = id.NewHash(entry.ID + absolutePath)
 		}
 		mf.Missing = false
-		mf.LibraryPath = rawPath
+		mf.LibraryPath = absolutePath
 		for _, idx := range indices {
 			entryPath := missing[idx]
 			clone := mf
@@ -370,7 +380,10 @@ func (d *discovery) loadMetadataForMissing(ctx context.Context, entry *model.Dis
 				clone.Path = entryPath.display
 			}
 			if clone.Path == "" {
-				clone.Path = rawPath
+				clone.Path = entryPath.absolute
+			}
+			if clone.Path == "" {
+				clone.Path = absolutePath
 			}
 			if entryPath.absolute != "" {
 				clone.LibraryPath = entryPath.absolute

--- a/core/discovery.go
+++ b/core/discovery.go
@@ -1,0 +1,421 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/id"
+	"golang.org/x/text/unicode/norm"
+)
+
+type Discovery interface {
+	List(ctx context.Context, refresh bool) (model.DiscoveryPlaylists, error)
+	Get(ctx context.Context, id string) (*model.DiscoveryPlaylist, error)
+	Export(ctx context.Context, id string, w io.Writer) error
+	Refresh(ctx context.Context) (model.DiscoveryPlaylists, error)
+	Tracks(ctx context.Context, id string) (model.DiscoveryTracks, error)
+}
+
+type discovery struct {
+	ds model.DataStore
+}
+
+func NewDiscovery(ds model.DataStore) Discovery {
+	return &discovery{ds: ds}
+}
+
+type discoveryTrackEntry struct {
+	display  string
+	absolute string
+}
+
+func (d *discovery) collectTrackEntries(folder string) ([]discoveryTrackEntry, error) {
+	entries := make([]discoveryTrackEntry, 0)
+	err := filepath.WalkDir(folder, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !model.IsAudioFile(path) {
+			return nil
+		}
+		absolute := filepath.Clean(path)
+		if !filepath.IsAbs(absolute) {
+			if absPath, err := filepath.Abs(absolute); err == nil {
+				absolute = absPath
+			}
+		}
+		display := absolute
+		musicRoot := conf.Server.MusicFolder
+		if musicRoot != "" {
+			if absRoot, absErr := filepath.Abs(musicRoot); absErr == nil {
+				musicRoot = absRoot
+			}
+			if rel, relErr := filepath.Rel(musicRoot, absolute); relErr == nil && !strings.HasPrefix(rel, "..") {
+				display = rel
+			}
+		}
+		display = filepath.ToSlash(display)
+		entries = append(entries, discoveryTrackEntry{
+			display:  display,
+			absolute: absolute,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].display < entries[j].display
+	})
+	return entries, nil
+}
+
+func (d *discovery) List(ctx context.Context, refresh bool) (model.DiscoveryPlaylists, error) {
+	if refresh {
+		return d.Refresh(ctx)
+	}
+	repo := d.ds.DiscoveryPlaylist(ctx)
+	playlists, err := repo.GetAll()
+	if err != nil {
+		return nil, err
+	}
+	if len(playlists) == 0 && conf.Server.DiscoveryPath != "" {
+		return d.Refresh(ctx)
+	}
+	return playlists, nil
+}
+
+func (d *discovery) Refresh(ctx context.Context) (model.DiscoveryPlaylists, error) {
+	root := conf.Server.DiscoveryPath
+	if root == "" {
+		return nil, errors.New("discovery directory not configured")
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+	type playlistBundle struct {
+		playlist model.DiscoveryPlaylist
+		tracks   model.DiscoveryTracks
+	}
+	bundles := make([]playlistBundle, 0, len(entries))
+	now := time.Now().UTC()
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		folderPath := filepath.Join(root, entry.Name())
+		playlist := model.DiscoveryPlaylist{
+			ID:         id.NewHash(folderPath),
+			Name:       entry.Name(),
+			FolderPath: folderPath,
+			UpdatedAt:  now,
+		}
+		tracks, scanErr := d.scanTracks(ctx, d.ds, &playlist)
+		if scanErr != nil {
+			log.Error(ctx, "Error collecting discovery playlist tracks", "folder", folderPath, scanErr)
+			continue
+		}
+		if len(tracks) == 0 {
+			continue
+		}
+		playlist.SongCount = len(tracks)
+		playlist.Duration = 0
+		playlist.Size = 0
+		for _, track := range tracks {
+			playlist.Duration += track.MediaFile.Duration
+			playlist.Size += track.MediaFile.Size
+		}
+		bundles = append(bundles, playlistBundle{playlist: playlist, tracks: tracks})
+	}
+	sort.SliceStable(bundles, func(i, j int) bool {
+		return strings.ToLower(bundles[i].playlist.Name) < strings.ToLower(bundles[j].playlist.Name)
+	})
+	storeErr := d.ds.WithTx(func(tx model.DataStore) error {
+		plain := make(model.DiscoveryPlaylists, 0, len(bundles))
+		for _, bundle := range bundles {
+			plain = append(plain, model.DiscoveryPlaylist{
+				ID:         bundle.playlist.ID,
+				Name:       bundle.playlist.Name,
+				FolderPath: bundle.playlist.FolderPath,
+				SongCount:  bundle.playlist.SongCount,
+				UpdatedAt:  bundle.playlist.UpdatedAt,
+			})
+		}
+		if err := tx.DiscoveryPlaylist(ctx).ReplaceAll(plain); err != nil {
+			return err
+		}
+		for _, bundle := range bundles {
+			if err := tx.DiscoveryTrack(ctx).ReplaceForDiscovery(bundle.playlist.ID, bundle.tracks); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if storeErr != nil {
+		return nil, storeErr
+	}
+	playlists := make(model.DiscoveryPlaylists, 0, len(bundles))
+	for _, bundle := range bundles {
+		playlists = append(playlists, bundle.playlist)
+	}
+	return playlists, nil
+}
+
+func (d *discovery) Get(ctx context.Context, id string) (*model.DiscoveryPlaylist, error) {
+	entry, err := d.ds.DiscoveryPlaylist(ctx).Get(id)
+	if err != nil {
+		return nil, err
+	}
+	tracks, err := d.loadTracks(ctx, entry)
+	if err != nil {
+		return nil, err
+	}
+	entry.Tracks = tracks
+	entry.SongCount = len(tracks)
+	entry.Sync = false
+	entry.Duration = 0
+	entry.Size = 0
+	for _, track := range tracks {
+		entry.Duration += track.MediaFile.Duration
+		entry.Size += track.MediaFile.Size
+	}
+	return entry, nil
+}
+
+func (d *discovery) Export(ctx context.Context, id string, w io.Writer) error {
+	entry, err := d.ds.DiscoveryPlaylist(ctx).Get(id)
+	if err != nil {
+		return err
+	}
+	builder := &strings.Builder{}
+	builder.WriteString("#EXTM3U\n")
+	builder.WriteString("#PLAYLIST:" + entry.Name + "\n")
+	trackPaths, err := d.collectTrackPaths(entry.FolderPath)
+	if err != nil {
+		return err
+	}
+	for _, track := range trackPaths {
+		builder.WriteString(track)
+		builder.WriteString("\n")
+	}
+	_, err = io.Copy(w, strings.NewReader(builder.String()))
+	return err
+}
+
+func (d *discovery) collectTrackPaths(folder string) ([]string, error) {
+	entries, err := d.collectTrackEntries(folder)
+	if err != nil {
+		return nil, err
+	}
+	tracks := make([]string, len(entries))
+	for i, entry := range entries {
+		tracks[i] = entry.display
+	}
+	return tracks, nil
+}
+
+func (d *discovery) libraryRoots(ctx context.Context, ds model.DataStore) []string {
+	libraries, err := ds.Library(ctx).GetAll()
+	if err != nil {
+		log.Warn(ctx, "Failed to list libraries for discovery matching", err)
+		return nil
+	}
+	roots := make([]string, 0, len(libraries))
+	for _, lib := range libraries {
+		if lib.Path == "" {
+			continue
+		}
+		root := lib.Path
+		if abs, absErr := filepath.Abs(root); absErr == nil {
+			root = abs
+		}
+		roots = append(roots, filepath.Clean(root))
+	}
+	return roots
+}
+
+func (d *discovery) discoveryPathVariants(displayPath, absolutePath string, libraryRoots []string) []string {
+	seen := make(map[string]struct{}, len(libraryRoots)+2)
+	variants := make([]string, 0, len(libraryRoots)+2)
+	add := func(candidate string) {
+		if candidate == "" {
+			return
+		}
+		cleaned := filepath.ToSlash(filepath.Clean(candidate))
+		if cleaned == "." {
+			return
+		}
+		for _, normalized := range []string{cleaned, norm.NFC.String(cleaned), norm.NFD.String(cleaned)} {
+			if normalized == "." {
+				continue
+			}
+			if _, ok := seen[normalized]; ok {
+				continue
+			}
+			seen[normalized] = struct{}{}
+			variants = append(variants, normalized)
+		}
+	}
+
+	add(displayPath)
+	if absolutePath != "" {
+		add(absolutePath)
+	}
+	basePath := absolutePath
+	for _, root := range libraryRoots {
+		absRoot := root
+		if !filepath.IsAbs(absRoot) {
+			if resolved, err := filepath.Abs(absRoot); err == nil {
+				absRoot = resolved
+			}
+		}
+		if basePath == "" {
+			continue
+		}
+		rel, relErr := filepath.Rel(absRoot, basePath)
+		if relErr != nil {
+			continue
+		}
+		if strings.HasPrefix(rel, "..") {
+			continue
+		}
+		add(rel)
+	}
+	return variants
+}
+
+func (d *discovery) scanTracks(ctx context.Context, ds model.DataStore, entry *model.DiscoveryPlaylist) (model.DiscoveryTracks, error) {
+	entries, err := d.collectTrackEntries(entry.FolderPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	repo := ds.MediaFile(ctx)
+	libraryRoots := d.libraryRoots(ctx, ds)
+	variantByPath := make(map[string][]string, len(entries))
+	lookupSet := make(map[string]struct{}, len(entries)*2)
+	lookup := make([]string, 0, len(entries)*2)
+	for _, entryPath := range entries {
+		normalized := entryPath.display
+		variants := d.discoveryPathVariants(entryPath.display, entryPath.absolute, libraryRoots)
+		variantByPath[normalized] = variants
+		for _, candidate := range variants {
+			if _, ok := lookupSet[candidate]; ok {
+				continue
+			}
+			lookupSet[candidate] = struct{}{}
+			lookup = append(lookup, candidate)
+		}
+	}
+	mediaFiles, err := repo.FindByPaths(lookup)
+	if err != nil {
+		return nil, err
+	}
+	mfByPath := make(map[string]model.MediaFile, len(mediaFiles)*2)
+	for _, mf := range mediaFiles {
+		key := strings.ToLower(filepath.ToSlash(filepath.Clean(mf.Path)))
+		mfByPath[key] = mf
+		if absPath := mf.AbsolutePath(); absPath != "" {
+			absKey := strings.ToLower(filepath.ToSlash(filepath.Clean(absPath)))
+			mfByPath[absKey] = mf
+		}
+	}
+	tracks := make(model.DiscoveryTracks, 0, len(entries))
+	for idx, entryPath := range entries {
+		normalized := entryPath.display
+		variants := variantByPath[normalized]
+		var (
+			mediaFile model.MediaFile
+			found     bool
+		)
+		for _, candidate := range variants {
+			if mf, ok := mfByPath[strings.ToLower(candidate)]; ok {
+				mediaFile = mf
+				found = true
+				break
+			}
+		}
+		if !found {
+			fallback := normalized
+			if len(variants) > 0 {
+				fallback = variants[0]
+			}
+			mediaFile = model.MediaFile{
+				ID:      id.NewHash(entry.ID + fallback),
+				Path:    fallback,
+				Title:   filepath.Base(fallback),
+				Missing: true,
+			}
+		}
+		if mediaFile.Path == "" {
+			mediaFile.Path = normalized
+		}
+		trackID := mediaFile.ID
+		if trackID == "" {
+			trackID = id.NewHash(entry.ID + normalized + "#" + strconv.Itoa(idx))
+		}
+		tracks = append(tracks, model.DiscoveryTrack{
+			ID:          trackID,
+			DiscoveryID: entry.ID,
+			MediaFileID: mediaFile.ID,
+			Position:    idx + 1,
+			MediaFile:   mediaFile,
+		})
+	}
+	return tracks, nil
+}
+
+func (d *discovery) loadTracks(ctx context.Context, entry *model.DiscoveryPlaylist) (model.DiscoveryTracks, error) {
+	repo := d.ds.DiscoveryTrack(ctx)
+	tracks, err := repo.GetByDiscovery(entry.ID)
+	if err != nil {
+		return nil, err
+	}
+	if len(tracks) > 0 {
+		return tracks, nil
+	}
+	return d.rescanAndPersist(ctx, entry)
+}
+
+func (d *discovery) rescanAndPersist(ctx context.Context, entry *model.DiscoveryPlaylist) (model.DiscoveryTracks, error) {
+	var tracks model.DiscoveryTracks
+	err := d.ds.WithTx(func(tx model.DataStore) error {
+		scanned, scanErr := d.scanTracks(ctx, tx, entry)
+		if scanErr != nil {
+			return scanErr
+		}
+		if err := tx.DiscoveryTrack(ctx).ReplaceForDiscovery(entry.ID, scanned); err != nil {
+			return err
+		}
+		tracks = scanned
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tracks, nil
+}
+
+func (d *discovery) Tracks(ctx context.Context, id string) (model.DiscoveryTracks, error) {
+	entry, err := d.ds.DiscoveryPlaylist(ctx).Get(id)
+	if err != nil {
+		return nil, err
+	}
+	return d.loadTracks(ctx, entry)
+}

--- a/core/media_streamer.go
+++ b/core/media_streamer.go
@@ -2,10 +2,14 @@ package core
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -50,11 +54,22 @@ func (j *streamJob) Key() string {
 
 func (ms *mediaStreamer) NewStream(ctx context.Context, id string, reqFormat string, reqBitRate int, reqOffset int) (*Stream, error) {
 	mf, err := ms.ds.MediaFile(ctx).Get(id)
-	if err != nil {
+	if err == nil {
+		return ms.DoStream(ctx, mf, reqFormat, reqBitRate, reqOffset)
+	}
+	if !errors.Is(err, model.ErrNotFound) && !errors.Is(err, sql.ErrNoRows) {
 		return nil, err
 	}
 
-	return ms.DoStream(ctx, mf, reqFormat, reqBitRate, reqOffset)
+	track, trackErr := ms.ds.DiscoveryTrack(ctx).Get(id)
+	if trackErr != nil {
+		return nil, trackErr
+	}
+	discoveryMF, buildErr := mediaFileFromDiscoveryTrack(track)
+	if buildErr != nil {
+		return nil, buildErr
+	}
+	return ms.DoStream(ctx, discoveryMF, reqFormat, reqBitRate, reqOffset)
 }
 
 func (ms *mediaStreamer) DoStream(ctx context.Context, mf *model.MediaFile, reqFormat string, reqBitRate int, reqOffset int) (*Stream, error) {
@@ -128,6 +143,61 @@ func (s *Stream) Name() string        { return s.mf.Title + "." + s.format }
 func (s *Stream) ModTime() time.Time  { return s.mf.UpdatedAt }
 func (s *Stream) EstimatedContentLength() int {
 	return int(s.mf.Duration * float32(s.bitRate) / 8 * 1024)
+}
+
+func mediaFileFromDiscoveryTrack(track *model.DiscoveryTrack) (*model.MediaFile, error) {
+	mf := track.MediaFile
+	if mf.ID == "" {
+		mf.ID = track.ID
+	}
+	abs := track.SourcePath
+	if abs == "" {
+		if filepath.IsAbs(mf.Path) {
+			abs = mf.Path
+		} else if mf.LibraryPath != "" && mf.Path != "" {
+			abs = filepath.Join(mf.LibraryPath, mf.Path)
+		}
+	}
+	if abs == "" && mf.Path != "" && mf.LibraryPath != "" {
+		abs = filepath.Join(mf.LibraryPath, mf.Path)
+	}
+	if abs == "" {
+		return nil, model.ErrNotFound
+	}
+	abs = filepath.Clean(abs)
+
+	libraryPath := mf.LibraryPath
+	relPath := mf.Path
+
+	if libraryPath == "" || !filepath.IsAbs(libraryPath) {
+		libraryPath = filepath.Dir(abs)
+	} else {
+		rel, err := filepath.Rel(libraryPath, abs)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			libraryPath = filepath.Dir(abs)
+			relPath = filepath.Base(abs)
+		} else if relPath == "" || filepath.IsAbs(relPath) {
+			relPath = filepath.ToSlash(rel)
+		}
+	}
+
+	if relPath == "" {
+		relPath = filepath.Base(abs)
+	}
+	if filepath.IsAbs(relPath) {
+		relPath = filepath.Base(abs)
+	}
+
+	mf.LibraryPath = filepath.Clean(libraryPath)
+	mf.Path = filepath.ToSlash(relPath)
+	mf.Missing = false
+	if mf.UpdatedAt.IsZero() {
+		mf.UpdatedAt = time.Now().UTC()
+	}
+	if mf.Title == "" {
+		mf.Title = filepath.Base(abs)
+	}
+	return &mf, nil
 }
 
 // TODO This function deserves some love (refactoring)

--- a/core/wire_providers.go
+++ b/core/wire_providers.go
@@ -17,6 +17,7 @@ var Set = wire.NewSet(
 	NewPlayers,
 	NewShare,
 	NewPlaylists,
+	NewDiscovery,
 	NewLibrary,
 	agents.GetAgents,
 	external.NewProvider,

--- a/db/migrations/20250819010109_create_discovery_playlists.go
+++ b/db/migrations/20250819010109_create_discovery_playlists.go
@@ -1,0 +1,32 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(Up20250819010109, Down20250819010109)
+}
+
+func Up20250819010109(_ context.Context, tx *sql.Tx) error {
+	_, err := tx.Exec(`
+create table if not exists discovery_playlists (
+    id varchar(255) not null primary key,
+    name varchar(255) not null,
+    folder_path text not null unique,
+    song_count integer not null default 0,
+    updated_at datetime not null
+);
+
+create index if not exists discovery_playlists_name on discovery_playlists(name);
+`)
+	return err
+}
+
+func Down20250819010109(_ context.Context, tx *sql.Tx) error {
+	_, err := tx.Exec(`drop table if exists discovery_playlists;`)
+	return err
+}

--- a/db/migrations/20250819010210_create_discovery_tracks.go
+++ b/db/migrations/20250819010210_create_discovery_tracks.go
@@ -1,0 +1,37 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(Up20250819010210, Down20250819010210)
+}
+
+func Up20250819010210(_ context.Context, tx *sql.Tx) error {
+	_, err := tx.Exec(`
+create table if not exists discovery_tracks (
+    id varchar(255) not null primary key,
+    discovery_id varchar(255) not null,
+    media_file_id varchar(255),
+    path text not null,
+    position integer not null,
+    missing boolean not null default false,
+    media_file text not null,
+    created_at datetime not null,
+    updated_at datetime not null,
+    foreign key(discovery_id) references discovery_playlists(id) on delete cascade
+);
+
+create index if not exists discovery_tracks_discovery_id on discovery_tracks(discovery_id, position);
+`)
+	return err
+}
+
+func Down20250819010210(_ context.Context, tx *sql.Tx) error {
+	_, err := tx.Exec(`drop table if exists discovery_tracks;`)
+	return err
+}

--- a/db/migrations/20250819010350_add_source_path_to_discovery_tracks.go
+++ b/db/migrations/20250819010350_add_source_path_to_discovery_tracks.go
@@ -1,0 +1,42 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(Up20250819010350, Down20250819010350)
+}
+
+func Up20250819010350(_ context.Context, tx *sql.Tx) error {
+	_, err := tx.Exec(`
+alter table discovery_tracks add column source_path text;
+`)
+	return err
+}
+
+func Down20250819010350(_ context.Context, tx *sql.Tx) error {
+	_, err := tx.Exec(`
+create table if not exists discovery_tracks_tmp as select id, discovery_id, media_file_id, path, position, missing, media_file, created_at, updated_at from discovery_tracks;
+drop table if exists discovery_tracks;
+create table if not exists discovery_tracks (
+    id varchar(255) not null primary key,
+    discovery_id varchar(255) not null,
+    media_file_id varchar(255),
+    path text not null,
+    position integer not null,
+    missing boolean not null default false,
+    media_file text not null,
+    created_at datetime not null,
+    updated_at datetime not null,
+    foreign key(discovery_id) references discovery_playlists(id) on delete cascade
+);
+insert into discovery_tracks select id, discovery_id, media_file_id, path, position, missing, media_file, created_at, updated_at from discovery_tracks_tmp;
+drop table if exists discovery_tracks_tmp;
+create index if not exists discovery_tracks_discovery_id on discovery_tracks(discovery_id, position);
+`)
+	return err
+}

--- a/model/datastore.go
+++ b/model/datastore.go
@@ -1,48 +1,50 @@
-	package model
+package model
 
-	import (
-		"context"
+import (
+	"context"
 
-		"github.com/Masterminds/squirrel"
-		"github.com/deluan/rest"
-	)
+	"github.com/Masterminds/squirrel"
+	"github.com/deluan/rest"
+)
 
-	type QueryOptions struct {
-		Sort    string
-		Order   string
-		Max     int
-		Offset  int
-		Filters squirrel.Sqlizer
-		Seed    string // for random sorting
-	}
+type QueryOptions struct {
+	Sort    string
+	Order   string
+	Max     int
+	Offset  int
+	Filters squirrel.Sqlizer
+	Seed    string // for random sorting
+}
 
-	type ResourceRepository interface {
-		rest.Repository
-	}
+type ResourceRepository interface {
+	rest.Repository
+}
 
-	type DataStore interface {
-		Library(ctx context.Context) LibraryRepository
-		Folder(ctx context.Context) FolderRepository
-		Album(ctx context.Context) AlbumRepository
-		Artist(ctx context.Context) ArtistRepository
-		MediaFile(ctx context.Context) MediaFileRepository
-		Genre(ctx context.Context) GenreRepository
-		Tag(ctx context.Context) TagRepository
-		Playlist(ctx context.Context) PlaylistRepository
-		PlaylistFolder(ctx context.Context) PlaylistFolderRepository
-		PlayQueue(ctx context.Context) PlayQueueRepository
-		Transcoding(ctx context.Context) TranscodingRepository
-		Player(ctx context.Context) PlayerRepository
-		Radio(ctx context.Context) RadioRepository
-		Share(ctx context.Context) ShareRepository
-		Property(ctx context.Context) PropertyRepository
-		User(ctx context.Context) UserRepository
-		UserProps(ctx context.Context) UserPropsRepository
-		ScrobbleBuffer(ctx context.Context) ScrobbleBufferRepository
+type DataStore interface {
+	Library(ctx context.Context) LibraryRepository
+	Folder(ctx context.Context) FolderRepository
+	Album(ctx context.Context) AlbumRepository
+	Artist(ctx context.Context) ArtistRepository
+	MediaFile(ctx context.Context) MediaFileRepository
+	Genre(ctx context.Context) GenreRepository
+        Tag(ctx context.Context) TagRepository
+        Playlist(ctx context.Context) PlaylistRepository
+        PlaylistFolder(ctx context.Context) PlaylistFolderRepository
+        DiscoveryPlaylist(ctx context.Context) DiscoveryPlaylistRepository
+        DiscoveryTrack(ctx context.Context) DiscoveryTrackRepository
+        PlayQueue(ctx context.Context) PlayQueueRepository
+        Transcoding(ctx context.Context) TranscodingRepository
+	Player(ctx context.Context) PlayerRepository
+	Radio(ctx context.Context) RadioRepository
+	Share(ctx context.Context) ShareRepository
+	Property(ctx context.Context) PropertyRepository
+	User(ctx context.Context) UserRepository
+	UserProps(ctx context.Context) UserPropsRepository
+	ScrobbleBuffer(ctx context.Context) ScrobbleBufferRepository
 
-		Resource(ctx context.Context, model interface{}) ResourceRepository
+	Resource(ctx context.Context, model interface{}) ResourceRepository
 
-		WithTx(block func(tx DataStore) error, scope ...string) error
-		WithTxImmediate(block func(tx DataStore) error, scope ...string) error
-		GC(ctx context.Context) error
-	}
+	WithTx(block func(tx DataStore) error, scope ...string) error
+	WithTxImmediate(block func(tx DataStore) error, scope ...string) error
+	GC(ctx context.Context) error
+}

--- a/model/discovery_playlist.go
+++ b/model/discovery_playlist.go
@@ -36,6 +36,7 @@ type DiscoveryPlaylistRepository interface {
 }
 
 type DiscoveryTrackRepository interface {
+	Get(id string) (*DiscoveryTrack, error)
 	GetByDiscovery(discoveryID string) (DiscoveryTracks, error)
 	ReplaceForDiscovery(discoveryID string, tracks DiscoveryTracks) error
 	GetByIDs(discoveryID string, ids []string) (DiscoveryTracks, error)

--- a/model/discovery_playlist.go
+++ b/model/discovery_playlist.go
@@ -1,0 +1,38 @@
+package model
+
+import "time"
+
+type DiscoveryPlaylist struct {
+	ID         string          `structs:"id" json:"id"`
+	Name       string          `structs:"name" json:"name"`
+	FolderPath string          `structs:"folder_path" json:"folderPath"`
+	SongCount  int             `structs:"song_count" json:"songCount"`
+	UpdatedAt  time.Time       `structs:"updated_at" json:"updatedAt"`
+	Duration   float32         `structs:"-" json:"duration"`
+	Size       int64           `structs:"-" json:"size"`
+	Sync       bool            `structs:"-" json:"sync"`
+	Tracks     DiscoveryTracks `structs:"-" json:"tracks,omitempty"`
+}
+
+type DiscoveryPlaylists []DiscoveryPlaylist
+
+type DiscoveryTrack struct {
+        ID          string `json:"id"`
+        DiscoveryID string `json:"discoveryId"`
+        MediaFileID string `json:"mediaFileId"`
+        Position    int    `json:"position"`
+        MediaFile
+}
+
+type DiscoveryTracks []DiscoveryTrack
+
+type DiscoveryPlaylistRepository interface {
+        GetAll(options ...QueryOptions) (DiscoveryPlaylists, error)
+        Get(id string) (*DiscoveryPlaylist, error)
+        ReplaceAll(playlists DiscoveryPlaylists) error
+}
+
+type DiscoveryTrackRepository interface {
+        GetByDiscovery(discoveryID string) (DiscoveryTracks, error)
+        ReplaceForDiscovery(discoveryID string, tracks DiscoveryTracks) error
+}

--- a/model/discovery_playlist.go
+++ b/model/discovery_playlist.go
@@ -17,22 +17,26 @@ type DiscoveryPlaylist struct {
 type DiscoveryPlaylists []DiscoveryPlaylist
 
 type DiscoveryTrack struct {
-        ID          string `json:"id"`
-        DiscoveryID string `json:"discoveryId"`
-        MediaFileID string `json:"mediaFileId"`
-        Position    int    `json:"position"`
-        MediaFile
+	ID          string `json:"id"`
+	DiscoveryID string `json:"discoveryId"`
+	MediaFileID string `json:"mediaFileId"`
+	Position    int    `json:"position"`
+	SourcePath  string `json:"sourcePath"`
+	MediaFile
 }
 
 type DiscoveryTracks []DiscoveryTrack
 
 type DiscoveryPlaylistRepository interface {
-        GetAll(options ...QueryOptions) (DiscoveryPlaylists, error)
-        Get(id string) (*DiscoveryPlaylist, error)
-        ReplaceAll(playlists DiscoveryPlaylists) error
+	GetAll(options ...QueryOptions) (DiscoveryPlaylists, error)
+	Get(id string) (*DiscoveryPlaylist, error)
+	ReplaceAll(playlists DiscoveryPlaylists) error
+	Put(entry *DiscoveryPlaylist) error
+	Delete(id string) error
 }
 
 type DiscoveryTrackRepository interface {
-        GetByDiscovery(discoveryID string) (DiscoveryTracks, error)
-        ReplaceForDiscovery(discoveryID string, tracks DiscoveryTracks) error
+	GetByDiscovery(discoveryID string) (DiscoveryTracks, error)
+	ReplaceForDiscovery(discoveryID string, tracks DiscoveryTracks) error
+	GetByIDs(discoveryID string, ids []string) (DiscoveryTracks, error)
 }

--- a/persistence/discovery_repository.go
+++ b/persistence/discovery_repository.go
@@ -51,3 +51,32 @@ func (r *discoveryPlaylistRepository) ReplaceAll(playlists model.DiscoveryPlayli
 	}
 	return nil
 }
+
+func (r *discoveryPlaylistRepository) Put(entry *model.DiscoveryPlaylist) error {
+	params := dbx.Params{
+		"name":        entry.Name,
+		"folder_path": entry.FolderPath,
+		"song_count":  entry.SongCount,
+		"updated_at":  entry.UpdatedAt,
+	}
+	res, err := r.db.Update("discovery_playlists", params, dbx.HashExp{"id": entry.ID}).Execute()
+	if err != nil {
+		return err
+	}
+	if res != nil {
+		if affected, affErr := res.RowsAffected(); affErr == nil && affected > 0 {
+			return nil
+		}
+	}
+	params["id"] = entry.ID
+	if _, err := r.db.Insert("discovery_playlists", params).Execute(); err != nil {
+		log.Error(r.ctx, "Error inserting discovery playlist", "name", entry.Name, err)
+		return err
+	}
+	return nil
+}
+
+func (r *discoveryPlaylistRepository) Delete(id string) error {
+	_, err := r.db.Delete("discovery_playlists", dbx.HashExp{"id": id}).Execute()
+	return err
+}

--- a/persistence/discovery_repository.go
+++ b/persistence/discovery_repository.go
@@ -1,0 +1,53 @@
+package persistence
+
+import (
+	"context"
+
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/pocketbase/dbx"
+)
+
+type discoveryPlaylistRepository struct {
+	ctx context.Context
+	db  dbx.Builder
+}
+
+func NewDiscoveryPlaylistRepository(ctx context.Context, db dbx.Builder) model.DiscoveryPlaylistRepository {
+	return &discoveryPlaylistRepository{ctx: ctx, db: db}
+}
+
+func (r *discoveryPlaylistRepository) GetAll(_ ...model.QueryOptions) (model.DiscoveryPlaylists, error) {
+	var entries model.DiscoveryPlaylists
+	err := r.db.Select("*").From("discovery_playlists").OrderBy("name asc").All(&entries)
+	return entries, err
+}
+
+func (r *discoveryPlaylistRepository) Get(id string) (*model.DiscoveryPlaylist, error) {
+	var entry model.DiscoveryPlaylist
+	err := r.db.Select("*").From("discovery_playlists").Where(dbx.HashExp{"id": id}).One(&entry)
+	if err != nil {
+		return nil, err
+	}
+	return &entry, nil
+}
+
+func (r *discoveryPlaylistRepository) ReplaceAll(playlists model.DiscoveryPlaylists) error {
+	if _, err := r.db.NewQuery("delete from discovery_playlists").Execute(); err != nil {
+		return err
+	}
+	for _, pls := range playlists {
+		params := dbx.Params{
+			"id":          pls.ID,
+			"name":        pls.Name,
+			"folder_path": pls.FolderPath,
+			"song_count":  pls.SongCount,
+			"updated_at":  pls.UpdatedAt,
+		}
+		if _, err := r.db.Insert("discovery_playlists", params).Execute(); err != nil {
+			log.Error(r.ctx, "Error persisting discovery playlist", "name", pls.Name, err)
+			return err
+		}
+	}
+	return nil
+}

--- a/persistence/discovery_track_repository.go
+++ b/persistence/discovery_track_repository.go
@@ -1,0 +1,98 @@
+package persistence
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/pocketbase/dbx"
+)
+
+type discoveryTrackRepository struct {
+	ctx context.Context
+	db  dbx.Builder
+}
+
+type discoveryTrackRow struct {
+	ID          string    `db:"id"`
+	DiscoveryID string    `db:"discovery_id"`
+	MediaFileID *string   `db:"media_file_id"`
+	Path        string    `db:"path"`
+	Position    int       `db:"position"`
+	Missing     bool      `db:"missing"`
+	MediaFile   string    `db:"media_file"`
+	CreatedAt   time.Time `db:"created_at"`
+	UpdatedAt   time.Time `db:"updated_at"`
+}
+
+func NewDiscoveryTrackRepository(ctx context.Context, db dbx.Builder) model.DiscoveryTrackRepository {
+	return &discoveryTrackRepository{ctx: ctx, db: db}
+}
+
+func (r *discoveryTrackRepository) GetByDiscovery(discoveryID string) (model.DiscoveryTracks, error) {
+	var rows []discoveryTrackRow
+	err := r.db.Select("*").From("discovery_tracks").Where(dbx.HashExp{"discovery_id": discoveryID}).OrderBy("position asc").All(&rows)
+	if err != nil {
+		return nil, err
+	}
+	tracks := make(model.DiscoveryTracks, 0, len(rows))
+	for _, row := range rows {
+		var mediaFile model.MediaFile
+		if err := json.Unmarshal([]byte(row.MediaFile), &mediaFile); err != nil {
+			log.Warn(r.ctx, "Failed to unmarshal discovery track mediafile", "trackID", row.ID, err)
+			mediaFile = model.MediaFile{ID: row.ID, Path: row.Path, Missing: row.Missing}
+		}
+		track := model.DiscoveryTrack{
+			ID:          row.ID,
+			DiscoveryID: row.DiscoveryID,
+			MediaFileID: "",
+			Position:    row.Position,
+			MediaFile:   mediaFile,
+		}
+		if row.MediaFileID != nil {
+			track.MediaFileID = *row.MediaFileID
+		}
+		tracks = append(tracks, track)
+	}
+	return tracks, nil
+}
+
+func (r *discoveryTrackRepository) ReplaceForDiscovery(discoveryID string, tracks model.DiscoveryTracks) error {
+	if _, err := r.db.NewQuery("delete from discovery_tracks where discovery_id = {:discovery_id}").Bind(dbx.Params{"discovery_id": discoveryID}).Execute(); err != nil {
+		return err
+	}
+	if len(tracks) == 0 {
+		return nil
+	}
+	now := time.Now().UTC()
+	for _, track := range tracks {
+		mediaPayload, err := json.Marshal(track.MediaFile)
+		if err != nil {
+			log.Error(r.ctx, "Error marshaling discovery track mediafile", "trackID", track.ID, err)
+			return err
+		}
+		params := dbx.Params{
+			"id":           track.ID,
+			"discovery_id": discoveryID,
+			"media_file_id": func() interface{} {
+				if track.MediaFileID == "" {
+					return nil
+				}
+				return track.MediaFileID
+			}(),
+			"path":       track.MediaFile.Path,
+			"position":   track.Position,
+			"missing":    track.MediaFile.Missing,
+			"media_file": string(mediaPayload),
+			"created_at": now,
+			"updated_at": now,
+		}
+		if _, err := r.db.Insert("discovery_tracks", params).Execute(); err != nil {
+			log.Error(r.ctx, "Error inserting discovery track", "trackID", track.ID, err)
+			return err
+		}
+	}
+	return nil
+}

--- a/persistence/discovery_track_repository.go
+++ b/persistence/discovery_track_repository.go
@@ -32,6 +32,38 @@ func NewDiscoveryTrackRepository(ctx context.Context, db dbx.Builder) model.Disc
 	return &discoveryTrackRepository{ctx: ctx, db: db}
 }
 
+func (r *discoveryTrackRepository) rowToModel(row discoveryTrackRow) model.DiscoveryTrack {
+	var mediaFile model.MediaFile
+	if err := json.Unmarshal([]byte(row.MediaFile), &mediaFile); err != nil {
+		log.Warn(r.ctx, "Failed to unmarshal discovery track mediafile", "trackID", row.ID, err)
+		mediaFile = model.MediaFile{ID: row.ID, Path: row.Path, Missing: row.Missing}
+	}
+	track := model.DiscoveryTrack{
+		ID:          row.ID,
+		DiscoveryID: row.DiscoveryID,
+		MediaFileID: "",
+		Position:    row.Position,
+		MediaFile:   mediaFile,
+	}
+	if row.MediaFileID != nil {
+		track.MediaFileID = *row.MediaFileID
+	}
+	if row.SourcePath != nil {
+		track.SourcePath = *row.SourcePath
+	}
+	return track
+}
+
+func (r *discoveryTrackRepository) Get(id string) (*model.DiscoveryTrack, error) {
+	var row discoveryTrackRow
+	err := r.db.Select("*").From("discovery_tracks").Where(dbx.HashExp{"id": id}).One(&row)
+	if err != nil {
+		return nil, err
+	}
+	track := r.rowToModel(row)
+	return &track, nil
+}
+
 func (r *discoveryTrackRepository) GetByDiscovery(discoveryID string) (model.DiscoveryTracks, error) {
 	var rows []discoveryTrackRow
 	err := r.db.Select("*").From("discovery_tracks").Where(dbx.HashExp{"discovery_id": discoveryID}).OrderBy("position asc").All(&rows)
@@ -40,24 +72,7 @@ func (r *discoveryTrackRepository) GetByDiscovery(discoveryID string) (model.Dis
 	}
 	tracks := make(model.DiscoveryTracks, 0, len(rows))
 	for _, row := range rows {
-		var mediaFile model.MediaFile
-		if err := json.Unmarshal([]byte(row.MediaFile), &mediaFile); err != nil {
-			log.Warn(r.ctx, "Failed to unmarshal discovery track mediafile", "trackID", row.ID, err)
-			mediaFile = model.MediaFile{ID: row.ID, Path: row.Path, Missing: row.Missing}
-		}
-		track := model.DiscoveryTrack{
-			ID:          row.ID,
-			DiscoveryID: row.DiscoveryID,
-			MediaFileID: "",
-			Position:    row.Position,
-			MediaFile:   mediaFile,
-		}
-		if row.MediaFileID != nil {
-			track.MediaFileID = *row.MediaFileID
-		}
-		if row.SourcePath != nil {
-			track.SourcePath = *row.SourcePath
-		}
+		track := r.rowToModel(row)
 		tracks = append(tracks, track)
 	}
 	return tracks, nil
@@ -77,24 +92,7 @@ func (r *discoveryTrackRepository) GetByIDs(discoveryID string, ids []string) (m
 	}
 	tracks := make(model.DiscoveryTracks, 0, len(rows))
 	for _, row := range rows {
-		var mediaFile model.MediaFile
-		if err := json.Unmarshal([]byte(row.MediaFile), &mediaFile); err != nil {
-			log.Warn(r.ctx, "Failed to unmarshal discovery track mediafile", "trackID", row.ID, err)
-			mediaFile = model.MediaFile{ID: row.ID, Path: row.Path, Missing: row.Missing}
-		}
-		track := model.DiscoveryTrack{
-			ID:          row.ID,
-			DiscoveryID: row.DiscoveryID,
-			MediaFileID: "",
-			Position:    row.Position,
-			MediaFile:   mediaFile,
-		}
-		if row.MediaFileID != nil {
-			track.MediaFileID = *row.MediaFileID
-		}
-		if row.SourcePath != nil {
-			track.SourcePath = *row.SourcePath
-		}
+		track := r.rowToModel(row)
 		tracks = append(tracks, track)
 	}
 	return tracks, nil

--- a/persistence/discovery_track_repository.go
+++ b/persistence/discovery_track_repository.go
@@ -23,6 +23,7 @@ type discoveryTrackRow struct {
 	Position    int       `db:"position"`
 	Missing     bool      `db:"missing"`
 	MediaFile   string    `db:"media_file"`
+	SourcePath  *string   `db:"source_path"`
 	CreatedAt   time.Time `db:"created_at"`
 	UpdatedAt   time.Time `db:"updated_at"`
 }
@@ -53,6 +54,46 @@ func (r *discoveryTrackRepository) GetByDiscovery(discoveryID string) (model.Dis
 		}
 		if row.MediaFileID != nil {
 			track.MediaFileID = *row.MediaFileID
+		}
+		if row.SourcePath != nil {
+			track.SourcePath = *row.SourcePath
+		}
+		tracks = append(tracks, track)
+	}
+	return tracks, nil
+}
+
+func (r *discoveryTrackRepository) GetByIDs(discoveryID string, ids []string) (model.DiscoveryTracks, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var rows []discoveryTrackRow
+	err := r.db.Select("*").From("discovery_tracks").Where(dbx.And(
+		dbx.HashExp{"discovery_id": discoveryID},
+		dbx.NewExp("id in {:ids*}", dbx.Params{"ids": ids}),
+	)).OrderBy("position asc").All(&rows)
+	if err != nil {
+		return nil, err
+	}
+	tracks := make(model.DiscoveryTracks, 0, len(rows))
+	for _, row := range rows {
+		var mediaFile model.MediaFile
+		if err := json.Unmarshal([]byte(row.MediaFile), &mediaFile); err != nil {
+			log.Warn(r.ctx, "Failed to unmarshal discovery track mediafile", "trackID", row.ID, err)
+			mediaFile = model.MediaFile{ID: row.ID, Path: row.Path, Missing: row.Missing}
+		}
+		track := model.DiscoveryTrack{
+			ID:          row.ID,
+			DiscoveryID: row.DiscoveryID,
+			MediaFileID: "",
+			Position:    row.Position,
+			MediaFile:   mediaFile,
+		}
+		if row.MediaFileID != nil {
+			track.MediaFileID = *row.MediaFileID
+		}
+		if row.SourcePath != nil {
+			track.SourcePath = *row.SourcePath
 		}
 		tracks = append(tracks, track)
 	}
@@ -86,6 +127,12 @@ func (r *discoveryTrackRepository) ReplaceForDiscovery(discoveryID string, track
 			"position":   track.Position,
 			"missing":    track.MediaFile.Missing,
 			"media_file": string(mediaPayload),
+			"source_path": func() interface{} {
+				if track.SourcePath == "" {
+					return nil
+				}
+				return track.SourcePath
+			}(),
 			"created_at": now,
 			"updated_at": now,
 		}

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -58,7 +58,15 @@ func (s *SQLStore) Playlist(ctx context.Context) model.PlaylistRepository {
 }
 
 func (s *SQLStore) PlaylistFolder(ctx context.Context) model.PlaylistFolderRepository {
-    return NewPlaylistFolderRepository(ctx, s.getDBXBuilder())
+        return NewPlaylistFolderRepository(ctx, s.getDBXBuilder())
+}
+
+func (s *SQLStore) DiscoveryPlaylist(ctx context.Context) model.DiscoveryPlaylistRepository {
+        return NewDiscoveryPlaylistRepository(ctx, s.getDBXBuilder())
+}
+
+func (s *SQLStore) DiscoveryTrack(ctx context.Context) model.DiscoveryTrackRepository {
+        return NewDiscoveryTrackRepository(ctx, s.getDBXBuilder())
 }
 
 func (s *SQLStore) Property(ctx context.Context) model.PropertyRepository {

--- a/server/nativeapi/discovery.go
+++ b/server/nativeapi/discovery.go
@@ -9,7 +9,9 @@ import (
 	"github.com/deluan/rest"
 	"github.com/go-chi/chi/v5"
 	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/server"
+	"github.com/navidrome/navidrome/utils/req"
 )
 
 func (n *Router) addDiscoveryRoute(r chi.Router) {
@@ -21,6 +23,8 @@ func (n *Router) addDiscoveryRoute(r chi.Router) {
 			r.Get("/", n.getDiscovery())
 			r.Get("/tracks", n.getDiscoveryTracks())
 			r.Get("/export", n.exportDiscovery())
+			r.Delete("/tracks", n.deleteDiscoveryTracks())
+			r.Post("/publish", n.publishDiscovery())
 		})
 	})
 }
@@ -106,5 +110,43 @@ func (n *Router) exportDiscovery() http.HandlerFunc {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+	}
+}
+
+func (n *Router) deleteDiscoveryTracks() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		p := req.Params(r)
+		id, _ := p.String(":id")
+		ids, _ := p.Strings("id")
+		if len(ids) == 0 {
+			writeDeleteManyResponse(w, r, ids)
+			return
+		}
+		if err := n.discovery.DeleteTracks(r.Context(), id, ids); err != nil {
+			if errors.Is(err, rest.ErrNotFound) || errors.Is(err, sql.ErrNoRows) || errors.Is(err, model.ErrNotFound) {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			log.Error(r.Context(), "Error deleting discovery tracks", "id", id, "tracks", ids, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeDeleteManyResponse(w, r, ids)
+	}
+}
+
+func (n *Router) publishDiscovery() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		if err := n.discovery.Publish(r.Context(), id); err != nil {
+			if errors.Is(err, rest.ErrNotFound) || errors.Is(err, sql.ErrNoRows) || errors.Is(err, model.ErrNotFound) {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			log.Error(r.Context(), "Error publishing discovery playlist", "id", id, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
 	}
 }

--- a/server/nativeapi/discovery.go
+++ b/server/nativeapi/discovery.go
@@ -1,0 +1,110 @@
+package nativeapi
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/deluan/rest"
+	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/server"
+)
+
+func (n *Router) addDiscoveryRoute(r chi.Router) {
+	r.Route("/discovery", func(r chi.Router) {
+		r.Get("/", n.listDiscovery())
+		r.Post("/refresh", n.refreshDiscovery())
+		r.Route("/{id}", func(r chi.Router) {
+			r.Use(server.URLParamsMiddleware)
+			r.Get("/", n.getDiscovery())
+			r.Get("/tracks", n.getDiscoveryTracks())
+			r.Get("/export", n.exportDiscovery())
+		})
+	})
+}
+
+func (n *Router) listDiscovery() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		refresh := strings.EqualFold(r.URL.Query().Get("refresh"), "true")
+		playlists, err := n.discovery.List(r.Context(), refresh)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		rest.RespondWithJSON(w, http.StatusOK, playlists)
+	}
+}
+
+func (n *Router) refreshDiscovery() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		playlists, err := n.discovery.Refresh(r.Context())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		rest.RespondWithJSON(w, http.StatusOK, playlists)
+	}
+}
+
+func (n *Router) getDiscovery() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		entry, err := n.discovery.Get(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, rest.ErrNotFound) || errors.Is(err, sql.ErrNoRows) {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			log.Error(r.Context(), "Error retrieving discovery playlist", "id", id, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		rest.RespondWithJSON(w, http.StatusOK, entry)
+	}
+}
+
+func (n *Router) getDiscoveryTracks() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		tracks, err := n.discovery.Tracks(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, rest.ErrNotFound) || errors.Is(err, sql.ErrNoRows) {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			log.Error(r.Context(), "Error retrieving discovery playlist tracks", "id", id, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		rest.RespondWithJSON(w, http.StatusOK, tracks)
+	}
+}
+
+func (n *Router) exportDiscovery() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		entry, err := n.discovery.Get(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, rest.ErrNotFound) || errors.Is(err, sql.ErrNoRows) {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			log.Error(r.Context(), "Error retrieving discovery playlist for export", "id", id, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "audio/x-mpegurl")
+		filename := entry.Name
+		if filename == "" {
+			filename = "discovery-" + id
+		}
+		w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+".m3u\"")
+		if err := n.discovery.Export(r.Context(), id, w); err != nil {
+			log.Error(r.Context(), "Error exporting discovery playlist", "id", id, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+}

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -26,12 +26,13 @@ type Router struct {
 	ds        model.DataStore
 	share     core.Share
 	playlists core.Playlists
+	discovery core.Discovery
 	insights  metrics.Insights
 	libs      core.Library
 }
 
-func New(ds model.DataStore, share core.Share, playlists core.Playlists, insights metrics.Insights, libraryService core.Library) *Router {
-	r := &Router{ds: ds, share: share, playlists: playlists, insights: insights, libs: libraryService}
+func New(ds model.DataStore, share core.Share, playlists core.Playlists, discovery core.Discovery, insights metrics.Insights, libraryService core.Library) *Router {
+	r := &Router{ds: ds, share: share, playlists: playlists, discovery: discovery, insights: insights, libs: libraryService}
 	r.Handler = r.routes()
 	return r
 }
@@ -63,6 +64,7 @@ func (n *Router) routes() http.Handler {
 		n.addPlaylistRoute(r)
 		n.addPlaylistFolderRoute(r)
 		n.addPlaylistTrackRoute(r)
+		n.addDiscoveryRoute(r)
 		n.addSongPlaylistsRoute(r)
 		n.addQueueRoute(r)
 		n.addMissingFilesRoute(r)

--- a/tests/mock_data_store.go
+++ b/tests/mock_data_store.go
@@ -95,6 +95,19 @@ func (r *MockDiscoveryTrackRepo) ensure() {
 	}
 }
 
+func (r *MockDiscoveryTrackRepo) Get(id string) (*model.DiscoveryTrack, error) {
+	r.ensure()
+	for _, tracks := range r.Items {
+		for _, track := range tracks {
+			if track.ID == id {
+				cloned := track
+				return &cloned, nil
+			}
+		}
+	}
+	return nil, model.ErrNotFound
+}
+
 func (r *MockDiscoveryTrackRepo) GetByDiscovery(discoveryID string) (model.DiscoveryTracks, error) {
 	r.ensure()
 	tracks := r.Items[discoveryID]

--- a/tests/mock_data_store.go
+++ b/tests/mock_data_store.go
@@ -33,6 +33,106 @@ type MockDataStore struct {
 	repoMu                  sync.Mutex
 }
 
+type MockDiscoveryPlaylistRepo struct {
+	Items map[string]model.DiscoveryPlaylist
+}
+
+func (r *MockDiscoveryPlaylistRepo) ensure() {
+	if r.Items == nil {
+		r.Items = make(map[string]model.DiscoveryPlaylist)
+	}
+}
+
+func (r *MockDiscoveryPlaylistRepo) GetAll(_ ...model.QueryOptions) (model.DiscoveryPlaylists, error) {
+	r.ensure()
+	playlists := make(model.DiscoveryPlaylists, 0, len(r.Items))
+	for _, entry := range r.Items {
+		playlists = append(playlists, entry)
+	}
+	return playlists, nil
+}
+
+func (r *MockDiscoveryPlaylistRepo) Get(id string) (*model.DiscoveryPlaylist, error) {
+	r.ensure()
+	entry, ok := r.Items[id]
+	if !ok {
+		return nil, model.ErrNotFound
+	}
+	copy := entry
+	return &copy, nil
+}
+
+func (r *MockDiscoveryPlaylistRepo) ReplaceAll(playlists model.DiscoveryPlaylists) error {
+	r.ensure()
+	r.Items = make(map[string]model.DiscoveryPlaylist, len(playlists))
+	for _, entry := range playlists {
+		r.Items[entry.ID] = entry
+	}
+	return nil
+}
+
+func (r *MockDiscoveryPlaylistRepo) Put(entry *model.DiscoveryPlaylist) error {
+	r.ensure()
+	if entry != nil {
+		r.Items[entry.ID] = *entry
+	}
+	return nil
+}
+
+func (r *MockDiscoveryPlaylistRepo) Delete(id string) error {
+	r.ensure()
+	delete(r.Items, id)
+	return nil
+}
+
+type MockDiscoveryTrackRepo struct {
+	Items map[string]model.DiscoveryTracks
+}
+
+func (r *MockDiscoveryTrackRepo) ensure() {
+	if r.Items == nil {
+		r.Items = make(map[string]model.DiscoveryTracks)
+	}
+}
+
+func (r *MockDiscoveryTrackRepo) GetByDiscovery(discoveryID string) (model.DiscoveryTracks, error) {
+	r.ensure()
+	tracks := r.Items[discoveryID]
+	if tracks == nil {
+		return model.DiscoveryTracks{}, nil
+	}
+	cloned := make(model.DiscoveryTracks, len(tracks))
+	copy(cloned, tracks)
+	return cloned, nil
+}
+
+func (r *MockDiscoveryTrackRepo) ReplaceForDiscovery(discoveryID string, tracks model.DiscoveryTracks) error {
+	r.ensure()
+	cloned := make(model.DiscoveryTracks, len(tracks))
+	copy(cloned, tracks)
+	r.Items[discoveryID] = cloned
+	return nil
+}
+
+func (r *MockDiscoveryTrackRepo) GetByIDs(discoveryID string, ids []string) (model.DiscoveryTracks, error) {
+	r.ensure()
+	existing := r.Items[discoveryID]
+	if existing == nil {
+		return model.DiscoveryTracks{}, nil
+	}
+	wanted := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		wanted[id] = struct{}{}
+	}
+	result := make(model.DiscoveryTracks, 0, len(ids))
+	for _, track := range existing {
+		if _, ok := wanted[track.ID]; ok {
+			result = append(result, track)
+		}
+	}
+	return result, nil
+}
+
 func (db *MockDataStore) Library(ctx context.Context) model.LibraryRepository {
 	if db.MockedLibrary == nil {
 		if db.RealDS != nil {
@@ -128,9 +228,7 @@ func (db *MockDataStore) DiscoveryPlaylist(ctx context.Context) model.DiscoveryP
 		if db.RealDS != nil {
 			db.MockedDiscoveryPlaylist = db.RealDS.DiscoveryPlaylist(ctx)
 		} else {
-			db.MockedDiscoveryPlaylist = struct {
-				model.DiscoveryPlaylistRepository
-			}{}
+			db.MockedDiscoveryPlaylist = &MockDiscoveryPlaylistRepo{}
 		}
 	}
 	return db.MockedDiscoveryPlaylist
@@ -141,9 +239,7 @@ func (db *MockDataStore) DiscoveryTrack(ctx context.Context) model.DiscoveryTrac
 		if db.RealDS != nil {
 			db.MockedDiscoveryTrack = db.RealDS.DiscoveryTrack(ctx)
 		} else {
-			db.MockedDiscoveryTrack = struct {
-				model.DiscoveryTrackRepository
-			}{}
+			db.MockedDiscoveryTrack = &MockDiscoveryTrackRepo{}
 		}
 	}
 	return db.MockedDiscoveryTrack

--- a/tests/mock_data_store.go
+++ b/tests/mock_data_store.go
@@ -8,27 +8,29 @@ import (
 )
 
 type MockDataStore struct {
-	RealDS               		model.DataStore
-	MockedLibrary        		model.LibraryRepository
-	MockedFolder         		model.FolderRepository
-	MockedGenre          		model.GenreRepository
-	MockedAlbum          		model.AlbumRepository
-	MockedArtist         		model.ArtistRepository
-	MockedMediaFile      		model.MediaFileRepository
-	MockedTag            		model.TagRepository
-	MockedUser           		model.UserRepository
-	MockedProperty       		model.PropertyRepository
-	MockedPlayer         		model.PlayerRepository
-	MockedPlaylist       		model.PlaylistRepository
-	MockedPlaylistFolder 		model.PlaylistFolderRepository
-	MockedPlayQueue      		model.PlayQueueRepository
-	MockedShare          		model.ShareRepository
-	MockedTranscoding    		model.TranscodingRepository
-	MockedUserProps      		model.UserPropsRepository
-	MockedScrobbleBuffer 		model.ScrobbleBufferRepository
-	MockedRadio          		model.RadioRepository
-	scrobbleBufferMu     		sync.Mutex
-	repoMu               		sync.Mutex
+	RealDS                  model.DataStore
+	MockedLibrary           model.LibraryRepository
+	MockedFolder            model.FolderRepository
+	MockedGenre             model.GenreRepository
+	MockedAlbum             model.AlbumRepository
+	MockedArtist            model.ArtistRepository
+	MockedMediaFile         model.MediaFileRepository
+	MockedTag               model.TagRepository
+	MockedUser              model.UserRepository
+	MockedProperty          model.PropertyRepository
+	MockedPlayer            model.PlayerRepository
+	MockedPlaylist          model.PlaylistRepository
+	MockedDiscoveryPlaylist model.DiscoveryPlaylistRepository
+	MockedDiscoveryTrack    model.DiscoveryTrackRepository
+	MockedPlaylistFolder    model.PlaylistFolderRepository
+	MockedPlayQueue         model.PlayQueueRepository
+	MockedShare             model.ShareRepository
+	MockedTranscoding       model.TranscodingRepository
+	MockedUserProps         model.UserPropsRepository
+	MockedScrobbleBuffer    model.ScrobbleBufferRepository
+	MockedRadio             model.RadioRepository
+	scrobbleBufferMu        sync.Mutex
+	repoMu                  sync.Mutex
 }
 
 func (db *MockDataStore) Library(ctx context.Context) model.LibraryRepository {
@@ -119,6 +121,32 @@ func (db *MockDataStore) Playlist(ctx context.Context) model.PlaylistRepository 
 		}
 	}
 	return db.MockedPlaylist
+}
+
+func (db *MockDataStore) DiscoveryPlaylist(ctx context.Context) model.DiscoveryPlaylistRepository {
+	if db.MockedDiscoveryPlaylist == nil {
+		if db.RealDS != nil {
+			db.MockedDiscoveryPlaylist = db.RealDS.DiscoveryPlaylist(ctx)
+		} else {
+			db.MockedDiscoveryPlaylist = struct {
+				model.DiscoveryPlaylistRepository
+			}{}
+		}
+	}
+	return db.MockedDiscoveryPlaylist
+}
+
+func (db *MockDataStore) DiscoveryTrack(ctx context.Context) model.DiscoveryTrackRepository {
+	if db.MockedDiscoveryTrack == nil {
+		if db.RealDS != nil {
+			db.MockedDiscoveryTrack = db.RealDS.DiscoveryTrack(ctx)
+		} else {
+			db.MockedDiscoveryTrack = struct {
+				model.DiscoveryTrackRepository
+			}{}
+		}
+	}
+	return db.MockedDiscoveryTrack
 }
 
 func (db *MockDataStore) PlaylistFolder(ctx context.Context) model.PlaylistFolderRepository {

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -13,6 +13,7 @@ import song from './song'
 import album from './album'
 import artist from './artist'
 import playlist from './playlist'
+import discovery from './discovery'
 import playlist_folder from './playlist_folder'
 import radio from './radio'
 import share from './share'
@@ -116,6 +117,11 @@ const Admin = (props) => {
           edit={PlaylistEdit}
         />,
         <Resource
+          name="discovery"
+          {...discovery}
+          options={{ subMenu: 'playlist' }}
+        />,
+        <Resource
           {...playlist_folder}
           name="folder"
           options={{ subMenu: 'playlist' }}
@@ -154,6 +160,7 @@ const Admin = (props) => {
         <Resource name="genre" />,
         <Resource name="tag" />,
         <Resource name="playlistTrack" />,
+        <Resource name="discoveryTrack" />,
         <Resource name="keepalive" />,
         <Resource name="insights" />,
         <Resource name="config" />,

--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -84,14 +84,176 @@ const handleUserLibraryAssociation = async (userId, libraryIds) => {
   }
 
   try {
-  await httpClient(`${REST_URL}/user/${userId}/library`, {
-    method: 'PUT',
-    body: JSON.stringify({ libraryIds }),
-  })
+    await httpClient(`${REST_URL}/user/${userId}/library`, {
+      method: 'PUT',
+      body: JSON.stringify({ libraryIds }),
+    })
   } catch (error) {
     console.error('Error setting user libraries:', error) //eslint-disable-line no-console
     throw error
   }
+}
+
+const sortDiscoveryRecords = (records, sort) => {
+  if (!sort?.field) return [...records]
+  const { field, order } = sort
+  const direction = order === 'DESC' ? -1 : 1
+  return [...records].sort((a, b) => {
+    const aValue = a?.[field]
+    const bValue = b?.[field]
+    if (aValue === undefined || aValue === null) {
+      return bValue === undefined || bValue === null ? 0 : -1 * direction
+    }
+    if (bValue === undefined || bValue === null) {
+      return 1 * direction
+    }
+    if (typeof aValue === 'number' && typeof bValue === 'number') {
+      return (aValue - bValue) * direction
+    }
+    if (typeof aValue === 'string' && typeof bValue === 'string') {
+      return aValue.localeCompare(bValue) * direction
+    }
+    const aText = `${aValue}`
+    const bText = `${bValue}`
+    const aNumber = Number(aText)
+    const bNumber = Number(bText)
+    if (!Number.isNaN(aNumber) && !Number.isNaN(bNumber)) {
+      return (aNumber - bNumber) * direction
+    }
+    return aText.localeCompare(bText) * direction
+  })
+}
+
+const applyDiscoveryFilter = (records, filter) => {
+  if (!filter?.q) return [...records]
+  const query = String(filter.q).trim().toLowerCase()
+  if (!query) return [...records]
+  return records.filter((record) =>
+    (record?.name || '').toLowerCase().includes(query)
+  )
+}
+
+const applyDiscoveryTrackFilter = (records, filter = {}) => {
+  const query = String(filter.q || '').trim().toLowerCase()
+  if (!query) {
+    return [...records]
+  }
+  return records.filter((track) => {
+    const candidates = [
+      track?.title,
+      track?.album,
+      track?.artist,
+      track?.albumArtist,
+      track?.path,
+    ]
+    return candidates.some((value) =>
+      String(value || '')
+        .toLowerCase()
+        .includes(query),
+    )
+  })
+}
+
+const getDiscoveryList = async (params = {}) => {
+  const { pagination = {}, sort, filter } = params
+  const { json } = await httpClient(`${REST_URL}/discovery`)
+  const records = Array.isArray(json) ? json : []
+  const filtered = applyDiscoveryFilter(records, filter)
+  const sorted = sortDiscoveryRecords(filtered, sort)
+  const perPageRaw = pagination.perPage
+  const perPage =
+    perPageRaw === 0
+      ? sorted.length || 1
+      : Math.max(1, perPageRaw || (sorted.length || 1))
+  const page = Math.max(1, pagination.page || 1)
+  const start = (page - 1) * perPage
+  const end = perPageRaw === 0 ? sorted.length : start + perPage
+  const paginated = sorted.slice(start, end)
+  return { data: paginated, total: sorted.length }
+}
+
+const getDiscoveryOne = async (id) => {
+  const { json } = await httpClient(`${REST_URL}/discovery/${id}`)
+  return { data: json }
+}
+
+const findDiscoveryTrack = async (trackId, discoveryId) => {
+  if (!trackId) {
+    return null
+  }
+
+  const searchWithin = async (id) => {
+    if (!id) {
+      return null
+    }
+    const res = await getDiscoveryTracks({
+      filter: { discovery_id: id },
+      pagination: { page: 1, perPage: 0 },
+    })
+    return res.data.find((item) => item.id === trackId) || null
+  }
+
+  const direct = await searchWithin(discoveryId)
+  if (direct) {
+    return direct
+  }
+
+  const all = await getDiscoveryList({
+    pagination: { page: 1, perPage: 0 },
+  })
+
+  for (const playlist of all.data) {
+    const found = await searchWithin(playlist.id)
+    if (found) {
+      return found
+    }
+  }
+
+  return null
+}
+
+const sortDiscoveryTracks = (records, sort) => {
+  if (!sort?.field) {
+    return [...records]
+  }
+  const { field, order } = sort
+  const direction = order === 'DESC' ? -1 : 1
+  return [...records].sort((a, b) => {
+    const aValue = a?.[field]
+    const bValue = b?.[field]
+    if (typeof aValue === 'number' && typeof bValue === 'number') {
+      return (aValue - bValue) * direction
+    }
+    const aText = String(aValue ?? '').toLowerCase()
+    const bText = String(bValue ?? '').toLowerCase()
+    return aText.localeCompare(bText) * direction
+  })
+}
+
+const getDiscoveryTracks = async (params = {}) => {
+  const { pagination = {}, sort, filter = {} } = params
+  const discoveryId =
+    filter.discovery_id || filter.discoveryId || filter.id || ''
+  if (!discoveryId) {
+    return { data: [], total: 0 }
+  }
+  const { json } = await httpClient(
+    `${REST_URL}/discovery/${discoveryId}/tracks`,
+  )
+  const records = Array.isArray(json) ? json : []
+  const filtered = applyDiscoveryTrackFilter(records, filter)
+  const sorted = sortDiscoveryTracks(filtered, sort)
+  const total = sorted.length
+  const perPageRaw = pagination.perPage
+  const perPage =
+    perPageRaw === 0
+      ? total || 1
+      : Math.max(1, perPageRaw || (sorted.length || 1))
+  const page = Math.max(1, pagination.page || 1)
+  const start = (page - 1) * perPage
+  const end = perPageRaw === 0 ? sorted.length : start + perPage
+  const paginated = sorted.slice(start, end)
+  return { data: paginated, total }
 }
 
 // Enhanced user creation that handles library associations
@@ -142,10 +304,24 @@ const emitFoldersChanged = (detail) => {
 const wrapperDataProvider = {
   ...dataProvider,
   getList: (resource, params) => {
+    if (resource === 'discovery') {
+      return getDiscoveryList(params)
+    }
+    if (resource === 'discoveryTrack') {
+      return getDiscoveryTracks(params)
+    }
     const [r, p] = mapResource(resource, params)
     return dataProvider.getList(r, p)
   },
   getOne: (resource, params) => {
+    if (resource === 'discovery') {
+      return getDiscoveryOne(params.id)
+    }
+    if (resource === 'discoveryTrack') {
+      return findDiscoveryTrack(params.id, params?.filter?.discovery_id).then(
+        (track) => ({ data: track }),
+      )
+    }
     const [r, p] = mapResource(resource, params)
     const response = dataProvider.getOne(r, p)
 
@@ -162,10 +338,31 @@ const wrapperDataProvider = {
     return response
   },
   getMany: (resource, params) => {
+    if (resource === 'discovery') {
+      const ids = params.ids || []
+      return Promise.all(ids.map((id) => getDiscoveryOne(id))).then((results) => ({
+        data: results.map((item) => item.data),
+      }))
+    }
+    if (resource === 'discoveryTrack') {
+      const filter = params?.filter || {}
+      return getDiscoveryTracks({
+        filter,
+        pagination: { page: 1, perPage: 0 },
+      }).then((res) => ({
+        data: res.data.filter((track) => params.ids.includes(track.id)),
+      }))
+    }
     const [r, p] = mapResource(resource, params)
     return dataProvider.getMany(r, p)
   },
   getManyReference: (resource, params) => {
+    if (resource === 'discovery') {
+      return getDiscoveryList(params)
+    }
+    if (resource === 'discoveryTrack') {
+      return getDiscoveryTracks(params)
+    }
     const [r, p] = mapResource(resource, params)
     return dataProvider.getManyReference(r, p)
   },
@@ -282,6 +479,11 @@ const wrapperDataProvider = {
       }
       return { data: json }
     })
+  },
+  refreshDiscovery: () => {
+    return httpClient(`${REST_URL}/discovery/refresh`, {
+      method: 'POST',
+    }).then(({ json }) => ({ data: json }))
   },
 }
 

--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -485,6 +485,11 @@ const wrapperDataProvider = {
       method: 'POST',
     }).then(({ json }) => ({ data: json }))
   },
+  publishDiscovery: (id) => {
+    return httpClient(`${REST_URL}/discovery/${id}/publish`, {
+      method: 'POST',
+    }).then(() => ({ data: { id } }))
+  },
 }
 
 export default wrapperDataProvider

--- a/ui/src/discovery/DiscoveryActions.jsx
+++ b/ui/src/discovery/DiscoveryActions.jsx
@@ -1,0 +1,172 @@
+import React from 'react'
+import { useDispatch } from 'react-redux'
+import {
+  Button,
+  sanitizeListRestProps,
+  TopToolbar,
+  useTranslate,
+  useDataProvider,
+  useNotify,
+} from 'react-admin'
+import { useMediaQuery, makeStyles } from '@material-ui/core'
+import PlayArrowIcon from '@material-ui/icons/PlayArrow'
+import ShuffleIcon from '@material-ui/icons/Shuffle'
+import CloudDownloadOutlinedIcon from '@material-ui/icons/CloudDownloadOutlined'
+import { RiPlayListAddFill, RiPlayList2Fill } from 'react-icons/ri'
+import QueueMusicIcon from '@material-ui/icons/QueueMusic'
+import ShareIcon from '@material-ui/icons/Share'
+import {
+  playNext,
+  addTracks,
+  playTracks,
+  shuffleTracks,
+  openDownloadMenu,
+  DOWNLOAD_MENU_PLAY,
+  openShareMenu,
+} from '../actions'
+import httpClient from '../dataProvider/httpClient'
+import { M3U_MIME_TYPE, REST_URL } from '../consts'
+import { formatBytes } from '../utils'
+import config from '../config'
+import { ToggleFieldsMenu } from '../common'
+
+const useStyles = makeStyles({
+  toolbar: { display: 'flex', justifyContent: 'space-between', width: '100%' },
+})
+
+const DiscoveryActions = ({ className, ids, data, record, ...rest }) => {
+  const dispatch = useDispatch()
+  const translate = useTranslate()
+  const classes = useStyles()
+  const dataProvider = useDataProvider()
+  const notify = useNotify()
+  const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
+  const isNotSmall = useMediaQuery((theme) => theme.breakpoints.up('sm'))
+
+  const getAllSongsAndDispatch = React.useCallback(
+    (action) => {
+      if (ids?.length === record.songCount) {
+        return dispatch(action(data, ids))
+      }
+
+      dataProvider
+        .getList('discoveryTrack', {
+          pagination: { page: 1, perPage: 0 },
+          sort: { field: 'position', order: 'ASC' },
+          filter: { discovery_id: record.id },
+        })
+        .then((res) => {
+          const mapped = res.data.reduce(
+            (acc, curr) => ({ ...acc, [curr.id]: curr }),
+            {},
+          )
+          dispatch(action(mapped))
+        })
+        .catch(() => {
+          notify('ra.page.error', 'warning')
+        })
+    },
+    [dataProvider, dispatch, record, data, ids, notify],
+  )
+
+  const handlePlay = React.useCallback(() => {
+    getAllSongsAndDispatch(playTracks)
+  }, [getAllSongsAndDispatch])
+
+  const handlePlayNext = React.useCallback(() => {
+    getAllSongsAndDispatch(playNext)
+  }, [getAllSongsAndDispatch])
+
+  const handlePlayLater = React.useCallback(() => {
+    getAllSongsAndDispatch(addTracks)
+  }, [getAllSongsAndDispatch])
+
+  const handleShuffle = React.useCallback(() => {
+    getAllSongsAndDispatch(shuffleTracks)
+  }, [getAllSongsAndDispatch])
+
+  const handleShare = React.useCallback(() => {
+    dispatch(openShareMenu([record.id], 'discovery', record.name))
+  }, [dispatch, record])
+
+  const handleDownload = React.useCallback(() => {
+    dispatch(openDownloadMenu(record, DOWNLOAD_MENU_PLAY))
+  }, [dispatch, record])
+
+  const handleExport = React.useCallback(() => {
+    return httpClient(`${REST_URL}/discovery/${record.id}/export`, {
+      headers: new Headers({ Accept: M3U_MIME_TYPE }),
+    })
+      .then((res) => {
+        const blob = new Blob([res.body], { type: M3U_MIME_TYPE })
+        const url = window.URL.createObjectURL(blob)
+        const link = document.createElement('a')
+        link.href = url
+        link.download = `${record.name}.m3u`
+        document.body.appendChild(link)
+        link.click()
+        link.parentNode.removeChild(link)
+      })
+      .catch(() => {
+        notify('ra.page.error', 'warning')
+      })
+  }, [record, notify])
+
+  return (
+    <TopToolbar className={className} {...sanitizeListRestProps(rest)}>
+      <div className={classes.toolbar}>
+        <div>
+          <Button
+            onClick={handlePlay}
+            label={translate('resources.album.actions.playAll')}
+          >
+            <PlayArrowIcon />
+          </Button>
+          <Button
+            onClick={handleShuffle}
+            label={translate('resources.album.actions.shuffle')}
+          >
+            <ShuffleIcon />
+          </Button>
+          <Button
+            onClick={handlePlayNext}
+            label={translate('resources.album.actions.playNext')}
+          >
+            <RiPlayList2Fill />
+          </Button>
+          <Button
+            onClick={handlePlayLater}
+            label={translate('resources.album.actions.addToQueue')}
+          >
+            <RiPlayListAddFill />
+          </Button>
+          {config.enableSharing && (
+            <Button onClick={handleShare} label={translate('ra.action.share')}>
+              <ShareIcon />
+            </Button>
+          )}
+          {config.enableDownloads && (
+            <Button
+              onClick={handleDownload}
+              label={
+                translate('ra.action.download') +
+                (isDesktop ? ` (${formatBytes(record.size)})` : '')
+              }
+            >
+              <CloudDownloadOutlinedIcon />
+            </Button>
+          )}
+          <Button
+            onClick={handleExport}
+            label={translate('resources.playlist.actions.export')}
+          >
+            <QueueMusicIcon />
+          </Button>
+        </div>
+        <div>{isNotSmall && <ToggleFieldsMenu resource="discoveryTrack" />}</div>
+      </div>
+    </TopToolbar>
+  )
+}
+
+export default DiscoveryActions

--- a/ui/src/discovery/DiscoveryActions.jsx
+++ b/ui/src/discovery/DiscoveryActions.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useDispatch } from 'react-redux'
 import {
   Button,
@@ -7,6 +7,8 @@ import {
   useTranslate,
   useDataProvider,
   useNotify,
+  useRedirect,
+  useRefresh,
 } from 'react-admin'
 import { useMediaQuery, makeStyles } from '@material-ui/core'
 import PlayArrowIcon from '@material-ui/icons/PlayArrow'
@@ -15,6 +17,7 @@ import CloudDownloadOutlinedIcon from '@material-ui/icons/CloudDownloadOutlined'
 import { RiPlayListAddFill, RiPlayList2Fill } from 'react-icons/ri'
 import QueueMusicIcon from '@material-ui/icons/QueueMusic'
 import ShareIcon from '@material-ui/icons/Share'
+import PublishIcon from '@material-ui/icons/Publish'
 import {
   playNext,
   addTracks,
@@ -40,8 +43,11 @@ const DiscoveryActions = ({ className, ids, data, record, ...rest }) => {
   const classes = useStyles()
   const dataProvider = useDataProvider()
   const notify = useNotify()
+  const redirect = useRedirect()
+  const refresh = useRefresh()
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   const isNotSmall = useMediaQuery((theme) => theme.breakpoints.up('sm'))
+  const [publishing, setPublishing] = useState(false)
 
   const getAllSongsAndDispatch = React.useCallback(
     (action) => {
@@ -112,6 +118,28 @@ const DiscoveryActions = ({ className, ids, data, record, ...rest }) => {
       })
   }, [record, notify])
 
+  const handlePublish = React.useCallback(async () => {
+    if (publishing) {
+      return
+    }
+    setPublishing(true)
+    try {
+      await dataProvider.publishDiscovery(record.id)
+      notify('resources.discovery.messages.published', 'info', {
+        _: translate('resources.discovery.messages.published', {
+          name: record.name,
+        }),
+        name: record.name,
+      })
+      redirect('/discovery')
+      refresh()
+    } catch (error) {
+      notify('ra.page.error', 'warning')
+    } finally {
+      setPublishing(false)
+    }
+  }, [publishing, dataProvider, record, notify, translate, redirect, refresh])
+
   return (
     <TopToolbar className={className} {...sanitizeListRestProps(rest)}>
       <div className={classes.toolbar}>
@@ -161,6 +189,13 @@ const DiscoveryActions = ({ className, ids, data, record, ...rest }) => {
             label={translate('resources.playlist.actions.export')}
           >
             <QueueMusicIcon />
+          </Button>
+          <Button
+            onClick={handlePublish}
+            label={translate('resources.discovery.actions.publish')}
+            disabled={publishing}
+          >
+            <PublishIcon />
           </Button>
         </div>
         <div>{isNotSmall && <ToggleFieldsMenu resource="discoveryTrack" />}</div>

--- a/ui/src/discovery/DiscoveryDetails.jsx
+++ b/ui/src/discovery/DiscoveryDetails.jsx
@@ -1,0 +1,16 @@
+import React, { useMemo } from 'react'
+import PlaylistDetails from '../playlist/PlaylistDetails'
+
+const DiscoveryDetails = (props) => {
+  const { record, ...rest } = props
+  const playlistRecord = useMemo(() => {
+    if (!record) {
+      return record
+    }
+    return { ...record, sync: false }
+  }, [record])
+
+  return <PlaylistDetails {...rest} record={playlistRecord} />
+}
+
+export default DiscoveryDetails

--- a/ui/src/discovery/DiscoveryList.jsx
+++ b/ui/src/discovery/DiscoveryList.jsx
@@ -1,0 +1,117 @@
+import React, { cloneElement, useCallback, useMemo, useState } from 'react'
+import {
+  Button,
+  Datagrid,
+  DateField,
+  Filter,
+  NumberField,
+  SearchInput,
+  TextField,
+  TopToolbar,
+  List,
+  sanitizeListRestProps,
+  useDataProvider,
+  useNotify,
+  useRefresh,
+  useTranslate,
+} from 'react-admin'
+import { makeStyles, CircularProgress } from '@material-ui/core'
+import RefreshIcon from '@material-ui/icons/Refresh'
+
+const useActionStyles = makeStyles(
+  (theme) => ({
+    toolbar: {
+      gap: theme.spacing(1),
+    },
+    spinner: {
+      marginRight: theme.spacing(1),
+    },
+  }),
+  { name: 'NDDiscoveryListActions' }
+)
+
+const DiscoveryFilter = (props) => (
+  <Filter {...props} variant="outlined">
+    <SearchInput source="q" alwaysOn />
+  </Filter>
+)
+
+const DiscoveryListActions = ({ className, ...rest }) => {
+  const classes = useActionStyles()
+  const dataProvider = useDataProvider()
+  const notify = useNotify()
+  const refresh = useRefresh()
+  const translate = useTranslate()
+  const [loading, setLoading] = useState(false)
+
+  const handleRefresh = useCallback(async () => {
+    if (loading) return
+    setLoading(true)
+    try {
+      await dataProvider.refreshDiscovery()
+      refresh()
+      notify('resources.discovery.messages.refreshed', 'info', {
+        _: translate('resources.discovery.messages.refreshed'),
+      })
+    } catch (error) {
+      notify('ra.page.error', 'warning')
+    } finally {
+      setLoading(false)
+    }
+  }, [dataProvider, loading, notify, refresh, translate])
+
+  return (
+    <TopToolbar
+      className={`${className || ''} ${classes.toolbar}`.trim()}
+      {...sanitizeListRestProps(rest)}
+    >
+      {rest.filters && cloneElement(rest.filters, { context: 'button' })}
+      <Button
+        label={translate('resources.discovery.actions.refresh')}
+        onClick={handleRefresh}
+        disabled={loading}
+      >
+        {loading ? <CircularProgress size={18} className={classes.spinner} /> : <RefreshIcon />}
+      </Button>
+    </TopToolbar>
+  )
+}
+
+const rowClick = (id) => `/discovery/${id}`
+
+const DiscoveryList = (props) => {
+  const translate = useTranslate()
+  const defaultSort = useMemo(() => ({ field: 'name', order: 'ASC' }), [])
+  const title = useMemo(
+    () => translate('resources.discovery.name', { smart_count: 2 }),
+    [translate]
+  )
+
+  return (
+    <List
+      {...props}
+      exporter={false}
+      filters={<DiscoveryFilter />}
+      actions={<DiscoveryListActions />}
+      bulkActionButtons={false}
+      perPage={50}
+      sort={defaultSort}
+      title={title}
+    >
+      <Datagrid rowClick={rowClick} optimized>
+        <TextField source="name" />
+        <NumberField
+          source="songCount"
+          label="resources.discovery.fields.songCount"
+        />
+        <DateField
+          source="updatedAt"
+          showTime
+          label="resources.discovery.fields.updatedAt"
+        />
+      </Datagrid>
+    </List>
+  )
+}
+
+export default DiscoveryList

--- a/ui/src/discovery/DiscoveryShow.jsx
+++ b/ui/src/discovery/DiscoveryShow.jsx
@@ -1,0 +1,104 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import {
+  Filter,
+  Pagination,
+  ReferenceManyField,
+  SearchInput,
+  ShowContextProvider,
+  Title as RaTitle,
+  useShowContext,
+  useShowController,
+} from 'react-admin'
+import { makeStyles } from '@material-ui/core/styles'
+import DiscoveryDetails from './DiscoveryDetails'
+import DiscoverySongs from './DiscoverySongs'
+import DiscoveryActions from './DiscoveryActions'
+import { Title, useResourceRefresh } from '../common'
+
+const useStyles = makeStyles(
+  () => ({
+    discoveryActions: {
+      width: '100%',
+    },
+  }),
+  { name: 'NDDiscoveryShow' },
+)
+
+const DiscoveryFilter = ({ value, onChange }) => (
+  <Filter variant="outlined">
+    <SearchInput
+      id="search"
+      source="q"
+      alwaysOn
+      value={value}
+      onChange={onChange}
+    />
+  </Filter>
+)
+
+const DiscoveryShowLayout = (props) => {
+  const context = useShowContext(props)
+  const { record } = context
+  const classes = useStyles()
+  useResourceRefresh('song')
+  const [searchTerm, setSearchTerm] = useState('')
+
+  const handleSearchChange = useCallback((event) => {
+    setSearchTerm(event.target.value)
+  }, [])
+
+  const filters = useMemo(
+    () => (
+      <DiscoveryFilter value={searchTerm} onChange={handleSearchChange} />
+    ),
+    [handleSearchChange, searchTerm],
+  )
+
+  if (!record) {
+    return null
+  }
+
+  return (
+    <>
+      {record && <RaTitle title={<Title subTitle={record.name} />} />}
+      <DiscoveryDetails {...context} />
+      {filters}
+      <ReferenceManyField
+        {...context}
+        addLabel={false}
+        reference="discoveryTrack"
+        target="discovery_id"
+        sort={{ field: 'position', order: 'ASC' }}
+        perPage={50}
+        filter={{ discovery_id: record.id, q: searchTerm }}
+      >
+        <DiscoverySongs
+          actions={
+            <DiscoveryActions
+              className={classes.discoveryActions}
+              record={record}
+            />
+          }
+          discoveryId={record.id}
+          pagination={
+            <Pagination
+              rowsPerPageOptions={[25, 50, 100, 200]}
+              perPage={50}
+            />
+          }
+        />
+      </ReferenceManyField>
+    </>
+  )
+}
+
+const DiscoveryShow = (props) => {
+  const controllerProps = useShowController(props)
+  return (
+    <ShowContextProvider value={controllerProps}>
+      <DiscoveryShowLayout {...props} {...controllerProps} />
+    </ShowContextProvider>
+  )
+}
+
+export default DiscoveryShow

--- a/ui/src/discovery/DiscoverySongBulkActions.jsx
+++ b/ui/src/discovery/DiscoverySongBulkActions.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { BulkDeleteButton, ResourceContextProvider } from 'react-admin'
+import { MdOutlinePlaylistRemove } from 'react-icons/md'
+
+const DiscoverySongBulkActions = ({ discoveryId, onUnselectItems, ...rest }) => {
+  const resource = `discovery/${discoveryId}/tracks`
+  return (
+    <ResourceContextProvider value={resource}>
+      <BulkDeleteButton
+        {...rest}
+        resource={resource}
+        label={'ra.action.remove'}
+        icon={<MdOutlinePlaylistRemove />}
+        onClick={onUnselectItems}
+      />
+    </ResourceContextProvider>
+  )
+}
+
+DiscoverySongBulkActions.propTypes = {
+  discoveryId: PropTypes.string.isRequired,
+  onUnselectItems: PropTypes.func,
+}
+
+export default DiscoverySongBulkActions

--- a/ui/src/discovery/DiscoverySongs.jsx
+++ b/ui/src/discovery/DiscoverySongs.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo } from 'react'
 import {
+  BulkActionsToolbar,
   ListToolbar,
   NumberField,
   TextField,
@@ -28,6 +29,7 @@ import { AlbumLinkField } from '../song/AlbumLinkField'
 import { playTracks } from '../actions'
 import ExpandInfoDialog from '../dialogs/ExpandInfoDialog'
 import config from '../config'
+import DiscoverySongBulkActions from './DiscoverySongBulkActions'
 
 const useStyles = makeStyles(
   (theme) => ({
@@ -42,6 +44,10 @@ const useStyles = makeStyles(
       [theme.breakpoints.down('xs')]: {
         boxShadow: 'none',
       },
+    },
+    bulkActionsDisplayed: {
+      marginTop: -theme.spacing(8),
+      transition: theme.transitions.create('margin-top'),
     },
     actions: {
       zIndex: 2,
@@ -74,7 +80,7 @@ const useStyles = makeStyles(
 
 const DiscoverySongs = ({ actions, pagination, filters, discoveryId }) => {
   const listContext = useListContext()
-  const { data, ids, selectedIds, setPage } = listContext
+  const { data, ids, selectedIds, setPage, onUnselectItems } = listContext
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   const classes = useStyles({ isDesktop })
   const dispatch = useDispatch()
@@ -170,8 +176,9 @@ const DiscoverySongs = ({ actions, pagination, filters, discoveryId }) => {
       ids,
       data,
       selectedIds,
+      onUnselectItems,
     })
-  }, [actions, ids, data, selectedIds])
+  }, [actions, ids, data, selectedIds, onUnselectItems])
 
   return (
     <>
@@ -181,11 +188,22 @@ const DiscoverySongs = ({ actions, pagination, filters, discoveryId }) => {
         actions={toolbarActions}
       />
       <div className={classes.main}>
-        <Card className={clsx(classes.content)} key={version}>
+        <Card
+          className={clsx(classes.content, {
+            [classes.bulkActionsDisplayed]: selectedIds.length > 0,
+          })}
+          key={version}
+        >
+          <BulkActionsToolbar>
+            <DiscoverySongBulkActions
+              discoveryId={discoveryId}
+              onUnselectItems={onUnselectItems}
+            />
+          </BulkActionsToolbar>
           <SongDatagrid
             rowClick={handleRowClick}
             {...listContext}
-            hasBulkActions={false}
+            hasBulkActions={true}
             contextAlwaysVisible={!isDesktop}
             classes={{ row: classes.row }}
           >

--- a/ui/src/discovery/DiscoverySongs.jsx
+++ b/ui/src/discovery/DiscoverySongs.jsx
@@ -1,0 +1,206 @@
+import React, { useCallback, useEffect, useMemo } from 'react'
+import {
+  ListToolbar,
+  NumberField,
+  TextField,
+  useListContext,
+  useVersion,
+} from 'react-admin'
+import clsx from 'clsx'
+import { useDispatch } from 'react-redux'
+import { Card, useMediaQuery } from '@material-ui/core'
+import { makeStyles } from '@material-ui/core/styles'
+import {
+  DurationField,
+  SongInfo,
+  SongContextMenu,
+  SongDatagrid,
+  SongTitleField,
+  QualityInfo,
+  useSelectedFields,
+  useResourceRefresh,
+  DateField,
+  ArtistLinkField,
+  PathField,
+  RatingField,
+} from '../common'
+import { AlbumLinkField } from '../song/AlbumLinkField'
+import { playTracks } from '../actions'
+import ExpandInfoDialog from '../dialogs/ExpandInfoDialog'
+import config from '../config'
+
+const useStyles = makeStyles(
+  (theme) => ({
+    main: {
+      display: 'flex',
+    },
+    content: {
+      marginTop: 0,
+      transition: theme.transitions.create('margin-top'),
+      position: 'relative',
+      flex: '1 1 auto',
+      [theme.breakpoints.down('xs')]: {
+        boxShadow: 'none',
+      },
+    },
+    actions: {
+      zIndex: 2,
+      display: 'flex',
+      justifyContent: 'flex-end',
+      flexWrap: 'wrap',
+    },
+    toolbar: {
+      justifyContent: 'flex-start',
+    },
+    row: {
+      '&:hover': {
+        '& $contextMenu': {
+          visibility: 'visible',
+        },
+        '& $ratingField': {
+          visibility: 'visible',
+        },
+      },
+    },
+    contextMenu: {
+      visibility: (props) => (props.isDesktop ? 'hidden' : 'visible'),
+    },
+    ratingField: {
+      visibility: 'hidden',
+    },
+  }),
+  { name: 'NDDiscoverySongs' },
+)
+
+const DiscoverySongs = ({ actions, pagination, filters, discoveryId }) => {
+  const listContext = useListContext()
+  const { data, ids, selectedIds, setPage } = listContext
+  const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
+  const classes = useStyles({ isDesktop })
+  const dispatch = useDispatch()
+  const version = useVersion()
+  useResourceRefresh('song')
+
+  useEffect(() => {
+    setPage(1)
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [discoveryId, setPage])
+
+  const handleRowClick = useCallback(
+    (id) => {
+      if (!ids || ids.length === 0) {
+        dispatch(playTracks(data, ids, id))
+        return
+      }
+
+      const startIndex = ids.indexOf(id)
+      if (startIndex === -1) {
+        dispatch(playTracks(data, ids, id))
+        return
+      }
+
+      const orderedIds = [
+        ...ids.slice(startIndex),
+        ...ids.slice(0, startIndex),
+      ]
+
+      dispatch(playTracks(data, orderedIds, id))
+    },
+    [dispatch, data, ids],
+  )
+
+  const toggleableFields = useMemo(() => {
+    return {
+      position: isDesktop && <TextField source="position" label={'#'} />,
+      title: <SongTitleField source="title" showTrackNumbers={false} />,
+      album: isDesktop && <AlbumLinkField source="album" />,
+      artist: isDesktop && <ArtistLinkField source="artist" />,
+      albumArtist: isDesktop && <ArtistLinkField source="albumArtist" />,
+      duration: <DurationField source="duration" />, 
+      year: isDesktop && (
+        <NumberField source="year" sortByOrder={'DESC'} />
+      ),
+      playCount: isDesktop && (
+        <NumberField source="playCount" sortByOrder={'DESC'} />
+      ),
+      playDate: isDesktop && (
+        <DateField source="playDate" sortByOrder={'DESC'} showTime />
+      ),
+      createdAt: (
+        <DateField source="createdAt" showTime sortable={false} />
+      ),
+      quality: isDesktop && <QualityInfo source="quality" sortable={false} />,
+      channels: isDesktop && <NumberField source="channels" />,
+      bpm: isDesktop && <NumberField source="bpm" />,
+      genre: <TextField source="genre" />,
+      comment: <TextField source="comment" />,
+      path: <PathField source="path" />,
+      rating: config.enableStarRating && (
+        <RatingField
+          source="rating"
+          sortByOrder={'DESC'}
+          resource={'song'}
+          className={classes.ratingField}
+        />
+      ),
+    }
+  }, [isDesktop, classes.ratingField])
+
+  const columns = useSelectedFields({
+    resource: 'discoveryTrack',
+    columns: toggleableFields,
+    defaultOff: [
+      'channels',
+      'bpm',
+      'year',
+      'playCount',
+      'comment',
+      'playDate',
+      'createdAt',
+      'albumArtist',
+      'rating',
+    ],
+  })
+
+  const toolbarActions = useMemo(() => {
+    if (!actions) {
+      return null
+    }
+    return React.cloneElement(actions, {
+      ids,
+      data,
+      selectedIds,
+    })
+  }, [actions, ids, data, selectedIds])
+
+  return (
+    <>
+      <ListToolbar
+        classes={{ toolbar: classes.toolbar }}
+        filters={filters}
+        actions={toolbarActions}
+      />
+      <div className={classes.main}>
+        <Card className={clsx(classes.content)} key={version}>
+          <SongDatagrid
+            rowClick={handleRowClick}
+            {...listContext}
+            hasBulkActions={false}
+            contextAlwaysVisible={!isDesktop}
+            classes={{ row: classes.row }}
+          >
+            {columns}
+            <SongContextMenu
+              showLove={true}
+              className={classes.contextMenu}
+            />
+          </SongDatagrid>
+        </Card>
+      </div>
+      <ExpandInfoDialog content={<SongInfo />} />
+      {pagination && React.cloneElement(pagination, listContext)}
+    </>
+  )
+}
+
+export default DiscoverySongs

--- a/ui/src/discovery/index.jsx
+++ b/ui/src/discovery/index.jsx
@@ -1,0 +1,17 @@
+import QueueMusicOutlinedIcon from '@material-ui/icons/QueueMusicOutlined'
+import QueueMusicIcon from '@material-ui/icons/QueueMusic'
+import DynamicMenuIcon from '../layout/DynamicMenuIcon'
+import DiscoveryList from './DiscoveryList'
+import DiscoveryShow from './DiscoveryShow'
+
+export default {
+  list: DiscoveryList,
+  show: DiscoveryShow,
+  icon: (
+    <DynamicMenuIcon
+      path={'discovery'}
+      icon={QueueMusicOutlinedIcon}
+      activeIcon={QueueMusicIcon}
+    />
+  ),
+}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -240,6 +240,20 @@
         "updatedAt": "Updated at"
       }
     },
+    "discovery": {
+      "name": "Discovery Folder |||| Discovery Folders",
+      "fields": {
+        "name": "Name",
+        "songCount": "Songs",
+        "updatedAt": "Updated at"
+      },
+      "actions": {
+        "refresh": "Refresh"
+      },
+      "messages": {
+        "refreshed": "Discovery folders refreshed"
+      }
+    },
     "radio": {
       "name": "Radio |||| Radios",
       "fields": {
@@ -530,6 +544,8 @@
   },
   "menu": {
     "library": "Library",
+    "discovery": "Discovery",
+    "discovery_empty": "No discovery playlists available",
     "librarySelector": {
       "allLibraries": "All Libraries (%{count})",
       "multipleLibraries": "%{selected} of %{total} Libraries",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -248,10 +248,12 @@
         "updatedAt": "Updated at"
       },
       "actions": {
-        "refresh": "Refresh"
+        "refresh": "Refresh",
+        "publish": "Publish"
       },
       "messages": {
-        "refreshed": "Discovery folders refreshed"
+        "refreshed": "Discovery folders refreshed",
+        "published": "Discovery folder %{name} published to Sync folder"
       }
     },
     "radio": {

--- a/ui/src/i18n/provider.js
+++ b/ui/src/i18n/provider.js
@@ -46,7 +46,15 @@ const prepareLanguage = (lang) => {
   lang.resources.albumSong = lang.resources.song
   lang.resources.playlistTrack = lang.resources.song
   // Discovery tracks share the same data model as songs, so reuse those labels too
-  lang.resources.discoveryTrack = lang.resources.song
+  if (lang.resources.song) {
+    const discoveryFields = lang.resources.song.fields || {}
+    lang.resources.discoveryTrack = deepmerge({}, lang.resources.song)
+    lang.resources.discoveryTrack.fields = {
+      ...discoveryFields,
+      position:
+        discoveryFields.position || discoveryFields.trackNumber || '#',
+    }
+  }
   // ra.boolean.null should always be empty
   lang.ra.boolean.null = ''
   // Fallback to english translations

--- a/ui/src/i18n/provider.js
+++ b/ui/src/i18n/provider.js
@@ -51,8 +51,9 @@ const prepareLanguage = (lang) => {
     lang.resources.discoveryTrack = deepmerge({}, lang.resources.song)
     lang.resources.discoveryTrack.fields = {
       ...discoveryFields,
-      position:
-        discoveryFields.position || discoveryFields.trackNumber || '#',
+      // Always surface the track position column as the traditional "#" label
+      // to match the playlists grid regardless of other per-locale overrides.
+      position: '#',
     }
   }
   // ra.boolean.null should always be empty

--- a/ui/src/i18n/provider.js
+++ b/ui/src/i18n/provider.js
@@ -45,6 +45,8 @@ const prepareLanguage = (lang) => {
   // Make "albumSong" and "playlistTrack" resource use the same translations as "song"
   lang.resources.albumSong = lang.resources.song
   lang.resources.playlistTrack = lang.resources.song
+  // Discovery tracks share the same data model as songs, so reuse those labels too
+  lang.resources.discoveryTrack = lang.resources.song
   // ra.boolean.null should always be empty
   lang.ra.boolean.null = ''
   // Fallback to english translations

--- a/ui/src/layout/DiscoverySubMenu.jsx
+++ b/ui/src/layout/DiscoverySubMenu.jsx
@@ -3,19 +3,17 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText,
-  IconButton,
   CircularProgress,
   makeStyles,
 } from '@material-ui/core'
-import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
 import QueueMusicIcon from '@material-ui/icons/QueueMusic'
 import RefreshIcon from '@material-ui/icons/Refresh'
-import CloudDownloadIcon from '@material-ui/icons/CloudDownload'
+import { FaCompass } from 'react-icons/fa'
 import { useHistory } from 'react-router-dom'
 import { useNotify, useTranslate } from 'react-admin'
 import SubMenu from './SubMenu'
 import httpClient from '../dataProvider/httpClient'
-import { M3U_MIME_TYPE, REST_URL } from '../consts'
+import { REST_URL } from '../consts'
 
 const useStyles = makeStyles((theme) => ({
   item: {
@@ -37,8 +35,6 @@ const DiscoverySubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
   const history = useHistory()
   const [items, setItems] = useState([])
   const [loading, setLoading] = useState(false)
-  const [exportingId, setExportingId] = useState(null)
-
   const fetchDiscovery = useCallback(
     async (refresh = false) => {
       setLoading(true)
@@ -68,39 +64,9 @@ const DiscoverySubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
     history.push(`/discovery/${item.id}`)
   }
 
-  const handleExport = async (item) => {
-    if (!item?.id || exportingId === item.id) return
-    setExportingId(item.id)
-    try {
-      const res = await httpClient(`${REST_URL}/discovery/${item.id}/export`, {
-        headers: new Headers({ Accept: M3U_MIME_TYPE }),
-      })
-      const blob = new Blob([res.body], { type: M3U_MIME_TYPE })
-      const url = window.URL.createObjectURL(blob)
-      const link = document.createElement('a')
-      link.href = url
-      link.download = `${item.name || 'discovery'}.m3u`
-      document.body.appendChild(link)
-      link.click()
-      link.parentNode.removeChild(link)
-      window.URL.revokeObjectURL(url)
-    } catch (error) {
-      notify('ra.page.error', 'warning')
-    } finally {
-      setExportingId(null)
-    }
-  }
-
-  const songCountLabel = (item) => {
-    if (typeof item.songCount !== 'number') return ''
-    return translate('resources.playlist.fields.songCount', {
-      smart_count: item.songCount,
-      _: translate('ra.page.items', { smart_count: item.songCount }),
-    })
-  }
-
   const handleRefresh = () => {
     if (!loading) {
+      history.push('/discovery')
       fetchDiscovery(true)
     }
   }
@@ -111,7 +77,7 @@ const DiscoverySubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
       isOpen={state.menuDiscovery}
       sidebarIsOpen={sidebarIsOpen}
       name="menu.discovery"
-      icon={<QueueMusicIcon />}
+      icon={<FaCompass />}
       dense={dense}
       onAction={handleRefresh}
       actionIcon={loading ? <CircularProgress size={16} className={classes.spinner} /> : <RefreshIcon fontSize="small" />}
@@ -132,18 +98,7 @@ const DiscoverySubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
           <ListItemIcon className={classes.icon}>
             <QueueMusicIcon fontSize="small" />
           </ListItemIcon>
-          <ListItemText primary={item.name} secondary={songCountLabel(item)} />
-          <ListItemSecondaryAction>
-            <IconButton
-              edge="end"
-              size="small"
-              onClick={() => handleExport(item)}
-              aria-label={translate('action.export')}
-              disabled={exportingId === item.id}
-            >
-              <CloudDownloadIcon fontSize="small" />
-            </IconButton>
-          </ListItemSecondaryAction>
+          <ListItemText primary={item.name} />
         </ListItem>
       ))}
     </SubMenu>

--- a/ui/src/layout/DiscoverySubMenu.jsx
+++ b/ui/src/layout/DiscoverySubMenu.jsx
@@ -23,6 +23,7 @@ const useStyles = makeStyles((theme) => ({
     paddingBottom: 1,
     '&:hover': { backgroundColor: theme.palette.action.hover },
   },
+  spacer: { width: 24 },
   icon: { minWidth: 28 },
   placeholder: { padding: theme.spacing(1, 2) },
   spinner: { marginLeft: theme.spacing(1) },
@@ -95,6 +96,7 @@ const DiscoverySubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
           onClick={() => handleNavigate(item)}
           className={classes.item}
         >
+          <span className={classes.spacer} />
           <ListItemIcon className={classes.icon}>
             <QueueMusicIcon fontSize="small" />
           </ListItemIcon>

--- a/ui/src/layout/DiscoverySubMenu.jsx
+++ b/ui/src/layout/DiscoverySubMenu.jsx
@@ -1,0 +1,153 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import {
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  IconButton,
+  CircularProgress,
+  makeStyles,
+} from '@material-ui/core'
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
+import QueueMusicIcon from '@material-ui/icons/QueueMusic'
+import RefreshIcon from '@material-ui/icons/Refresh'
+import CloudDownloadIcon from '@material-ui/icons/CloudDownload'
+import { useHistory } from 'react-router-dom'
+import { useNotify, useTranslate } from 'react-admin'
+import SubMenu from './SubMenu'
+import httpClient from '../dataProvider/httpClient'
+import { M3U_MIME_TYPE, REST_URL } from '../consts'
+
+const useStyles = makeStyles((theme) => ({
+  item: {
+    borderRadius: 6,
+    marginRight: 4,
+    paddingTop: 1,
+    paddingBottom: 1,
+    '&:hover': { backgroundColor: theme.palette.action.hover },
+  },
+  icon: { minWidth: 28 },
+  placeholder: { padding: theme.spacing(1, 2) },
+  spinner: { marginLeft: theme.spacing(1) },
+}))
+
+const DiscoverySubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
+  const classes = useStyles()
+  const notify = useNotify()
+  const translate = useTranslate()
+  const history = useHistory()
+  const [items, setItems] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [exportingId, setExportingId] = useState(null)
+
+  const fetchDiscovery = useCallback(
+    async (refresh = false) => {
+      setLoading(true)
+      try {
+        const suffix = refresh ? '?refresh=true' : ''
+        const res = await httpClient(`${REST_URL}/discovery${suffix}`)
+        const list = Array.isArray(res?.json) ? res.json : []
+        setItems(list)
+      } catch (error) {
+        notify('ra.page.error', 'warning')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [notify]
+  )
+
+  useEffect(() => {
+    fetchDiscovery(false)
+  }, [fetchDiscovery])
+
+  const handleToggle = () => {
+    setState((prev) => ({ ...prev, menuDiscovery: !prev.menuDiscovery }))
+  }
+
+  const handleNavigate = (item) => {
+    history.push(`/discovery/${item.id}`)
+  }
+
+  const handleExport = async (item) => {
+    if (!item?.id || exportingId === item.id) return
+    setExportingId(item.id)
+    try {
+      const res = await httpClient(`${REST_URL}/discovery/${item.id}/export`, {
+        headers: new Headers({ Accept: M3U_MIME_TYPE }),
+      })
+      const blob = new Blob([res.body], { type: M3U_MIME_TYPE })
+      const url = window.URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = url
+      link.download = `${item.name || 'discovery'}.m3u`
+      document.body.appendChild(link)
+      link.click()
+      link.parentNode.removeChild(link)
+      window.URL.revokeObjectURL(url)
+    } catch (error) {
+      notify('ra.page.error', 'warning')
+    } finally {
+      setExportingId(null)
+    }
+  }
+
+  const songCountLabel = (item) => {
+    if (typeof item.songCount !== 'number') return ''
+    return translate('resources.playlist.fields.songCount', {
+      smart_count: item.songCount,
+      _: translate('ra.page.items', { smart_count: item.songCount }),
+    })
+  }
+
+  const handleRefresh = () => {
+    if (!loading) {
+      fetchDiscovery(true)
+    }
+  }
+
+  return (
+    <SubMenu
+      handleToggle={handleToggle}
+      isOpen={state.menuDiscovery}
+      sidebarIsOpen={sidebarIsOpen}
+      name="menu.discovery"
+      icon={<QueueMusicIcon />}
+      dense={dense}
+      onAction={handleRefresh}
+      actionIcon={loading ? <CircularProgress size={16} className={classes.spinner} /> : <RefreshIcon fontSize="small" />}
+    >
+      {items.length === 0 && !loading ? (
+        <ListItem disabled className={classes.placeholder}>
+          <ListItemText primary={translate('menu.discovery_empty', { _: translate('ra.message.no_results') })} />
+        </ListItem>
+      ) : null}
+      {items.map((item) => (
+        <ListItem
+          button
+          dense={dense}
+          key={item.id}
+          onClick={() => handleNavigate(item)}
+          className={classes.item}
+        >
+          <ListItemIcon className={classes.icon}>
+            <QueueMusicIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText primary={item.name} secondary={songCountLabel(item)} />
+          <ListItemSecondaryAction>
+            <IconButton
+              edge="end"
+              size="small"
+              onClick={() => handleExport(item)}
+              aria-label={translate('action.export')}
+              disabled={exportingId === item.id}
+            >
+              <CloudDownloadIcon fontSize="small" />
+            </IconButton>
+          </ListItemSecondaryAction>
+        </ListItem>
+      ))}
+    </SubMenu>
+  )
+}
+
+export default DiscoverySubMenu

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -58,7 +58,7 @@ const Menu = ({ dense = false }) => {
 
   // TODO State is not persisted in mobile when you close the sidebar menu. Move to redux?
   const [state, setState] = useState({
-    menuAlbumList: true,
+    menuAlbumList: false,
     menuPlaylists: true,
     menuSharedPlaylists: true,
     menuDiscovery: true,

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -9,6 +9,7 @@ import SubMenu from './SubMenu'
 import { humanize, pluralize } from 'inflection'
 import albumLists from '../album/albumLists'
 import PlaylistsSubMenu from './PlaylistsSubMenu'
+import DiscoverySubMenu from './DiscoverySubMenu'
 import LibrarySelector from '../common/LibrarySelector'
 import config from '../config'
 
@@ -60,6 +61,7 @@ const Menu = ({ dense = false }) => {
     menuAlbumList: true,
     menuPlaylists: true,
     menuSharedPlaylists: true,
+    menuDiscovery: true,
   })
 
   const handleToggle = (menu) => {
@@ -131,6 +133,12 @@ const Menu = ({ dense = false }) => {
       {config.devSidebarPlaylists && open ? (
         <>
           <Divider />
+          <DiscoverySubMenu
+            state={state}
+            setState={setState}
+            sidebarIsOpen={open}
+            dense={dense}
+          />
           <PlaylistsSubMenu
             state={state}
             setState={setState}
@@ -139,7 +147,15 @@ const Menu = ({ dense = false }) => {
           />
         </>
       ) : (
-        resources.filter(subItems('playlist')).map(renderResourceMenuItemLink)
+        <>
+          <DiscoverySubMenu
+            state={state}
+            setState={setState}
+            sidebarIsOpen={open}
+            dense={dense}
+          />
+          {resources.filter(subItems('playlist')).map(renderResourceMenuItemLink)}
+        </>
       )}
     </div>
   )

--- a/ui/src/routes.jsx
+++ b/ui/src/routes.jsx
@@ -1,9 +1,23 @@
 import React from 'react'
 import { Route } from 'react-router-dom'
 import Personal from './personal/Personal'
+import DiscoveryShow from './discovery/DiscoveryShow'
 
 const routes = [
   <Route exact path="/personal" render={() => <Personal />} key={'personal'} />,
+  <Route
+    exact
+    path="/discovery/:id"
+    render={(routeProps) => (
+      <DiscoveryShow
+        {...routeProps}
+        resource="discovery"
+        basePath="/discovery"
+        id={routeProps.match.params.id}
+      />
+    )}
+    key={'discovery-show'}
+  />,
 ]
 
 export default routes


### PR DESCRIPTION
## Summary
- add a discovery_tracks migration and repository so folder scans persist discovery song metadata
- update the discovery service to store playlist tracks during refresh and reuse the saved rows when reading playlists
- expose the new repository on the datastore implementation and mocks to satisfy the expanded discovery flow

## Testing
- go test ./core/... ./persistence/... *(fails: ui/embed.go expects built UI assets in build/3rdparty)*

------
https://chatgpt.com/codex/tasks/task_e_68e18e3f58c083308bc5a1617ff56d63