### PR TITLE
Retail Player: style Devices page to portal layout (mock data, Navidrome colors)

### DIFF
--- a/ui/src/retailPlayer/ChannelListsPage.jsx
+++ b/ui/src/retailPlayer/ChannelListsPage.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { Paper, Typography, makeStyles } from '@material-ui/core'
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    backgroundColor: theme.palette.background.paper,
+    borderRadius: theme.shape.borderRadius * 1.5,
+    border: `1px solid ${theme.palette.divider}`,
+    padding: theme.spacing(4),
+    boxShadow: theme.shadows[1],
+    maxWidth: 720,
+  },
+  heading: {
+    marginBottom: theme.spacing(1.5),
+  },
+}))
+
+const ChannelListsPage = () => {
+  const classes = useStyles()
+
+  return (
+    <Paper className={classes.root} elevation={0}>
+      <Typography variant="h4" component="h1" className={classes.heading}>
+        Channel Lists
+      </Typography>
+      <Typography variant="body1" color="textSecondary">
+        Coming soon.
+      </Typography>
+    </Paper>
+  )
+}
+
+export default ChannelListsPage

--- a/ui/src/retailPlayer/ChannelsPage.jsx
+++ b/ui/src/retailPlayer/ChannelsPage.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { Paper, Typography, makeStyles } from '@material-ui/core'
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    backgroundColor: theme.palette.background.paper,
+    borderRadius: theme.shape.borderRadius * 1.5,
+    border: `1px solid ${theme.palette.divider}`,
+    padding: theme.spacing(4),
+    boxShadow: theme.shadows[1],
+    maxWidth: 720,
+  },
+  heading: {
+    marginBottom: theme.spacing(1.5),
+  },
+}))
+
+const ChannelsPage = () => {
+  const classes = useStyles()
+
+  return (
+    <Paper className={classes.root} elevation={0}>
+      <Typography variant="h4" component="h1" className={classes.heading}>
+        Channels
+      </Typography>
+      <Typography variant="body1" color="textSecondary">
+        Coming soon.
+      </Typography>
+    </Paper>
+  )
+}
+
+export default ChannelsPage

--- a/ui/src/retailPlayer/DevicesPage.jsx
+++ b/ui/src/retailPlayer/DevicesPage.jsx
@@ -1,0 +1,340 @@
+import React, { useMemo } from 'react'
+import clsx from 'clsx'
+import {
+  Box,
+  Divider,
+  IconButton,
+  InputAdornment,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TableSortLabel,
+  TextField,
+  Tooltip,
+  Typography,
+  makeStyles,
+} from '@material-ui/core'
+import SearchIcon from '@material-ui/icons/Search'
+import RefreshIcon from '@material-ui/icons/Refresh'
+import AddIcon from '@material-ui/icons/Add'
+import LinkIcon from '@material-ui/icons/Link'
+import VolumeUpIcon from '@material-ui/icons/VolumeUp'
+import VolumeOffIcon from '@material-ui/icons/VolumeOff'
+import WifiTetheringIcon from '@material-ui/icons/WifiTethering'
+import EmojiEventsIcon from '@material-ui/icons/EmojiEvents'
+import ChevronLeftIcon from '@material-ui/icons/ChevronLeft'
+import ChevronRightIcon from '@material-ui/icons/ChevronRight'
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(3),
+  },
+  surface: {
+    backgroundColor: theme.palette.background.paper,
+    borderRadius: theme.shape.borderRadius * 1.5,
+    border: `1px solid ${theme.palette.divider}`,
+    boxShadow: theme.shadows[1],
+    overflow: 'hidden',
+  },
+  toolbar: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing(2),
+    flexWrap: 'wrap',
+    padding: theme.spacing(2.5, 3),
+  },
+  toolbarTitle: {
+    flex: '1 1 auto',
+    minWidth: 200,
+  },
+  toolbarSubtitle: {
+    marginTop: theme.spacing(0.5),
+    color: theme.palette.text.secondary,
+  },
+  toolbarActions: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+  },
+  searchField: {
+    minWidth: 220,
+    '& .MuiOutlinedInput-root': {
+      borderRadius: theme.shape.borderRadius,
+    },
+  },
+  tableContainer: {
+    maxWidth: '100%',
+  },
+  table: {
+    minWidth: 960,
+  },
+  headCell: {
+    color: theme.palette.text.secondary,
+    fontSize: 12,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    borderBottom: `1px solid ${theme.palette.divider}`,
+  },
+  bodyCell: {
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    color: theme.palette.text.primary,
+    fontSize: 14,
+    maxWidth: 220,
+  },
+  actionsCell: {
+    width: 140,
+    maxWidth: 140,
+    whiteSpace: 'nowrap',
+  },
+  actionsGroup: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+  },
+  actionButton: {
+    padding: theme.spacing(0.5),
+  },
+  nameCell: {
+    fontWeight: 600,
+  },
+  ellipsis: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  heroIcon: {
+    color: theme.palette.primary.light,
+  },
+  footer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    flexWrap: 'wrap',
+    gap: theme.spacing(2),
+    padding: theme.spacing(2, 3),
+  },
+  footerControls: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+  },
+  footerButton: {
+    padding: theme.spacing(0.5),
+  },
+}))
+
+const mockRows = [
+  {
+    id: 'device-1',
+    name: 'Lobby Speaker - North Entrance',
+    uptime: '12d 4h',
+    channel: 'Main Floor Mix',
+    channelList: 'Weekday Rotation',
+    organization: 'Acme Retail Group',
+    retailHero: true,
+    status: 'online',
+  },
+  {
+    id: 'device-2',
+    name: 'Cafe Bar Display',
+    uptime: '3d 9h',
+    channel: 'Acoustic Evenings',
+    channelList: 'Weekend Chill',
+    organization: 'Acme Retail Group',
+    retailHero: false,
+    status: 'online',
+  },
+  {
+    id: 'device-3',
+    name: 'Warehouse Zone C',
+    uptime: '8h 22m',
+    channel: 'Logistics Updates',
+    channelList: 'Operations Messaging',
+    organization: 'Acme Logistics',
+    retailHero: true,
+    status: 'muted',
+  },
+]
+
+const DevicesPage = () => {
+  const classes = useStyles()
+  const devices = useMemo(() => mockRows, [])
+
+  return (
+    <div className={classes.root}>
+      <Paper className={classes.surface} elevation={0}>
+        <div className={classes.toolbar}>
+          <div className={classes.toolbarTitle}>
+            <Typography variant="h5" component="h1" noWrap>
+              Acme Retail Group’s Devices
+            </Typography>
+            <Typography variant="body2" className={classes.toolbarSubtitle} noWrap>
+              Monitor connectivity, playback, and assignments at a glance.
+            </Typography>
+          </div>
+          <div className={classes.toolbarActions}>
+            <TextField
+              variant="outlined"
+              size="small"
+              placeholder="Search devices"
+              aria-label="Search devices"
+              className={classes.searchField}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon fontSize="small" />
+                  </InputAdornment>
+                ),
+              }}
+            />
+            <Tooltip title="Refresh">
+              <IconButton aria-label="Refresh" size="small">
+                <RefreshIcon />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Add device">
+              <IconButton aria-label="Add device" size="small" color="primary">
+                <AddIcon />
+              </IconButton>
+            </Tooltip>
+          </div>
+        </div>
+        <Divider />
+        <TableContainer className={classes.tableContainer}>
+          <Table className={classes.table} size="medium" aria-label="Devices table">
+            <TableHead>
+              <TableRow>
+                <TableCell className={clsx(classes.headCell, classes.actionsCell)} align="left">
+                  Actions
+                </TableCell>
+                <TableCell className={classes.headCell}>
+                  <TableSortLabel active direction="asc" hideSortIcon={false}>
+                    Name
+                  </TableSortLabel>
+                </TableCell>
+                <TableCell className={classes.headCell}>Uptime</TableCell>
+                <TableCell className={classes.headCell}>RetailHero</TableCell>
+                <TableCell className={classes.headCell}>Channel</TableCell>
+                <TableCell className={classes.headCell}>Channel List</TableCell>
+                <TableCell className={classes.headCell}>Organization</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {devices.map((device) => (
+                <TableRow hover key={device.id}>
+                  <TableCell className={clsx(classes.bodyCell, classes.actionsCell)}>
+                    <div className={classes.actionsGroup}>
+                      <Tooltip title="Connection status">
+                        <IconButton
+                          aria-label={`Connection status for ${device.name}`}
+                          size="small"
+                          className={classes.actionButton}
+                        >
+                          <WifiTetheringIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Link">
+                        <IconButton
+                          aria-label={`Link ${device.name}`}
+                          size="small"
+                          className={classes.actionButton}
+                        >
+                          <LinkIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title={device.status === 'muted' ? 'Unmute' : 'Mute'}>
+                        <IconButton
+                          aria-label={`${device.status === 'muted' ? 'Unmute' : 'Mute'} ${device.name}`}
+                          size="small"
+                          className={classes.actionButton}
+                        >
+                          {device.status === 'muted' ? (
+                            <VolumeOffIcon fontSize="small" />
+                          ) : (
+                            <VolumeUpIcon fontSize="small" />
+                          )}
+                        </IconButton>
+                      </Tooltip>
+                    </div>
+                  </TableCell>
+                  <TableCell className={clsx(classes.bodyCell, classes.nameCell)}>
+                    <Typography variant="body1" className={classes.ellipsis} noWrap>
+                      {device.name}
+                    </Typography>
+                  </TableCell>
+                  <TableCell className={classes.bodyCell}>
+                    <Typography variant="body2" className={classes.ellipsis} noWrap>
+                      {device.uptime}
+                    </Typography>
+                  </TableCell>
+                  <TableCell className={classes.bodyCell}>
+                    {device.retailHero ? (
+                      <Tooltip title="RetailHero enabled">
+                        <EmojiEventsIcon className={classes.heroIcon} fontSize="small" />
+                      </Tooltip>
+                    ) : (
+                      <Typography variant="body2" color="textSecondary">
+                        —
+                      </Typography>
+                    )}
+                  </TableCell>
+                  <TableCell className={classes.bodyCell}>
+                    <Typography variant="body2" className={classes.ellipsis} noWrap>
+                      {device.channel}
+                    </Typography>
+                  </TableCell>
+                  <TableCell className={classes.bodyCell}>
+                    <Typography variant="body2" className={classes.ellipsis} noWrap>
+                      {device.channelList}
+                    </Typography>
+                  </TableCell>
+                  <TableCell className={classes.bodyCell}>
+                    <Typography variant="body2" className={classes.ellipsis} noWrap>
+                      {device.organization}
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <Divider />
+        <Box className={classes.footer} role="navigation" aria-label="Device pagination">
+          <Typography variant="body2" color="textSecondary" noWrap>
+            Showing {devices.length} of {devices.length} devices
+          </Typography>
+          <div className={classes.footerControls}>
+            <Typography variant="body2" color="textSecondary">
+              Page 1 of 1
+            </Typography>
+            <IconButton
+              aria-label="Previous page"
+              size="small"
+              className={classes.footerButton}
+              disabled
+            >
+              <ChevronLeftIcon />
+            </IconButton>
+            <IconButton
+              aria-label="Next page"
+              size="small"
+              className={classes.footerButton}
+              disabled
+            >
+              <ChevronRightIcon />
+            </IconButton>
+          </div>
+        </Box>
+      </Paper>
+    </div>
+  )
+}
+
+export default DevicesPage

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1,258 +1,40 @@
-import React, { useEffect, useMemo, useState } from 'react'
-import {
-  Card,
-  CardActions,
-  CardContent,
-  Grid,
-  IconButton,
-  MenuItem,
-  Typography,
-} from '@material-ui/core'
-import { makeStyles } from '@material-ui/core/styles'
-import { Title } from 'react-admin'
-import Select from '@material-ui/core/Select'
-import Slider from '@material-ui/core/Slider'
-import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord'
-import PlayArrowIcon from '@material-ui/icons/PlayArrow'
-import PauseIcon from '@material-ui/icons/Pause'
-import SkipNextIcon from '@material-ui/icons/SkipNext'
-import SkipPreviousIcon from '@material-ui/icons/SkipPrevious'
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    marginTop: theme.spacing(2),
-  },
-  card: {
-    height: '100%',
-  },
-  header: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: theme.spacing(1),
-  },
-  status: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-    color: theme.palette.text.secondary,
-  },
-  statusIconOnline: {
-    color: theme.palette.success.main,
-  },
-  statusIconOffline: {
-    color: theme.palette.action.disabled,
-  },
-  controls: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-    width: '100%',
-  },
-  channelSelect: {
-    minWidth: 160,
-  },
-  slider: {
-    flex: 1,
-    marginLeft: theme.spacing(2),
-    marginRight: theme.spacing(2),
-  },
-}))
-
-const createMockService = () => {
-  const channels = [
-    { id: 'channel-1', name: 'Main Floor' },
-    { id: 'channel-2', name: 'Outdoor Patio' },
-    { id: 'channel-3', name: 'Seasonal Playlist' },
-    { id: 'channel-4', name: 'Announcements' },
-  ]
-
-  const devices = [
-    {
-      id: 'device-1',
-      name: 'Lobby Speaker',
-      online: true,
-      channelId: channels[0].id,
-      volume: 65,
-    },
-    {
-      id: 'device-2',
-      name: 'Warehouse Receiver',
-      online: false,
-      channelId: channels[1].id,
-      volume: 30,
-    },
-  ]
-
-  return {
-    getDevices: () => Promise.resolve(devices.map((device) => ({ ...device }))),
-    getChannels: () => Promise.resolve(channels.map((channel) => ({ ...channel }))),
-    setDeviceChannel: (deviceId, channelId) => {
-      console.log(`[RetailPlayer] setDeviceChannel`, { deviceId, channelId })
-    },
-    setDeviceVolume: (deviceId, volume) => {
-      console.log(`[RetailPlayer] setDeviceVolume`, { deviceId, volume })
-    },
-    controlPlayback: (deviceId, action) => {
-      console.log(`[RetailPlayer] controlPlayback`, { deviceId, action })
-    },
-  }
-}
-
-const mockService = createMockService()
+import React, { useMemo } from 'react'
+import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom'
+import RetailPlayerLayout from './RetailPlayerLayout'
+import DevicesPage from './DevicesPage'
+import ChannelsPage from './ChannelsPage'
+import ChannelListsPage from './ChannelListsPage'
 
 const RetailPlayerDashboard = () => {
-  const classes = useStyles()
-  const [devices, setDevices] = useState([])
-  const [channels, setChannels] = useState([])
+  const { path, url } = useRouteMatch()
 
-  useEffect(() => {
-    let isMounted = true
-    const loadData = async () => {
-      const [deviceList, channelList] = await Promise.all([
-        mockService.getDevices(),
-        mockService.getChannels(),
-      ])
-      if (isMounted) {
-        setDevices(deviceList)
-        setChannels(channelList)
-      }
-    }
-    loadData()
-    return () => {
-      isMounted = false
-    }
-  }, [])
-
-  const channelMap = useMemo(
-    () =>
-      channels.reduce((acc, channel) => {
-        acc[channel.id] = channel
-        return acc
-      }, {}),
-    [channels],
+  const menuItems = useMemo(
+    () => [
+      { label: 'Devices', to: `${url}/devices`, exact: true },
+      { label: 'Channels', to: `${url}/channels`, exact: true },
+      { label: 'Channel Lists', to: `${url}/channel-lists`, exact: true },
+    ],
+    [url],
   )
 
-  const handleChannelChange = (deviceId) => (event) => {
-    const channelId = event.target.value
-    setDevices((prevDevices) =>
-      prevDevices.map((device) =>
-        device.id === deviceId ? { ...device, channelId } : device,
-      ),
-    )
-    mockService.setDeviceChannel(deviceId, channelId)
-  }
-
-  const handleVolumeChange = (deviceId) => (event, value) => {
-    const volume = Array.isArray(value) ? value[0] : value
-    setDevices((prevDevices) =>
-      prevDevices.map((device) =>
-        device.id === deviceId ? { ...device, volume } : device,
-      ),
-    )
-    mockService.setDeviceVolume(deviceId, volume)
-  }
-
-  const handlePlayback = (deviceId, action) => () => {
-    mockService.controlPlayback(deviceId, action)
-  }
-
-  const renderDevice = (device) => {
-    const isOnline = device.online
-    const nowPlaying = channelMap[device.channelId]?.name || '—'
-    return (
-      <Grid item xs={12} md={6} key={device.id}>
-        <Card className={classes.card}>
-          <CardContent>
-            <div className={classes.header}>
-              <Typography variant="h6">{device.name}</Typography>
-              <div className={classes.status}>
-                <FiberManualRecordIcon
-                  fontSize="small"
-                  className={
-                    isOnline ? classes.statusIconOnline : classes.statusIconOffline
-                  }
-                />
-                <Typography variant="body2">
-                  {isOnline ? 'Online' : 'Offline'}
-                </Typography>
-              </div>
-            </div>
-            <Typography variant="subtitle2" color="textSecondary">
-              Now Playing
-            </Typography>
-            <Typography variant="body1" gutterBottom>
-              {nowPlaying}
-            </Typography>
-            <div className={classes.controls}>
-              <Select
-                value={device.channelId}
-                onChange={handleChannelChange(device.id)}
-                className={classes.channelSelect}
-                disabled={!isOnline}
-                variant="outlined"
-              >
-                {channels.map((channel) => (
-                  <MenuItem value={channel.id} key={channel.id}>
-                    {channel.name}
-                  </MenuItem>
-                ))}
-              </Select>
-              <Slider
-                value={device.volume}
-                onChange={handleVolumeChange(device.id)}
-                aria-labelledby={`${device.id}-volume`}
-                step={1}
-                min={0}
-                max={100}
-                className={classes.slider}
-                disabled={!isOnline}
-              />
-              <Typography variant="body2">{device.volume}</Typography>
-            </div>
-          </CardContent>
-          <CardActions>
-            <IconButton
-              aria-label="previous"
-              onClick={handlePlayback(device.id, 'previous')}
-              disabled={!isOnline}
-            >
-              <SkipPreviousIcon />
-            </IconButton>
-            <IconButton
-              aria-label="play"
-              onClick={handlePlayback(device.id, 'play')}
-              disabled={!isOnline}
-            >
-              <PlayArrowIcon />
-            </IconButton>
-            <IconButton
-              aria-label="pause"
-              onClick={handlePlayback(device.id, 'pause')}
-              disabled={!isOnline}
-            >
-              <PauseIcon />
-            </IconButton>
-            <IconButton
-              aria-label="next"
-              onClick={handlePlayback(device.id, 'next')}
-              disabled={!isOnline}
-            >
-              <SkipNextIcon />
-            </IconButton>
-          </CardActions>
-        </Card>
-      </Grid>
-    )
-  }
-
   return (
-    <div className={classes.root}>
-      <Title title="Retail Player" />
-      <Grid container spacing={2}>
-        {devices.map(renderDevice)}
-      </Grid>
-    </div>
+    <RetailPlayerLayout menuItems={menuItems}>
+      <Switch>
+        <Route exact path={path}>
+          <Redirect to={`${url}/devices`} />
+        </Route>
+        <Route path={`${path}/devices`}>
+          <DevicesPage />
+        </Route>
+        <Route path={`${path}/channels`}>
+          <ChannelsPage />
+        </Route>
+        <Route path={`${path}/channel-lists`}>
+          <ChannelListsPage />
+        </Route>
+        <Redirect to={`${url}/devices`} />
+      </Switch>
+    </RetailPlayerLayout>
   )
 }
 

--- a/ui/src/retailPlayer/RetailPlayerLayout.jsx
+++ b/ui/src/retailPlayer/RetailPlayerLayout.jsx
@@ -1,0 +1,185 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+import clsx from 'clsx'
+import {
+  Button,
+  Collapse,
+  Paper,
+  Typography,
+  makeStyles,
+  useMediaQuery,
+  useTheme,
+} from '@material-ui/core'
+import ExpandLessIcon from '@material-ui/icons/ExpandLess'
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
+import { NavLink } from 'react-router-dom'
+import { Title } from 'react-admin'
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    minHeight: '100%',
+    backgroundColor: theme.palette.background.default,
+  },
+  layout: {
+    display: 'flex',
+    flexGrow: 1,
+    width: '100%',
+  },
+  navDesktop: {
+    width: 240,
+    flexShrink: 0,
+    backgroundColor: theme.palette.background.paper,
+    borderRight: `1px solid ${theme.palette.divider}`,
+    padding: theme.spacing(2, 0),
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+  },
+  sectionLabel: {
+    padding: theme.spacing(0, 3),
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    fontSize: 12,
+    color: theme.palette.text.secondary,
+  },
+  navList: {
+    listStyle: 'none',
+    padding: 0,
+    margin: 0,
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  navLink: {
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    padding: theme.spacing(1.5, 3),
+    textDecoration: 'none',
+    color: theme.palette.text.secondary,
+    fontWeight: 500,
+    borderLeft: '4px solid transparent',
+    transition: 'background-color 0.2s ease, color 0.2s ease, border-left-color 0.2s ease',
+    '&:hover': {
+      color: theme.palette.text.primary,
+      backgroundColor: theme.palette.action.hover,
+    },
+  },
+  navLinkActive: {
+    color: theme.palette.text.primary,
+    fontWeight: 600,
+    borderLeftColor: theme.palette.primary.main,
+    backgroundColor: theme.palette.action.selected,
+  },
+  mobileNavWrapper: {
+    padding: theme.spacing(0, 2, 2),
+  },
+  mobileToggle: {
+    width: '100%',
+    justifyContent: 'space-between',
+  },
+  mobileNav: {
+    marginTop: theme.spacing(1),
+    backgroundColor: theme.palette.background.paper,
+    borderRadius: theme.shape.borderRadius,
+    border: `1px solid ${theme.palette.divider}`,
+  },
+  mobileNavList: {
+    padding: theme.spacing(1, 0),
+  },
+  content: {
+    flexGrow: 1,
+    padding: theme.spacing(3),
+    minWidth: 0,
+  },
+}))
+
+const RetailPlayerLayout = ({ menuItems, children }) => {
+  const classes = useStyles()
+  const theme = useTheme()
+  const isDesktop = useMediaQuery(theme.breakpoints.up('md'))
+  const [mobileOpen, setMobileOpen] = useState(false)
+
+  const handleToggle = () => {
+    setMobileOpen((open) => !open)
+  }
+
+  const handleNavigate = () => {
+    setMobileOpen(false)
+  }
+
+  const renderNavItems = (itemClassName) => (
+    <ul className={clsx(classes.navList, itemClassName)}>
+      {menuItems.map((item) => (
+        <li key={item.to}>
+          <NavLink
+            to={item.to}
+            exact={item.exact}
+            className={classes.navLink}
+            activeClassName={classes.navLinkActive}
+            onClick={handleNavigate}
+          >
+            <Typography variant="body1" component="span" noWrap>
+              {item.label}
+            </Typography>
+          </NavLink>
+        </li>
+      ))}
+    </ul>
+  )
+
+  return (
+    <div className={classes.root}>
+      <Title title="Retail Player" />
+      <div className={classes.layout}>
+        {isDesktop ? (
+          <nav className={classes.navDesktop} aria-label="Retail player sections">
+            <Typography variant="overline" className={classes.sectionLabel}>
+              Retail Player
+            </Typography>
+            {renderNavItems()}
+          </nav>
+        ) : (
+          <div className={classes.mobileNavWrapper}>
+            <Button
+              onClick={handleToggle}
+              variant="outlined"
+              color="default"
+              className={classes.mobileToggle}
+              endIcon={mobileOpen ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+              aria-expanded={mobileOpen}
+              aria-controls="retail-player-mobile-nav"
+            >
+              Retail Player Menu
+            </Button>
+            <Collapse in={mobileOpen} timeout="auto" unmountOnExit>
+              <Paper id="retail-player-mobile-nav" className={classes.mobileNav} elevation={1}>
+                {renderNavItems(classes.mobileNavList)}
+              </Paper>
+            </Collapse>
+          </div>
+        )}
+        <main className={classes.content}>{children}</main>
+      </div>
+    </div>
+  )
+}
+
+RetailPlayerLayout.propTypes = {
+  menuItems: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      to: PropTypes.string.isRequired,
+      exact: PropTypes.bool,
+    }),
+  ).isRequired,
+  children: PropTypes.node,
+}
+
+RetailPlayerLayout.defaultProps = {
+  children: null,
+}
+
+export default RetailPlayerLayout

--- a/ui/src/routes.jsx
+++ b/ui/src/routes.jsx
@@ -6,7 +6,6 @@ import RetailPlayerDashboard from './retailPlayer/RetailPlayerDashboard'
 const routes = [
   <Route exact path="/personal" render={() => <Personal />} key={'personal'} />,
   <Route
-    exact
     path="/retailplayer"
     render={() => <RetailPlayerDashboard />}
     key={'retailplayer'}


### PR DESCRIPTION
## Summary
- add a responsive Retail Player layout with nested routing and internal sub-menu
- scaffold Channels and Channel Lists placeholders under the new section
- restyle the Devices page with portal-inspired toolbar, mock data table, and pagination stub

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fbecb819248330b8ce0d3bc68e2519