### PR TITLE
Support streaming discovery-only tracks

### DIFF
--- a/core/media_streamer.go
+++ b/core/media_streamer.go
@@ -2,10 +2,13 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -50,11 +53,58 @@ func (j *streamJob) Key() string {
 
 func (ms *mediaStreamer) NewStream(ctx context.Context, id string, reqFormat string, reqBitRate int, reqOffset int) (*Stream, error) {
 	mf, err := ms.ds.MediaFile(ctx).Get(id)
-	if err != nil {
+	if err == nil {
+		return ms.DoStream(ctx, mf, reqFormat, reqBitRate, reqOffset)
+	}
+	if !errors.Is(err, model.ErrNotFound) {
 		return nil, err
 	}
 
-	return ms.DoStream(ctx, mf, reqFormat, reqBitRate, reqOffset)
+	track, trackErr := ms.ds.DiscoveryTrack(ctx).Get(id)
+	if trackErr != nil {
+		return nil, trackErr
+	}
+
+	if track.MediaFileID != "" && track.MediaFileID != id {
+		if mf, mfErr := ms.ds.MediaFile(ctx).Get(track.MediaFileID); mfErr == nil {
+			return ms.DoStream(ctx, mf, reqFormat, reqBitRate, reqOffset)
+		} else if !errors.Is(mfErr, model.ErrNotFound) {
+			return nil, mfErr
+		}
+	}
+
+	mediaFile := track.MediaFile
+	if mediaFile.ID == "" {
+		mediaFile.ID = id
+	}
+	if track.SourcePath != "" {
+		absSource := track.SourcePath
+		if !filepath.IsAbs(absSource) && mediaFile.LibraryPath != "" {
+			absSource = filepath.Join(mediaFile.LibraryPath, absSource)
+		}
+		absSource = filepath.Clean(absSource)
+		if filepath.IsAbs(absSource) && filepath.Clean(mediaFile.AbsolutePath()) != absSource {
+			mediaFile.LibraryPath = filepath.Dir(absSource)
+			mediaFile.Path = filepath.Base(absSource)
+		}
+		if mediaFile.Suffix == "" {
+			if ext := filepath.Ext(absSource); ext != "" {
+				mediaFile.Suffix = strings.TrimPrefix(ext, ".")
+			}
+		}
+	} else {
+		if mediaFile.LibraryPath == "" && filepath.IsAbs(mediaFile.Path) {
+			mediaFile.LibraryPath = filepath.Dir(mediaFile.Path)
+			mediaFile.Path = filepath.Base(mediaFile.Path)
+		}
+		if mediaFile.Suffix == "" {
+			if ext := filepath.Ext(mediaFile.Path); ext != "" {
+				mediaFile.Suffix = strings.TrimPrefix(ext, ".")
+			}
+		}
+	}
+
+	return ms.DoStream(ctx, &mediaFile, reqFormat, reqBitRate, reqOffset)
 }
 
 func (ms *mediaStreamer) DoStream(ctx context.Context, mf *model.MediaFile, reqFormat string, reqBitRate int, reqOffset int) (*Stream, error) {

--- a/core/media_streamer_test.go
+++ b/core/media_streamer_test.go
@@ -29,6 +29,19 @@ var _ = Describe("MediaStreamer", func() {
 		ds.MediaFile(ctx).(*tests.MockMediaFileRepo).SetData(model.MediaFiles{
 			{ID: "123", Path: "tests/fixtures/test.mp3", Suffix: "mp3", BitRate: 128, Duration: 257.0},
 		})
+		Expect(ds.DiscoveryTrack(ctx).ReplaceForDiscovery("disc1", model.DiscoveryTracks{
+			{
+				ID:          "disc-track-1",
+				DiscoveryID: "disc1",
+				MediaFile: model.MediaFile{
+					ID:       "disc-track-1",
+					Path:     "tests/fixtures/test.mp3",
+					Suffix:   "mp3",
+					BitRate:  128,
+					Duration: 257.0,
+				},
+			},
+		})).To(Succeed())
 		testCache := core.NewTranscodingCache()
 		Eventually(func() bool { return testCache.Available(context.TODO()) }).Should(BeTrue())
 		streamer = core.NewMediaStreamer(ds, ffmpeg, testCache)
@@ -69,6 +82,12 @@ var _ = Describe("MediaStreamer", func() {
 			s, err = streamer.NewStream(ctx, "123", "mp3", 32, 0)
 			Expect(err).To(BeNil())
 			Expect(s.Seekable()).To(BeTrue())
+		})
+		It("streams tracks stored only in discovery", func() {
+			s, err := streamer.NewStream(ctx, "disc-track-1", "raw", 0, 0)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(s.Seekable()).To(BeTrue())
+			Expect(s.ContentType()).To(Equal("audio/mpeg"))
 		})
 	})
 })

--- a/model/discovery_playlist.go
+++ b/model/discovery_playlist.go
@@ -39,4 +39,5 @@ type DiscoveryTrackRepository interface {
 	GetByDiscovery(discoveryID string) (DiscoveryTracks, error)
 	ReplaceForDiscovery(discoveryID string, tracks DiscoveryTracks) error
 	GetByIDs(discoveryID string, ids []string) (DiscoveryTracks, error)
+	Get(id string) (*DiscoveryTrack, error)
 }

--- a/persistence/discovery_track_repository.go
+++ b/persistence/discovery_track_repository.go
@@ -2,7 +2,9 @@ package persistence
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/navidrome/navidrome/log"
@@ -40,25 +42,7 @@ func (r *discoveryTrackRepository) GetByDiscovery(discoveryID string) (model.Dis
 	}
 	tracks := make(model.DiscoveryTracks, 0, len(rows))
 	for _, row := range rows {
-		var mediaFile model.MediaFile
-		if err := json.Unmarshal([]byte(row.MediaFile), &mediaFile); err != nil {
-			log.Warn(r.ctx, "Failed to unmarshal discovery track mediafile", "trackID", row.ID, err)
-			mediaFile = model.MediaFile{ID: row.ID, Path: row.Path, Missing: row.Missing}
-		}
-		track := model.DiscoveryTrack{
-			ID:          row.ID,
-			DiscoveryID: row.DiscoveryID,
-			MediaFileID: "",
-			Position:    row.Position,
-			MediaFile:   mediaFile,
-		}
-		if row.MediaFileID != nil {
-			track.MediaFileID = *row.MediaFileID
-		}
-		if row.SourcePath != nil {
-			track.SourcePath = *row.SourcePath
-		}
-		tracks = append(tracks, track)
+		tracks = append(tracks, r.rowToModel(row))
 	}
 	return tracks, nil
 }
@@ -77,25 +61,7 @@ func (r *discoveryTrackRepository) GetByIDs(discoveryID string, ids []string) (m
 	}
 	tracks := make(model.DiscoveryTracks, 0, len(rows))
 	for _, row := range rows {
-		var mediaFile model.MediaFile
-		if err := json.Unmarshal([]byte(row.MediaFile), &mediaFile); err != nil {
-			log.Warn(r.ctx, "Failed to unmarshal discovery track mediafile", "trackID", row.ID, err)
-			mediaFile = model.MediaFile{ID: row.ID, Path: row.Path, Missing: row.Missing}
-		}
-		track := model.DiscoveryTrack{
-			ID:          row.ID,
-			DiscoveryID: row.DiscoveryID,
-			MediaFileID: "",
-			Position:    row.Position,
-			MediaFile:   mediaFile,
-		}
-		if row.MediaFileID != nil {
-			track.MediaFileID = *row.MediaFileID
-		}
-		if row.SourcePath != nil {
-			track.SourcePath = *row.SourcePath
-		}
-		tracks = append(tracks, track)
+		tracks = append(tracks, r.rowToModel(row))
 	}
 	return tracks, nil
 }
@@ -142,4 +108,39 @@ func (r *discoveryTrackRepository) ReplaceForDiscovery(discoveryID string, track
 		}
 	}
 	return nil
+}
+
+func (r *discoveryTrackRepository) Get(id string) (*model.DiscoveryTrack, error) {
+	var row discoveryTrackRow
+	err := r.db.Select("*").From("discovery_tracks").Where(dbx.HashExp{"id": id}).One(&row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, model.ErrNotFound
+		}
+		return nil, err
+	}
+	track := r.rowToModel(row)
+	return &track, nil
+}
+
+func (r *discoveryTrackRepository) rowToModel(row discoveryTrackRow) model.DiscoveryTrack {
+	var mediaFile model.MediaFile
+	if err := json.Unmarshal([]byte(row.MediaFile), &mediaFile); err != nil {
+		log.Warn(r.ctx, "Failed to unmarshal discovery track mediafile", "trackID", row.ID, err)
+		mediaFile = model.MediaFile{ID: row.ID, Path: row.Path, Missing: row.Missing}
+	}
+	track := model.DiscoveryTrack{
+		ID:          row.ID,
+		DiscoveryID: row.DiscoveryID,
+		MediaFileID: "",
+		Position:    row.Position,
+		MediaFile:   mediaFile,
+	}
+	if row.MediaFileID != nil {
+		track.MediaFileID = *row.MediaFileID
+	}
+	if row.SourcePath != nil {
+		track.SourcePath = *row.SourcePath
+	}
+	return track
 }

--- a/tests/mock_data_store.go
+++ b/tests/mock_data_store.go
@@ -133,6 +133,19 @@ func (r *MockDiscoveryTrackRepo) GetByIDs(discoveryID string, ids []string) (mod
 	return result, nil
 }
 
+func (r *MockDiscoveryTrackRepo) Get(id string) (*model.DiscoveryTrack, error) {
+	r.ensure()
+	for _, tracks := range r.Items {
+		for _, track := range tracks {
+			if track.ID == id {
+				copy := track
+				return &copy, nil
+			}
+		}
+	}
+	return nil, model.ErrNotFound
+}
+
 func (db *MockDataStore) Library(ctx context.Context) model.LibraryRepository {
 	if db.MockedLibrary == nil {
 		if db.RealDS != nil {


### PR DESCRIPTION
## Summary
- allow the media streamer to fall back to discovery track metadata when a media file ID cannot be found
- add discovery track repository lookups and helpers for the SQL and mock implementations
- cover the discovery-only streaming scenario with a unit test

## Testing
- go test ./... *(fails: ui/embed.go cannot embed build assets in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6c1a204508330a7a56ad9e3c973bc