### PR TITLE
Fix previous track hotkey behavior

### DIFF
--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -165,7 +165,7 @@ const Player = () => {
       glassBg: false,
       showThemeSwitch: false,
       showMediaSession: true,
-      restartCurrentOnPrev: true,
+      restartCurrentOnPrev: false,
       quietUpdate: true,
       defaultPosition: {
         top: 300,


### PR DESCRIPTION
## Summary
- disable the player option that restarts the current track when pressing the previous action
- allow the left arrow shortcut to jump straight to the previous song

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f0b4930e788330b14a0e19b1a31dc6