### PR TITLE
Ensure play queue starts from first track

### DIFF
--- a/ui/src/reducers/playerReducer.js
+++ b/ui/src/reducers/playerReducer.js
@@ -90,18 +90,14 @@ const mapToAudioLists = (item) => {
 
 const reduceClearQueue = () => ({ ...initialState, clear: true })
 
-const reducePlayTracks = (state, { data, id }) => {
-  let playIndex = 0
-  const queue = Object.keys(data).map((key, idx) => {
-    if (key === id) {
-      playIndex = idx
-    }
+const reducePlayTracks = (state, { data }) => {
+  const queue = Object.keys(data).map((key) => {
     return mapToAudioLists(data[key])
   })
   return {
     ...state,
     queue,
-    playIndex,
+    playIndex: 0,
     clear: true,
   }
 }


### PR DESCRIPTION
## Summary
- update the player reducer so the play queue always begins at the first track when starting playback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f0f7c253fc8330b8e3acdb6721520b