### PR TITLE
Fix playlist duplicate filtering display and title search

### DIFF
--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -48,6 +48,37 @@ func (t dbPlaylistTracks) toModels() model.PlaylistTracks {
 	})
 }
 
+func playlistTrackQueryFilter(_ string, value any) Sqlizer {
+	term, ok := value.(string)
+	if !ok {
+		return nil
+	}
+
+	term = strings.TrimSpace(term)
+	if term == "" {
+		return nil
+	}
+
+	conditions := Or{}
+
+	if filter := fullTextFilter("f")("q", term); filter != nil {
+		conditions = append(conditions, filter)
+	}
+
+	conditions = append(
+		conditions,
+		substringFilter("f.title", term),
+		substringFilter("f.artist", term),
+		substringFilter("f.album", term),
+	)
+
+	if len(conditions) == 0 {
+		return nil
+	}
+
+	return conditions
+}
+
 func (r *playlistRepository) Tracks(playlistId string, refreshSmartPlaylist bool) model.PlaylistTrackRepository {
 	p := &playlistTrackRepository{}
 	p.playlistRepo = r
@@ -58,7 +89,7 @@ func (r *playlistRepository) Tracks(playlistId string, refreshSmartPlaylist bool
 	p.registerModel(&model.PlaylistTrack{}, map[string]filterFunc{
 		"missing":    booleanFilter,
 		"library_id": libraryIdFilter,
-		"q":          fullTextFilter("f"),
+		"q":          playlistTrackQueryFilter,
 	})
 	p.setSortMappings(
 		map[string]string{

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -412,9 +412,28 @@ const PlaylistSongs = ({
     [playlistId, reorder, ids],
   )
 
+  const renderTrackIndex = useCallback(
+    (record) => {
+      if (!record) {
+        return ''
+      }
+
+      const index = ids.indexOf(record.id)
+      if (index === -1) {
+        return ''
+      }
+
+      return index + 1
+    },
+    [ids],
+  )
+
   const toggleableFields = useMemo(() => {
     return {
-      trackNumber: isDesktop && <TextField source="id" label={'#'} />,
+      trackNumber:
+        isDesktop && (
+          <FunctionField label={'#'} render={renderTrackIndex} sortable={false} />
+        ),
       title: <SongTitleField source="title" showTrackNumbers={false} />,
       album: isDesktop && <AlbumLinkField source="album" />,
       artist: isDesktop && <ArtistLinkField source="artist" />,
@@ -453,7 +472,7 @@ const PlaylistSongs = ({
         />
       ),
     }
-  }, [isDesktop, classes.draggable, classes.ratingField])
+  }, [isDesktop, classes.draggable, classes.ratingField, renderTrackIndex])
 
   const columns = useSelectedFields({
     resource: 'playlistTrack',


### PR DESCRIPTION
## Summary
- ensure playlist track rows compute their position from the rendered order so the index remains sequential when toggling duplicate view
- broaden the playlist track search filter to include direct title, artist, and album substring matches so title queries return results

## Testing
- go test ./persistence
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ea7ce31f1c8330a316f0164f6fba50