### PR TITLE
Fix search reset handling on playlist and discovery pages

### DIFF
--- a/ui/src/discovery/DiscoveryShow.jsx
+++ b/ui/src/discovery/DiscoveryShow.jsx
@@ -20,8 +20,13 @@ const DiscoveryShowLayout = (props) => {
   const [searchTerm, setSearchTerm] = useState('')
   useResourceRefresh('discovery')
 
-  const handleSearchChange = useCallback((event) => {
-    setSearchTerm(event.target.value)
+  const handleSearchChange = useCallback((eventOrValue) => {
+    const value =
+      typeof eventOrValue === 'string'
+        ? eventOrValue
+        : eventOrValue?.target?.value ?? ''
+
+    setSearchTerm(value)
   }, [])
 
   if (loading) {

--- a/ui/src/playlist/PlaylistShow.jsx
+++ b/ui/src/playlist/PlaylistShow.jsx
@@ -37,8 +37,13 @@ const PlaylistShowLayout = (props) => {
   const [searchTerm, setSearchTerm] = useState('')
 
   // Handle search change
-  const handleSearchChange = useCallback((event) => {
-    setSearchTerm(event.target.value)
+  const handleSearchChange = useCallback((eventOrValue) => {
+    const value =
+      typeof eventOrValue === 'string'
+        ? eventOrValue
+        : eventOrValue?.target?.value ?? ''
+
+    setSearchTerm(value)
   }, [])
 
   return (


### PR DESCRIPTION
## Summary
- update the playlist search change handler to work with both event objects and direct string values from the reset button
- apply the same resilient search change handler to the discovery page to keep behaviour consistent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e77dbe8c38833098e4b77254f5a4ca