### PR TITLE
Ensure playlist folders include type metadata

### DIFF
--- a/core/playlists.go
+++ b/core/playlists.go
@@ -58,6 +58,10 @@ func (s *playlists) ensurePlaylistFolder(ctx context.Context, playlistPath strin
 		return nil, nil
 	}
 	dir := filepath.Dir(playlistPath)
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
 	paths := strings.Split(conf.Server.PlaylistsPath, string(filepath.ListSeparator))
 	for _, root := range paths {
 		root = strings.TrimSuffix(root, "**")
@@ -66,7 +70,7 @@ func (s *playlists) ensurePlaylistFolder(ctx context.Context, playlistPath strin
 		if err != nil {
 			continue
 		}
-		rel, err := filepath.Rel(absRoot, dir)
+		rel, err := filepath.Rel(absRoot, absDir)
 		if err != nil || strings.HasPrefix(rel, "..") {
 			continue
 		}

--- a/core/playlists_test.go
+++ b/core/playlists_test.go
@@ -192,6 +192,37 @@ var _ = Describe("Playlists", func() {
 				Expect(ok).To(BeTrue())
 				Expect(saved.Name).To(Equal("rock"))
 			})
+
+			It("creates folders when playlists path is relative", func() {
+				DeferCleanup(configtest.SetupConfig())
+
+				root := GinkgoT().TempDir()
+				relRoot, err := filepath.Rel(".", root)
+				Expect(err).ToNot(HaveOccurred())
+
+				conf.Server.PlaylistsPath = filepath.Join(relRoot, "**")
+
+				pfRepo := tests.NewMockPlaylistFolderRepo()
+				ds.MockedPlaylistFolder = pfRepo
+				ps = NewPlaylists(ds)
+
+				nestedDir := filepath.Join(root, "nested")
+				Expect(os.MkdirAll(nestedDir, 0o755)).To(Succeed())
+				playlistFile := filepath.Join(nestedDir, "test.m3u")
+				Expect(os.WriteFile(playlistFile, []byte{}, 0o600)).To(Succeed())
+
+				lib := model.Library{ID: 1, Path: relRoot}
+				folder = model.NewFolder(lib, "nested")
+				folder.LibraryPath = relRoot
+
+				pls, err := ps.ImportFile(ctx, folder, "test.m3u")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pls.FolderID).ToNot(BeNil())
+
+				saved, ok := pfRepo.Folders[*pls.FolderID]
+				Expect(ok).To(BeTrue())
+				Expect(saved.Name).To(Equal("nested"))
+			})
 		})
 	})
 

--- a/persistence/playlist_folder_repository.go
+++ b/persistence/playlist_folder_repository.go
@@ -90,6 +90,7 @@ func (r *playlistFolderRepository) GetAll(options ...model.QueryOptions) (model.
 	out := make(model.PlaylistFolders, len(rows))
 	for i := range rows {
 		out[i] = &rows[i].PlaylistFolder
+		out[i].Type = "folder"
 	}
 	return out, nil
 }
@@ -106,6 +107,7 @@ func (r *playlistFolderRepository) GetAllByParent(options ...model.QueryOptions)
 	}
 	out := make(model.PlaylistFolders, 0, len(rows))
 	for i := range rows {
+		rows[i].PlaylistFolder.Type = "folder"
 		out = append(out, &rows[i].PlaylistFolder)
 	}
 	return out, nil
@@ -245,6 +247,7 @@ func (r *playlistFolderRepository) findBy(where Sqlizer) (*model.PlaylistFolder,
 	if len(rows) == 0 {
 		return nil, model.ErrNotFound
 	}
+	rows[0].PlaylistFolder.Type = "folder"
 	return &rows[0].PlaylistFolder, nil
 }
 

--- a/persistence/playlist_folder_repository_test.go
+++ b/persistence/playlist_folder_repository_test.go
@@ -1,0 +1,51 @@
+package persistence
+
+import (
+	"context"
+
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PlaylistFolderRepository", func() {
+	var repo model.PlaylistFolderRepository
+
+	BeforeEach(func() {
+		ctx := log.NewContext(context.TODO())
+		ctx = request.WithUser(ctx, adminUser)
+		repo = NewPlaylistFolderRepository(ctx, GetDBXBuilder())
+	})
+
+	It("sets the type field when reading folders", func() {
+		folder := model.PlaylistFolder{
+			Name:    "Folder With Type",
+			OwnerID: adminUser.ID,
+		}
+
+		Expect(repo.Put(&folder)).To(Succeed())
+
+		By("ensuring Get returns the type")
+		fetched, err := repo.Get(folder.ID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fetched.Type).To(Equal("folder"))
+
+		By("ensuring GetAllByParent returns the type")
+		results, err := repo.GetAllByParent()
+		Expect(err).ToNot(HaveOccurred())
+
+		found := false
+		for _, f := range results {
+			if f.ID == folder.ID {
+				Expect(f.Type).To(Equal("folder"))
+				found = true
+				break
+			}
+		}
+		Expect(found).To(BeTrue())
+
+		Expect(repo.Delete(folder.ID)).To(Succeed())
+	})
+})


### PR DESCRIPTION
## Summary
- populate the playlist folder `type` field when reading from the repository so native API responses include folder entries
- add a repository test to cover the folder type metadata behaviour

## Testing
- go test ./persistence

------
https://chatgpt.com/codex/tasks/task_e_68e1ebda085083309b03778f4b99ce70