### PR TITLE
Ensure playlist track sorting honors selected fields

### DIFF
--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -2,14 +2,17 @@ package persistence
 
 import (
 	"bufio"
+	"cmp"
 	"context"
 	"database/sql"
 	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/Masterminds/squirrel"
 	"github.com/deluan/rest"
@@ -287,7 +290,159 @@ func (r *playlistTrackRepository) listWithMissing(opt model.QueryOptions, restOp
 		log.Warn(r.ctx, "Error resolving missing playlist tracks", "playlistId", r.playlistId, err)
 		return tracks, nil
 	}
+	applyPlaylistTrackSort(merged, opt.Sort, opt.Order)
 	return merged, nil
+}
+
+func applyPlaylistTrackSort(tracks model.PlaylistTracks, sortField, sortOrder string) {
+	normalized := normalizePlaylistSortField(sortField)
+	if normalized == "" || normalized == "id" {
+		return
+	}
+
+	descending := strings.EqualFold(sortOrder, "desc")
+
+	slices.SortStableFunc(tracks, func(a, b model.PlaylistTrack) int {
+		if a.Missing != b.Missing {
+			if a.Missing {
+				return 1
+			}
+			return -1
+		}
+
+		cmpResult := comparePlaylistTracksByField(normalized, a, b)
+		if cmpResult == 0 {
+			cmpResult = cmp.Compare(a.ID, b.ID)
+		}
+
+		if descending {
+			cmpResult = -cmpResult
+		}
+
+		return cmpResult
+	})
+}
+
+func comparePlaylistTracksByField(field string, a, b model.PlaylistTrack) int {
+	getter, ok := playlistTrackSortExtractors[field]
+	if !ok {
+		return 0
+	}
+
+	av := getter(a)
+	bv := getter(b)
+	result := comparePlaylistSortValues(av, bv)
+
+	if result == 0 {
+		switch field {
+		case "album":
+			return comparePlaylistTracksByField("albumartist", a, b)
+		}
+	}
+
+	return result
+}
+
+func comparePlaylistSortValues(av, bv any) int {
+	switch a := av.(type) {
+	case string:
+		b := bv.(string)
+		return strings.Compare(strings.ToLower(a), strings.ToLower(b))
+	case int:
+		return cmp.Compare(a, bv.(int))
+	case int64:
+		return cmp.Compare(a, bv.(int64))
+	case float32:
+		return cmp.Compare(float64(a), float64(bv.(float32)))
+	case float64:
+		return cmp.Compare(a, bv.(float64))
+	case time.Time:
+		return cmp.Compare(a, bv.(time.Time))
+	case bool:
+		return cmp.Compare(a, bv.(bool))
+	default:
+		return strings.Compare(strings.ToLower(fmt.Sprint(av)), strings.ToLower(fmt.Sprint(bv)))
+	}
+}
+
+func normalizePlaylistSortField(field string) string {
+	field = strings.TrimSpace(strings.ToLower(field))
+	if field == "" {
+		return ""
+	}
+
+	field = strings.TrimPrefix(field, "playlist_tracks.")
+	field = strings.TrimPrefix(field, "f.")
+	field = strings.ReplaceAll(field, ".", "_")
+	field = strings.ReplaceAll(field, "_", "")
+
+	return field
+}
+
+var playlistTrackSortExtractors = map[string]func(model.PlaylistTrack) any{
+	"album": func(t model.PlaylistTrack) any {
+		return t.Album
+	},
+	"albumartist": func(t model.PlaylistTrack) any {
+		return t.AlbumArtist
+	},
+	"orderalbumartistname": func(t model.PlaylistTrack) any {
+		return t.OrderAlbumArtistName
+	},
+	"orderalbumname": func(t model.PlaylistTrack) any {
+		return t.OrderAlbumName
+	},
+	"artist": func(t model.PlaylistTrack) any {
+		return t.Artist
+	},
+	"orderartistname": func(t model.PlaylistTrack) any {
+		return t.OrderArtistName
+	},
+	"title": func(t model.PlaylistTrack) any {
+		return t.Title
+	},
+	"ordertitle": func(t model.PlaylistTrack) any {
+		return t.OrderTitle
+	},
+	"duration": func(t model.PlaylistTrack) any {
+		return float64(t.Duration)
+	},
+	"year": func(t model.PlaylistTrack) any {
+		return t.Year
+	},
+	"bpm": func(t model.PlaylistTrack) any {
+		return t.BPM
+	},
+	"channels": func(t model.PlaylistTrack) any {
+		return t.Channels
+	},
+	"playcount": func(t model.PlaylistTrack) any {
+		return t.PlayCount
+	},
+	"playdate": func(t model.PlaylistTrack) any {
+		if t.PlayDate != nil {
+			return *t.PlayDate
+		}
+		return time.Time{}
+	},
+	"createdat": func(t model.PlaylistTrack) any {
+		return t.CreatedAt
+	},
+	"comment": func(t model.PlaylistTrack) any {
+		return t.Comment
+	},
+	"path": func(t model.PlaylistTrack) any {
+		return t.Path
+	},
+	"genre": func(t model.PlaylistTrack) any {
+		return t.Genre
+	},
+	"rating": func(t model.PlaylistTrack) any {
+		return t.Rating
+	},
+	"tracknumber": func(t model.PlaylistTrack) any {
+		return t.TrackNumber
+	},
 }
 
 func parseBoolFilter(value interface{}) bool {

--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -357,9 +357,25 @@ func comparePlaylistSortValues(av, bv any) int {
 	case float64:
 		return cmp.Compare(a, bv.(float64))
 	case time.Time:
-		return cmp.Compare(a, bv.(time.Time))
+		b := bv.(time.Time)
+		switch {
+		case a.Before(b):
+			return -1
+		case a.After(b):
+			return 1
+		default:
+			return 0
+		}
 	case bool:
-		return cmp.Compare(a, bv.(bool))
+		b := bv.(bool)
+		switch {
+		case a == b:
+			return 0
+		case !a && b:
+			return -1
+		default:
+			return 1
+		}
 	default:
 		return strings.Compare(strings.ToLower(fmt.Sprint(av)), strings.ToLower(fmt.Sprint(bv)))
 	}
@@ -375,10 +391,32 @@ func normalizePlaylistSortField(field string) string {
 		return normalized
 	}
 
-	for key := range playlistTrackSortExtractors {
-		if strings.Contains(normalized, key) {
-			return key
+	for _, token := range splitPlaylistSortFieldTokens(field) {
+		tokenNormalized := sanitizePlaylistSortField(token)
+		if tokenNormalized == "" {
+			continue
 		}
+		if _, ok := playlistTrackSortExtractors[tokenNormalized]; ok {
+			return tokenNormalized
+		}
+	}
+
+	bestKey := ""
+	bestPos := len(normalized) + 1
+	for key := range playlistTrackSortExtractors {
+		pos := strings.Index(normalized, key)
+		if pos == -1 {
+			continue
+		}
+
+		if pos < bestPos || (pos == bestPos && len(key) > len(bestKey)) {
+			bestKey = key
+			bestPos = pos
+		}
+	}
+
+	if bestKey != "" {
+		return bestKey
 	}
 
 	return ""
@@ -403,6 +441,32 @@ func sanitizePlaylistSortField(field string) string {
 	}
 
 	return b.String()
+}
+
+func splitPlaylistSortFieldTokens(field string) []string {
+	if field == "" {
+		return nil
+	}
+
+	lower := strings.ToLower(field)
+	tokens := strings.FieldsFunc(lower, func(r rune) bool {
+		switch r {
+		case ' ', '\t', '\n', '\r', ',', '(', ')', '+', '-', '*', '/', '"':
+			return true
+		}
+		return false
+	})
+
+	cleaned := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		trimmed := strings.Trim(token, "'")
+		if idx := strings.LastIndex(trimmed, "."); idx != -1 {
+			trimmed = trimmed[idx+1:]
+		}
+		cleaned = append(cleaned, trimmed)
+	}
+
+	return cleaned
 }
 
 var playlistTrackSortExtractors = map[string]func(model.PlaylistTrack) any{

--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -366,17 +366,43 @@ func comparePlaylistSortValues(av, bv any) int {
 }
 
 func normalizePlaylistSortField(field string) string {
-	field = strings.TrimSpace(strings.ToLower(field))
+	normalized := sanitizePlaylistSortField(field)
+	if normalized == "" || normalized == "id" {
+		return ""
+	}
+
+	if _, ok := playlistTrackSortExtractors[normalized]; ok {
+		return normalized
+	}
+
+	for key := range playlistTrackSortExtractors {
+		if strings.Contains(normalized, key) {
+			return key
+		}
+	}
+
+	return ""
+}
+
+func sanitizePlaylistSortField(field string) string {
 	if field == "" {
 		return ""
 	}
 
-	field = strings.TrimPrefix(field, "playlist_tracks.")
-	field = strings.TrimPrefix(field, "f.")
-	field = strings.ReplaceAll(field, ".", "_")
-	field = strings.ReplaceAll(field, "_", "")
+	lower := strings.ToLower(strings.TrimSpace(field))
+	var b strings.Builder
+	b.Grow(len(lower))
 
-	return field
+	for _, r := range lower {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		}
+	}
+
+	return b.String()
 }
 
 var playlistTrackSortExtractors = map[string]func(model.PlaylistTrack) any{

--- a/persistence/playlist_track_sort_test.go
+++ b/persistence/playlist_track_sort_test.go
@@ -16,6 +16,7 @@ func TestNormalizePlaylistSortField(t *testing.T) {
 		{name: "with prefix", input: "playlist_tracks.created_at", expected: "createdat"},
 		{name: "prefer sort tags expression", input: "(coalesce(nullif(f.sort_title,''),f.order_title) collate nocase)", expected: "ordertitle"},
 		{name: "multiple columns", input: "order_album_name, order_album_artist_name", expected: "orderalbumname"},
+		{name: "multiple with overlap", input: "order_title, order_artist_name", expected: "ordertitle"},
 		{name: "desc order", input: "f.order_artist_name desc", expected: "orderartistname"},
 		{name: "unknown", input: "playlist_tracks.rowid", expected: ""},
 	}

--- a/persistence/playlist_track_sort_test.go
+++ b/persistence/playlist_track_sort_test.go
@@ -1,0 +1,56 @@
+package persistence
+
+import "testing"
+
+func TestNormalizePlaylistSortField(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "empty", input: "", expected: ""},
+		{name: "id", input: "id", expected: ""},
+		{name: "simple order", input: "order_title", expected: "ordertitle"},
+		{name: "with prefix", input: "playlist_tracks.created_at", expected: "createdat"},
+		{name: "prefer sort tags expression", input: "(coalesce(nullif(f.sort_title,''),f.order_title) collate nocase)", expected: "ordertitle"},
+		{name: "multiple columns", input: "order_album_name, order_album_artist_name", expected: "orderalbumname"},
+		{name: "desc order", input: "f.order_artist_name desc", expected: "orderartistname"},
+		{name: "unknown", input: "playlist_tracks.rowid", expected: ""},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizePlaylistSortField(tc.input); got != tc.expected {
+				t.Fatalf("normalizePlaylistSortField(%q) = %q, expected %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizePlaylistSortField(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "basic", input: "order_title", expected: "ordertitle"},
+		{name: "with spaces and punctuation", input: "(coalesce(nullif(f.sort_title,''),f.order_title) collate nocase)", expected: "coalescenulliffsorttitleffordertitlecollatenocase"},
+		{name: "empty", input: "", expected: ""},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := sanitizePlaylistSortField(tc.input); got != tc.expected {
+				t.Fatalf("sanitizePlaylistSortField(%q) = %q, expected %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- ensure playlist track queries sort merged missing entries according to the selected column
- keep missing tracks at the end of sorted playlists while supporting the existing ordering fallback

## Testing
- go test ./... *(fails: requires taglib development headers in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2a3f743508330b82de4903a060a12