### PR TITLE
Enable sorting on playlist tracks

### DIFF
--- a/ui/src/layout/AppBar.test.jsx
+++ b/ui/src/layout/AppBar.test.jsx
@@ -14,6 +14,7 @@ vi.mock('react-admin', () => ({
   useTranslate: () => (x) => x,
   usePermissions: () => ({ permissions: 'admin' }),
   getResources: () => [],
+  useNotify: () => () => {},
 }))
 
 vi.mock('./NowPlayingPanel', () => ({

--- a/ui/src/playlist/PlaylistShow.jsx
+++ b/ui/src/playlist/PlaylistShow.jsx
@@ -113,6 +113,7 @@ const PlaylistShowLayout = (props) => {
                 />}
               searchTerm={searchTerm} // Pass search term to child
               showDuplicatesOnly={showDuplicatesOnly}
+              sort={sort}
               onSortChange={handleSortChange}
             />
           </ReferenceManyField>

--- a/ui/src/playlist/PlaylistShow.jsx
+++ b/ui/src/playlist/PlaylistShow.jsx
@@ -36,6 +36,7 @@ const PlaylistShowLayout = (props) => {
   // Store search query in state to prevent losing focus
   const [searchTerm, setSearchTerm] = useState('')
   const [showDuplicatesOnly, setShowDuplicatesOnly] = useState(false)
+  const [sort, setSort] = useState({ field: 'title', order: 'ASC' })
 
   // Handle search change
   const handleSearchChange = useCallback((eventOrValue) => {
@@ -53,7 +54,15 @@ const PlaylistShowLayout = (props) => {
 
   React.useEffect(() => {
     setShowDuplicatesOnly(false)
+    setSort({ field: 'title', order: 'ASC' })
   }, [record?.id])
+
+  const handleSortChange = useCallback((nextSort) => {
+    if (!nextSort) {
+      return
+    }
+    setSort(nextSort)
+  }, [])
 
   return (
     <>
@@ -77,7 +86,7 @@ const PlaylistShowLayout = (props) => {
             addLabel={false}
             reference="playlistTrack"
             target="playlist_id"
-            sort={{ field: 'id', order: 'ASC' }}
+            sort={sort}
             perPage={50}
             filter={{
               playlist_id: props.id,
@@ -104,6 +113,7 @@ const PlaylistShowLayout = (props) => {
                 />}
               searchTerm={searchTerm} // Pass search term to child
               showDuplicatesOnly={showDuplicatesOnly}
+              onSortChange={handleSortChange}
             />
           </ReferenceManyField>
         </>

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -100,6 +100,7 @@ const PlaylistSongs = ({
   readOnly,
   actions,
   showDuplicatesOnly,
+  onSortChange,
   ...props
 }) => {
   const listContext = useListContext()
@@ -140,8 +141,9 @@ const PlaylistSongs = ({
   const {
     onSelect: contextOnSelect,
     filterValues = {},
-    currentSort,
+    currentSort: contextCurrentSort,
     total: contextTotal,
+    setSort: contextSetSort,
   } = listContext
 
   const handleSelect = useCallback(
@@ -172,8 +174,8 @@ const PlaylistSongs = ({
       if (shouldLoadAllIds) {
         const filter = { ...filterValues, playlist_id: playlistId }
         const sort =
-          currentSort && currentSort.field
-            ? currentSort
+          contextCurrentSort && contextCurrentSort.field
+            ? contextCurrentSort
             : { field: 'id', order: 'ASC' }
 
         dataProvider
@@ -211,9 +213,35 @@ const PlaylistSongs = ({
       contextTotal,
       filterValues,
       playlistId,
-      currentSort,
+      contextCurrentSort,
       dataProvider,
     ],
+  )
+
+  const handleSetSort = useCallback(
+    (sort, order) => {
+      if (typeof contextSetSort === 'function') {
+        contextSetSort(sort, order)
+      }
+
+      if (!onSortChange) {
+        return
+      }
+
+      let nextOrder = order
+      if (typeof nextOrder === 'undefined') {
+        if (contextCurrentSort?.field === sort) {
+          nextOrder = contextCurrentSort.order === 'ASC' ? 'DESC' : 'ASC'
+        } else {
+          nextOrder = 'ASC'
+        }
+      }
+
+      if (sort) {
+        onSortChange({ field: sort, order: nextOrder })
+      }
+    },
+    [contextSetSort, onSortChange, contextCurrentSort],
   )
 
   const filteredListContext = useMemo(
@@ -221,8 +249,9 @@ const PlaylistSongs = ({
       ...listContext,
       selectedIds,
       onSelect: handleSelect,
+      setSort: handleSetSort,
     }),
-    [listContext, selectedIds, handleSelect],
+    [listContext, selectedIds, handleSelect, handleSetSort],
   )
 
   const onAddToPlaylist = useCallback(

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -101,6 +101,7 @@ const PlaylistSongs = ({
   actions,
   showDuplicatesOnly,
   onSortChange,
+  sort: currentSortProp,
   ...props
 }) => {
   const listContext = useListContext()
@@ -143,7 +144,6 @@ const PlaylistSongs = ({
     filterValues = {},
     currentSort: contextCurrentSort,
     total: contextTotal,
-    setSort: contextSetSort,
   } = listContext
 
   const handleSelect = useCallback(
@@ -218,41 +218,52 @@ const PlaylistSongs = ({
     ],
   )
 
-  const handleSetSort = useCallback(
-    (sort, order) => {
-      if (typeof contextSetSort === 'function') {
-        contextSetSort(sort, order)
-      }
-
-      if (!onSortChange) {
-        return
-      }
-
-      let nextOrder = order
-      if (typeof nextOrder === 'undefined') {
-        if (contextCurrentSort?.field === sort) {
-          nextOrder = contextCurrentSort.order === 'ASC' ? 'DESC' : 'ASC'
-        } else {
-          nextOrder = 'ASC'
-        }
-      }
-
-      if (sort) {
-        onSortChange({ field: sort, order: nextOrder })
-      }
-    },
-    [contextSetSort, onSortChange, contextCurrentSort],
-  )
-
   const filteredListContext = useMemo(
     () => ({
       ...listContext,
       selectedIds,
       onSelect: handleSelect,
-      setSort: handleSetSort,
     }),
-    [listContext, selectedIds, handleSelect, handleSetSort],
+    [listContext, selectedIds, handleSelect],
   )
+
+  const normalizedContextSort = useMemo(() => {
+    if (!contextCurrentSort?.field) {
+      return null
+    }
+
+    return {
+      field: contextCurrentSort.field,
+      order: (contextCurrentSort.order || 'ASC').toUpperCase(),
+    }
+  }, [contextCurrentSort])
+
+  const normalizedPropSort = useMemo(() => {
+    if (!currentSortProp?.field) {
+      return null
+    }
+
+    return {
+      field: currentSortProp.field,
+      order: (currentSortProp.order || 'ASC').toUpperCase(),
+    }
+  }, [currentSortProp])
+
+  useEffect(() => {
+    if (!onSortChange || !normalizedContextSort) {
+      return
+    }
+
+    if (
+      normalizedPropSort &&
+      normalizedPropSort.field === normalizedContextSort.field &&
+      normalizedPropSort.order === normalizedContextSort.order
+    ) {
+      return
+    }
+
+    onSortChange(normalizedContextSort)
+  }, [normalizedContextSort, normalizedPropSort, onSortChange])
 
   const onAddToPlaylist = useCallback(
     (pls) => {


### PR DESCRIPTION
## Summary
- maintain playlist track sort state in the Playlist show page with a default of title ascending
- forward header sort changes from the playlist track grid so users can toggle column sorting without breaking existing actions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f297f7c4ec83309db465f4b08b91a2