### PR TITLE
Prevent duplicates-only playlist search from surfacing lone missing entries

### DIFF
--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	. "github.com/Masterminds/squirrel"
@@ -56,9 +57,10 @@ func (r *playlistRepository) Tracks(playlistId string, refreshSmartPlaylist bool
 	p.db = r.db
 	p.tableName = "playlist_tracks"
 	p.registerModel(&model.PlaylistTrack{}, map[string]filterFunc{
-		"missing":    booleanFilter,
-		"library_id": libraryIdFilter,
-		"q":          fullTextFilter("f"),
+		"missing":        booleanFilter,
+		"library_id":     libraryIdFilter,
+		"q":              fullTextFilter("f"),
+		"duplicatesonly": ignoreFilter,
 	})
 	p.setSortMappings(
 		map[string]string{
@@ -203,15 +205,39 @@ func (r *playlistTrackRepository) listWithMissing(opt model.QueryOptions, restOp
 		return nil, err
 	}
 
-	if r.playlist == nil || !r.playlist.Sync || r.playlist.Path == "" {
-		return tracks, nil
-	}
-
 	searchTerm := ""
+	duplicatesOnly := false
 	if restOpts.Filters != nil {
 		if v, ok := restOpts.Filters["q"].(string); ok {
 			searchTerm = strings.TrimSpace(strings.ToLower(v))
 		}
+		if v, ok := restOpts.Filters["duplicatesOnly"]; ok {
+			duplicatesOnly = parseBoolFilter(v)
+		}
+	}
+
+	if duplicatesOnly {
+		duplicates := filterDuplicatePlaylistTracks(tracks)
+		duplicateKeys := collectDuplicateTrackKeys(tracks)
+
+		if r.playlist != nil && r.playlist.Sync && r.playlist.Path != "" {
+			merged, err := mergePlaylistTracksWithMissing(r.ctx, tracks, r.playlist, searchTerm)
+			if err != nil {
+				log.Warn(r.ctx, "Error resolving missing playlist tracks", "playlistId", r.playlistId, err)
+				return duplicates, nil
+			}
+
+			missingDuplicates := filterDuplicateMissingPlaylistTracks(merged, duplicateKeys)
+			if len(missingDuplicates) > 0 {
+				duplicates = append(duplicates, missingDuplicates...)
+			}
+		}
+
+		return duplicates, nil
+	}
+
+	if r.playlist == nil || !r.playlist.Sync || r.playlist.Path == "" {
+		return tracks, nil
 	}
 
 	merged, err := mergePlaylistTracksWithMissing(r.ctx, tracks, r.playlist, searchTerm)
@@ -220,6 +246,154 @@ func (r *playlistTrackRepository) listWithMissing(opt model.QueryOptions, restOp
 		return tracks, nil
 	}
 	return merged, nil
+}
+
+func parseBoolFilter(value interface{}) bool {
+	switch v := value.(type) {
+	case bool:
+		return v
+	case string:
+		b, err := strconv.ParseBool(v)
+		return err == nil && b
+	case int:
+		return v != 0
+	case int64:
+		return v != 0
+	case float64:
+		return v != 0
+	default:
+		return false
+	}
+}
+
+func normalizeDuplicateMeta(value string) string {
+	normalized := strings.TrimSpace(strings.ToLower(value))
+	if normalized == "" {
+		return ""
+	}
+
+	switch normalized {
+	case "unknown", "unknown artist", "unknown artists":
+		return ""
+	default:
+		return normalized
+	}
+}
+
+func normalizeDuplicatePath(value string) string {
+	return strings.TrimSpace(strings.ToLower(value))
+}
+
+func duplicateTrackKey(track model.PlaylistTrack) (string, bool) {
+	title := normalizeDuplicateMeta(track.Title)
+	artist := normalizeDuplicateMeta(track.Artist)
+	if title != "" || artist != "" {
+		return "meta:" + title + "|" + artist, true
+	}
+
+	path := normalizeDuplicatePath(track.Path)
+	if path != "" {
+		return "path:" + path, true
+	}
+
+	return "", false
+}
+
+func collectDuplicateTrackKeys(tracks model.PlaylistTracks) map[string]struct{} {
+	if len(tracks) == 0 {
+		return map[string]struct{}{}
+	}
+
+	counts := make(map[string]int, len(tracks))
+	for _, track := range tracks {
+		if key, ok := duplicateTrackKey(track); ok {
+			counts[key]++
+		}
+	}
+
+	duplicateKeys := make(map[string]struct{})
+	for key, count := range counts {
+		if count > 1 {
+			duplicateKeys[key] = struct{}{}
+		}
+	}
+
+	return duplicateKeys
+}
+
+func filterDuplicatePlaylistTracks(tracks model.PlaylistTracks) model.PlaylistTracks {
+	if len(tracks) == 0 {
+		return tracks
+	}
+
+	seen := make(map[string]struct{}, len(tracks))
+	duplicates := make(model.PlaylistTracks, 0)
+
+	for _, track := range tracks {
+		key, ok := duplicateTrackKey(track)
+		if !ok {
+			continue
+		}
+
+		if _, dup := seen[key]; dup {
+			duplicates = append(duplicates, track)
+			continue
+		}
+
+		seen[key] = struct{}{}
+	}
+
+	return duplicates
+}
+
+func filterDuplicateMissingPlaylistTracks(tracks model.PlaylistTracks, allowedKeys map[string]struct{}) model.PlaylistTracks {
+	duplicates := filterDuplicatePlaylistTracks(tracks)
+	if len(duplicates) == 0 {
+		return nil
+	}
+
+	missingCounts := make(map[string]int)
+	for _, track := range tracks {
+		if !track.Missing {
+			continue
+		}
+
+		if key, ok := duplicateTrackKey(track); ok {
+			missingCounts[key]++
+		}
+	}
+
+	missing := make(model.PlaylistTracks, 0, len(duplicates))
+	for _, track := range duplicates {
+		if !track.Missing {
+			continue
+		}
+
+		key, ok := duplicateTrackKey(track)
+		if !ok {
+			continue
+		}
+
+		if _, allowed := allowedKeys[key]; allowed || missingCounts[key] > 1 {
+			missing = append(missing, track)
+		}
+	}
+
+	return missing
+}
+
+func filterMissingPlaylistTracks(tracks model.PlaylistTracks) model.PlaylistTracks {
+	if len(tracks) == 0 {
+		return tracks
+	}
+
+	missing := make(model.PlaylistTracks, 0)
+	for _, track := range tracks {
+		if track.Missing {
+			missing = append(missing, track)
+		}
+	}
+	return missing
 }
 
 func (r *playlistTrackRepository) EntityName() string {

--- a/persistence/playlist_track_repository_test.go
+++ b/persistence/playlist_track_repository_test.go
@@ -1,0 +1,109 @@
+package persistence
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/deluan/rest"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PlaylistTrackRepository", func() {
+	var (
+		playlistRepo model.PlaylistRepository
+		ctx          context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = log.NewContext(context.TODO())
+		ctx = request.WithUser(ctx, model.User{ID: "userid", UserName: "userid", IsAdmin: true})
+		playlistRepo = NewPlaylistRepository(ctx, GetDBXBuilder())
+	})
+
+	Describe("duplicatesOnly filter", func() {
+		var playlist model.Playlist
+
+		BeforeEach(func() {
+			playlist = model.Playlist{Name: "Duplicates Filter", OwnerID: "userid", OwnerName: "userid"}
+			playlist.AddMediaFilesByID([]string{"1001", "1001", "1003", "1003", "1003"})
+			Expect(playlistRepo.Put(&playlist)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			if playlist.ID != "" {
+				Expect(playlistRepo.Delete(playlist.ID)).To(Succeed())
+			}
+		})
+
+		It("returns only duplicate playlist tracks", func() {
+			repo := playlistRepo.Tracks(playlist.ID, true)
+
+			result, err := repo.ReadAll(rest.QueryOptions{
+				Filters: map[string]interface{}{"duplicatesOnly": true},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			tracks, ok := result.(model.PlaylistTracks)
+			Expect(ok).To(BeTrue())
+
+			Expect(tracks).To(HaveLen(3))
+			Expect(tracks[0].ID).To(Equal("2"))
+			Expect(tracks[1].ID).To(Equal("4"))
+			Expect(tracks[2].ID).To(Equal("5"))
+		})
+
+		It("includes only duplicate missing playlist entries when filtering duplicates", func() {
+			playlist.Sync = true
+			playlist.Path = filepath.Join(GinkgoT().TempDir(), "duplicates_missing.m3u")
+			Expect(os.WriteFile(playlist.Path, []byte("ghost-track.mp3\n"+
+				"ghost-track.mp3\n"+
+				"phantom.mp3\n"), 0o600)).To(Succeed())
+			Expect(playlistRepo.Put(&playlist)).To(Succeed())
+
+			repo := playlistRepo.Tracks(playlist.ID, true)
+
+			result, err := repo.ReadAll(rest.QueryOptions{
+				Filters: map[string]interface{}{"duplicatesOnly": true},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			tracks, ok := result.(model.PlaylistTracks)
+			Expect(ok).To(BeTrue())
+
+			Expect(tracks).To(HaveLen(4))
+			Expect(tracks[0].ID).To(Equal("2"))
+			Expect(tracks[1].ID).To(Equal("4"))
+			Expect(tracks[2].ID).To(Equal("5"))
+			Expect(tracks[3].Missing).To(BeTrue())
+			Expect(tracks[3].Path).To(Equal("ghost-track.mp3"))
+			for _, track := range tracks {
+				Expect(track.Path).ToNot(Equal("phantom.mp3"))
+			}
+		})
+
+		It("ignores missing playlist entries that are not duplicates", func() {
+			playlist.Sync = true
+			playlist.Path = filepath.Join(GinkgoT().TempDir(), "single_missing.m3u")
+			Expect(os.WriteFile(playlist.Path, []byte("ghost-track.mp3\n"+
+				"phantom.mp3\n"), 0o600)).To(Succeed())
+			Expect(playlistRepo.Put(&playlist)).To(Succeed())
+
+			repo := playlistRepo.Tracks(playlist.ID, true)
+
+			result, err := repo.ReadAll(rest.QueryOptions{
+				Filters: map[string]interface{}{"duplicatesOnly": true, "q": "ghost"},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			tracks, ok := result.(model.PlaylistTracks)
+			Expect(ok).To(BeTrue())
+
+			Expect(tracks).To(BeEmpty())
+		})
+	})
+})

--- a/persistence/sql_restful.go
+++ b/persistence/sql_restful.go
@@ -121,6 +121,10 @@ func substringFilter(field string, value any) Sqlizer {
 	return filters
 }
 
+func ignoreFilter(string, any) Sqlizer {
+	return nil
+}
+
 func idFilter(tableName string) func(string, any) Sqlizer {
 	return func(field string, value any) Sqlizer { return Eq{tableName + ".id": value} }
 }

--- a/ui/src/playlist/PlaylistShow.jsx
+++ b/ui/src/playlist/PlaylistShow.jsx
@@ -79,7 +79,11 @@ const PlaylistShowLayout = (props) => {
             target="playlist_id"
             sort={{ field: 'id', order: 'ASC' }}
             perPage={50}
-            filter={{ playlist_id: props.id, q: searchTerm }} // Pass searchTerm as a filter
+            filter={{
+              playlist_id: props.id,
+              q: searchTerm,
+              ...(showDuplicatesOnly ? { duplicatesOnly: true } : {}),
+            }} // Pass searchTerm as a filter
           >
             <PlaylistSongs
               {...props}

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -100,7 +100,6 @@ const PlaylistSongs = ({
   readOnly,
   actions,
   showDuplicatesOnly,
-  searchTerm = '',
   ...props
 }) => {
   const listContext = useListContext()
@@ -112,7 +111,8 @@ const PlaylistSongs = ({
     refetch,
     setPage: setContextPage,
   } = listContext
-  const listVersion = listContext.version ?? 0
+  const ids = contextIds
+  const data = contextData
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   const classes = useStyles({ isDesktop })
   const dispatch = useDispatch()
@@ -120,261 +120,35 @@ const PlaylistSongs = ({
   const notify = useNotify()
   const version = useVersion()
   useResourceRefresh('song', 'playlist')
-  const searchValue = useMemo(
-    () => (typeof searchTerm === 'string' ? searchTerm.trim() : ''),
-    [searchTerm],
-  )
-  const fullDataCache = React.useRef({})
-  const [fullDataset, setFullDataset] = React.useState({
-    playlistId: null,
-    search: '',
-    ids: [],
-    data: {},
-    version: null,
-    loading: false,
-    ready: false,
-  })
-  const noopSetPage = useCallback(() => {}, [])
+
+  const prevShowDuplicates = React.useRef(showDuplicatesOnly)
 
   useEffect(() => {
-    if (!showDuplicatesOnly || !playlistId) {
-      return
+    if (prevShowDuplicates.current !== showDuplicatesOnly) {
+      refetch()
     }
+    prevShowDuplicates.current = showDuplicatesOnly
+  }, [showDuplicatesOnly, refetch])
 
-    const cacheKey = `${playlistId}::${searchValue}`
-    const cached = fullDataCache.current[cacheKey]
+  useEffect(() => {
+    setContextPage(1)
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [playlistId, showDuplicatesOnly, setContextPage])
 
-    if (cached && cached.version === listVersion) {
-      setFullDataset({
-        playlistId,
-        search: searchValue,
-        ids: cached.ids,
-        data: cached.data,
-        version: cached.version,
-        loading: false,
-        ready: true,
-      })
-      return
-    }
-
-    let isActive = true
-
-    setFullDataset({
-      playlistId,
-      search: searchValue,
-      ids: [],
-      data: {},
-      version: listVersion,
-      loading: true,
-      ready: false,
-    })
-
-    dataProvider
-      .getList('playlistTrack', {
-        pagination: { page: 1, perPage: 0 },
-        sort: { field: 'id', order: 'ASC' },
-        filter: {
-          playlist_id: playlistId,
-          ...(searchValue ? { q: searchValue } : {}),
-        },
-      })
-      .then(({ data }) => {
-        if (!isActive) {
-          return
-        }
-
-        const mappedData = data.reduce((acc, track) => {
-          acc[track.id] = track
-          return acc
-        }, {})
-        const ids = data.map((track) => track.id)
-        const entry = { ids, data: mappedData, version: listVersion }
-
-        fullDataCache.current[cacheKey] = entry
-
-        setFullDataset({
-          playlistId,
-          search: searchValue,
-          ids,
-          data: mappedData,
-          version: listVersion,
-          loading: false,
-          ready: true,
-        })
-      })
-      .catch(() => {
-        if (!isActive) {
-          return
-        }
-
-        notify('ra.page.error', 'warning')
-
-        setFullDataset({
-          playlistId,
-          search: searchValue,
-          ids: [],
-          data: {},
-          version: listVersion,
-          loading: false,
-          ready: true,
-        })
-      })
-
-    return () => {
-      isActive = false
-    }
-  }, [
-    showDuplicatesOnly,
-    playlistId,
-    searchValue,
-    dataProvider,
-    notify,
-    listVersion,
-  ])
-
-  const usingFullData =
-    showDuplicatesOnly &&
-    fullDataset.ready &&
-    fullDataset.playlistId === playlistId &&
-    fullDataset.search === searchValue
-
-  const duplicateIds = useMemo(() => {
-    if (!showDuplicatesOnly || !usingFullData) {
-      return []
-    }
-
-    const normalizeMeta = (value) => {
-      if (typeof value !== 'string') {
-        return ''
-      }
-      const normalized = value.trim().toLowerCase()
-      if (
-        !normalized ||
-        normalized === 'unknown' ||
-        normalized === 'unknown artist' ||
-        normalized === 'unknown artists'
-      ) {
-        return ''
-      }
-      return normalized
-    }
-
-    const normalizePath = (value) =>
-      typeof value === 'string' ? value.trim().toLowerCase() : ''
-
-    const seen = new Map()
-    const duplicates = []
-
-    fullDataset.ids.forEach((id) => {
-      const track = fullDataset.data[id]
-      if (!track) {
-        return
-      }
-
-      const title = normalizeMeta(track.title)
-      const artist = normalizeMeta(track.artist)
-      const path = normalizePath(track.path)
-
-      let key = null
-      if (title || artist) {
-        key = `meta:${title}|${artist}`
-      } else if (path) {
-        key = `path:${path}`
-      }
-
-      if (!key) {
-        return
-      }
-
-      if (!seen.has(key)) {
-        seen.set(key, [])
-      }
-
-      const list = seen.get(key)
-      list.push(id)
-      if (list.length > 1) {
-        duplicates.push(id)
-      }
-    })
-
-    return duplicates
-  }, [showDuplicatesOnly, usingFullData, fullDataset.ids, fullDataset.data])
-
-  const ids = useMemo(() => {
-    if (!showDuplicatesOnly) {
-      return contextIds
-    }
-
-    return duplicateIds
-  }, [contextIds, duplicateIds, showDuplicatesOnly])
-
-  const data = useMemo(() => {
-    if (!showDuplicatesOnly) {
-      return contextData
-    }
-
-    if (!usingFullData) {
-      return {}
-    }
-
-    return duplicateIds.reduce((acc, id) => {
-      const track = fullDataset.data[id]
-      if (track) {
-        acc[id] = track
-      }
-      return acc
-    }, {})
-  }, [
-    contextData,
-    duplicateIds,
-    fullDataset.data,
-    showDuplicatesOnly,
-    usingFullData,
-  ])
-
-  const displayedIdSet = useMemo(() => new Set(ids), [ids])
+  const displayedIdSet = useMemo(() => new Set(contextIds), [contextIds])
 
   const selectedIds = useMemo(
     () => contextSelectedIds.filter((id) => displayedIdSet.has(id)),
     [contextSelectedIds, displayedIdSet],
   )
 
-  const duplicateLoading =
-    showDuplicatesOnly && (!usingFullData || fullDataset.loading)
-
   const filteredListContext = useMemo(
     () => ({
       ...listContext,
-      ids,
-      data,
       selectedIds,
-      total: showDuplicatesOnly ? ids.length : listContext.total,
-      page: showDuplicatesOnly ? 1 : listContext.page,
-      perPage: showDuplicatesOnly
-        ? ids.length > 0
-          ? ids.length
-          : listContext.perPage
-        : listContext.perPage,
-      loading: showDuplicatesOnly ? duplicateLoading : listContext.loading,
-      loaded: showDuplicatesOnly ? usingFullData : listContext.loaded,
-      setPage: showDuplicatesOnly ? noopSetPage : listContext.setPage,
     }),
-    [
-      data,
-      duplicateLoading,
-      ids,
-      listContext,
-      noopSetPage,
-      selectedIds,
-      showDuplicatesOnly,
-      usingFullData,
-    ],
+    [listContext, selectedIds],
   )
-
-  useEffect(() => {
-    setContextPage(1)
-    window.scrollTo({ top: 0, behavior: 'smooth' })
-  }, [playlistId, setContextPage])
 
   const onAddToPlaylist = useCallback(
     (pls) => {
@@ -516,7 +290,7 @@ const PlaylistSongs = ({
                 readOnly={readOnly}
               />
             </BulkActionsToolbar>
-            {showDuplicatesOnly && duplicateLoading && <LinearProgress />}
+            {showDuplicatesOnly && listContext.loading && <LinearProgress />}
             <ReorderableList
               readOnly={readOnly}
               onDragEnd={handleDragEnd}


### PR DESCRIPTION
## Summary
- add helpers that build duplicate keys so duplicates-only queries can correlate missing entries with actual duplicate sets
- require missing duplicates to share a duplicate key or appear more than once before they are added back to the duplicates-only response
- add a regression test ensuring a single missing playlist entry is ignored when filtering duplicates-only results

## Testing
- go test ./persistence


------
https://chatgpt.com/codex/tasks/task_e_68ea897448dc833087bad81c7f317b5a