### PR TITLE
Fix playlist track sorting for metadata columns

### DIFF
--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -177,7 +177,7 @@ func (r *playlistRepository) GetWithTracks(id string, refreshSmartPlaylist, incl
 		return nil, err
 	}
 	if includeMissing && pls.Sync && pls.Path != "" {
-		if merged, mergeErr := mergePlaylistTracksWithMissing(r.ctx, tracks, pls, ""); mergeErr == nil {
+		if merged, mergeErr := mergePlaylistTracksWithMissing(r.ctx, tracks, pls, "", true); mergeErr == nil {
 			tracks = merged
 		} else {
 			log.Warn(r.ctx, "Error resolving missing tracks for playlist", "playlistId", pls.ID, mergeErr)

--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -88,6 +88,64 @@ func playlistTrackQueryFilter() filterFunc {
 	}
 }
 
+var playlistTrackMediaFileSorts = map[string]struct{}{
+	"order_artist_name":       {},
+	"order_album_artist_name": {},
+	"order_album_name":        {},
+	"order_title":             {},
+	"duration":                {},
+	"year":                    {},
+	"bpm":                     {},
+	"channels":                {},
+	"genre":                   {},
+	"comment":                 {},
+	"track_number":            {},
+}
+
+func qualifyPlaylistTrackSort(sort string) string {
+	if sort == "" {
+		return sort
+	}
+
+	parts := strings.Split(sort, ",")
+	for i, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+
+		field := trimmed
+		if idx := strings.IndexFunc(field, func(r rune) bool { return r == ' ' || r == '\t' }); idx != -1 {
+			field = field[:idx]
+		}
+
+		if strings.Contains(field, ".") || strings.Contains(field, "(") {
+			parts[i] = trimmed
+			continue
+		}
+
+		if _, ok := playlistTrackMediaFileSorts[field]; ok {
+			parts[i] = strings.Replace(trimmed, field, "f."+field, 1)
+		} else {
+			parts[i] = trimmed
+		}
+	}
+
+	return strings.Join(parts, ", ")
+}
+
+func (r *playlistTrackRepository) newSelect(options ...model.QueryOptions) SelectBuilder {
+	if len(options) > 0 {
+		qualified := make([]model.QueryOptions, len(options))
+		for i, opt := range options {
+			opt.Sort = qualifyPlaylistTrackSort(opt.Sort)
+			qualified[i] = opt
+		}
+		return r.sqlRepository.newSelect(qualified...)
+	}
+	return r.sqlRepository.newSelect(options...)
+}
+
 func (r *playlistRepository) Tracks(playlistId string, refreshSmartPlaylist bool) model.PlaylistTrackRepository {
 	p := &playlistTrackRepository{}
 	p.playlistRepo = r
@@ -103,16 +161,22 @@ func (r *playlistRepository) Tracks(playlistId string, refreshSmartPlaylist bool
 	})
 	p.setSortMappings(
 		map[string]string{
-			"id":           "playlist_tracks.id",
-			"artist":       "order_artist_name",
-			"album_artist": "order_album_artist_name",
-			"album":        "order_album_name, order_album_artist_name",
-			"title":        "order_title",
-			// To make sure these fields will be whitelisted
-			"duration": "duration",
-			"year":     "year",
-			"bpm":      "bpm",
-			"channels": "channels",
+			"id":                      "playlist_tracks.id",
+			"artist":                  "order_artist_name",
+			"album_artist":            "order_album_artist_name",
+			"album":                   "order_album_name, order_album_artist_name",
+			"title":                   "order_title",
+			"duration":                "duration",
+			"year":                    "year",
+			"bpm":                     "bpm",
+			"channels":                "channels",
+			"genre":                   "genre",
+			"comment":                 "comment",
+			"track_number":            "track_number",
+			"order_artist_name":       "order_artist_name",
+			"order_album_artist_name": "order_album_artist_name",
+			"order_album_name":        "order_album_name",
+			"order_title":             "order_title",
 		},
 		"f") // TODO I don't like this solution, but I won't change it now as it's not the focus of BFR.
 

--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -308,6 +308,8 @@ func (r *playlistTrackRepository) listWithMissing(opt model.QueryOptions, restOp
 		return nil, err
 	}
 
+	preservePlaylistOrder := opt.Sort == ""
+
 	searchTerm := ""
 	duplicatesOnly := false
 	if restOpts.Filters != nil {
@@ -323,7 +325,7 @@ func (r *playlistTrackRepository) listWithMissing(opt model.QueryOptions, restOp
 		duplicates := filterDuplicatePlaylistTracks(tracks)
 
 		if r.playlist != nil && r.playlist.Sync && r.playlist.Path != "" {
-			merged, err := mergePlaylistTracksWithMissing(r.ctx, tracks, r.playlist, searchTerm)
+			merged, err := mergePlaylistTracksWithMissing(r.ctx, tracks, r.playlist, searchTerm, preservePlaylistOrder)
 			if err != nil {
 				log.Warn(r.ctx, "Error resolving missing playlist tracks", "playlistId", r.playlistId, err)
 				return duplicates, nil
@@ -346,7 +348,7 @@ func (r *playlistTrackRepository) listWithMissing(opt model.QueryOptions, restOp
 		return tracks, nil
 	}
 
-	merged, err := mergePlaylistTracksWithMissing(r.ctx, tracks, r.playlist, searchTerm)
+	merged, err := mergePlaylistTracksWithMissing(r.ctx, tracks, r.playlist, searchTerm, preservePlaylistOrder)
 	if err != nil {
 		log.Warn(r.ctx, "Error resolving missing playlist tracks", "playlistId", r.playlistId, err)
 		return tracks, nil
@@ -540,7 +542,7 @@ func (r *playlistTrackRepository) AddDiscs(discs []model.DiscID) (int, error) {
 	return r.addMediaFileIds(clauses)
 }
 
-func mergePlaylistTracksWithMissing(ctx context.Context, tracks model.PlaylistTracks, pls *model.Playlist, searchTerm string) (model.PlaylistTracks, error) {
+func mergePlaylistTracksWithMissing(ctx context.Context, tracks model.PlaylistTracks, pls *model.Playlist, searchTerm string, preservePlaylistOrder bool) (model.PlaylistTracks, error) {
 	entries, err := readPlaylistEntries(pls.Path)
 	if err != nil {
 		return nil, err
@@ -566,7 +568,11 @@ func mergePlaylistTracksWithMissing(ctx context.Context, tracks model.PlaylistTr
 	}
 
 	used := make([]bool, len(tracks))
-	result := make(model.PlaylistTracks, 0, len(entries))
+	var result model.PlaylistTracks
+	if preservePlaylistOrder {
+		result = make(model.PlaylistTracks, 0, len(entries))
+	}
+	missing := make(model.PlaylistTracks, 0)
 	missingCount := 0
 
 	for _, entry := range entries {
@@ -575,7 +581,11 @@ func mergePlaylistTracksWithMissing(ctx context.Context, tracks model.PlaylistTr
 
 		var matched bool
 		if matchIdx, ok := popTrackIndex(normalizedEntry, normalized); ok {
-			matched = consumePlaylistTrack(matchIdx, tracks, used, &result, normalized)
+			if preservePlaylistOrder {
+				matched = consumePlaylistTrack(matchIdx, tracks, used, &result, normalized)
+			} else {
+				matched = consumePlaylistTrack(matchIdx, tracks, used, nil, normalized)
+			}
 			if matched {
 				continue
 			}
@@ -594,7 +604,11 @@ func mergePlaylistTracksWithMissing(ctx context.Context, tracks model.PlaylistTr
 				}
 			}
 			if fallbackFound {
-				matched = consumePlaylistTrack(fallbackIdx, tracks, used, &result, normalized)
+				if preservePlaylistOrder {
+					matched = consumePlaylistTrack(fallbackIdx, tracks, used, &result, normalized)
+				} else {
+					matched = consumePlaylistTrack(fallbackIdx, tracks, used, nil, normalized)
+				}
 				if matched {
 					continue
 				}
@@ -629,17 +643,27 @@ func mergePlaylistTracksWithMissing(ctx context.Context, tracks model.PlaylistTr
 				Suffix:  suffix,
 			},
 		}
-		result = append(result, placeholder)
-	}
-
-	for idx, t := range tracks {
-		if used[idx] {
-			continue
+		if preservePlaylistOrder {
+			result = append(result, placeholder)
+		} else {
+			missing = append(missing, placeholder)
 		}
-		result = append(result, t)
 	}
 
-	return result, nil
+	if preservePlaylistOrder {
+		for idx, t := range tracks {
+			if used[idx] {
+				continue
+			}
+			result = append(result, t)
+		}
+		return result, nil
+	}
+
+	merged := make(model.PlaylistTracks, 0, len(tracks)+len(missing))
+	merged = append(merged, tracks...)
+	merged = append(merged, missing...)
+	return merged, nil
 }
 
 func consumePlaylistTrack(idx int, tracks model.PlaylistTracks, used []bool, result *model.PlaylistTracks, indexes map[string][]int) bool {
@@ -651,7 +675,9 @@ func consumePlaylistTrack(idx int, tracks model.PlaylistTracks, used []bool, res
 		return false
 	}
 
-	*result = append(*result, tracks[idx])
+	if result != nil {
+		*result = append(*result, tracks[idx])
+	}
 	used[idx] = true
 	removeTrackFromIndexes(idx, indexes)
 	return true

--- a/persistence/playlist_track_repository_test.go
+++ b/persistence/playlist_track_repository_test.go
@@ -199,5 +199,148 @@ var _ = Describe("PlaylistTrackRepository", func() {
 			Expect(tracks[0].MediaFileID).To(Equal(songDayInALife.ID))
 			Expect(tracks[0].Missing).To(BeFalse())
 		})
+
+		Describe("sorting", func() {
+			var (
+				playlist        model.Playlist
+				repo            model.PlaylistTrackRepository
+				mediaRepo       model.MediaFileRepository
+				cleanupTrackIDs []string
+			)
+
+			beforePlaylist := func() {
+				mediaRepo = NewMediaFileRepository(ctx, GetDBXBuilder())
+				tracks := []model.MediaFile{
+					mf(model.MediaFile{
+						ID:                   "9901",
+						Title:                "Gamma Track",
+						OrderTitle:           "gamma track",
+						ArtistID:             songComeTogether.ArtistID,
+						Artist:               "Artist C",
+						OrderArtistName:      "artist c",
+						AlbumID:              songComeTogether.AlbumID,
+						Album:                "Album C",
+						OrderAlbumName:       "album c",
+						AlbumArtist:          "Album Artist C",
+						OrderAlbumArtistName: "album artist c",
+						Duration:             300,
+						Genre:                "Rock",
+						Comment:              "Zulu",
+						TrackNumber:          3,
+					}),
+					mf(model.MediaFile{
+						ID:                   "9902",
+						Title:                "Alpha Track",
+						OrderTitle:           "alpha track",
+						ArtistID:             songComeTogether.ArtistID,
+						Artist:               "Artist A",
+						OrderArtistName:      "artist a",
+						AlbumID:              songComeTogether.AlbumID,
+						Album:                "Album A",
+						OrderAlbumName:       "album a",
+						AlbumArtist:          "Album Artist A",
+						OrderAlbumArtistName: "album artist a",
+						Duration:             120,
+						Genre:                "Blues",
+						Comment:              "Alpha",
+						TrackNumber:          1,
+					}),
+					mf(model.MediaFile{
+						ID:                   "9903",
+						Title:                "Beta Track",
+						OrderTitle:           "beta track",
+						ArtistID:             songComeTogether.ArtistID,
+						Artist:               "Artist B",
+						OrderArtistName:      "artist b",
+						AlbumID:              songComeTogether.AlbumID,
+						Album:                "Album B",
+						OrderAlbumName:       "album b",
+						AlbumArtist:          "Album Artist B",
+						OrderAlbumArtistName: "album artist b",
+						Duration:             210,
+						Genre:                "Classical",
+						Comment:              "Mid",
+						TrackNumber:          2,
+					}),
+				}
+
+				cleanupTrackIDs = make([]string, len(tracks))
+				for i := range tracks {
+					track := tracks[i]
+					cleanupTrackIDs[i] = track.ID
+					Expect(mediaRepo.Put(&track)).To(Succeed())
+				}
+
+				playlist = model.Playlist{Name: "Sort Playlist", OwnerID: "userid", OwnerName: "userid"}
+				playlist.AddMediaFilesByID(cleanupTrackIDs)
+				Expect(playlistRepo.Put(&playlist)).To(Succeed())
+				repo = playlistRepo.Tracks(playlist.ID, true)
+			}
+
+			AfterEach(func() {
+				if playlist.ID != "" {
+					Expect(playlistRepo.Delete(playlist.ID)).To(Succeed())
+				}
+				for _, id := range cleanupTrackIDs {
+					Expect(mediaRepo.Delete(id)).To(Succeed())
+				}
+				cleanupTrackIDs = nil
+			})
+
+			It("sorts by artist metadata", func() {
+				beforePlaylist()
+				result, err := repo.ReadAll(rest.QueryOptions{Sort: "artist", Order: "ASC"})
+				Expect(err).ToNot(HaveOccurred())
+
+				tracks, ok := result.(model.PlaylistTracks)
+				Expect(ok).To(BeTrue())
+				Expect(tracks).To(HaveLen(3))
+				Expect([]string{tracks[0].Title, tracks[1].Title, tracks[2].Title}).To(Equal([]string{"Alpha Track", "Beta Track", "Gamma Track"}))
+			})
+
+			It("sorts by duration", func() {
+				beforePlaylist()
+				result, err := repo.ReadAll(rest.QueryOptions{Sort: "duration", Order: "ASC"})
+				Expect(err).ToNot(HaveOccurred())
+
+				tracks, ok := result.(model.PlaylistTracks)
+				Expect(ok).To(BeTrue())
+				Expect(tracks).To(HaveLen(3))
+				Expect([]string{tracks[0].Title, tracks[1].Title, tracks[2].Title}).To(Equal([]string{"Alpha Track", "Beta Track", "Gamma Track"}))
+			})
+
+			It("sorts by genre", func() {
+				beforePlaylist()
+				result, err := repo.ReadAll(rest.QueryOptions{Sort: "genre", Order: "ASC"})
+				Expect(err).ToNot(HaveOccurred())
+
+				tracks, ok := result.(model.PlaylistTracks)
+				Expect(ok).To(BeTrue())
+				Expect(tracks).To(HaveLen(3))
+				Expect([]string{tracks[0].Title, tracks[1].Title, tracks[2].Title}).To(Equal([]string{"Alpha Track", "Beta Track", "Gamma Track"}))
+			})
+
+			It("sorts by comment", func() {
+				beforePlaylist()
+				result, err := repo.ReadAll(rest.QueryOptions{Sort: "comment", Order: "ASC"})
+				Expect(err).ToNot(HaveOccurred())
+
+				tracks, ok := result.(model.PlaylistTracks)
+				Expect(ok).To(BeTrue())
+				Expect(tracks).To(HaveLen(3))
+				Expect([]string{tracks[0].Title, tracks[1].Title, tracks[2].Title}).To(Equal([]string{"Alpha Track", "Beta Track", "Gamma Track"}))
+			})
+
+			It("sorts by title", func() {
+				beforePlaylist()
+				result, err := repo.ReadAll(rest.QueryOptions{Sort: "title", Order: "ASC"})
+				Expect(err).ToNot(HaveOccurred())
+
+				tracks, ok := result.(model.PlaylistTracks)
+				Expect(ok).To(BeTrue())
+				Expect(tracks).To(HaveLen(3))
+				Expect([]string{tracks[0].Title, tracks[1].Title, tracks[2].Title}).To(Equal([]string{"Alpha Track", "Beta Track", "Gamma Track"}))
+			})
+		})
 	})
 })

--- a/persistence/playlist_track_repository_test.go
+++ b/persistence/playlist_track_repository_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/deluan/rest"
 	"github.com/navidrome/navidrome/log"
@@ -206,6 +207,7 @@ var _ = Describe("PlaylistTrackRepository", func() {
 				repo            model.PlaylistTrackRepository
 				mediaRepo       model.MediaFileRepository
 				cleanupTrackIDs []string
+				seededTracks    []model.MediaFile
 			)
 
 			beforePlaylist := func() {
@@ -227,6 +229,7 @@ var _ = Describe("PlaylistTrackRepository", func() {
 						Genre:                "Rock",
 						Comment:              "Zulu",
 						TrackNumber:          3,
+						Path:                 p("/playlist/gamma.mp3"),
 					}),
 					mf(model.MediaFile{
 						ID:                   "9902",
@@ -244,6 +247,7 @@ var _ = Describe("PlaylistTrackRepository", func() {
 						Genre:                "Blues",
 						Comment:              "Alpha",
 						TrackNumber:          1,
+						Path:                 p("/playlist/alpha.mp3"),
 					}),
 					mf(model.MediaFile{
 						ID:                   "9903",
@@ -261,9 +265,11 @@ var _ = Describe("PlaylistTrackRepository", func() {
 						Genre:                "Classical",
 						Comment:              "Mid",
 						TrackNumber:          2,
+						Path:                 p("/playlist/beta.mp3"),
 					}),
 				}
 
+				seededTracks = append([]model.MediaFile(nil), tracks...)
 				cleanupTrackIDs = make([]string, len(tracks))
 				for i := range tracks {
 					track := tracks[i]
@@ -285,6 +291,7 @@ var _ = Describe("PlaylistTrackRepository", func() {
 					Expect(mediaRepo.Delete(id)).To(Succeed())
 				}
 				cleanupTrackIDs = nil
+				seededTracks = nil
 			})
 
 			It("sorts by artist metadata", func() {
@@ -340,6 +347,34 @@ var _ = Describe("PlaylistTrackRepository", func() {
 				Expect(ok).To(BeTrue())
 				Expect(tracks).To(HaveLen(3))
 				Expect([]string{tracks[0].Title, tracks[1].Title, tracks[2].Title}).To(Equal([]string{"Alpha Track", "Beta Track", "Gamma Track"}))
+			})
+
+			It("sorts synced playlists when missing entries are merged", func() {
+				beforePlaylist()
+
+				playlist.Sync = true
+				playlist.Path = filepath.Join(GinkgoT().TempDir(), "sorted_sync.m3u")
+				contents := strings.Join([]string{
+					seededTracks[0].Path,
+					"ghost-track.mp3",
+					seededTracks[2].Path,
+					seededTracks[1].Path,
+				}, "\n")
+				Expect(os.WriteFile(playlist.Path, []byte(contents), 0o600)).To(Succeed())
+				playlist.Tracks = nil
+				Expect(playlistRepo.Put(&playlist)).To(Succeed())
+
+				repo = playlistRepo.Tracks(playlist.ID, true)
+
+				result, err := repo.ReadAll(rest.QueryOptions{Sort: "artist", Order: "ASC"})
+				Expect(err).ToNot(HaveOccurred())
+
+				tracks, ok := result.(model.PlaylistTracks)
+				Expect(ok).To(BeTrue())
+				Expect(tracks).To(HaveLen(4))
+				Expect([]string{tracks[0].Title, tracks[1].Title, tracks[2].Title}).To(Equal([]string{"Alpha Track", "Beta Track", "Gamma Track"}))
+				Expect(tracks[3].Missing).To(BeTrue())
+				Expect(tracks[3].Path).To(Equal("ghost-track.mp3"))
 			})
 		})
 	})


### PR DESCRIPTION
## Summary
- qualify playlist track sort fields to use media file metadata columns so sorting works for artist, title, duration, genre, and comment
- allow additional playlist track sort mappings and add regression tests that cover sorting behaviour

## Testing
- go test ./persistence

------
https://chatgpt.com/codex/tasks/task_e_68f2892673a88330b338eaa1fb58dc65