### PR TITLE
Fix playlist track sorting to align with songs view

### DIFF
--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -109,10 +109,13 @@ func (r *playlistRepository) Tracks(playlistId string, refreshSmartPlaylist bool
 			"album":        "order_album_name, order_album_artist_name",
 			"title":        "order_title",
 			// To make sure these fields will be whitelisted
-			"duration": "duration",
-			"year":     "year",
-			"bpm":      "bpm",
-			"channels": "channels",
+			"duration":     "f.duration",
+			"year":         "year",
+			"bpm":          "bpm",
+			"channels":     "channels",
+			"track_number": "f.track_number",
+			"genre":        "f.genre",
+			"comment":      "f.comment",
 		},
 		"f") // TODO I don't like this solution, but I won't change it now as it's not the focus of BFR.
 

--- a/persistence/playlist_track_repository_test.go
+++ b/persistence/playlist_track_repository_test.go
@@ -200,4 +200,147 @@ var _ = Describe("PlaylistTrackRepository", func() {
 			Expect(tracks[0].Missing).To(BeFalse())
 		})
 	})
+
+	Describe("sorting", func() {
+		var (
+			playlist      model.Playlist
+			mediaRepo     model.MediaFileRepository
+			createdTracks []model.MediaFile
+			repo          model.PlaylistTrackRepository
+		)
+
+		BeforeEach(func() {
+			mediaRepo = NewMediaFileRepository(ctx, GetDBXBuilder())
+			createdTracks = []model.MediaFile{
+				mf(model.MediaFile{
+					ID:              "9101",
+					Title:           "Sort Song Gamma",
+					ArtistID:        "3",
+					Artist:          "Gamma Artist",
+					OrderArtistName: "gamma artist",
+					AlbumID:         "101",
+					Album:           "Sgt Peppers",
+					TrackNumber:     3,
+					Genre:           "Jazz",
+					Comment:         "Charlie",
+					Duration:        240,
+					Path:            p("/sort/gamma.mp3"),
+				}),
+				mf(model.MediaFile{
+					ID:              "9102",
+					Title:           "Sort Song Alpha",
+					ArtistID:        "3",
+					Artist:          "Alpha Artist",
+					OrderArtistName: "alpha artist",
+					AlbumID:         "101",
+					Album:           "Sgt Peppers",
+					TrackNumber:     1,
+					Genre:           "Blues",
+					Comment:         "Alpha",
+					Duration:        120,
+					Path:            p("/sort/alpha.mp3"),
+				}),
+				mf(model.MediaFile{
+					ID:              "9103",
+					Title:           "Sort Song Beta",
+					ArtistID:        "3",
+					Artist:          "Beta Artist",
+					OrderArtistName: "beta artist",
+					AlbumID:         "101",
+					Album:           "Sgt Peppers",
+					TrackNumber:     2,
+					Genre:           "Rock",
+					Comment:         "Bravo",
+					Duration:        180,
+					Path:            p("/sort/beta.mp3"),
+				}),
+			}
+
+			for i := range createdTracks {
+				track := createdTracks[i]
+				Expect(mediaRepo.Put(&track)).To(Succeed())
+				createdTracks[i] = track
+			}
+
+			playlist = model.Playlist{Name: "Sorting", OwnerID: "userid", OwnerName: "userid"}
+			playlist.AddMediaFilesByID([]string{createdTracks[0].ID, createdTracks[1].ID, createdTracks[2].ID})
+			Expect(playlistRepo.Put(&playlist)).To(Succeed())
+
+			repo = playlistRepo.Tracks(playlist.ID, true)
+		})
+
+		AfterEach(func() {
+			if playlist.ID != "" {
+				Expect(playlistRepo.Delete(playlist.ID)).To(Succeed())
+			}
+			for _, track := range createdTracks {
+				Expect(mediaRepo.Delete(track.ID)).To(Succeed())
+			}
+		})
+
+		It("sorts playlist tracks by key metadata fields", func() {
+			cases := []struct {
+				field   string
+				asc     []string
+				message string
+			}{
+				{
+					field:   "artist",
+					asc:     []string{"9102", "9103", "9101"},
+					message: "artist",
+				},
+				{
+					field:   "trackNumber",
+					asc:     []string{"9102", "9103", "9101"},
+					message: "track number",
+				},
+				{
+					field:   "genre",
+					asc:     []string{"9102", "9101", "9103"},
+					message: "genre",
+				},
+				{
+					field:   "comment",
+					asc:     []string{"9102", "9103", "9101"},
+					message: "comment",
+				},
+				{
+					field:   "duration",
+					asc:     []string{"9102", "9103", "9101"},
+					message: "duration",
+				},
+			}
+
+			for _, tc := range cases {
+				tc := tc
+				resultAsc, err := repo.ReadAll(rest.QueryOptions{Sort: tc.field, Order: "ASC"})
+				Expect(err).ToNot(HaveOccurred())
+				ascTracks, ok := resultAsc.(model.PlaylistTracks)
+				Expect(ok).To(BeTrue())
+				Expect(extractMediaFileIDs(ascTracks)).To(Equal(tc.asc), "ascending sort by %s", tc.message)
+
+				resultDesc, err := repo.ReadAll(rest.QueryOptions{Sort: tc.field, Order: "DESC"})
+				Expect(err).ToNot(HaveOccurred())
+				descTracks, ok := resultDesc.(model.PlaylistTracks)
+				Expect(ok).To(BeTrue())
+				Expect(extractMediaFileIDs(descTracks)).To(Equal(reverseStrings(tc.asc)), "descending sort by %s", tc.message)
+			}
+		})
+	})
 })
+
+func extractMediaFileIDs(tracks model.PlaylistTracks) []string {
+	ids := make([]string, len(tracks))
+	for i, track := range tracks {
+		ids[i] = track.MediaFileID
+	}
+	return ids
+}
+
+func reverseStrings(values []string) []string {
+	reversed := make([]string, len(values))
+	for i := range values {
+		reversed[i] = values[len(values)-1-i]
+	}
+	return reversed
+}

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -263,13 +263,21 @@ const PlaylistSongs = ({
 
   const toggleableFields = useMemo(() => {
     return {
-      trackNumber: isDesktop && <TextField source="id" label={'#'} />,
+      trackNumber:
+        isDesktop && (
+          <NumberField source="trackNumber" label={'#'} sortBy="trackNumber" />
+        ),
       title: <SongTitleField source="title" showTrackNumbers={false} />,
       album: isDesktop && <AlbumLinkField source="album" />,
-      artist: isDesktop && <ArtistLinkField source="artist" />,
+      artist:
+        isDesktop && <ArtistLinkField source="artist" sortBy="artist" />, 
       albumArtist: isDesktop && <ArtistLinkField source="albumArtist" />,
       duration: (
-        <DurationField source="duration" className={classes.draggable} />
+        <DurationField
+          source="duration"
+          sortBy="duration"
+          className={classes.draggable}
+        />
       ),
       year: isDesktop && (
         <FunctionField
@@ -290,8 +298,8 @@ const PlaylistSongs = ({
       quality: isDesktop && <QualityInfo source="quality" sortable={false} />,
       channels: isDesktop && <NumberField source="channels" />,
       bpm: isDesktop && <NumberField source="bpm" />,
-      genre: <TextField source="genre" />,
-      comment: <TextField source="comment" />,
+      genre: <TextField source="genre" sortBy="genre" />,
+      comment: <TextField source="comment" sortBy="comment" />,
       path: <PathField source="path" />,
       rating: config.enableStarRating && (
         <RatingField


### PR DESCRIPTION
## Summary
- ensure playlist playlistTrack datagrid uses sortable artist, track number, duration, genre, and comment columns
- align playlist time column with sortable configuration to match the songs view

## Testing
- npm --prefix ui run lint

------
https://chatgpt.com/codex/tasks/task_e_68f28ed184148330978b9c3d15fdee2a