### PR TITLE
Improve playlist duplicate filter

### DIFF
--- a/ui/src/playlist/PlaylistActions.jsx
+++ b/ui/src/playlist/PlaylistActions.jsx
@@ -171,16 +171,16 @@ const PlaylistActions = ({
           >
             <QueueMusicIcon />
           </Button>
+          <PublishPlaylistButton record={record} />
           <Button
             onClick={onToggleDuplicates}
             label={translate('resources.playlist.actions.duplicates')}
-            color={showDuplicatesOnly ? 'primary' : 'default'}
+            color={'secondary'}
             variant={showDuplicatesOnly ? 'contained' : 'text'}
             aria-pressed={showDuplicatesOnly}
           >
             <FilterNoneIcon />
           </Button>
-          <PublishPlaylistButton record={record} />
         </div>
         <div>{isNotSmall && <ToggleFieldsMenu resource="playlistTrack" />}</div>
       </div>

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -13,7 +13,7 @@ import {
 } from 'react-admin'
 import clsx from 'clsx'
 import { useDispatch } from 'react-redux'
-import { Card, useMediaQuery } from '@material-ui/core'
+import { Card, useMediaQuery, LinearProgress } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core/styles'
 import ReactDragListView from 'react-drag-listview'
 import {
@@ -100,6 +100,7 @@ const PlaylistSongs = ({
   readOnly,
   actions,
   showDuplicatesOnly,
+  searchTerm = '',
   ...props
 }) => {
   const listContext = useListContext()
@@ -109,8 +110,9 @@ const PlaylistSongs = ({
     selectedIds: contextSelectedIds = [],
     onUnselectItems,
     refetch,
-    setPage,
+    setPage: setContextPage,
   } = listContext
+  const listVersion = listContext.version ?? 0
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   const classes = useStyles({ isDesktop })
   const dispatch = useDispatch()
@@ -118,59 +120,192 @@ const PlaylistSongs = ({
   const notify = useNotify()
   const version = useVersion()
   useResourceRefresh('song', 'playlist')
+  const searchValue = useMemo(
+    () => (typeof searchTerm === 'string' ? searchTerm.trim() : ''),
+    [searchTerm],
+  )
+  const fullDataCache = React.useRef({})
+  const [fullDataset, setFullDataset] = React.useState({
+    playlistId: null,
+    search: '',
+    ids: [],
+    data: {},
+    version: null,
+    loading: false,
+    ready: false,
+  })
+  const noopSetPage = useCallback(() => {}, [])
 
-  const duplicateIds = useMemo(() => {
-    if (!showDuplicatesOnly) {
-      return new Set()
+  useEffect(() => {
+    if (!showDuplicatesOnly || !playlistId) {
+      return
     }
 
-    const seen = new Map()
-    const duplicates = new Set()
+    const cacheKey = `${playlistId}::${searchValue}`
+    const cached = fullDataCache.current[cacheKey]
 
-    const normalize = (value) =>
+    if (cached && cached.version === listVersion) {
+      setFullDataset({
+        playlistId,
+        search: searchValue,
+        ids: cached.ids,
+        data: cached.data,
+        version: cached.version,
+        loading: false,
+        ready: true,
+      })
+      return
+    }
+
+    let isActive = true
+
+    setFullDataset({
+      playlistId,
+      search: searchValue,
+      ids: [],
+      data: {},
+      version: listVersion,
+      loading: true,
+      ready: false,
+    })
+
+    dataProvider
+      .getList('playlistTrack', {
+        pagination: { page: 1, perPage: 0 },
+        sort: { field: 'id', order: 'ASC' },
+        filter: {
+          playlist_id: playlistId,
+          ...(searchValue ? { q: searchValue } : {}),
+        },
+      })
+      .then(({ data }) => {
+        if (!isActive) {
+          return
+        }
+
+        const mappedData = data.reduce((acc, track) => {
+          acc[track.id] = track
+          return acc
+        }, {})
+        const ids = data.map((track) => track.id)
+        const entry = { ids, data: mappedData, version: listVersion }
+
+        fullDataCache.current[cacheKey] = entry
+
+        setFullDataset({
+          playlistId,
+          search: searchValue,
+          ids,
+          data: mappedData,
+          version: listVersion,
+          loading: false,
+          ready: true,
+        })
+      })
+      .catch(() => {
+        if (!isActive) {
+          return
+        }
+
+        notify('ra.page.error', 'warning')
+
+        setFullDataset({
+          playlistId,
+          search: searchValue,
+          ids: [],
+          data: {},
+          version: listVersion,
+          loading: false,
+          ready: true,
+        })
+      })
+
+    return () => {
+      isActive = false
+    }
+  }, [
+    showDuplicatesOnly,
+    playlistId,
+    searchValue,
+    dataProvider,
+    notify,
+    listVersion,
+  ])
+
+  const usingFullData =
+    showDuplicatesOnly &&
+    fullDataset.ready &&
+    fullDataset.playlistId === playlistId &&
+    fullDataset.search === searchValue
+
+  const duplicateIds = useMemo(() => {
+    if (!showDuplicatesOnly || !usingFullData) {
+      return []
+    }
+
+    const normalizeMeta = (value) => {
+      if (typeof value !== 'string') {
+        return ''
+      }
+      const normalized = value.trim().toLowerCase()
+      if (
+        !normalized ||
+        normalized === 'unknown' ||
+        normalized === 'unknown artist' ||
+        normalized === 'unknown artists'
+      ) {
+        return ''
+      }
+      return normalized
+    }
+
+    const normalizePath = (value) =>
       typeof value === 'string' ? value.trim().toLowerCase() : ''
 
-    contextIds.forEach((id) => {
-      const track = contextData[id]
+    const seen = new Map()
+    const duplicates = []
+
+    fullDataset.ids.forEach((id) => {
+      const track = fullDataset.data[id]
       if (!track) {
         return
       }
 
-      const keys = []
-      const title = normalize(track.title)
-      const artist = normalize(track.artist)
-      const path = normalize(track.path)
+      const title = normalizeMeta(track.title)
+      const artist = normalizeMeta(track.artist)
+      const path = normalizePath(track.path)
 
-      if (title && artist) {
-        keys.push(`title:${title}|artist:${artist}`)
-      }
-      if (title && !artist) {
-        keys.push(`title:${title}`)
-      }
-      if (path) {
-        keys.push(`path:${path}`)
+      let key = null
+      if (title || artist) {
+        key = `meta:${title}|${artist}`
+      } else if (path) {
+        key = `path:${path}`
       }
 
-      keys.forEach((key) => {
-        if (!seen.has(key)) {
-          seen.set(key, [])
-        }
-        const list = seen.get(key)
-        list.push(id)
-        if (list.length > 1) {
-          list.forEach((duplicateId) => duplicates.add(duplicateId))
-        }
-      })
+      if (!key) {
+        return
+      }
+
+      if (!seen.has(key)) {
+        seen.set(key, [])
+      }
+
+      const list = seen.get(key)
+      list.push(id)
+      if (list.length > 1) {
+        duplicates.push(id)
+      }
     })
 
     return duplicates
-  }, [contextIds, contextData, showDuplicatesOnly])
+  }, [showDuplicatesOnly, usingFullData, fullDataset.ids, fullDataset.data])
 
   const ids = useMemo(() => {
     if (!showDuplicatesOnly) {
       return contextIds
     }
-    return contextIds.filter((id) => duplicateIds.has(id))
+
+    return duplicateIds
   }, [contextIds, duplicateIds, showDuplicatesOnly])
 
   const data = useMemo(() => {
@@ -178,13 +313,24 @@ const PlaylistSongs = ({
       return contextData
     }
 
-    return ids.reduce((acc, id) => {
-      if (contextData[id]) {
-        acc[id] = contextData[id]
+    if (!usingFullData) {
+      return {}
+    }
+
+    return duplicateIds.reduce((acc, id) => {
+      const track = fullDataset.data[id]
+      if (track) {
+        acc[id] = track
       }
       return acc
     }, {})
-  }, [contextData, ids, showDuplicatesOnly])
+  }, [
+    contextData,
+    duplicateIds,
+    fullDataset.data,
+    showDuplicatesOnly,
+    usingFullData,
+  ])
 
   const displayedIdSet = useMemo(() => new Set(ids), [ids])
 
@@ -193,20 +339,42 @@ const PlaylistSongs = ({
     [contextSelectedIds, displayedIdSet],
   )
 
+  const duplicateLoading =
+    showDuplicatesOnly && (!usingFullData || fullDataset.loading)
+
   const filteredListContext = useMemo(
     () => ({
       ...listContext,
       ids,
       data,
       selectedIds,
+      total: showDuplicatesOnly ? ids.length : listContext.total,
+      page: showDuplicatesOnly ? 1 : listContext.page,
+      perPage: showDuplicatesOnly
+        ? ids.length > 0
+          ? ids.length
+          : listContext.perPage
+        : listContext.perPage,
+      loading: showDuplicatesOnly ? duplicateLoading : listContext.loading,
+      loaded: showDuplicatesOnly ? usingFullData : listContext.loaded,
+      setPage: showDuplicatesOnly ? noopSetPage : listContext.setPage,
     }),
-    [data, ids, listContext, selectedIds],
+    [
+      data,
+      duplicateLoading,
+      ids,
+      listContext,
+      noopSetPage,
+      selectedIds,
+      showDuplicatesOnly,
+      usingFullData,
+    ],
   )
 
   useEffect(() => {
-    setPage(1)
+    setContextPage(1)
     window.scrollTo({ top: 0, behavior: 'smooth' })
-  }, [playlistId, setPage])
+  }, [playlistId, setContextPage])
 
   const onAddToPlaylist = useCallback(
     (pls) => {
@@ -348,6 +516,7 @@ const PlaylistSongs = ({
                 readOnly={readOnly}
               />
             </BulkActionsToolbar>
+            {showDuplicatesOnly && duplicateLoading && <LinearProgress />}
             <ReorderableList
               readOnly={readOnly}
               onDragEnd={handleDragEnd}


### PR DESCRIPTION
## Summary
- fetch and cache complete playlist data when toggling the duplicates view so detection spans every page
- surface only n-1 items per duplicate group with a loading indicator and pagination override while the view is active
- restyle and reposition the duplicates toggle button after the publish button for consistent coloring

## Testing
- npm --prefix ui run lint

------
https://chatgpt.com/codex/tasks/task_e_68e8488af7b08330a9335d7aaa9a0822