### PR TITLE
Fix duplicate missing playlist tracks when sorting

### DIFF
--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"bufio"
 	"context"
+	"crypto/sha1"
 	"database/sql"
 	"fmt"
 	"net/url"
@@ -546,7 +547,7 @@ func mergePlaylistTracksWithMissing(ctx context.Context, tracks model.PlaylistTr
 		}
 
 		missingCount++
-		id := fmt.Sprintf("%d", missingCount)
+		id := buildMissingTrackID(pls.ID, normalizedEntry, missingCount)
 		title := strings.TrimSuffix(filepath.Base(display), filepath.Ext(display))
 		if title == "" {
 			title = display
@@ -650,6 +651,15 @@ func readPlaylistEntries(path string) ([]string, error) {
 
 func normalizePlaylistPath(path string) string {
 	return strings.ToLower(norm.NFC.String(path))
+}
+
+func buildMissingTrackID(playlistID, entry string, counter int) string {
+	normalized := normalizePlaylistPath(entry)
+	if normalized != "" {
+		sum := sha1.Sum([]byte(playlistID + ":" + normalized))
+		return fmt.Sprintf("missing:%x", sum)
+	}
+	return fmt.Sprintf("missing:%s:%d", playlistID, counter)
 }
 
 func popTrackIndex(key string, indexes map[string][]int) (int, bool) {

--- a/persistence/playlist_track_repository_test.go
+++ b/persistence/playlist_track_repository_test.go
@@ -88,6 +88,66 @@ var _ = Describe("PlaylistTrackRepository", func() {
 		})
 	})
 
+	Describe("missing entries", func() {
+		var playlist model.Playlist
+
+		BeforeEach(func() {
+			playlist = model.Playlist{
+				Name:      "Missing Entries",
+				OwnerID:   "userid",
+				OwnerName: "userid",
+				Sync:      true,
+			}
+			playlist.Path = filepath.Join(GinkgoT().TempDir(), "missing_entries.m3u")
+			Expect(os.WriteFile(playlist.Path, []byte("ghost-track.mp3\n"), 0o600)).To(Succeed())
+			Expect(playlistRepo.Put(&playlist)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			if playlist.ID != "" {
+				Expect(playlistRepo.Delete(playlist.ID)).To(Succeed())
+			}
+		})
+
+		It("uses stable ids for missing playlist tracks across queries", func() {
+			repo := playlistRepo.Tracks(playlist.ID, true)
+
+			fetch := func(opts rest.QueryOptions) model.PlaylistTracks {
+				result, err := repo.ReadAll(opts)
+				Expect(err).ToNot(HaveOccurred())
+
+				tracks, ok := result.(model.PlaylistTracks)
+				Expect(ok).To(BeTrue())
+				return tracks
+			}
+
+			first := fetch(rest.QueryOptions{})
+			second := fetch(rest.QueryOptions{Sort: "title", Order: "DESC"})
+			third := fetch(rest.QueryOptions{Sort: "title", Order: "ASC"})
+
+			missingIDs := func(tracks model.PlaylistTracks) []string {
+				ids := make([]string, 0)
+				for _, track := range tracks {
+					if track.Missing {
+						ids = append(ids, track.ID)
+					}
+				}
+				return ids
+			}
+
+			firstMissing := missingIDs(first)
+			secondMissing := missingIDs(second)
+			thirdMissing := missingIDs(third)
+
+			Expect(firstMissing).To(HaveLen(1))
+			Expect(secondMissing).To(HaveLen(1))
+			Expect(thirdMissing).To(HaveLen(1))
+			Expect(firstMissing[0]).To(HavePrefix("missing:"))
+			Expect(secondMissing[0]).To(Equal(firstMissing[0]))
+			Expect(thirdMissing[0]).To(Equal(firstMissing[0]))
+		})
+	})
+
 	Describe("search filter", func() {
 		var playlist model.Playlist
 


### PR DESCRIPTION
## Summary
- generate deterministic identifiers for placeholder records representing missing playlist entries so repeated queries do not create duplicate rows
- add a regression test to confirm missing playlist tracks keep a single stable ID across different sorts

## Testing
- go test ./persistence -run PlaylistTrackRepository

------
https://chatgpt.com/codex/tasks/task_e_68f2c8fa7b04833092fb18861227a58d