### PR TITLE
Fix playlist missing tracks duplication when sorting

### DIFF
--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -111,8 +111,35 @@ const PlaylistSongs = ({
     refetch,
     setPage: setContextPage,
   } = listContext
-  const ids = contextIds
   const data = contextData
+  const sanitizedIds = useMemo(() => {
+    if (!contextIds || contextIds.length === 0) {
+      return contextIds
+    }
+
+    const seen = new Set()
+    const present = []
+    const missing = []
+
+    contextIds.forEach((id) => {
+      if (seen.has(id)) {
+        return
+      }
+      seen.add(id)
+
+      const record = contextData?.[id]
+      if (record?.missing) {
+        missing.push(id)
+        return
+      }
+
+      present.push(id)
+    })
+
+    return [...present, ...missing]
+  }, [contextIds, contextData])
+
+  const ids = sanitizedIds
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   const classes = useStyles({ isDesktop })
   const dispatch = useDispatch()
@@ -219,10 +246,12 @@ const PlaylistSongs = ({
   const filteredListContext = useMemo(
     () => ({
       ...listContext,
+      ids,
+      total: ids?.length ?? listContext.total,
       selectedIds,
       onSelect: handleSelect,
     }),
-    [listContext, selectedIds, handleSelect],
+    [listContext, ids, selectedIds, handleSelect],
   )
 
   const onAddToPlaylist = useCallback(


### PR DESCRIPTION
## Summary
- sanitize playlist track ids to remove duplicates and gather missing tracks at the end of the list
- provide the sanitized ids and count to the playlist song list context so sorting keeps missing tracks last

## Testing
- npm --prefix ui test *(fails: missing optional @dnd-kit/core dependency and react-admin mock exports in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68f2c7a6b8188330a7d8304c4482278d