### PR TITLE
Fix playlist select all to include entire playlist

### DIFF
--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -36,6 +36,65 @@ import PlaylistSongBulkActions from './PlaylistSongBulkActions'
 import ExpandInfoDialog from '../dialogs/ExpandInfoDialog'
 import config from '../config'
 
+export const selectPlaylistTrackIds = ({
+  idsToSelect,
+  pageIds = [],
+  selectedIds = [],
+  contextTotal,
+  filterValues = {},
+  playlistId,
+  currentSort,
+  dataProvider,
+  onSelect,
+}) => {
+  if (!onSelect) {
+    return Promise.resolve()
+  }
+
+  if (!Array.isArray(idsToSelect)) {
+    onSelect(idsToSelect)
+    return Promise.resolve()
+  }
+
+  const newlyAddedIds = idsToSelect.filter((id) => !selectedIds.includes(id))
+
+  const isSelectingCurrentPage =
+    newlyAddedIds.length > 0 && newlyAddedIds.every((id) => pageIds.includes(id))
+
+  const shouldLoadAllIds =
+    isSelectingCurrentPage && typeof contextTotal === 'number' && contextTotal > idsToSelect.length
+
+  if (!shouldLoadAllIds) {
+    onSelect(idsToSelect)
+    return Promise.resolve()
+  }
+
+  const filter = { ...filterValues, playlist_id: playlistId }
+  const sort =
+    currentSort && currentSort.field ? currentSort : { field: 'id', order: 'ASC' }
+
+  return dataProvider
+    .getList('playlistTrack', {
+      filter,
+      pagination: {
+        page: 1,
+        // perPage: 0 tells the API to return the full playlist regardless of the
+        // pagination limit so that the "Select all" checkbox truly selects
+        // every track, not only the ones visible on the current page.
+        perPage: 0,
+      },
+      sort: sort,
+    })
+    .then(({ data: records }) => {
+      const preservedIds = idsToSelect.filter((id) => !pageIds.includes(id))
+      const allIds = records.map((record) => record.id)
+      onSelect([...new Set([...preservedIds, ...allIds])])
+    })
+    .catch(() => {
+      onSelect(idsToSelect)
+    })
+}
+
 const useStyles = makeStyles(
   (theme) => ({
     root: {},
@@ -145,67 +204,19 @@ const PlaylistSongs = ({
   } = listContext
 
   const handleSelect = useCallback(
-    (idsToSelect) => {
-      if (!contextOnSelect) {
-        return
-      }
-
-      if (!Array.isArray(idsToSelect)) {
-        contextOnSelect(idsToSelect)
-        return
-      }
-
-      const pageIds = ids || []
-      const newlyAddedIds = idsToSelect.filter(
-        (id) => !selectedIds.includes(id),
-      )
-
-      const isSelectingCurrentPage =
-        newlyAddedIds.length > 0 &&
-        newlyAddedIds.every((id) => pageIds.includes(id))
-
-      const shouldLoadAllIds =
-        isSelectingCurrentPage &&
-        typeof contextTotal === 'number' &&
-        contextTotal > idsToSelect.length
-
-      if (shouldLoadAllIds) {
-        const filter = { ...filterValues, playlist_id: playlistId }
-        const sort =
-          currentSort && currentSort.field
-            ? currentSort
-            : { field: 'id', order: 'ASC' }
-
-        dataProvider
-          .getList('playlistTrack', {
-            filter,
-            pagination: {
-              page: 1,
-              perPage:
-                contextTotal && contextTotal > 0
-                  ? contextTotal
-                  : idsToSelect.length,
-            },
-            sort: sort,
-          })
-          .then(({ data: records }) => {
-            const preservedIds = idsToSelect.filter(
-              (id) => !pageIds.includes(id),
-            )
-            const allIds = records.map((record) => record.id)
-            contextOnSelect([...new Set([...preservedIds, ...allIds])])
-          })
-          .catch(() => {
-            contextOnSelect(idsToSelect)
-          })
-
-        return
-      }
-
-      contextOnSelect(idsToSelect)
-    },
+    (idsToSelect) =>
+      selectPlaylistTrackIds({
+        idsToSelect,
+        pageIds: ids,
+        selectedIds,
+        contextTotal,
+        filterValues,
+        playlistId,
+        currentSort,
+        dataProvider,
+        onSelect: contextOnSelect,
+      }),
     [
-      contextOnSelect,
       ids,
       selectedIds,
       contextTotal,
@@ -213,6 +224,7 @@ const PlaylistSongs = ({
       playlistId,
       currentSort,
       dataProvider,
+      contextOnSelect,
     ],
   )
 

--- a/ui/src/playlist/PlaylistSongs.test.jsx
+++ b/ui/src/playlist/PlaylistSongs.test.jsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest'
+import { selectPlaylistTrackIds } from './PlaylistSongs.jsx'
+
+const createRecords = (count, offset = 1) =>
+  Array.from({ length: count }, (_, index) => ({ id: index + offset }))
+
+describe('selectPlaylistTrackIds', () => {
+  it('requests all playlist tracks when selecting the current page and more records exist', async () => {
+    const idsToSelect = Array.from({ length: 50 }, (_, index) => index + 1)
+    const contextTotal = 63
+    const onSelect = vi.fn()
+    const getList = vi
+      .fn()
+      .mockResolvedValue({ data: createRecords(contextTotal) })
+
+    await selectPlaylistTrackIds({
+      idsToSelect,
+      pageIds: idsToSelect,
+      selectedIds: [],
+      contextTotal,
+      filterValues: { foo: 'bar' },
+      playlistId: 'playlist-id',
+      currentSort: { field: 'title', order: 'DESC' },
+      dataProvider: { getList },
+      onSelect,
+    })
+
+    expect(getList).toHaveBeenCalledWith('playlistTrack', {
+      filter: { foo: 'bar', playlist_id: 'playlist-id' },
+      pagination: { page: 1, perPage: 0 },
+      sort: { field: 'title', order: 'DESC' },
+    })
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.arrayContaining(Array.from({ length: contextTotal }, (_, index) => index + 1)),
+    )
+    expect(onSelect.mock.calls[0][0]).toHaveLength(contextTotal)
+  })
+
+  it('forwards idsToSelect when there is nothing else to load', async () => {
+    const idsToSelect = ['track-1', 'track-2']
+    const onSelect = vi.fn()
+    const getList = vi.fn()
+
+    await selectPlaylistTrackIds({
+      idsToSelect,
+      pageIds: idsToSelect,
+      selectedIds: [],
+      contextTotal: idsToSelect.length,
+      filterValues: {},
+      playlistId: 'playlist-id',
+      currentSort: undefined,
+      dataProvider: { getList },
+      onSelect,
+    })
+
+    expect(getList).not.toHaveBeenCalled()
+    expect(onSelect).toHaveBeenCalledWith(idsToSelect)
+  })
+})


### PR DESCRIPTION
## Summary
- ensure the playlist "select all" bulk action loads every track instead of only the current page
- add unit coverage for the selection helper

## Testing
- npm run test -- PlaylistSongs

------
https://chatgpt.com/codex/tasks/task_e_68fbe3c15e648330a629836c974691c8