### PR TITLE
Fix player arrow-key handling after manual seeking

### DIFF
--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -28,7 +28,7 @@ import { sendNotification } from '../utils'
 import subsonic from '../subsonic'
 import locale from './locale'
 import { keyMap } from '../hotkeys'
-import keyHandlers from './keyHandlers'
+import usePlayerKeyboard from './usePlayerKeyboard'
 import { calculateGain } from '../utils/calculateReplayGain'
 
 const buildNotificationBody = (song) => {
@@ -329,10 +329,7 @@ const Player = () => {
     document.title = 'MusicMatters'
   }
 
-  const handlers = useMemo(
-    () => keyHandlers(audioInstance, playerState),
-    [audioInstance, playerState],
-  )
+  const handlers = usePlayerKeyboard(audioInstance, playerState)
 
   useEffect(() => {
     if (isMobilePlayer && audioInstance) {

--- a/ui/src/audioplayer/usePlayerKeyboard.js
+++ b/ui/src/audioplayer/usePlayerKeyboard.js
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import keyHandlers from './keyHandlers'
 
 const usePlayerKeyboard = (audioInstance, playerState) => {
@@ -6,6 +6,68 @@ const usePlayerKeyboard = (audioInstance, playerState) => {
     () => keyHandlers(audioInstance, playerState),
     [audioInstance, playerState],
   )
+
+  const hasPrevTrack = useCallback(() => {
+    const queue = playerState?.queue || []
+    if (!queue.length) {
+      return false
+    }
+
+    const currentUuid = playerState?.current?.uuid
+    if (!currentUuid) {
+      return false
+    }
+
+    const currentIndex = queue.findIndex((item) => item.uuid === currentUuid)
+    return currentIndex > 0
+  }, [playerState])
+
+  const runPrevSong = useCallback(
+    (event) => {
+      const handler = handlers?.PREV_SONG
+      if (typeof handler !== 'function') {
+        return
+      }
+
+      if (
+        !event?.metaKey &&
+        hasPrevTrack() &&
+        audioInstance &&
+        typeof audioInstance.currentTime === 'number'
+      ) {
+        try {
+          audioInstance.currentTime = 0
+        } catch (err) {
+          // Ignore failures when resetting the current time (e.g. if metadata
+          // is not yet available)
+        }
+      }
+
+      handler(event)
+    },
+    [audioInstance, handlers, hasPrevTrack],
+  )
+
+  const runNextSong = useCallback(
+    (event) => {
+      const handler = handlers?.NEXT_SONG
+      if (typeof handler === 'function') {
+        handler(event)
+      }
+    },
+    [handlers],
+  )
+
+  const prevHandlerRef = useRef(runPrevSong)
+  const nextHandlerRef = useRef(runNextSong)
+
+  useEffect(() => {
+    prevHandlerRef.current = runPrevSong
+  }, [runPrevSong])
+
+  useEffect(() => {
+    nextHandlerRef.current = runNextSong
+  }, [runNextSong])
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -20,11 +82,11 @@ const usePlayerKeyboard = (audioInstance, playerState) => {
       event.preventDefault()
       event.stopPropagation()
 
-      const handlerKey = event.key === 'ArrowLeft' ? 'PREV_SONG' : 'NEXT_SONG'
-      const handler = handlers?.[handlerKey]
+      const ref = event.key === 'ArrowLeft' ? prevHandlerRef : nextHandlerRef
+      const callback = ref.current
 
-      if (typeof handler === 'function') {
-        handler(event)
+      if (typeof callback === 'function') {
+        callback(event)
       }
     }
 
@@ -33,7 +95,7 @@ const usePlayerKeyboard = (audioInstance, playerState) => {
     return () => {
       window.removeEventListener('keydown', handleKeyDown, true)
     }
-  }, [handlers])
+  }, [])
 
   return handlers
 }

--- a/ui/src/audioplayer/usePlayerKeyboard.js
+++ b/ui/src/audioplayer/usePlayerKeyboard.js
@@ -7,45 +7,14 @@ const usePlayerKeyboard = (audioInstance, playerState) => {
     [audioInstance, playerState],
   )
 
-  const hasPrevTrack = useCallback(() => {
-    const queue = playerState?.queue || []
-    if (!queue.length) {
-      return false
-    }
-
-    const currentUuid = playerState?.current?.uuid
-    if (!currentUuid) {
-      return false
-    }
-
-    const currentIndex = queue.findIndex((item) => item.uuid === currentUuid)
-    return currentIndex > 0
-  }, [playerState])
-
   const runPrevSong = useCallback(
     (event) => {
       const handler = handlers?.PREV_SONG
-      if (typeof handler !== 'function') {
-        return
+      if (typeof handler === 'function') {
+        handler(event)
       }
-
-      if (
-        !event?.metaKey &&
-        hasPrevTrack() &&
-        audioInstance &&
-        typeof audioInstance.currentTime === 'number'
-      ) {
-        try {
-          audioInstance.currentTime = 0
-        } catch (err) {
-          // Ignore failures when resetting the current time (e.g. if metadata
-          // is not yet available)
-        }
-      }
-
-      handler(event)
     },
-    [audioInstance, handlers, hasPrevTrack],
+    [handlers],
   )
 
   const runNextSong = useCallback(

--- a/ui/src/audioplayer/usePlayerKeyboard.js
+++ b/ui/src/audioplayer/usePlayerKeyboard.js
@@ -1,0 +1,41 @@
+import { useEffect, useMemo } from 'react'
+import keyHandlers from './keyHandlers'
+
+const usePlayerKeyboard = (audioInstance, playerState) => {
+  const handlers = useMemo(
+    () => keyHandlers(audioInstance, playerState),
+    [audioInstance, playerState],
+  )
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+
+      const handlerKey = event.key === 'ArrowLeft' ? 'PREV_SONG' : 'NEXT_SONG'
+      const handler = handlers?.[handlerKey]
+
+      if (typeof handler === 'function') {
+        handler(event)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown, true)
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown, true)
+    }
+  }, [handlers])
+
+  return handlers
+}
+
+export default usePlayerKeyboard


### PR DESCRIPTION
## Summary
- add a dedicated `usePlayerKeyboard` hook that installs a global keydown listener for the player's prev/next handlers
- use the new hook in the player so ArrowLeft/ArrowRight always trigger Navidrome's track navigation instead of the native audio element

## Testing
- CI=1 npm --prefix ui test *(fails: existing react-admin mock misses useNotify export)*

------
https://chatgpt.com/codex/tasks/task_e_68f0a05d4d648330b43e6df46386e357