### PR TITLE
Fix Songs list queue to include all tracks

### DIFF
--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -10,6 +10,7 @@ import {
   useTranslate,
   NullableBooleanInput,
   usePermissions,
+  useListContext,
 } from 'react-admin'
 import { useMediaQuery } from '@material-ui/core'
 import FavoriteIcon from '@material-ui/icons/Favorite'
@@ -28,7 +29,7 @@ import {
   ArtistLinkField,
   PathField,
 } from '../common'
-import { useSelector, useDispatch } from 'react-redux'
+import { useDispatch } from 'react-redux'
 import { makeStyles } from '@material-ui/core/styles'
 import FavoriteBorderIcon from '@material-ui/icons/FavoriteBorder'
 import { playTracks } from '../actions'
@@ -130,47 +131,50 @@ const SongFilter = (props) => {
   )
 }
 
-const SongList = (props) => {
-  const classes = useStyles()
+const SongListQueueDatagrid = ({ children, ...props }) => {
   const dispatch = useDispatch()
-  const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
-  const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
-  useResourceRefresh('song')
+  const { ids, data } = useListContext()
 
-  const songs = useSelector((state) => state.admin.resources.song)
+  const playableIds = useMemo(() => {
+    if (!data) {
+      return []
+    }
+
+    const sourceIds = Array.isArray(ids) ? ids : Object.keys(data)
+
+    return sourceIds.filter((songId) => {
+      const song = data[songId]
+      return song && !song.missing
+    })
+  }, [ids, data])
 
   const handleRowClick = useCallback(
     (id, basePath, record) => {
-      const ids = songs.list?.ids
-      const data = songs.data
-
-      if (!Array.isArray(ids) || !data) {
+      if (!record || playableIds.length === 0) {
         return
       }
 
-      const visibleSongs = ids
-        .map((songId) => data?.[songId])
-        .filter((song) => Boolean(song) && !song?.missing)
+      const selectedId =
+        playableIds.find((songId) => String(songId) === String(record.id)) ??
+        playableIds[0]
 
-      if (visibleSongs.length === 0) {
-        return
-      }
-
-      const startIndex = visibleSongs.findIndex((song) => song.id === record.id)
-
-      if (startIndex === -1) {
-        return
-      }
-
-      const queue = visibleSongs.reduce((acc, song, idx) => {
-        acc[idx] = song
-        return acc
-      }, {})
-
-      dispatch(playTracks(queue, undefined, String(startIndex)))
+      dispatch(playTracks(data, playableIds, selectedId))
     },
-    [dispatch, songs],
+    [dispatch, data, playableIds],
   )
+
+  return (
+    <SongDatagrid {...props} rowClick={handleRowClick}>
+      {children}
+    </SongDatagrid>
+  )
+}
+
+const SongList = (props) => {
+  const classes = useStyles()
+  const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
+  const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
+  useResourceRefresh('song')
 
   const toggleableFields = useMemo(() => {
     return {
@@ -248,8 +252,7 @@ const SongList = (props) => {
         {isXsmall ? (
           <SongSimpleList />
         ) : (
-          <SongDatagrid
-            rowClick={handleRowClick}
+          <SongListQueueDatagrid
             contextAlwaysVisible={!isDesktop}
             classes={{ row: classes.row }}
           >
@@ -269,7 +272,7 @@ const SongList = (props) => {
                 )
               }
             />
-          </SongDatagrid>
+          </SongListQueueDatagrid>
         )}
       </List>
       <ExpandInfoDialog content={<SongInfo />} />

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -139,38 +139,38 @@ const SongList = (props) => {
 
   const songs = useSelector((state) => state.admin.resources.song)
 
-  const handleRowClick = useCallback((id, basePath, record) => {
-      // Convert songs.data to an array if it's an object
-      const songsArray = Array.isArray(songs.data) ? songs.data : Object.values(songs.data);
+  const handleRowClick = useCallback(
+    (id, basePath, record) => {
+      const ids = songs.list?.ids
+      const data = songs.data
 
-      if (songsArray.length > 0 && Array.isArray(songs.list?.ids)) {
-        // Filter songs to include only those whose IDs exist in songs.list.ids
-        const filteredSongs = songsArray.filter(song => songs.list.ids.includes(song.id));
-
-        // Find the index of the selected song
-        const index = filteredSongs.findIndex(song => song.id === record.id);
-
-        if (index !== -1) {
-          // Rearrange array to start from the selected song
-          const orderedSongs = [
-            ...filteredSongs.slice(index),
-            ...filteredSongs.slice(0, index)
-          ];
-
-          // Convert the array into an object where key = song.id, value = song
-          // const updatedSongs = Object.fromEntries(orderedSongs.map(song => [song.id, song]));
-
-          // Convert array to an object with index-based keys, updating the song id as well
-          const updatedSongs = Object.fromEntries(
-            orderedSongs.map((song, idx) => 
-               [idx, song] // Setting both the key and `id` inside each song
-            )
-          );
-
-          dispatch(playTracks(updatedSongs,0));
-        }
+      if (!Array.isArray(ids) || !data) {
+        return
       }
-    }, [dispatch, songs.data, songs.list?.ids]);
+
+      const visibleSongs = ids
+        .map((songId) => data?.[songId])
+        .filter((song) => Boolean(song) && !song?.missing)
+
+      if (visibleSongs.length === 0) {
+        return
+      }
+
+      const startIndex = visibleSongs.findIndex((song) => song.id === record.id)
+
+      if (startIndex === -1) {
+        return
+      }
+
+      const queue = visibleSongs.reduce((acc, song, idx) => {
+        acc[idx] = song
+        return acc
+      }, {})
+
+      dispatch(playTracks(queue, undefined, String(startIndex)))
+    },
+    [dispatch, songs],
+  )
 
   const toggleableFields = useMemo(() => {
     return {


### PR DESCRIPTION
## Summary
- ensure the Songs list builds the play queue from the full visible list
- start playback at the clicked song without affecting other views

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68f0baae29948330b91a9ff8fe2629c4