### PR TITLE
Fix playlist select all to load full track list

### DIFF
--- a/ui/src/layout/AppBar.test.jsx
+++ b/ui/src/layout/AppBar.test.jsx
@@ -14,6 +14,7 @@ vi.mock('react-admin', () => ({
   useTranslate: () => (x) => x,
   usePermissions: () => ({ permissions: 'admin' }),
   getResources: () => [],
+  useNotify: () => vi.fn(),
 }))
 
 vi.mock('./NowPlayingPanel', () => ({

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -175,11 +175,13 @@ const PlaylistSongs = ({
         pageIds.length > 0 &&
         pageIds.every((id) => idsToSelect.includes(id))
 
+      const totalCount =
+        typeof contextTotal === 'number' ? contextTotal : undefined
+
       const shouldLoadAllIds =
         isSelectingCurrentPage &&
         isSelectingEntirePage &&
-        typeof contextTotal === 'number' &&
-        contextTotal > idsToSelect.length
+        (totalCount === undefined || totalCount > idsToSelect.length)
 
       if (shouldLoadAllIds) {
         const filter = { ...filterValues, playlist_id: playlistId }
@@ -188,19 +190,59 @@ const PlaylistSongs = ({
             ? currentSort
             : { field: 'id', order: 'ASC' }
 
-        dataProvider
-          .getList('playlistTrack', {
-            filter,
-            pagination: {
-              page: 1,
-              perPage:
-                contextTotal && contextTotal > 0
-                  ? contextTotal
-                  : idsToSelect.length,
-            },
-            sort: sort,
-          })
-          .then(({ data: records }) => {
+        const perPageBase = Math.max(ids?.length ?? 0, idsToSelect.length, 1)
+
+        const loadAllRecords = async () => {
+          const allRecords = []
+          let page = 1
+          let expectedTotal = totalCount
+
+          while (true) {
+            const perPage =
+              expectedTotal !== undefined && expectedTotal < perPageBase
+                ? expectedTotal
+                : perPageBase
+
+            const response = await dataProvider.getList('playlistTrack', {
+              filter,
+              pagination: {
+                page,
+                perPage,
+              },
+              sort,
+            })
+
+            const records = response?.data ?? []
+
+            if (records.length === 0) {
+              break
+            }
+
+            allRecords.push(...records)
+
+            if (
+              expectedTotal === undefined &&
+              typeof response?.total === 'number'
+            ) {
+              expectedTotal = response.total
+            }
+
+            if (
+              (expectedTotal !== undefined &&
+                allRecords.length >= expectedTotal) ||
+              records.length < perPage
+            ) {
+              break
+            }
+
+            page += 1
+          }
+
+          return allRecords
+        }
+
+        loadAllRecords()
+          .then((records) => {
             const recordsById = records.reduce((acc, record) => {
               acc[record.id] = record
               return acc

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -197,10 +197,16 @@ const PlaylistSongs = ({
           let page = 1
           let expectedTotal = totalCount
 
+          const getRemainingFromTotal = () =>
+            expectedTotal !== undefined
+              ? Math.max(expectedTotal - allRecords.length, 0)
+              : undefined
+
           while (true) {
+            const remainingFromTotal = getRemainingFromTotal()
             const perPage =
-              expectedTotal !== undefined && expectedTotal < perPageBase
-                ? expectedTotal
+              remainingFromTotal !== undefined && remainingFromTotal > 0
+                ? Math.min(remainingFromTotal, perPageBase)
                 : perPageBase
 
             const response = await dataProvider.getList('playlistTrack', {
@@ -221,8 +227,8 @@ const PlaylistSongs = ({
             allRecords.push(...records)
 
             if (
-              expectedTotal === undefined &&
-              typeof response?.total === 'number'
+              typeof response?.total === 'number' &&
+              response.total > allRecords.length
             ) {
               expectedTotal = response.total
             }

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -142,6 +142,7 @@ const PlaylistSongs = ({
     filterValues = {},
     currentSort,
     total: contextTotal,
+    perPage: contextPerPage,
   } = listContext
 
   const [loadedRecords, setLoadedRecords] = useState({})
@@ -178,10 +179,18 @@ const PlaylistSongs = ({
       const totalCount =
         typeof contextTotal === 'number' ? contextTotal : undefined
 
+      const effectivePerPage =
+        typeof contextPerPage === 'number' && contextPerPage > 0
+          ? contextPerPage
+          : undefined
+
       const shouldLoadAllIds =
         isSelectingCurrentPage &&
         isSelectingEntirePage &&
-        (totalCount === undefined || totalCount > idsToSelect.length)
+        (totalCount === undefined ||
+          totalCount > idsToSelect.length ||
+          (effectivePerPage !== undefined &&
+            idsToSelect.length >= effectivePerPage))
 
       if (shouldLoadAllIds) {
         const filter = { ...filterValues, playlist_id: playlistId }
@@ -190,7 +199,12 @@ const PlaylistSongs = ({
             ? currentSort
             : { field: 'id', order: 'ASC' }
 
-        const perPageBase = Math.max(ids?.length ?? 0, idsToSelect.length, 1)
+        const perPageBase = Math.max(
+          effectivePerPage ?? 0,
+          ids?.length ?? 0,
+          idsToSelect.length,
+          1,
+        )
 
         const loadAllRecords = async () => {
           const allRecords = []
@@ -275,6 +289,7 @@ const PlaylistSongs = ({
       ids,
       selectedIds,
       contextTotal,
+      contextPerPage,
       filterValues,
       playlistId,
       currentSort,


### PR DESCRIPTION
## Summary
- ensure selecting all playlist tracks fetches every page when the total count is unknown
- load additional playlist track pages sequentially and merge results before updating selection

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fba12e605c83309b4eb9de53fa7070