### PR TITLE
Fix playlist missing track display issues

### DIFF
--- a/ui/src/common/SongContextMenu.jsx
+++ b/ui/src/common/SongContextMenu.jsx
@@ -33,7 +33,10 @@ const useStyles = makeStyles({
   },
 })
 
-const MoreButton = ({ record, onClick, info }) => {
+const MoreButton = ({ record, onClick, info, showMissingInfo }) => {
+  if (record?.missing && !showMissingInfo) {
+    return null
+  }
   const handleClick = record.missing
     ? (e) => {
         info.action(record)
@@ -57,6 +60,7 @@ export const SongContextMenu = ({
   showLove,
   onAddToPlaylist,
   className,
+  showMissingInfo,
 }) => {
   const classes = useStyles()
   const dispatch = useDispatch()
@@ -226,7 +230,12 @@ export const SongContextMenu = ({
         resource={resource}
         visible={config.enableFavourites && showLove && present}
       />
-      <MoreButton record={record} onClick={handleClick} info={options.info} />
+      <MoreButton
+        record={record}
+        onClick={handleClick}
+        info={options.info}
+        showMissingInfo={showMissingInfo}
+      />
       <Menu
         id={'menu' + record.id}
         anchorEl={anchorEl}
@@ -285,6 +294,7 @@ SongContextMenu.propTypes = {
   record: PropTypes.object.isRequired,
   onAddToPlaylist: PropTypes.func,
   showLove: PropTypes.bool,
+  showMissingInfo: PropTypes.bool,
 }
 
 SongContextMenu.defaultProps = {
@@ -293,4 +303,5 @@ SongContextMenu.defaultProps = {
   resource: 'song',
   showLove: true,
   addLabel: true,
+  showMissingInfo: true,
 }

--- a/ui/src/playlist/PlaylistPathField.jsx
+++ b/ui/src/playlist/PlaylistPathField.jsx
@@ -1,0 +1,14 @@
+import { useRecordContext } from 'react-admin'
+import { PathField } from '../common'
+
+const PlaylistPathField = (props) => {
+  const record = useRecordContext(props)
+
+  if (!record || record.missing) {
+    return <span />
+  }
+
+  return <PathField {...props} />
+}
+
+export default PlaylistPathField

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -26,7 +26,6 @@ import {
   useResourceRefresh,
   DateField,
   ArtistLinkField,
-  PathField,
   RatingField,
 } from '../common'
 import { AlbumLinkField } from '../song/AlbumLinkField'
@@ -34,6 +33,8 @@ import { playTracks } from '../actions'
 import PlaylistSongBulkActions from './PlaylistSongBulkActions'
 import ExpandInfoDialog from '../dialogs/ExpandInfoDialog'
 import config from '../config'
+import PlaylistTrackNumberField from './PlaylistTrackNumberField'
+import PlaylistPathField from './PlaylistPathField'
 
 const useStyles = makeStyles(
   (theme) => ({
@@ -149,7 +150,10 @@ const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
 
   const toggleableFields = useMemo(() => {
     return {
-      trackNumber: isDesktop && <TextField source="id" label={'#'} />,
+      trackNumber:
+        isDesktop && (
+          <PlaylistTrackNumberField source="id" label={'#'} />
+        ),
       title: <SongTitleField source="title" showTrackNumbers={false} />,
       album: isDesktop && <AlbumLinkField source="album" />,
       artist: isDesktop && <ArtistLinkField source="artist" />,
@@ -178,7 +182,7 @@ const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
       bpm: isDesktop && <NumberField source="bpm" />,
       genre: <TextField source="genre" />,
       comment: <TextField source="comment" />,
-      path: <PathField source="path" />,
+      path: <PlaylistPathField source="path" />, 
       rating: config.enableStarRating && (
         <RatingField
           source="rating"
@@ -268,6 +272,7 @@ const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
                 onAddToPlaylist={onAddToPlaylist}
                 showLove={true}
                 className={classes.contextMenu}
+                showMissingInfo={false}
               />
             </SongDatagrid>
           </ReorderableList>

--- a/ui/src/playlist/PlaylistTrackNumberField.jsx
+++ b/ui/src/playlist/PlaylistTrackNumberField.jsx
@@ -1,0 +1,30 @@
+import { useCallback } from 'react'
+import PropTypes from 'prop-types'
+import { FunctionField, useListContext } from 'react-admin'
+
+const PlaylistTrackNumberField = (props) => {
+  const { ids = [], page = 1, perPage } = useListContext()
+
+  const renderValue = useCallback(
+    (record) => {
+      if (!record) {
+        return ''
+      }
+      const index = ids.indexOf(record.id)
+      if (index === -1) {
+        return ''
+      }
+      const offset = perPage ? (page - 1) * perPage : 0
+      return offset + index + 1
+    },
+    [ids, page, perPage],
+  )
+
+  return <FunctionField {...props} render={renderValue} />
+}
+
+PlaylistTrackNumberField.propTypes = {
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+}
+
+export default PlaylistTrackNumberField


### PR DESCRIPTION
## Summary
- ensure playlist track numbering stays sequential even when missing entries are present
- hide file paths and the Get Info button for missing tracks in playlist views to align the row layout

## Testing
- npm --prefix ui run lint

------
https://chatgpt.com/codex/tasks/task_e_68e79182119c8330a8de488ee691ec88