### PR TITLE
feat(playlist): add duplicates filter toggle

### DIFF
--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -217,6 +217,7 @@
         "saveQueue": "Save Queue to Playlist",
         "makePublic": "Make Public",
         "makePrivate": "Make Private",
+        "duplicates": "Duplicates",
         "searchOrCreate": "Search playlists or type to create new...",
         "pressEnterToCreate": "Press Enter to create new playlist",
         "removeFromSelection": "Remove from selection"

--- a/ui/src/playlist/PlaylistActions.jsx
+++ b/ui/src/playlist/PlaylistActions.jsx
@@ -12,6 +12,7 @@ import { useMediaQuery, makeStyles } from '@material-ui/core'
 import PlayArrowIcon from '@material-ui/icons/PlayArrow'
 import ShuffleIcon from '@material-ui/icons/Shuffle'
 import CloudDownloadOutlinedIcon from '@material-ui/icons/CloudDownloadOutlined'
+import FilterNoneIcon from '@material-ui/icons/FilterNone'
 import { RiPlayListAddFill, RiPlayList2Fill } from 'react-icons/ri'
 import QueueMusicIcon from '@material-ui/icons/QueueMusic'
 import ShareIcon from '@material-ui/icons/Share'
@@ -36,7 +37,15 @@ const useStyles = makeStyles({
   toolbar: { display: 'flex', justifyContent: 'space-between', width: '100%' },
 })
 
-const PlaylistActions = ({ className, ids, data, record, ...rest }) => {
+const PlaylistActions = ({
+  className,
+  ids,
+  data,
+  record,
+  showDuplicatesOnly,
+  onToggleDuplicates,
+  ...rest
+}) => {
   const dispatch = useDispatch()
   const translate = useTranslate()
   const classes = useStyles()
@@ -162,6 +171,15 @@ const PlaylistActions = ({ className, ids, data, record, ...rest }) => {
           >
             <QueueMusicIcon />
           </Button>
+          <Button
+            onClick={onToggleDuplicates}
+            label={translate('resources.playlist.actions.duplicates')}
+            color={showDuplicatesOnly ? 'primary' : 'default'}
+            variant={showDuplicatesOnly ? 'contained' : 'text'}
+            aria-pressed={showDuplicatesOnly}
+          >
+            <FilterNoneIcon />
+          </Button>
           <PublishPlaylistButton record={record} />
         </div>
         <div>{isNotSmall && <ToggleFieldsMenu resource="playlistTrack" />}</div>
@@ -173,12 +191,16 @@ const PlaylistActions = ({ className, ids, data, record, ...rest }) => {
 PlaylistActions.propTypes = {
   record: PropTypes.object.isRequired,
   selectedIds: PropTypes.arrayOf(PropTypes.number),
+  showDuplicatesOnly: PropTypes.bool,
+  onToggleDuplicates: PropTypes.func,
 }
 
 PlaylistActions.defaultProps = {
   record: {},
   selectedIds: [],
   onUnselectItems: () => null,
+  showDuplicatesOnly: false,
+  onToggleDuplicates: () => null,
 }
 
 export default PlaylistActions

--- a/ui/src/playlist/PlaylistShow.jsx
+++ b/ui/src/playlist/PlaylistShow.jsx
@@ -35,11 +35,20 @@ const PlaylistShowLayout = (props) => {
 
   // Store search query in state to prevent losing focus
   const [searchTerm, setSearchTerm] = useState('')
+  const [showDuplicatesOnly, setShowDuplicatesOnly] = useState(false)
 
   // Handle search change
   const handleSearchChange = useCallback((event) => {
     setSearchTerm(event.target.value)
   }, [])
+
+  const handleToggleDuplicates = useCallback(() => {
+    setShowDuplicatesOnly((prev) => !prev)
+  }, [])
+
+  React.useEffect(() => {
+    setShowDuplicatesOnly(false)
+  }, [record?.id])
 
   return (
     <>
@@ -75,6 +84,8 @@ const PlaylistShowLayout = (props) => {
                 <PlaylistActions
                   className={classes.playlistActions}
                   record={record}
+                  showDuplicatesOnly={showDuplicatesOnly}
+                  onToggleDuplicates={handleToggleDuplicates}
                 />
               }
               resource={'playlistTrack'}
@@ -83,6 +94,7 @@ const PlaylistShowLayout = (props) => {
               perPage={50}
                 />}
               searchTerm={searchTerm} // Pass search term to child
+              showDuplicatesOnly={showDuplicatesOnly}
             />
           </ReferenceManyField>
         </>

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -9,6 +9,7 @@ import {
   useVersion,
   useListContext,
   FunctionField,
+  ListContextProvider,
 } from 'react-admin'
 import clsx from 'clsx'
 import { useDispatch } from 'react-redux'
@@ -94,10 +95,22 @@ const ReorderableList = ({ readOnly, children, ...rest }) => {
   return <ReactDragListView {...rest}>{children}</ReactDragListView>
 }
 
-const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
+const PlaylistSongs = ({
+  playlistId,
+  readOnly,
+  actions,
+  showDuplicatesOnly,
+  ...props
+}) => {
   const listContext = useListContext()
-  const { data, ids, selectedIds, onUnselectItems, refetch, setPage } =
-    listContext
+  const {
+    data: contextData = {},
+    ids: contextIds = [],
+    selectedIds: contextSelectedIds = [],
+    onUnselectItems,
+    refetch,
+    setPage,
+  } = listContext
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   const classes = useStyles({ isDesktop })
   const dispatch = useDispatch()
@@ -105,6 +118,90 @@ const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
   const notify = useNotify()
   const version = useVersion()
   useResourceRefresh('song', 'playlist')
+
+  const duplicateIds = useMemo(() => {
+    if (!showDuplicatesOnly) {
+      return new Set()
+    }
+
+    const seen = new Map()
+    const duplicates = new Set()
+
+    const normalize = (value) =>
+      typeof value === 'string' ? value.trim().toLowerCase() : ''
+
+    contextIds.forEach((id) => {
+      const track = contextData[id]
+      if (!track) {
+        return
+      }
+
+      const keys = []
+      const title = normalize(track.title)
+      const artist = normalize(track.artist)
+      const path = normalize(track.path)
+
+      if (title && artist) {
+        keys.push(`title:${title}|artist:${artist}`)
+      }
+      if (title && !artist) {
+        keys.push(`title:${title}`)
+      }
+      if (path) {
+        keys.push(`path:${path}`)
+      }
+
+      keys.forEach((key) => {
+        if (!seen.has(key)) {
+          seen.set(key, [])
+        }
+        const list = seen.get(key)
+        list.push(id)
+        if (list.length > 1) {
+          list.forEach((duplicateId) => duplicates.add(duplicateId))
+        }
+      })
+    })
+
+    return duplicates
+  }, [contextIds, contextData, showDuplicatesOnly])
+
+  const ids = useMemo(() => {
+    if (!showDuplicatesOnly) {
+      return contextIds
+    }
+    return contextIds.filter((id) => duplicateIds.has(id))
+  }, [contextIds, duplicateIds, showDuplicatesOnly])
+
+  const data = useMemo(() => {
+    if (!showDuplicatesOnly) {
+      return contextData
+    }
+
+    return ids.reduce((acc, id) => {
+      if (contextData[id]) {
+        acc[id] = contextData[id]
+      }
+      return acc
+    }, {})
+  }, [contextData, ids, showDuplicatesOnly])
+
+  const displayedIdSet = useMemo(() => new Set(ids), [ids])
+
+  const selectedIds = useMemo(
+    () => contextSelectedIds.filter((id) => displayedIdSet.has(id)),
+    [contextSelectedIds, displayedIdSet],
+  )
+
+  const filteredListContext = useMemo(
+    () => ({
+      ...listContext,
+      ids,
+      data,
+      selectedIds,
+    }),
+    [data, ids, listContext, selectedIds],
+  )
 
   useEffect(() => {
     setPage(1)
@@ -231,48 +328,50 @@ const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
 
   return (
     <>
-      <ListToolbar
-        classes={{ toolbar: classes.toolbar }}
-        filters={props.filters}
-        actions={actions}
-      />
-      <div className={classes.main}>
-        <Card
-          className={clsx(classes.content, {
-            [classes.bulkActionsDisplayed]: selectedIds.length > 0,
-          })}
-          key={version}
-        >
-          <BulkActionsToolbar>
-            <PlaylistSongBulkActions
-              playlistId={playlistId}
-              onUnselectItems={onUnselectItems}
-              readOnly={readOnly}
-            />
-          </BulkActionsToolbar>
-          <ReorderableList
-            readOnly={readOnly}
-            onDragEnd={handleDragEnd}
-            nodeSelector={'tr'}
-            handleSelector={'.draggable'}
+      <ListContextProvider value={filteredListContext}>
+        <ListToolbar
+          classes={{ toolbar: classes.toolbar }}
+          filters={props.filters}
+          actions={actions}
+        />
+        <div className={classes.main}>
+          <Card
+            className={clsx(classes.content, {
+              [classes.bulkActionsDisplayed]: selectedIds.length > 0,
+            })}
+            key={version}
           >
-            <SongDatagrid
-              rowClick={handleRowClick}
-              {...listContext}
-              hasBulkActions={!readOnly}
-              contextAlwaysVisible={!isDesktop}
-              classes={{ row: classes.row }}
-            >
-              {columns}
-              <SongContextMenu
-                onAddToPlaylist={onAddToPlaylist}
-                showLove={true}
-                className={classes.contextMenu}
+            <BulkActionsToolbar>
+              <PlaylistSongBulkActions
+                playlistId={playlistId}
+                onUnselectItems={onUnselectItems}
+                readOnly={readOnly}
               />
-            </SongDatagrid>
-          </ReorderableList>
-        </Card>
-      </div>
+            </BulkActionsToolbar>
+            <ReorderableList
+              readOnly={readOnly}
+              onDragEnd={handleDragEnd}
+              nodeSelector={'tr'}
+              handleSelector={'.draggable'}
+            >
+              <SongDatagrid
+                rowClick={handleRowClick}
+                {...filteredListContext}
+                hasBulkActions={!readOnly}
+                contextAlwaysVisible={!isDesktop}
+                classes={{ row: classes.row }}
+              >
+                {columns}
+                <SongContextMenu
+                  onAddToPlaylist={onAddToPlaylist}
+                  showLove={true}
+                  className={classes.contextMenu}
+                />
+              </SongDatagrid>
+            </ReorderableList>
+          </Card>
+        </div>
+      </ListContextProvider>
       <ExpandInfoDialog content={<SongInfo />} />
       {React.cloneElement(props.pagination, listContext)}
     </>


### PR DESCRIPTION
## Summary
- add a "Duplicates" toggle to the playlist action bar and reset it on playlist change
- filter the playlist tracks client-side to show only duplicate items when the toggle is active while preserving selection context
- add a translation string for the new toggle label

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e83b0922248330a08ff31e91118820