### PR TITLE
Fix playlist select-all to use full track data

### DIFF
--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -170,8 +170,14 @@ const PlaylistSongs = ({
         newlyAddedIds.length > 0 &&
         newlyAddedIds.every((id) => pageIds.includes(id))
 
+      const isSelectingEntirePage =
+        Array.isArray(pageIds) &&
+        pageIds.length > 0 &&
+        pageIds.every((id) => idsToSelect.includes(id))
+
       const shouldLoadAllIds =
         isSelectingCurrentPage &&
+        isSelectingEntirePage &&
         typeof contextTotal === 'number' &&
         contextTotal > idsToSelect.length
 

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   BulkActionsToolbar,
   ListToolbar,
@@ -135,19 +135,106 @@ const PlaylistSongs = ({
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }, [playlistId, showDuplicatesOnly, setContextPage])
 
-  const displayedIdSet = useMemo(() => new Set(contextIds), [contextIds])
+  const selectedIds = contextSelectedIds
 
-  const selectedIds = useMemo(
-    () => contextSelectedIds.filter((id) => displayedIdSet.has(id)),
-    [contextSelectedIds, displayedIdSet],
+  const {
+    onSelect: contextOnSelect,
+    filterValues = {},
+    currentSort,
+    total: contextTotal,
+  } = listContext
+
+  const [loadedRecords, setLoadedRecords] = useState({})
+
+  useEffect(() => {
+    setLoadedRecords({})
+  }, [playlistId])
+
+  const handleSelect = useCallback(
+    (idsToSelect) => {
+      if (!contextOnSelect) {
+        return
+      }
+
+      if (!Array.isArray(idsToSelect)) {
+        contextOnSelect(idsToSelect)
+        return
+      }
+
+      const pageIds = ids || []
+      const newlyAddedIds = idsToSelect.filter(
+        (id) => !selectedIds.includes(id),
+      )
+
+      const isSelectingCurrentPage =
+        newlyAddedIds.length > 0 &&
+        newlyAddedIds.every((id) => pageIds.includes(id))
+
+      const shouldLoadAllIds =
+        isSelectingCurrentPage &&
+        typeof contextTotal === 'number' &&
+        contextTotal > idsToSelect.length
+
+      if (shouldLoadAllIds) {
+        const filter = { ...filterValues, playlist_id: playlistId }
+        const sort =
+          currentSort && currentSort.field
+            ? currentSort
+            : { field: 'id', order: 'ASC' }
+
+        dataProvider
+          .getList('playlistTrack', {
+            filter,
+            pagination: {
+              page: 1,
+              perPage:
+                contextTotal && contextTotal > 0
+                  ? contextTotal
+                  : idsToSelect.length,
+            },
+            sort: sort,
+          })
+          .then(({ data: records }) => {
+            const recordsById = records.reduce((acc, record) => {
+              acc[record.id] = record
+              return acc
+            }, {})
+            setLoadedRecords((prev) => ({ ...prev, ...recordsById }))
+            const preservedIds = idsToSelect.filter(
+              (id) => !pageIds.includes(id),
+            )
+            const allIds = records.map((record) => record.id)
+            contextOnSelect([...new Set([...preservedIds, ...allIds])])
+          })
+          .catch(() => {
+            contextOnSelect(idsToSelect)
+          })
+
+        return
+      }
+
+      contextOnSelect(idsToSelect)
+    },
+    [
+      contextOnSelect,
+      ids,
+      selectedIds,
+      contextTotal,
+      filterValues,
+      playlistId,
+      currentSort,
+      dataProvider,
+    ],
   )
 
   const filteredListContext = useMemo(
     () => ({
       ...listContext,
+      data: { ...contextData, ...loadedRecords },
       selectedIds,
+      onSelect: handleSelect,
     }),
-    [listContext, selectedIds],
+    [listContext, selectedIds, handleSelect, contextData, loadedRecords],
   )
 
   const onAddToPlaylist = useCallback(


### PR DESCRIPTION
## Summary
- cache fetched playlist track records when select-all loads the full list
- merge the cached records into the list context so bulk actions keep the true media ids

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f28666f7b483309c13eed76813dd35