### PR TITLE
Fix pagination dropdown to display selected page size

### DIFF
--- a/ui/src/common/Pagination.jsx
+++ b/ui/src/common/Pagination.jsx
@@ -2,14 +2,15 @@ import React from 'react'
 import { Pagination as RAPagination, useListContext } from 'react-admin'
 
 export const Pagination = (props) => {
+  const { rowsPerPage: _ignoredRowsPerPage, ...rest } = props
   const { perPage } = useListContext()
   const rowsPerPage = perPage ?? 50
 
   return (
     <RAPagination
       rowsPerPageOptions={[25, 50, 100, 200, 500]}
+      {...rest}
       rowsPerPage={rowsPerPage}
-      {...props}
     />
   )
 }

--- a/ui/src/common/Pagination.jsx
+++ b/ui/src/common/Pagination.jsx
@@ -1,10 +1,15 @@
 import React from 'react'
-import { Pagination as RAPagination } from 'react-admin'
+import { Pagination as RAPagination, useListContext } from 'react-admin'
 
-export const Pagination = (props) => (
- 
- <RAPagination
- rowsPerPageOptions={[25, 50, 100, 200, 500]} {...props}
- rowsPerPage={50} //
- />
-)
+export const Pagination = (props) => {
+  const { perPage } = useListContext()
+  const rowsPerPage = perPage ?? 50
+
+  return (
+    <RAPagination
+      rowsPerPageOptions={[25, 50, 100, 200, 500]}
+      rowsPerPage={rowsPerPage}
+      {...props}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- read the current per-page value from the list context in the shared Pagination component
- pass the resolved page size to the React-Admin pagination control so the dropdown reflects the active selection

## Testing
- npm --prefix ui run lint

------
https://chatgpt.com/codex/tasks/task_e_68e82881248c83308356db54b22e0413