### PR TITLE
Fix playlist track index display for missing entries

### DIFF
--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -94,6 +94,30 @@ const ReorderableList = ({ readOnly, children, ...rest }) => {
   return <ReactDragListView {...rest}>{children}</ReactDragListView>
 }
 
+const PlaylistTrackIndexField = (props) => {
+  const { ids = [] } = useListContext()
+
+  return (
+    <FunctionField
+      {...props}
+      sortable={false}
+      render={(record) => {
+        if (!record) {
+          return ''
+        }
+
+        const index = ids.indexOf(record.id)
+
+        if (index === -1) {
+          return ''
+        }
+
+        return index + 1
+      }}
+    />
+  )
+}
+
 const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
   const listContext = useListContext()
   const { data, ids, selectedIds, onUnselectItems, refetch, setPage } =
@@ -149,7 +173,8 @@ const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
 
   const toggleableFields = useMemo(() => {
     return {
-      trackNumber: isDesktop && <TextField source="id" label={'#'} />,
+      trackNumber:
+        isDesktop && <PlaylistTrackIndexField label={'#'} />, 
       title: <SongTitleField source="title" showTrackNumbers={false} />,
       album: isDesktop && <AlbumLinkField source="album" />,
       artist: isDesktop && <ArtistLinkField source="artist" />,

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -106,7 +106,10 @@ const PlaylistTrackIndexField = (props) => {
           return ''
         }
 
-        const index = ids.indexOf(record.id)
+        const recordId = record.id
+        const index = ids.findIndex(
+          (candidate) => String(candidate) === String(recordId),
+        )
 
         if (index === -1) {
           return ''


### PR DESCRIPTION
## Summary
- replace the playlist track number column with a list-context aware renderer so missing tracks no longer display placeholder ids
- add a dedicated field component to derive playlist row indices from the current ordering

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea0378f1808330a1bc8857e8fee1c8