### PR TITLE
Fix mobile song queue and highlighting

### DIFF
--- a/ui/src/common/SongSimpleList.jsx
+++ b/ui/src/common/SongSimpleList.jsx
@@ -9,11 +9,12 @@ import { makeStyles } from '@material-ui/core/styles'
 import { sanitizeListRestProps } from 'react-admin'
 import { DurationField, SongContextMenu, RatingField } from './index'
 import { setTrack } from '../actions'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
+import clsx from 'clsx'
 import config from '../config'
 
 const useStyles = makeStyles(
-  {
+  (theme) => ({
     link: {
       textDecoration: 'none',
       color: 'inherit',
@@ -46,7 +47,24 @@ const useStyles = makeStyles(
     rightIcon: {
       top: '26px',
     },
-  },
+    currentListItem: {
+      backgroundColor: theme.palette.action.hover,
+      '& $title, & $secondary, & $artist': {
+        color: '#ff007f',
+      },
+      '& $timeStamp': {
+        color: '#ff007f',
+        opacity: 1,
+      },
+      '& svg': {
+        fill: '#ff007f',
+        color: '#ff007f',
+      },
+      '& .MuiRating-iconFilled, & .MuiRating-iconHover': {
+        color: '#ff007f',
+      },
+    },
+  }),
   { name: 'RaSongSimpleList' },
 )
 
@@ -61,18 +79,49 @@ export const SongSimpleList = ({
   onToggleItem,
   selectedIds,
   total,
+  onItemClick,
+  highlightCurrentTrack,
   ...rest
 }) => {
   const dispatch = useDispatch()
+  const currentTrack = useSelector((state) => state?.player?.current || {})
   const classes = useStyles({ classes: classesOverride })
+  const highlight = Boolean(highlightCurrentTrack)
   return (
     (loading || total > 0) && (
       <List className={className} {...sanitizeListRestProps(rest)}>
         {ids.map(
           (id) =>
             data[id] && (
-              <span key={id} onClick={() => dispatch(setTrack(data[id]))}>
-                <ListItem className={classes.listItem} button={true}>
+              <span
+                key={id}
+                onClick={() =>
+                  onItemClick
+                    ? onItemClick({
+                        id,
+                        record: data[id],
+                        data,
+                        ids,
+                      })
+                    : dispatch(setTrack(data[id]))
+                }
+              >
+                <ListItem
+                  className={clsx(
+                    classes.listItem,
+                    highlight &&
+                      currentTrack?.trackId != null &&
+                      (currentTrack.trackId?.toString() === id?.toString() ||
+                        (data[id]?.id &&
+                          currentTrack.trackId?.toString() ===
+                            data[id]?.id?.toString()) ||
+                        (data[id]?.mediaFileId &&
+                          currentTrack.trackId?.toString() ===
+                            data[id]?.mediaFileId?.toString())) &&
+                      classes.currentListItem,
+                  )}
+                  button={true}
+                >
                   <ListItemText
                     primary={
                       <div className={classes.title}>{data[id].title}</div>
@@ -124,9 +173,12 @@ SongSimpleList.propTypes = {
   ids: PropTypes.array,
   onToggleItem: PropTypes.func,
   selectedIds: PropTypes.arrayOf(PropTypes.any).isRequired,
+  onItemClick: PropTypes.func,
+  highlightCurrentTrack: PropTypes.bool,
 }
 
 SongSimpleList.defaultProps = {
   hasBulkActions: false,
   selectedIds: [],
+  highlightCurrentTrack: false,
 }

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -31,7 +31,7 @@ import {
 import { useSelector, useDispatch } from 'react-redux'
 import { makeStyles } from '@material-ui/core/styles'
 import FavoriteBorderIcon from '@material-ui/icons/FavoriteBorder'
-import { playTracks } from '../actions'
+import { playTracks, setTrack } from '../actions'
 import { SongListActions } from './SongListActions'
 import { AlbumLinkField } from './AlbumLinkField'
 import { SongBulkActions, QualityInfo, useSelectedFields } from '../common'
@@ -135,42 +135,100 @@ const SongList = (props) => {
   const dispatch = useDispatch()
   const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
+  const isMobileLayout = useMediaQuery('(max-width:768px)')
   useResourceRefresh('song')
 
   const songs = useSelector((state) => state.admin.resources.song)
 
-  const handleRowClick = useCallback((id, basePath, record) => {
-      // Convert songs.data to an array if it's an object
-      const songsArray = Array.isArray(songs.data) ? songs.data : Object.values(songs.data);
-
-      if (songsArray.length > 0 && Array.isArray(songs.list?.ids)) {
-        // Filter songs to include only those whose IDs exist in songs.list.ids
-        const filteredSongs = songsArray.filter(song => songs.list.ids.includes(song.id));
-
-        // Find the index of the selected song
-        const index = filteredSongs.findIndex(song => song.id === record.id);
-
-        if (index !== -1) {
-          // Rearrange array to start from the selected song
-          const orderedSongs = [
-            ...filteredSongs.slice(index),
-            ...filteredSongs.slice(0, index)
-          ];
-
-          // Convert the array into an object where key = song.id, value = song
-          // const updatedSongs = Object.fromEntries(orderedSongs.map(song => [song.id, song]));
-
-          // Convert array to an object with index-based keys, updating the song id as well
-          const updatedSongs = Object.fromEntries(
-            orderedSongs.map((song, idx) => 
-               [idx, song] // Setting both the key and `id` inside each song
-            )
-          );
-
-          dispatch(playTracks(updatedSongs,0));
+  const normalizedSongsData = useMemo(() => {
+    if (!songs?.data) {
+      return undefined
+    }
+    if (Array.isArray(songs.data)) {
+      return songs.data.reduce((acc, song) => {
+        if (song?.id !== undefined) {
+          acc[song.id] = song
         }
+        return acc
+      }, {})
+    }
+    return songs.data
+  }, [songs?.data])
+
+  const queueIds = useMemo(() => {
+    if (Array.isArray(songs?.list?.ids) && songs.list.ids.length) {
+      return songs.list.ids
+    }
+    if (normalizedSongsData) {
+      return Object.keys(normalizedSongsData)
+    }
+    return []
+  }, [songs?.list?.ids, normalizedSongsData])
+
+  const findMatchingKey = useCallback(
+    (record, fallback) => {
+      if (!record) {
+        return fallback ?? queueIds[0]
       }
-    }, [dispatch, songs.data, songs.list?.ids]);
+      const recordId = record.id != null ? record.id.toString() : undefined
+      const mediaId =
+        record.mediaFileId != null ? record.mediaFileId.toString() : undefined
+      const matchRecord =
+        recordId &&
+        queueIds.find((itemId) => itemId?.toString() === recordId)
+      if (matchRecord !== undefined) {
+        return matchRecord
+      }
+      const matchMedia =
+        mediaId && queueIds.find((itemId) => itemId?.toString() === mediaId)
+      if (matchMedia !== undefined) {
+        return matchMedia
+      }
+      return fallback ?? recordId ?? mediaId ?? queueIds[0]
+    },
+    [queueIds],
+  )
+
+  const queuePlayback = useCallback(
+    (selectedKey, record) => {
+      if (!normalizedSongsData || !queueIds.length) {
+        if (record) {
+          dispatch(setTrack(record))
+        }
+        return
+      }
+
+      const selectedKeyStr = selectedKey != null ? selectedKey.toString() : undefined
+      const matchKey =
+        (selectedKeyStr
+          ? queueIds.find((itemId) => itemId?.toString() === selectedKeyStr)
+          : undefined) ?? findMatchingKey(record, queueIds[0])
+
+      if (matchKey == null) {
+        if (record) {
+          dispatch(setTrack(record))
+        }
+        return
+      }
+
+      dispatch(playTracks(normalizedSongsData, queueIds, matchKey))
+    },
+    [dispatch, normalizedSongsData, queueIds, findMatchingKey],
+  )
+
+  const handleRowClick = useCallback(
+    (id, basePath, record) => {
+      queuePlayback(id, record)
+    },
+    [queuePlayback],
+  )
+
+  const handleMobileItemClick = useCallback(
+    ({ id: itemId, record }) => {
+      queuePlayback(itemId, record)
+    },
+    [queuePlayback],
+  )
 
   const toggleableFields = useMemo(() => {
     return {
@@ -246,7 +304,10 @@ const SongList = (props) => {
         perPage={isXsmall ? 50 : 50}
       >
         {isXsmall ? (
-          <SongSimpleList />
+          <SongSimpleList
+            onItemClick={isMobileLayout ? handleMobileItemClick : undefined}
+            highlightCurrentTrack={isMobileLayout}
+          />
         ) : (
           <SongDatagrid
             rowClick={handleRowClick}


### PR DESCRIPTION
## Summary
- ensure the Songs mobile list queues the visible tracks and starts playback from the tapped item
- highlight the currently playing song in the mobile Songs list using the existing playing color palette

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e83a15229c8330a8673e365ed554e1