### PR TITLE
Add pagination to missing track notifications

### DIFF
--- a/server/nativeapi/notifications.go
+++ b/server/nativeapi/notifications.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -29,9 +30,27 @@ func (n *Router) handleMissingTrackNotifications() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		entries := []missingTrackNotification{}
+		total := 0
+
+		limit := 200
+		if limitParam := r.URL.Query().Get("limit"); limitParam != "" {
+			if parsed, err := strconv.Atoi(limitParam); err == nil && parsed > 0 {
+				if parsed > 500 {
+					parsed = 500
+				}
+				limit = parsed
+			}
+		}
+
+		offset := 0
+		if offsetParam := r.URL.Query().Get("offset"); offsetParam != "" {
+			if parsed, err := strconv.Atoi(offsetParam); err == nil && parsed >= 0 {
+				offset = parsed
+			}
+		}
 
 		if conf.Server.DataFolder == "" {
-			writeMissingTrackResponse(w, entries, ctx)
+			writeMissingTrackResponse(w, entries, total, ctx)
 			return
 		}
 
@@ -41,7 +60,7 @@ func (n *Router) handleMissingTrackNotifications() http.HandlerFunc {
 		db, err := sql.Open("sqlite3", dsn)
 		if err != nil {
 			log.Warn(ctx, "Unable to open missing tracks database", "path", dbFile, "err", err)
-			writeMissingTrackResponse(w, entries, ctx)
+			writeMissingTrackResponse(w, entries, total, ctx)
 			return
 		}
 		defer db.Close()
@@ -50,10 +69,20 @@ func (n *Router) handleMissingTrackNotifications() http.HandlerFunc {
 			log.Debug(ctx, "Unable to enable WAL for missing tracks database", "path", dbFile, "err", err)
 		}
 
-		rows, err := db.QueryContext(ctx, `SELECT track_path FROM missing_playlist_tracks GROUP BY track_path ORDER BY MAX(created_at) DESC LIMIT 200`)
+		err = db.QueryRowContext(ctx, `SELECT COUNT(DISTINCT track_path) FROM missing_playlist_tracks`).Scan(&total)
 		if err != nil {
 			if strings.Contains(err.Error(), "no such table") {
-				writeMissingTrackResponse(w, entries, ctx)
+				writeMissingTrackResponse(w, entries, total, ctx)
+				return
+			}
+			log.Warn(ctx, "Unable to count missing tracks notifications", "path", dbFile, "err", err)
+			total = 0
+		}
+
+		rows, err := db.QueryContext(ctx, `SELECT track_path FROM missing_playlist_tracks GROUP BY track_path ORDER BY MAX(created_at) DESC LIMIT ? OFFSET ?`, limit, offset)
+		if err != nil {
+			if strings.Contains(err.Error(), "no such table") {
+				writeMissingTrackResponse(w, entries, total, ctx)
 				return
 			}
 			log.Error(ctx, "Unable to query missing tracks notifications", "path", dbFile, "err", err)
@@ -91,12 +120,15 @@ func (n *Router) handleMissingTrackNotifications() http.HandlerFunc {
 			}
 		}
 
-		writeMissingTrackResponse(w, entries, ctx)
+		writeMissingTrackResponse(w, entries, total, ctx)
 	}
 }
 
-func writeMissingTrackResponse(w http.ResponseWriter, entries []missingTrackNotification, ctx context.Context) {
+func writeMissingTrackResponse(w http.ResponseWriter, entries []missingTrackNotification, total int, ctx context.Context) {
 	w.Header().Set("Content-Type", "application/json")
+	if total >= 0 {
+		w.Header().Set("X-Total-Count", strconv.Itoa(total))
+	}
 	if err := json.NewEncoder(w).Encode(entries); err != nil {
 		log.Error(ctx, "Unable to encode missing track notifications", err)
 	}

--- a/ui/src/layout/MissingTracksPanel.jsx
+++ b/ui/src/layout/MissingTracksPanel.jsx
@@ -62,9 +62,9 @@ const useStyles = makeStyles((theme) => ({
     '& .MuiBadge-badge': {
       minWidth: theme.spacing(2),
       height: theme.spacing(2),
-      borderRadius: '50%',
+      borderRadius: theme.spacing(1),
       fontSize: '0.65rem',
-      padding: 0,
+      padding: theme.spacing(0, 0.5),
       top: theme.spacing(0.5),
       right: theme.spacing(0.5),
     },
@@ -159,6 +159,7 @@ const MissingTracksPanel = () => {
       <Tooltip title={translate('notifications.missingTracks')}>
         <Badge
           badgeContent={totalCount}
+          max={9999}
           color="secondary"
           invisible={totalCount === 0}
           className={classes.notificationBadge}
@@ -212,7 +213,7 @@ const MissingTracksPanel = () => {
                       <CircularProgress size={20} />
                     ) : (
                       <ListItemText
-                        primary={translate('ra.action.load_more')}
+                        primary={translate('ra.action.load_more', { _: 'Load More…' })}
                         primaryTypographyProps={{ align: 'center' }}
                       />
                     )}

--- a/ui/src/layout/MissingTracksPanel.jsx
+++ b/ui/src/layout/MissingTracksPanel.jsx
@@ -3,6 +3,7 @@ import {
   Badge,
   Card,
   CardContent,
+  CircularProgress,
   IconButton,
   List,
   ListItem,
@@ -10,12 +11,13 @@ import {
   Popover,
   Tooltip,
   Typography,
-  CircularProgress,
   makeStyles,
 } from '@material-ui/core'
 import { MdOutlineNotifications } from 'react-icons/md'
 import { useTranslate, useNotify } from 'react-admin'
 import { httpClient } from '../dataProvider'
+
+const PAGE_SIZE = 100
 
 const useStyles = makeStyles((theme) => ({
   button: (props) => ({
@@ -52,6 +54,10 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'center',
     padding: theme.spacing(2),
   },
+  loadMoreItem: {
+    display: 'flex',
+    justifyContent: 'center',
+  },
   notificationBadge: {
     '& .MuiBadge-badge': {
       minWidth: theme.spacing(2),
@@ -71,30 +77,56 @@ const MissingTracksPanel = () => {
   const [anchorEl, setAnchorEl] = useState(null)
   const [entries, setEntries] = useState([])
   const [loading, setLoading] = useState(false)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [totalCount, setTotalCount] = useState(0)
+  const [hasMore, setHasMore] = useState(false)
+  const [nextOffset, setNextOffset] = useState(0)
 
   const open = Boolean(anchorEl)
   const classes = useStyles({ open })
 
-  const fetchEntries = useCallback(() => {
-    setLoading(true)
-    httpClient('/api/notifications/missing-tracks')
-      .then(({ json }) => {
-        const list = Array.isArray(json) ? json : []
-        setEntries(list)
+  const fetchEntries = useCallback(
+    (offset = 0, append = false) => {
+      const setLoadingState = append ? setLoadingMore : setLoading
+      setLoadingState(true)
+      const params = new URLSearchParams({
+        limit: PAGE_SIZE.toString(),
+        offset: Math.max(offset, 0).toString(),
       })
-      .catch((error) => {
-        notify('ra.notification.http_error', 'warning', {
-          messageArgs: { error: error.message || 'Unknown error' },
+      httpClient(`/api/notifications/missing-tracks?${params.toString()}`)
+        .then(({ json, headers }) => {
+          const list = Array.isArray(json) ? json : []
+          const totalHeader = headers && headers.get ? headers.get('X-Total-Count') : null
+          const parsedTotal = totalHeader ? parseInt(totalHeader, 10) : NaN
+          setEntries((prev) => {
+            const nextEntries = append ? [...prev, ...list] : list
+            const totalValue = Number.isNaN(parsedTotal) ? nextEntries.length : parsedTotal
+            setTotalCount(totalValue)
+            setNextOffset(nextEntries.length)
+            setHasMore(nextEntries.length < totalValue && list.length > 0)
+            return nextEntries
+          })
         })
-        setEntries([])
-      })
-      .finally(() => setLoading(false))
-  }, [notify])
+        .catch((error) => {
+          notify('ra.notification.http_error', 'warning', {
+            messageArgs: { error: error.message || 'Unknown error' },
+          })
+          if (!append) {
+            setEntries([])
+            setTotalCount(0)
+            setNextOffset(0)
+            setHasMore(false)
+          }
+        })
+        .finally(() => setLoadingState(false))
+    },
+    [notify],
+  )
 
   const handleOpen = useCallback(
     (event) => {
       setAnchorEl(event.currentTarget)
-      fetchEntries()
+      fetchEntries(0, false)
     },
     [fetchEntries],
   )
@@ -102,6 +134,10 @@ const MissingTracksPanel = () => {
   const handleClose = useCallback(() => {
     setAnchorEl(null)
   }, [])
+
+  const handleLoadMore = useCallback(() => {
+    fetchEntries(nextOffset, true)
+  }, [fetchEntries, nextOffset])
   const getEntryLabel = useCallback(
     (entry) => {
       if (!entry) {
@@ -122,9 +158,9 @@ const MissingTracksPanel = () => {
     <div>
       <Tooltip title={translate('notifications.missingTracks')}>
         <Badge
-          badgeContent={entries.length}
+          badgeContent={totalCount}
           color="secondary"
-          invisible={entries.length === 0}
+          invisible={totalCount === 0}
           className={classes.notificationBadge}
         >
           <IconButton
@@ -165,6 +201,23 @@ const MissingTracksPanel = () => {
                     <ListItemText primary={getEntryLabel(entry)} />
                   </ListItem>
                 ))}
+                {hasMore && (
+                  <ListItem
+                    button
+                    onClick={handleLoadMore}
+                    disabled={loadingMore}
+                    className={classes.loadMoreItem}
+                  >
+                    {loadingMore ? (
+                      <CircularProgress size={20} />
+                    ) : (
+                      <ListItemText
+                        primary={translate('ra.action.load_more')}
+                        primaryTypographyProps={{ align: 'center' }}
+                      />
+                    )}
+                  </ListItem>
+                )}
               </List>
             )}
           </CardContent>


### PR DESCRIPTION
## Summary
- allow the missing track notifications endpoint to accept limit and offset parameters and return the total count in a response header
- update the missing tracks panel to fetch results in 100-track pages and append more entries on demand, updating the badge count accordingly

## Testing
- go test ./... *(fails: requires system library `taglib` not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e787453e2c8330a3d6cd57dd7f9851