### PR TITLE
Fix repeated playlist track requests triggered by sorting

### DIFF
--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -130,10 +130,18 @@ const PlaylistSongs = ({
     prevShowDuplicates.current = showDuplicatesOnly
   }, [showDuplicatesOnly, refetch])
 
+  const setPageRef = React.useRef(setContextPage)
+
   useEffect(() => {
-    setContextPage(1)
+    setPageRef.current = setContextPage
+  }, [setContextPage])
+
+  useEffect(() => {
+    if (typeof setPageRef.current === 'function') {
+      setPageRef.current(1)
+    }
     window.scrollTo({ top: 0, behavior: 'smooth' })
-  }, [playlistId, showDuplicatesOnly, setContextPage])
+  }, [playlistId, showDuplicatesOnly])
 
   const selectedIds = contextSelectedIds
 


### PR DESCRIPTION
## Summary
- keep a stable reference to the list controller's setPage function in the playlist song list
- avoid re-running the page reset effect every render so sorting no longer fires repeated fetches
- scroll to the top only when the playlist or duplicate filter changes

## Testing
- not run (explain why): UI-only change

------
https://chatgpt.com/codex/tasks/task_e_68f5a69e273083308ca1712b5d9078a9