### PR TITLE
Prevent duplicate missing playlist placeholders

### DIFF
--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -505,6 +505,24 @@ func mergePlaylistTracksWithMissing(ctx context.Context, tracks model.PlaylistTr
 	result := make(model.PlaylistTracks, 0, len(entries))
 	missingCount := 0
 
+	seenPaths := make(map[string]struct{}, len(tracks))
+	markSeenPath := func(path string) {
+		if path == "" {
+			return
+		}
+		normalizedPath := normalizePlaylistPath(filepath.ToSlash(path))
+		if normalizedPath == "" {
+			return
+		}
+		seenPaths[normalizedPath] = struct{}{}
+	}
+	for _, t := range tracks {
+		markSeenPath(t.Path)
+		if t.LibraryPath != "" && t.Path != "" {
+			markSeenPath(filepath.Join(t.LibraryPath, t.Path))
+		}
+	}
+
 	for _, entry := range entries {
 		display := filepath.ToSlash(entry)
 		normalizedEntry := normalizePlaylistPath(display)
@@ -541,6 +559,12 @@ func mergePlaylistTracksWithMissing(ctx context.Context, tracks model.PlaylistTr
 			lowerDisplay := strings.ToLower(display)
 			base := strings.ToLower(filepath.Base(display))
 			if !strings.Contains(lowerDisplay, searchTerm) && !strings.Contains(base, searchTerm) {
+				continue
+			}
+		}
+
+		if normalizedEntry != "" {
+			if _, alreadySeen := seenPaths[normalizedEntry]; alreadySeen {
 				continue
 			}
 		}


### PR DESCRIPTION
## Summary
- avoid re-appending missing playlist placeholders when merging synced playlists
- preserve playlist ordering while keeping legitimately duplicated entries intact

## Testing
- go test ./persistence

------
https://chatgpt.com/codex/tasks/task_e_68f2ca3651348330a912691373d785de