### PR TITLE
Ensure missing tracks sort last in song lists

### DIFF
--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -369,6 +370,22 @@ func (r *mediaFileRepository) ReadAll(options ...rest.QueryOptions) (interface{}
 
 func (r *mediaFileRepository) EntityName() string {
 	return "mediafile"
+}
+
+func (r *mediaFileRepository) parseRestOptions(ctx context.Context, options ...rest.QueryOptions) model.QueryOptions {
+	qo := r.sqlRepository.parseRestOptions(ctx, options...)
+
+	const missingSort = "media_file.missing asc"
+	if qo.Sort == "" {
+		qo.Sort = missingSort
+		return qo
+	}
+
+	if !strings.Contains(qo.Sort, "missing") {
+		qo.Sort = missingSort + ", " + qo.Sort
+	}
+
+	return qo
 }
 
 func (r *mediaFileRepository) NewInstance() interface{} {

--- a/persistence/sql_base_repository.go
+++ b/persistence/sql_base_repository.go
@@ -148,12 +148,22 @@ func (r sqlRepository) buildSortOrder(sort, order string) string {
 		f := strings.FieldsFunc(p, splitFunc(' '))
 		newField := make([]string, 1, len(f))
 		newField[0] = f[0]
+
+		forceAsc := strings.Contains(f[0], "missing")
 		if len(f) == 1 {
-			newField = append(newField, order)
-		} else {
-			if f[1] == "asc" {
-				newField = append(newField, order)
+			if forceAsc {
+				newField = append(newField, "asc")
 			} else {
+				newField = append(newField, order)
+			}
+		} else {
+			dir := strings.ToLower(f[1])
+			switch {
+			case forceAsc:
+				newField = append(newField, "asc")
+			case dir == "asc":
+				newField = append(newField, order)
+			default:
 				newField = append(newField, reverseOrder)
 			}
 		}


### PR DESCRIPTION
## Summary
- prefix song queries with a missing-first filter so unavailable tracks stay grouped at the bottom
- keep the missing flag ordered ascending regardless of the requested sort direction to avoid duplicate rows during resorting

## Testing
- `go test ./...` *(fails: missing system taglib dependency and several upstream tests require additional fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68f2c05d0248833080dd790b409e2d68