### PR TITLE
Ensure missing songs render once and at list end

### DIFF
--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -233,7 +233,31 @@ const SongDatagridBody = ({
   ...rest
 }) => {
   const dispatch = useDispatch()
-  const { ids, data } = rest
+  const { ids: rawIds = [], data, ...bodyProps } = rest
+
+  const ids = useMemo(() => {
+    if (!rawIds) {
+      return []
+    }
+
+    const seen = new Set()
+    const regular = []
+    const missing = []
+
+    rawIds.forEach((id) => {
+      if (seen.has(id) || !data?.[id]) {
+        return
+      }
+      seen.add(id)
+      if (data[id].missing) {
+        missing.push(id)
+      } else {
+        regular.push(id)
+      }
+    })
+
+    return [...regular, ...missing]
+  }, [rawIds, data])
 
   const playSubset = useCallback(
     (discNumber) => {
@@ -279,7 +303,9 @@ const SongDatagridBody = ({
 
   return (
     <PureDatagridBody
-      {...rest}
+      {...bodyProps}
+      ids={ids}
+      data={data}
       row={
         <SongDatagridRow
           firstTracksOfDiscs={firstTracksOfDiscs}

--- a/ui/src/layout/AppBar.test.jsx
+++ b/ui/src/layout/AppBar.test.jsx
@@ -14,6 +14,7 @@ vi.mock('react-admin', () => ({
   useTranslate: () => (x) => x,
   usePermissions: () => ({ permissions: 'admin' }),
   getResources: () => [],
+  useNotify: () => () => {},
 }))
 
 vi.mock('./NowPlayingPanel', () => ({


### PR DESCRIPTION
## Summary
- normalize the song datagrid row ids to de-duplicate missing tracks and keep them sorted to the end of the list
- extend the AppBar test's react-admin mock with useNotify so the MissingTracksPanel renders during tests

## Testing
- npm --prefix ui test

------
https://chatgpt.com/codex/tasks/task_e_68f2c4ffd7e88330861ee481fc5c6753