### PR TITLE
Ensure playlist select all loads full list

### DIFF
--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -175,11 +175,13 @@ const PlaylistSongs = ({
         pageIds.length > 0 &&
         pageIds.every((id) => idsToSelect.includes(id))
 
+      const totalCount = Number(contextTotal)
+
       const shouldLoadAllIds =
         isSelectingCurrentPage &&
         isSelectingEntirePage &&
-        typeof contextTotal === 'number' &&
-        contextTotal > idsToSelect.length
+        Number.isFinite(totalCount) &&
+        totalCount > idsToSelect.length
 
       if (shouldLoadAllIds) {
         const filter = { ...filterValues, playlist_id: playlistId }
@@ -194,8 +196,8 @@ const PlaylistSongs = ({
             pagination: {
               page: 1,
               perPage:
-                contextTotal && contextTotal > 0
-                  ? contextTotal
+                totalCount && totalCount > 0
+                  ? totalCount
                   : idsToSelect.length,
             },
             sort: sort,


### PR DESCRIPTION
## Summary
- coerce playlist totals to numbers before deciding whether to load all tracks
- use the numeric total when requesting all playlist tracks so the selection covers every song

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbdfe44c7083309d7f64bfaa86bff2