### PR TITLE
Retail player layout matches mock

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -7,25 +7,10 @@ import SignalWifi4BarIcon from '@material-ui/icons/SignalWifi4Bar'
 import VolumeOffIcon from '@material-ui/icons/VolumeOff'
 import DescriptionIcon from '@material-ui/icons/Description'
 import GetAppIcon from '@material-ui/icons/GetApp'
+import { Link as RouterLink, useParams } from 'react-router-dom'
+import { retailDeviceDetails } from './deviceData'
 
 const combineClasses = (...classNames) => classNames.filter(Boolean).join(' ')
-
-const RETAIL_PLAYER_DATA = {
-  title: 'ThompsonChicago_Lobby',
-  status: [
-    { key: 'connected', icon: LinkIcon, intent: 'success', label: 'Connected' },
-    { key: 'time', label: '16:40' },
-    { key: 'signal', icon: SignalWifi4BarIcon, intent: 'success', label: 'Signal' },
-    { key: 'muted', icon: VolumeOffIcon, intent: 'danger', label: 'Muted' },
-  ],
-  schedules: [
-    { key: 'early', label: 'ThompsonChicago_LobbyEarly', disabled: false },
-    { key: 'late', label: 'ThompsonChicago_LobbyLate', disabled: true },
-    { key: 'mid', label: 'ThompsonChicago_LobbyMid', disabled: true },
-  ],
-  nowPlaying: 'The Kids | Dog Trainer',
-  volume: 75,
-}
 
 const useStyles = makeStyles((theme) => {
   const successMain =
@@ -210,27 +195,99 @@ const useStyles = makeStyles((theme) => {
     sliderRail: {
       backgroundColor: theme.palette.action.disabled,
     },
+    notFoundWrapper: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(2),
+      padding: theme.spacing(5),
+      maxWidth: 720,
+      width: '100%',
+      margin: '0 auto',
+      [theme.breakpoints.down('sm')]: {
+        padding: theme.spacing(3),
+      },
+    },
+    notFoundTitle: {
+      fontWeight: theme.typography.fontWeightBold,
+      fontSize: theme.typography.pxToRem(36),
+    },
+    notFoundMessage: {
+      color: theme.palette.text.secondary,
+      fontSize: theme.typography.pxToRem(18),
+    },
+    backLink: {
+      color:
+        (theme.palette.primary && theme.palette.primary.main) ||
+        theme.palette.text.primary,
+      fontWeight: theme.typography.fontWeightMedium,
+      textDecoration: 'none',
+    },
+    controlIconSuccess: {
+      color: successMain,
+    },
   }
 })
 
 const RetailPlayerDashboard = () => {
   const classes = useStyles()
+  const { deviceId } = useParams()
+  const device = (deviceId && retailDeviceDetails[deviceId]) || null
+
+  if (!device) {
+    return (
+      <div className={classes.notFoundWrapper}>
+        <Title title="Retail Player" />
+        <Typography component="h1" className={classes.notFoundTitle}>
+          Device not found
+        </Typography>
+        <Typography className={classes.notFoundMessage}>
+          The device you are looking for is unavailable. Choose a device from the list to
+          continue.
+        </Typography>
+        <RouterLink to="/retailplayer/devices" className={classes.backLink}>
+          ← Back to devices
+        </RouterLink>
+      </div>
+    )
+  }
+
+  const statusItems = [
+    {
+      key: 'connected',
+      icon: LinkIcon,
+      intent: device.isConnected ? 'success' : 'danger',
+      label: 'Connected',
+    },
+    { key: 'time', label: device.time, labelForAria: 'Time' },
+    {
+      key: 'signal',
+      icon: SignalWifi4BarIcon,
+      intent: device.hasSignal ? 'success' : 'danger',
+      label: 'Signal',
+    },
+    {
+      key: 'muted',
+      icon: VolumeOffIcon,
+      intent: device.isMuted ? 'danger' : 'success',
+      label: device.isMuted ? 'Muted' : 'Audio Enabled',
+    },
+  ]
 
   return (
     <div className={classes.root}>
       <Title title="Retail Player" />
       <header className={classes.header}>
         <Typography component="h1" className={classes.title}>
-          {RETAIL_PLAYER_DATA.title}
+          {device.name}
         </Typography>
         <div className={classes.statusGroup}>
-          {RETAIL_PLAYER_DATA.status.map((statusItem) => {
+          {statusItems.map((statusItem) => {
             if (statusItem.key === 'time') {
               return (
                 <span
                   key={statusItem.key}
                   className={classes.timePill}
-                  aria-label="Time"
+                  aria-label={statusItem.labelForAria || 'Time'}
                 >
                   {statusItem.label}
                 </span>
@@ -258,31 +315,31 @@ const RetailPlayerDashboard = () => {
       </header>
 
       <section className={classes.list} aria-label="Available schedules">
-        {RETAIL_PLAYER_DATA.schedules.map((schedule, index) => {
+        {device.schedules.map((schedule, index) => {
           return (
             <div
               key={schedule.key}
               className={combineClasses(
                 classes.listItem,
-                schedule.disabled
+                schedule.isDisabled
                   ? classes.listItemDisabled
-                  : index === 0
+                  : schedule.isActive || (!schedule.isDisabled && index === 0)
                   ? classes.listItemActive
                   : null,
               )}
-              aria-disabled={schedule.disabled}
+              aria-disabled={Boolean(schedule.isDisabled)}
             >
               <DescriptionIcon
                 className={combineClasses(
                   classes.listIcon,
-                  schedule.disabled ? classes.listIconDisabled : null,
+                  schedule.isDisabled ? classes.listIconDisabled : null,
                 )}
                 aria-hidden="true"
               />
               <Typography
                 className={combineClasses(
                   classes.listText,
-                  schedule.disabled ? classes.listTextDisabled : null,
+                  schedule.isDisabled ? classes.listTextDisabled : null,
                 )}
               >
                 {schedule.label}
@@ -293,13 +350,16 @@ const RetailPlayerDashboard = () => {
       </section>
 
       <Typography component="h2" className={classes.nowPlaying}>
-        {RETAIL_PLAYER_DATA.nowPlaying}
+        {device.nowPlaying}
       </Typography>
 
       <section className={classes.controls}>
         <span
-          className={`${classes.controlIcon} ${classes.controlIconMuted}`}
-          aria-label="Muted"
+          className={combineClasses(
+            classes.controlIcon,
+            device.isMuted ? classes.controlIconMuted : classes.controlIconSuccess,
+          )}
+          aria-label={device.isMuted ? 'Muted' : 'Audio Enabled'}
           role="img"
         >
           <VolumeOffIcon fontSize="inherit" />
@@ -313,7 +373,7 @@ const RetailPlayerDashboard = () => {
               thumb: classes.sliderThumb,
               rail: classes.sliderRail,
             }}
-            defaultValue={RETAIL_PLAYER_DATA.volume}
+            defaultValue={device.volume}
             aria-label="Volume"
           />
         </div>

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -8,6 +8,25 @@ import VolumeOffIcon from '@material-ui/icons/VolumeOff'
 import DescriptionIcon from '@material-ui/icons/Description'
 import GetAppIcon from '@material-ui/icons/GetApp'
 
+const combineClasses = (...classNames) => classNames.filter(Boolean).join(' ')
+
+const RETAIL_PLAYER_DATA = {
+  title: 'ThompsonChicago_Lobby',
+  status: [
+    { key: 'connected', icon: LinkIcon, intent: 'success', label: 'Connected' },
+    { key: 'time', label: '16:40' },
+    { key: 'signal', icon: SignalWifi4BarIcon, intent: 'success', label: 'Signal' },
+    { key: 'muted', icon: VolumeOffIcon, intent: 'danger', label: 'Muted' },
+  ],
+  schedules: [
+    { key: 'early', label: 'ThompsonChicago_LobbyEarly', disabled: false },
+    { key: 'late', label: 'ThompsonChicago_LobbyLate', disabled: true },
+    { key: 'mid', label: 'ThompsonChicago_LobbyMid', disabled: true },
+  ],
+  nowPlaying: 'The Kids | Dog Trainer',
+  volume: 75,
+}
+
 const useStyles = makeStyles((theme) => {
   const successMain =
     (theme.palette.success && theme.palette.success.main) ||
@@ -24,17 +43,29 @@ const useStyles = makeStyles((theme) => {
     (theme.palette.primary && theme.palette.primary.main) ||
     (theme.palette.secondary && theme.palette.secondary.main) ||
     theme.palette.text.primary
+  const infoMain =
+    (theme.palette.info && theme.palette.info.main) || accentMain
   const sliderMain =
     (theme.palette.secondary && theme.palette.secondary.main) || theme.palette.primary.main
+  const disabledBackground =
+    (theme.palette.action && theme.palette.action.disabledBackground) ||
+    theme.palette.background.paper
 
   return {
     root: {
       display: 'flex',
       flexDirection: 'column',
-      gap: theme.spacing(4),
-      padding: theme.spacing(4),
+      gap: theme.spacing(5),
+      padding: theme.spacing(5),
+      maxWidth: 960,
+      width: '100%',
+      margin: '0 auto',
+      [theme.breakpoints.down('md')]: {
+        padding: theme.spacing(4),
+        gap: theme.spacing(4),
+      },
       [theme.breakpoints.down('sm')]: {
-        padding: theme.spacing(2),
+        padding: theme.spacing(2.5),
         gap: theme.spacing(3),
       },
     },
@@ -47,9 +78,9 @@ const useStyles = makeStyles((theme) => {
     },
     title: {
       fontWeight: theme.typography.fontWeightBold,
-      fontSize: theme.typography.pxToRem(48),
+      fontSize: theme.typography.pxToRem(60),
       [theme.breakpoints.down('md')]: {
-        fontSize: theme.typography.pxToRem(36),
+        fontSize: theme.typography.pxToRem(44),
       },
       [theme.breakpoints.down('sm')]: {
         fontSize: theme.typography.pxToRem(28),
@@ -60,6 +91,7 @@ const useStyles = makeStyles((theme) => {
       alignItems: 'center',
       gap: theme.spacing(2),
       flexWrap: 'wrap',
+      justifyContent: 'flex-end',
     },
     statusIcon: {
       display: 'inline-flex',
@@ -103,9 +135,18 @@ const useStyles = makeStyles((theme) => {
         borderBottom: 'none',
       },
     },
+    listItemActive: {
+      backgroundColor: theme.palette.action.hover,
+    },
+    listItemDisabled: {
+      backgroundColor: disabledBackground,
+    },
     listIcon: {
       color: theme.palette.text.secondary,
       fontSize: theme.typography.pxToRem(24),
+    },
+    listIconDisabled: {
+      color: theme.palette.text.disabled,
     },
     listText: {
       fontSize: theme.typography.pxToRem(20),
@@ -115,10 +156,10 @@ const useStyles = makeStyles((theme) => {
       color: theme.palette.text.disabled,
     },
     nowPlaying: {
-      fontSize: theme.typography.pxToRem(40),
+      fontSize: theme.typography.pxToRem(48),
       fontWeight: theme.typography.fontWeightBold,
       [theme.breakpoints.down('md')]: {
-        fontSize: theme.typography.pxToRem(32),
+        fontSize: theme.typography.pxToRem(36),
       },
       [theme.breakpoints.down('sm')]: {
         fontSize: theme.typography.pxToRem(26),
@@ -129,6 +170,8 @@ const useStyles = makeStyles((theme) => {
       alignItems: 'center',
       gap: theme.spacing(4),
       flexWrap: 'wrap',
+      justifyContent: 'space-between',
+      width: '100%',
     },
     controlIcon: {
       display: 'inline-flex',
@@ -140,7 +183,7 @@ const useStyles = makeStyles((theme) => {
       color: dangerMain,
     },
     controlIconDownload: {
-      color: accentMain,
+      color: infoMain,
     },
     volumeControl: {
       display: 'flex',
@@ -148,6 +191,7 @@ const useStyles = makeStyles((theme) => {
       flex: 1,
       minWidth: 240,
       gap: theme.spacing(1),
+      maxWidth: 480,
     },
     volumeLabel: {
       textTransform: 'lowercase',
@@ -177,59 +221,79 @@ const RetailPlayerDashboard = () => {
       <Title title="Retail Player" />
       <header className={classes.header}>
         <Typography component="h1" className={classes.title}>
-          ThompsonChicago_Lobby
+          {RETAIL_PLAYER_DATA.title}
         </Typography>
         <div className={classes.statusGroup}>
-          <span
-            className={`${classes.statusIcon} ${classes.statusIconSuccess}`}
-            aria-label="Connected"
-            role="img"
-          >
-            <LinkIcon fontSize="inherit" />
-          </span>
-          <span className={classes.timePill} aria-label="Time">
-            16:40
-          </span>
-          <span
-            className={`${classes.statusIcon} ${classes.statusIconSuccess}`}
-            aria-label="Signal"
-            role="img"
-          >
-            <SignalWifi4BarIcon fontSize="inherit" />
-          </span>
-          <span
-            className={`${classes.statusIcon} ${classes.statusIconDanger}`}
-            aria-label="Muted"
-            role="img"
-          >
-            <VolumeOffIcon fontSize="inherit" />
-          </span>
+          {RETAIL_PLAYER_DATA.status.map((statusItem) => {
+            if (statusItem.key === 'time') {
+              return (
+                <span
+                  key={statusItem.key}
+                  className={classes.timePill}
+                  aria-label="Time"
+                >
+                  {statusItem.label}
+                </span>
+              )
+            }
+
+            const StatusIcon = statusItem.icon
+            return (
+              <span
+                key={statusItem.key}
+                className={combineClasses(
+                  classes.statusIcon,
+                  statusItem.intent === 'success'
+                    ? classes.statusIconSuccess
+                    : classes.statusIconDanger,
+                )}
+                aria-label={statusItem.label}
+                role="img"
+              >
+                <StatusIcon fontSize="inherit" />
+              </span>
+            )
+          })}
         </div>
       </header>
 
       <section className={classes.list} aria-label="Available schedules">
-        <div className={classes.listItem}>
-          <DescriptionIcon className={classes.listIcon} aria-hidden="true" />
-          <Typography className={classes.listText}>
-            ThompsonChicago_LobbyEarly
-          </Typography>
-        </div>
-        <div className={classes.listItem}>
-          <DescriptionIcon className={classes.listIcon} aria-hidden="true" />
-          <Typography className={`${classes.listText} ${classes.listTextDisabled}`}>
-            ThompsonChicago_LobbyLate
-          </Typography>
-        </div>
-        <div className={classes.listItem}>
-          <DescriptionIcon className={classes.listIcon} aria-hidden="true" />
-          <Typography className={`${classes.listText} ${classes.listTextDisabled}`}>
-            ThompsonChicago_LobbyMid
-          </Typography>
-        </div>
+        {RETAIL_PLAYER_DATA.schedules.map((schedule, index) => {
+          return (
+            <div
+              key={schedule.key}
+              className={combineClasses(
+                classes.listItem,
+                schedule.disabled
+                  ? classes.listItemDisabled
+                  : index === 0
+                  ? classes.listItemActive
+                  : null,
+              )}
+              aria-disabled={schedule.disabled}
+            >
+              <DescriptionIcon
+                className={combineClasses(
+                  classes.listIcon,
+                  schedule.disabled ? classes.listIconDisabled : null,
+                )}
+                aria-hidden="true"
+              />
+              <Typography
+                className={combineClasses(
+                  classes.listText,
+                  schedule.disabled ? classes.listTextDisabled : null,
+                )}
+              >
+                {schedule.label}
+              </Typography>
+            </div>
+          )
+        })}
       </section>
 
       <Typography component="h2" className={classes.nowPlaying}>
-        The Kids | Dog Trainer
+        {RETAIL_PLAYER_DATA.nowPlaying}
       </Typography>
 
       <section className={classes.controls}>
@@ -249,7 +313,7 @@ const RetailPlayerDashboard = () => {
               thumb: classes.sliderThumb,
               rail: classes.sliderRail,
             }}
-            defaultValue={75}
+            defaultValue={RETAIL_PLAYER_DATA.volume}
             aria-label="Volume"
           />
         </div>

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1,10 +1,11 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
-import { Slider, Typography } from '@material-ui/core'
+import { ButtonBase, Slider, Typography } from '@material-ui/core'
 import { Title } from 'react-admin'
 import LinkIcon from '@material-ui/icons/Link'
 import SignalWifi4BarIcon from '@material-ui/icons/SignalWifi4Bar'
 import VolumeOffIcon from '@material-ui/icons/VolumeOff'
+import VolumeUpIcon from '@material-ui/icons/VolumeUp'
 import DescriptionIcon from '@material-ui/icons/Description'
 import GetAppIcon from '@material-ui/icons/GetApp'
 import { Link as RouterLink, useParams } from 'react-router-dom'
@@ -61,6 +62,12 @@ const useStyles = makeStyles((theme) => {
       gap: theme.spacing(2),
       flexWrap: 'wrap',
     },
+    backLinkTop: {
+      alignSelf: 'flex-start',
+      fontSize: theme.typography.pxToRem(14),
+      textTransform: 'uppercase',
+      letterSpacing: 1,
+    },
     title: {
       fontWeight: theme.typography.fontWeightBold,
       fontSize: theme.typography.pxToRem(60),
@@ -110,35 +117,58 @@ const useStyles = makeStyles((theme) => {
       overflow: 'hidden',
       border: `1px solid ${theme.palette.divider}`,
     },
+    listItemButton: {
+      display: 'block',
+      width: '100%',
+      textAlign: 'left',
+      '&:hover $listItem, &:focus-visible $listItem': {
+        backgroundColor: theme.palette.action.hover,
+      },
+      '&:last-child $listItem': {
+        borderBottom: 'none',
+      },
+    },
     listItem: {
       display: 'flex',
       alignItems: 'center',
       gap: theme.spacing(2),
       padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`,
       borderBottom: `1px solid ${theme.palette.divider}`,
-      '&:last-child': {
-        borderBottom: 'none',
-      },
+      transition: theme.transitions.create(['background-color'], {
+        duration: theme.transitions.duration.shortest,
+      }),
     },
     listItemActive: {
-      backgroundColor: theme.palette.action.hover,
+      backgroundColor: theme.palette.action.selected,
     },
-    listItemDisabled: {
+    listItemInactive: {
       backgroundColor: disabledBackground,
     },
     listIcon: {
       color: theme.palette.text.secondary,
       fontSize: theme.typography.pxToRem(24),
     },
-    listIconDisabled: {
+    listIconInactive: {
       color: theme.palette.text.disabled,
     },
     listText: {
       fontSize: theme.typography.pxToRem(20),
       fontWeight: theme.typography.fontWeightMedium,
     },
-    listTextDisabled: {
+    listTextInactive: {
       color: theme.palette.text.disabled,
+    },
+    artworkWrapper: {
+      alignSelf: 'center',
+      width: 200,
+      maxWidth: '100%',
+    },
+    artworkPlaceholder: {
+      width: '100%',
+      paddingTop: '100%',
+      borderRadius: theme.shape.borderRadius,
+      backgroundColor: theme.palette.action.hover,
+      border: `1px solid ${theme.palette.divider}`,
     },
     nowPlaying: {
       fontSize: theme.typography.pxToRem(48),
@@ -158,14 +188,27 @@ const useStyles = makeStyles((theme) => {
       justifyContent: 'space-between',
       width: '100%',
     },
+    controlButton: {
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: theme.shape.borderRadius * 2,
+      padding: theme.spacing(1.5),
+      transition: theme.transitions.create(['background-color', 'color'], {
+        duration: theme.transitions.duration.shortest,
+      }),
+    },
     controlIcon: {
       display: 'inline-flex',
       alignItems: 'center',
       justifyContent: 'center',
       fontSize: theme.typography.pxToRem(64),
     },
-    controlIconMuted: {
+    controlButtonMuted: {
       color: dangerMain,
+    },
+    controlButtonUnmuted: {
+      color: successMain,
     },
     controlIconDownload: {
       color: infoMain,
@@ -183,6 +226,11 @@ const useStyles = makeStyles((theme) => {
       fontSize: theme.typography.pxToRem(16),
       color: theme.palette.text.secondary,
     },
+    volumeSliderRow: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(2),
+    },
     slider: {
       color: sliderMain,
     },
@@ -194,6 +242,12 @@ const useStyles = makeStyles((theme) => {
     },
     sliderRail: {
       backgroundColor: theme.palette.action.disabled,
+    },
+    volumeValue: {
+      minWidth: 32,
+      textAlign: 'right',
+      fontVariantNumeric: 'tabular-nums',
+      fontWeight: theme.typography.fontWeightMedium,
     },
     notFoundWrapper: {
       display: 'flex',
@@ -221,9 +275,9 @@ const useStyles = makeStyles((theme) => {
         theme.palette.text.primary,
       fontWeight: theme.typography.fontWeightMedium,
       textDecoration: 'none',
-    },
-    controlIconSuccess: {
-      color: successMain,
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: theme.spacing(1),
     },
   }
 })
@@ -232,6 +286,36 @@ const RetailPlayerDashboard = () => {
   const classes = useStyles()
   const { deviceId } = useParams()
   const device = (deviceId && retailDeviceDetails[deviceId]) || null
+  const schedules = device?.schedules || []
+
+  const [activeChannelKey, setActiveChannelKey] = useState(() => {
+    const initialSchedule =
+      schedules.find((schedule) => schedule.isActive) || schedules[0] || null
+    return initialSchedule ? initialSchedule.key : null
+  })
+  const [nowPlaying, setNowPlaying] = useState(device?.nowPlaying || '')
+  const [isMuted, setIsMuted] = useState(Boolean(device?.isMuted))
+  const [volume, setVolume] = useState(
+    typeof device?.volume === 'number' ? device.volume : 0,
+  )
+
+  useEffect(() => {
+    if (!device) {
+      setActiveChannelKey(null)
+      setNowPlaying('')
+      setIsMuted(false)
+      setVolume(0)
+      return
+    }
+
+    const nextSchedules = device.schedules || []
+    const initialSchedule =
+      nextSchedules.find((schedule) => schedule.isActive) || nextSchedules[0] || null
+    setActiveChannelKey(initialSchedule ? initialSchedule.key : null)
+    setNowPlaying(device.nowPlaying)
+    setIsMuted(device.isMuted)
+    setVolume(device.volume)
+  }, [device])
 
   if (!device) {
     return (
@@ -251,6 +335,23 @@ const RetailPlayerDashboard = () => {
     )
   }
 
+  const handleSelectChannel = (schedule) => {
+    setActiveChannelKey(schedule.key)
+    setNowPlaying(`${schedule.label} | ${schedule.artist}`)
+  }
+
+  const handleToggleMute = () => {
+    setIsMuted((prev) => !prev)
+  }
+
+  const handleVolumeChange = (_, newValue) => {
+    if (Array.isArray(newValue)) {
+      setVolume(newValue[0])
+    } else if (typeof newValue === 'number') {
+      setVolume(newValue)
+    }
+  }
+
   const statusItems = [
     {
       key: 'connected',
@@ -267,15 +368,18 @@ const RetailPlayerDashboard = () => {
     },
     {
       key: 'muted',
-      icon: VolumeOffIcon,
-      intent: device.isMuted ? 'danger' : 'success',
-      label: device.isMuted ? 'Muted' : 'Audio Enabled',
+      icon: isMuted ? VolumeOffIcon : VolumeUpIcon,
+      intent: isMuted ? 'danger' : 'success',
+      label: isMuted ? 'Muted' : 'Audio Enabled',
     },
   ]
 
   return (
     <div className={classes.root}>
       <Title title="Retail Player" />
+      <RouterLink to="/retailplayer/devices" className={`${classes.backLink} ${classes.backLinkTop}`}>
+        ← Back to Devices
+      </RouterLink>
       <header className={classes.header}>
         <Typography component="h1" className={classes.title}>
           {device.name}
@@ -315,67 +419,86 @@ const RetailPlayerDashboard = () => {
       </header>
 
       <section className={classes.list} aria-label="Available schedules">
-        {device.schedules.map((schedule, index) => {
+        {device.schedules.map((schedule) => {
+          const isActive = schedule.key === activeChannelKey
           return (
-            <div
+            <ButtonBase
               key={schedule.key}
-              className={combineClasses(
-                classes.listItem,
-                schedule.isDisabled
-                  ? classes.listItemDisabled
-                  : schedule.isActive || (!schedule.isDisabled && index === 0)
-                  ? classes.listItemActive
-                  : null,
-              )}
-              aria-disabled={Boolean(schedule.isDisabled)}
+              className={classes.listItemButton}
+              onClick={() => handleSelectChannel(schedule)}
+              focusRipple
+              aria-label={`Select channel: ${schedule.label}`}
+              aria-pressed={isActive}
             >
-              <DescriptionIcon
+              <div
                 className={combineClasses(
-                  classes.listIcon,
-                  schedule.isDisabled ? classes.listIconDisabled : null,
-                )}
-                aria-hidden="true"
-              />
-              <Typography
-                className={combineClasses(
-                  classes.listText,
-                  schedule.isDisabled ? classes.listTextDisabled : null,
+                  classes.listItem,
+                  isActive ? classes.listItemActive : classes.listItemInactive,
                 )}
               >
-                {schedule.label}
-              </Typography>
-            </div>
+                <DescriptionIcon
+                  className={combineClasses(
+                    classes.listIcon,
+                    !isActive ? classes.listIconInactive : null,
+                  )}
+                  aria-hidden="true"
+                />
+                <Typography
+                  className={combineClasses(
+                    classes.listText,
+                    !isActive ? classes.listTextInactive : null,
+                  )}
+                >
+                  {schedule.label}
+                </Typography>
+              </div>
+            </ButtonBase>
           )
         })}
       </section>
 
+      <div className={classes.artworkWrapper}>
+        <div className={classes.artworkPlaceholder} role="img" aria-label="Album artwork placeholder" />
+      </div>
+
       <Typography component="h2" className={classes.nowPlaying}>
-        {device.nowPlaying}
+        {nowPlaying}
       </Typography>
 
       <section className={classes.controls}>
-        <span
+        <ButtonBase
           className={combineClasses(
-            classes.controlIcon,
-            device.isMuted ? classes.controlIconMuted : classes.controlIconSuccess,
+            classes.controlButton,
+            isMuted ? classes.controlButtonMuted : classes.controlButtonUnmuted,
           )}
-          aria-label={device.isMuted ? 'Muted' : 'Audio Enabled'}
-          role="img"
+          aria-label="Mute/Unmute"
+          onClick={handleToggleMute}
+          focusRipple
         >
-          <VolumeOffIcon fontSize="inherit" />
-        </span>
+          <span className={classes.controlIcon} role="img" aria-hidden="true">
+            {isMuted ? <VolumeOffIcon fontSize="inherit" /> : <VolumeUpIcon fontSize="inherit" />}
+          </span>
+        </ButtonBase>
         <div className={classes.volumeControl}>
           <Typography className={classes.volumeLabel}>volume</Typography>
-          <Slider
-            classes={{
-              root: classes.slider,
-              track: classes.sliderTrack,
-              thumb: classes.sliderThumb,
-              rail: classes.sliderRail,
-            }}
-            defaultValue={device.volume}
-            aria-label="Volume"
-          />
+          <div className={classes.volumeSliderRow}>
+            <Slider
+              classes={{
+                root: classes.slider,
+                track: classes.sliderTrack,
+                thumb: classes.sliderThumb,
+                rail: classes.sliderRail,
+              }}
+              value={volume}
+              min={0}
+              max={100}
+              aria-label="Volume"
+              onChange={handleVolumeChange}
+            />
+            <Typography className={classes.volumeValue} aria-live="polite">
+              {volume}
+            </Typography>
+          </div>
         </div>
         <span
           className={`${classes.controlIcon} ${classes.controlIconDownload}`}

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1,257 +1,266 @@
-import React, { useEffect, useMemo, useState } from 'react'
-import {
-  Card,
-  CardActions,
-  CardContent,
-  Grid,
-  IconButton,
-  MenuItem,
-  Typography,
-} from '@material-ui/core'
+import React from 'react'
 import { makeStyles } from '@material-ui/core/styles'
+import { Slider, Typography } from '@material-ui/core'
 import { Title } from 'react-admin'
-import Select from '@material-ui/core/Select'
-import Slider from '@material-ui/core/Slider'
-import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord'
-import PlayArrowIcon from '@material-ui/icons/PlayArrow'
-import PauseIcon from '@material-ui/icons/Pause'
-import SkipNextIcon from '@material-ui/icons/SkipNext'
-import SkipPreviousIcon from '@material-ui/icons/SkipPrevious'
+import LinkIcon from '@material-ui/icons/Link'
+import SignalWifi4BarIcon from '@material-ui/icons/SignalWifi4Bar'
+import VolumeOffIcon from '@material-ui/icons/VolumeOff'
+import DescriptionIcon from '@material-ui/icons/Description'
+import GetAppIcon from '@material-ui/icons/GetApp'
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    marginTop: theme.spacing(2),
-  },
-  card: {
-    height: '100%',
-  },
-  header: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: theme.spacing(1),
-  },
-  status: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-    color: theme.palette.text.secondary,
-  },
-  statusIconOnline: {
-    color: theme.palette.success.main,
-  },
-  statusIconOffline: {
-    color: theme.palette.action.disabled,
-  },
-  controls: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-    width: '100%',
-  },
-  channelSelect: {
-    minWidth: 160,
-  },
-  slider: {
-    flex: 1,
-    marginLeft: theme.spacing(2),
-    marginRight: theme.spacing(2),
-  },
-}))
-
-const createMockService = () => {
-  const channels = [
-    { id: 'channel-1', name: 'Main Floor' },
-    { id: 'channel-2', name: 'Outdoor Patio' },
-    { id: 'channel-3', name: 'Seasonal Playlist' },
-    { id: 'channel-4', name: 'Announcements' },
-  ]
-
-  const devices = [
-    {
-      id: 'device-1',
-      name: 'Lobby Speaker',
-      online: true,
-      channelId: channels[0].id,
-      volume: 65,
-    },
-    {
-      id: 'device-2',
-      name: 'Warehouse Receiver',
-      online: false,
-      channelId: channels[1].id,
-      volume: 30,
-    },
-  ]
+const useStyles = makeStyles((theme) => {
+  const successMain =
+    (theme.palette.success && theme.palette.success.main) ||
+    (theme.palette.secondary && theme.palette.secondary.main) ||
+    theme.palette.primary.main
+  const successContrast =
+    (theme.palette.success && theme.palette.success.contrastText) ||
+    theme.palette.getContrastText(successMain)
+  const dangerMain =
+    (theme.palette.error && theme.palette.error.main) ||
+    (theme.palette.secondary && theme.palette.secondary.main) ||
+    theme.palette.primary.main
+  const accentMain =
+    (theme.palette.primary && theme.palette.primary.main) ||
+    (theme.palette.secondary && theme.palette.secondary.main) ||
+    theme.palette.text.primary
+  const sliderMain =
+    (theme.palette.secondary && theme.palette.secondary.main) || theme.palette.primary.main
 
   return {
-    getDevices: () => Promise.resolve(devices.map((device) => ({ ...device }))),
-    getChannels: () => Promise.resolve(channels.map((channel) => ({ ...channel }))),
-    setDeviceChannel: (deviceId, channelId) => {
-      console.log(`[RetailPlayer] setDeviceChannel`, { deviceId, channelId })
+    root: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(4),
+      padding: theme.spacing(4),
+      [theme.breakpoints.down('sm')]: {
+        padding: theme.spacing(2),
+        gap: theme.spacing(3),
+      },
     },
-    setDeviceVolume: (deviceId, volume) => {
-      console.log(`[RetailPlayer] setDeviceVolume`, { deviceId, volume })
+    header: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: theme.spacing(2),
+      flexWrap: 'wrap',
     },
-    controlPlayback: (deviceId, action) => {
-      console.log(`[RetailPlayer] controlPlayback`, { deviceId, action })
+    title: {
+      fontWeight: theme.typography.fontWeightBold,
+      fontSize: theme.typography.pxToRem(48),
+      [theme.breakpoints.down('md')]: {
+        fontSize: theme.typography.pxToRem(36),
+      },
+      [theme.breakpoints.down('sm')]: {
+        fontSize: theme.typography.pxToRem(28),
+      },
+    },
+    statusGroup: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(2),
+      flexWrap: 'wrap',
+    },
+    statusIcon: {
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      fontSize: theme.typography.pxToRem(32),
+      '& svg': {
+        fontSize: 'inherit',
+      },
+    },
+    statusIconSuccess: {
+      color: successMain,
+    },
+    statusIconDanger: {
+      color: dangerMain,
+    },
+    timePill: {
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: `${theme.spacing(0.5)}px ${theme.spacing(2)}px`,
+      borderRadius: theme.shape.borderRadius * 2,
+      backgroundColor: successMain,
+      color: successContrast,
+      fontWeight: theme.typography.fontWeightMedium,
+      fontSize: theme.typography.pxToRem(18),
+    },
+    list: {
+      borderRadius: theme.shape.borderRadius,
+      backgroundColor: theme.palette.background.paper,
+      overflow: 'hidden',
+      border: `1px solid ${theme.palette.divider}`,
+    },
+    listItem: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(2),
+      padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`,
+      borderBottom: `1px solid ${theme.palette.divider}`,
+      '&:last-child': {
+        borderBottom: 'none',
+      },
+    },
+    listIcon: {
+      color: theme.palette.text.secondary,
+      fontSize: theme.typography.pxToRem(24),
+    },
+    listText: {
+      fontSize: theme.typography.pxToRem(20),
+      fontWeight: theme.typography.fontWeightMedium,
+    },
+    listTextDisabled: {
+      color: theme.palette.text.disabled,
+    },
+    nowPlaying: {
+      fontSize: theme.typography.pxToRem(40),
+      fontWeight: theme.typography.fontWeightBold,
+      [theme.breakpoints.down('md')]: {
+        fontSize: theme.typography.pxToRem(32),
+      },
+      [theme.breakpoints.down('sm')]: {
+        fontSize: theme.typography.pxToRem(26),
+      },
+    },
+    controls: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(4),
+      flexWrap: 'wrap',
+    },
+    controlIcon: {
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      fontSize: theme.typography.pxToRem(64),
+    },
+    controlIconMuted: {
+      color: dangerMain,
+    },
+    controlIconDownload: {
+      color: accentMain,
+    },
+    volumeControl: {
+      display: 'flex',
+      flexDirection: 'column',
+      flex: 1,
+      minWidth: 240,
+      gap: theme.spacing(1),
+    },
+    volumeLabel: {
+      textTransform: 'lowercase',
+      fontSize: theme.typography.pxToRem(16),
+      color: theme.palette.text.secondary,
+    },
+    slider: {
+      color: sliderMain,
+    },
+    sliderTrack: {
+      backgroundColor: sliderMain,
+    },
+    sliderThumb: {
+      backgroundColor: sliderMain,
+    },
+    sliderRail: {
+      backgroundColor: theme.palette.action.disabled,
     },
   }
-}
-
-const mockService = createMockService()
+})
 
 const RetailPlayerDashboard = () => {
   const classes = useStyles()
-  const [devices, setDevices] = useState([])
-  const [channels, setChannels] = useState([])
-
-  useEffect(() => {
-    let isMounted = true
-    const loadData = async () => {
-      const [deviceList, channelList] = await Promise.all([
-        mockService.getDevices(),
-        mockService.getChannels(),
-      ])
-      if (isMounted) {
-        setDevices(deviceList)
-        setChannels(channelList)
-      }
-    }
-    loadData()
-    return () => {
-      isMounted = false
-    }
-  }, [])
-
-  const channelMap = useMemo(
-    () =>
-      channels.reduce((acc, channel) => {
-        acc[channel.id] = channel
-        return acc
-      }, {}),
-    [channels],
-  )
-
-  const handleChannelChange = (deviceId) => (event) => {
-    const channelId = event.target.value
-    setDevices((prevDevices) =>
-      prevDevices.map((device) =>
-        device.id === deviceId ? { ...device, channelId } : device,
-      ),
-    )
-    mockService.setDeviceChannel(deviceId, channelId)
-  }
-
-  const handleVolumeChange = (deviceId) => (event, value) => {
-    const volume = Array.isArray(value) ? value[0] : value
-    setDevices((prevDevices) =>
-      prevDevices.map((device) =>
-        device.id === deviceId ? { ...device, volume } : device,
-      ),
-    )
-    mockService.setDeviceVolume(deviceId, volume)
-  }
-
-  const handlePlayback = (deviceId, action) => () => {
-    mockService.controlPlayback(deviceId, action)
-  }
-
-  const renderDevice = (device) => {
-    const isOnline = device.online
-    const nowPlaying = channelMap[device.channelId]?.name || '—'
-    return (
-      <Grid item xs={12} md={6} key={device.id}>
-        <Card className={classes.card}>
-          <CardContent>
-            <div className={classes.header}>
-              <Typography variant="h6">{device.name}</Typography>
-              <div className={classes.status}>
-                <FiberManualRecordIcon
-                  fontSize="small"
-                  className={
-                    isOnline ? classes.statusIconOnline : classes.statusIconOffline
-                  }
-                />
-                <Typography variant="body2">
-                  {isOnline ? 'Online' : 'Offline'}
-                </Typography>
-              </div>
-            </div>
-            <Typography variant="subtitle2" color="textSecondary">
-              Now Playing
-            </Typography>
-            <Typography variant="body1" gutterBottom>
-              {nowPlaying}
-            </Typography>
-            <div className={classes.controls}>
-              <Select
-                value={device.channelId}
-                onChange={handleChannelChange(device.id)}
-                className={classes.channelSelect}
-                disabled={!isOnline}
-                variant="outlined"
-              >
-                {channels.map((channel) => (
-                  <MenuItem value={channel.id} key={channel.id}>
-                    {channel.name}
-                  </MenuItem>
-                ))}
-              </Select>
-              <Slider
-                value={device.volume}
-                onChange={handleVolumeChange(device.id)}
-                aria-labelledby={`${device.id}-volume`}
-                step={1}
-                min={0}
-                max={100}
-                className={classes.slider}
-                disabled={!isOnline}
-              />
-              <Typography variant="body2">{device.volume}</Typography>
-            </div>
-          </CardContent>
-          <CardActions>
-            <IconButton
-              aria-label="previous"
-              onClick={handlePlayback(device.id, 'previous')}
-              disabled={!isOnline}
-            >
-              <SkipPreviousIcon />
-            </IconButton>
-            <IconButton
-              aria-label="play"
-              onClick={handlePlayback(device.id, 'play')}
-              disabled={!isOnline}
-            >
-              <PlayArrowIcon />
-            </IconButton>
-            <IconButton
-              aria-label="pause"
-              onClick={handlePlayback(device.id, 'pause')}
-              disabled={!isOnline}
-            >
-              <PauseIcon />
-            </IconButton>
-            <IconButton
-              aria-label="next"
-              onClick={handlePlayback(device.id, 'next')}
-              disabled={!isOnline}
-            >
-              <SkipNextIcon />
-            </IconButton>
-          </CardActions>
-        </Card>
-      </Grid>
-    )
-  }
 
   return (
     <div className={classes.root}>
       <Title title="Retail Player" />
-      <Grid container spacing={2}>
-        {devices.map(renderDevice)}
-      </Grid>
+      <header className={classes.header}>
+        <Typography component="h1" className={classes.title}>
+          ThompsonChicago_Lobby
+        </Typography>
+        <div className={classes.statusGroup}>
+          <span
+            className={`${classes.statusIcon} ${classes.statusIconSuccess}`}
+            aria-label="Connected"
+            role="img"
+          >
+            <LinkIcon fontSize="inherit" />
+          </span>
+          <span className={classes.timePill} aria-label="Time">
+            16:40
+          </span>
+          <span
+            className={`${classes.statusIcon} ${classes.statusIconSuccess}`}
+            aria-label="Signal"
+            role="img"
+          >
+            <SignalWifi4BarIcon fontSize="inherit" />
+          </span>
+          <span
+            className={`${classes.statusIcon} ${classes.statusIconDanger}`}
+            aria-label="Muted"
+            role="img"
+          >
+            <VolumeOffIcon fontSize="inherit" />
+          </span>
+        </div>
+      </header>
+
+      <section className={classes.list} aria-label="Available schedules">
+        <div className={classes.listItem}>
+          <DescriptionIcon className={classes.listIcon} aria-hidden="true" />
+          <Typography className={classes.listText}>
+            ThompsonChicago_LobbyEarly
+          </Typography>
+        </div>
+        <div className={classes.listItem}>
+          <DescriptionIcon className={classes.listIcon} aria-hidden="true" />
+          <Typography className={`${classes.listText} ${classes.listTextDisabled}`}>
+            ThompsonChicago_LobbyLate
+          </Typography>
+        </div>
+        <div className={classes.listItem}>
+          <DescriptionIcon className={classes.listIcon} aria-hidden="true" />
+          <Typography className={`${classes.listText} ${classes.listTextDisabled}`}>
+            ThompsonChicago_LobbyMid
+          </Typography>
+        </div>
+      </section>
+
+      <Typography component="h2" className={classes.nowPlaying}>
+        The Kids | Dog Trainer
+      </Typography>
+
+      <section className={classes.controls}>
+        <span
+          className={`${classes.controlIcon} ${classes.controlIconMuted}`}
+          aria-label="Muted"
+          role="img"
+        >
+          <VolumeOffIcon fontSize="inherit" />
+        </span>
+        <div className={classes.volumeControl}>
+          <Typography className={classes.volumeLabel}>volume</Typography>
+          <Slider
+            classes={{
+              root: classes.slider,
+              track: classes.sliderTrack,
+              thumb: classes.sliderThumb,
+              rail: classes.sliderRail,
+            }}
+            defaultValue={75}
+            aria-label="Volume"
+          />
+        </div>
+        <span
+          className={`${classes.controlIcon} ${classes.controlIconDownload}`}
+          aria-label="Download"
+          role="img"
+        >
+          <GetAppIcon fontSize="inherit" />
+        </span>
+      </section>
     </div>
   )
 }

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import { ButtonBase, Slider, Typography } from '@material-ui/core'
 import { Title } from 'react-admin'
@@ -8,10 +8,20 @@ import VolumeOffIcon from '@material-ui/icons/VolumeOff'
 import VolumeUpIcon from '@material-ui/icons/VolumeUp'
 import DescriptionIcon from '@material-ui/icons/Description'
 import GetAppIcon from '@material-ui/icons/GetApp'
+import CachedIcon from '@material-ui/icons/Cached'
 import { Link as RouterLink, useParams } from 'react-router-dom'
-import { retailDeviceDetails } from './deviceData'
+import RetailPlayerMockService from './RetailPlayerMockService'
 
 const combineClasses = (...classNames) => classNames.filter(Boolean).join(' ')
+
+const formatTime = (date) =>
+  date
+    .toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    })
+    .replace(/^24:/, '00:')
 
 const useStyles = makeStyles((theme) => {
   const successMain =
@@ -99,6 +109,9 @@ const useStyles = makeStyles((theme) => {
     },
     statusIconDanger: {
       color: dangerMain,
+    },
+    statusIconNeutral: {
+      color: theme.palette.text.secondary,
     },
     timePill: {
       display: 'inline-flex',
@@ -279,43 +292,208 @@ const useStyles = makeStyles((theme) => {
       alignItems: 'center',
       gap: theme.spacing(1),
     },
+    refreshButton: {
+      borderRadius: theme.shape.borderRadius * 2,
+      padding: theme.spacing(0.75),
+      border: `1px solid ${theme.palette.divider}`,
+      '&:hover, &:focus-visible': {
+        backgroundColor: theme.palette.action.hover,
+      },
+    },
+    artworkImage: {
+      width: '100%',
+      height: 'auto',
+      borderRadius: theme.shape.borderRadius,
+      display: 'block',
+    },
   }
 })
 
 const RetailPlayerDashboard = () => {
   const classes = useStyles()
   const { deviceId } = useParams()
-  const device = (deviceId && retailDeviceDetails[deviceId]) || null
-  const schedules = device?.schedules || []
+  const [device, setDevice] = useState(null)
+  const [artworkUrl, setArtworkUrl] = useState(null)
+  const [currentTime, setCurrentTime] = useState(() => formatTime(new Date()))
 
-  const [activeChannelKey, setActiveChannelKey] = useState(() => {
-    const initialSchedule =
-      schedules.find((schedule) => schedule.isActive) || schedules[0] || null
-    return initialSchedule ? initialSchedule.key : null
-  })
-  const [nowPlaying, setNowPlaying] = useState(device?.nowPlaying || '')
-  const [isMuted, setIsMuted] = useState(Boolean(device?.isMuted))
-  const [volume, setVolume] = useState(
-    typeof device?.volume === 'number' ? device.volume : 0,
-  )
-
-  useEffect(() => {
-    if (!device) {
-      setActiveChannelKey(null)
-      setNowPlaying('')
-      setIsMuted(false)
-      setVolume(0)
+  const refreshDevice = useCallback(() => {
+    if (!deviceId) {
+      setDevice(null)
+      setArtworkUrl(null)
       return
     }
 
-    const nextSchedules = device.schedules || []
-    const initialSchedule =
-      nextSchedules.find((schedule) => schedule.isActive) || nextSchedules[0] || null
-    setActiveChannelKey(initialSchedule ? initialSchedule.key : null)
-    setNowPlaying(device.nowPlaying)
-    setIsMuted(device.isMuted)
-    setVolume(device.volume)
-  }, [device])
+    const nextDevice = RetailPlayerMockService.getDevice(deviceId)
+    setDevice(nextDevice)
+    setArtworkUrl(RetailPlayerMockService.getArtwork(deviceId))
+    setCurrentTime(formatTime(new Date()))
+  }, [deviceId])
+
+  useEffect(() => {
+    refreshDevice()
+  }, [refreshDevice])
+
+  useEffect(() => {
+    const updateTime = () => setCurrentTime(formatTime(new Date()))
+    const intervalId = window.setInterval(updateTime, 60000)
+    return () => window.clearInterval(intervalId)
+  }, [])
+
+  const schedules = useMemo(() => device?.schedules || [], [device])
+
+  const activeChannelKey = useMemo(() => {
+    const activeSchedule = schedules.find((schedule) => schedule.isActive)
+    return activeSchedule ? activeSchedule.key : null
+  }, [schedules])
+
+  const isMuted = Boolean(device?.isMuted)
+  const volume = typeof device?.volume === 'number' ? device.volume : 0
+  const nowPlaying = device?.nowPlaying || ''
+
+  const statusItems = useMemo(() => {
+    if (!device) {
+      return []
+    }
+
+    return [
+      {
+        key: 'connected',
+        icon: LinkIcon,
+        intent: device.isConnected ? 'success' : 'danger',
+        label: 'Connected',
+      },
+      { key: 'time', label: currentTime, labelForAria: 'Time' },
+      {
+        key: 'signal',
+        icon: SignalWifi4BarIcon,
+        intent: device.hasSignal ? 'success' : 'danger',
+        label: 'Signal',
+      },
+      {
+        key: 'muted',
+        icon: isMuted ? VolumeOffIcon : VolumeUpIcon,
+        intent: isMuted ? 'danger' : 'success',
+        label: isMuted ? 'Muted' : 'Audio Enabled',
+      },
+    ]
+  }, [currentTime, device, isMuted])
+
+  const handleSelectChannel = useCallback(
+    (schedule) => {
+      if (!device) {
+        return
+      }
+      RetailPlayerMockService.setActiveChannel(deviceId, schedule.key)
+      refreshDevice()
+    },
+    [device, deviceId, refreshDevice],
+  )
+
+  const handleToggleMute = useCallback(() => {
+    if (!device) {
+      return
+    }
+    RetailPlayerMockService.setMute(deviceId, !device.isMuted)
+    refreshDevice()
+  }, [device, deviceId, refreshDevice])
+
+  const handleVolumeChange = useCallback(
+    (_, newValue) => {
+      if (!device) {
+        return
+      }
+
+      const resolvedValue = Array.isArray(newValue) ? newValue[0] : newValue
+      if (typeof resolvedValue !== 'number' || Number.isNaN(resolvedValue)) {
+        return
+      }
+
+      RetailPlayerMockService.setVolume(deviceId, resolvedValue)
+      refreshDevice()
+    },
+    [device, deviceId, refreshDevice],
+  )
+
+  const handleRefresh = useCallback(() => {
+    refreshDevice()
+  }, [refreshDevice])
+
+  const handleAdjustVolume = useCallback(
+    (delta) => {
+      if (!device) {
+        return
+      }
+      const nextVolume = device.volume + delta
+      RetailPlayerMockService.setVolume(deviceId, nextVolume)
+      refreshDevice()
+    },
+    [device, deviceId, refreshDevice],
+  )
+
+  const handleShortcutChannel = useCallback(
+    (index) => {
+      const schedule = schedules[index]
+      if (!schedule) {
+        return
+      }
+      RetailPlayerMockService.setActiveChannel(deviceId, schedule.key)
+      refreshDevice()
+    },
+    [deviceId, refreshDevice, schedules],
+  )
+
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (!device) {
+        return
+      }
+
+      const target = event.target
+      const tagName = target && target.tagName
+      if (
+        tagName === 'INPUT' ||
+        tagName === 'TEXTAREA' ||
+        (target && target.isContentEditable)
+      ) {
+        return
+      }
+
+      switch (event.key) {
+        case 'm':
+        case 'M':
+          event.preventDefault()
+          RetailPlayerMockService.setMute(deviceId, !device.isMuted)
+          refreshDevice()
+          break
+        case '+':
+        case '=':
+          event.preventDefault()
+          handleAdjustVolume(5)
+          break
+        case '-':
+          event.preventDefault()
+          handleAdjustVolume(-5)
+          break
+        case '1':
+          event.preventDefault()
+          handleShortcutChannel(0)
+          break
+        case '2':
+          event.preventDefault()
+          handleShortcutChannel(1)
+          break
+        case '3':
+          event.preventDefault()
+          handleShortcutChannel(2)
+          break
+        default:
+          break
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [device, deviceId, handleAdjustVolume, handleShortcutChannel, refreshDevice])
 
   if (!device) {
     return (
@@ -335,45 +513,6 @@ const RetailPlayerDashboard = () => {
     )
   }
 
-  const handleSelectChannel = (schedule) => {
-    setActiveChannelKey(schedule.key)
-    setNowPlaying(`${schedule.label} | ${schedule.artist}`)
-  }
-
-  const handleToggleMute = () => {
-    setIsMuted((prev) => !prev)
-  }
-
-  const handleVolumeChange = (_, newValue) => {
-    if (Array.isArray(newValue)) {
-      setVolume(newValue[0])
-    } else if (typeof newValue === 'number') {
-      setVolume(newValue)
-    }
-  }
-
-  const statusItems = [
-    {
-      key: 'connected',
-      icon: LinkIcon,
-      intent: device.isConnected ? 'success' : 'danger',
-      label: 'Connected',
-    },
-    { key: 'time', label: device.time, labelForAria: 'Time' },
-    {
-      key: 'signal',
-      icon: SignalWifi4BarIcon,
-      intent: device.hasSignal ? 'success' : 'danger',
-      label: 'Signal',
-    },
-    {
-      key: 'muted',
-      icon: isMuted ? VolumeOffIcon : VolumeUpIcon,
-      intent: isMuted ? 'danger' : 'success',
-      label: isMuted ? 'Muted' : 'Audio Enabled',
-    },
-  ]
-
   return (
     <div className={classes.root}>
       <Title title="Retail Player" />
@@ -385,6 +524,14 @@ const RetailPlayerDashboard = () => {
           {device.name}
         </Typography>
         <div className={classes.statusGroup}>
+          <ButtonBase
+            className={combineClasses(classes.statusIcon, classes.statusIconNeutral, classes.refreshButton)}
+            onClick={handleRefresh}
+            aria-label="Refresh"
+            focusRipple
+          >
+            <CachedIcon fontSize="inherit" />
+          </ButtonBase>
           {statusItems.map((statusItem) => {
             if (statusItem.key === 'time') {
               return (
@@ -458,7 +605,15 @@ const RetailPlayerDashboard = () => {
       </section>
 
       <div className={classes.artworkWrapper}>
-        <div className={classes.artworkPlaceholder} role="img" aria-label="Album artwork placeholder" />
+        {artworkUrl ? (
+          <img
+            src={artworkUrl}
+            alt="Album artwork"
+            className={classes.artworkImage}
+          />
+        ) : (
+          <div className={classes.artworkPlaceholder} role="img" aria-label="Album artwork placeholder" />
+        )}
       </div>
 
       <Typography component="h2" className={classes.nowPlaying}>

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -444,6 +444,12 @@ const RetailPlayerDashboard = () => {
   const [showDislikedToast, setShowDislikedToast] = useState(false)
   const dislikeTimeoutRef = useRef(null)
 
+  const schedules = useMemo(() => device?.schedules || [], [device])
+  const trackList = useMemo(
+    () => (device?.tracks && Array.isArray(device.tracks) ? device.tracks : []),
+    [device],
+  )
+
   const refreshDevice = useCallback(() => {
     if (!deviceId) {
       setDevice(null)
@@ -517,9 +523,6 @@ const RetailPlayerDashboard = () => {
       }
     }
   }, [])
-
-  const schedules = useMemo(() => device?.schedules || [], [device])
-  const trackList = useMemo(() => (device?.tracks && Array.isArray(device.tracks) ? device.tracks : []), [device])
 
   const activeChannelKey = useMemo(() => {
     const activeSchedule = schedules.find((schedule) => schedule.isActive)

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import { ButtonBase, Slider, Typography } from '@material-ui/core'
 import { Title } from 'react-admin'
@@ -9,6 +9,9 @@ import VolumeUpIcon from '@material-ui/icons/VolumeUp'
 import DescriptionIcon from '@material-ui/icons/Description'
 import GetAppIcon from '@material-ui/icons/GetApp'
 import CachedIcon from '@material-ui/icons/Cached'
+import ThumbDownIcon from '@material-ui/icons/ThumbDown'
+import SkipNextIcon from '@material-ui/icons/SkipNext'
+import CloseIcon from '@material-ui/icons/Close'
 import { Link as RouterLink, useParams } from 'react-router-dom'
 import RetailPlayerMockService from './RetailPlayerMockService'
 
@@ -176,6 +179,15 @@ const useStyles = makeStyles((theme) => {
       width: 200,
       maxWidth: '100%',
     },
+    artworkButton: {
+      width: '100%',
+      display: 'block',
+      borderRadius: theme.shape.borderRadius,
+      overflow: 'hidden',
+      '&:hover, &:focus-visible': {
+        boxShadow: theme.shadows[4],
+      },
+    },
     artworkPlaceholder: {
       width: '100%',
       paddingTop: '100%',
@@ -306,6 +318,116 @@ const useStyles = makeStyles((theme) => {
       borderRadius: theme.shape.borderRadius,
       display: 'block',
     },
+    nowPlayingPanelContainer: {
+      display: 'flex',
+      justifyContent: 'center',
+      width: '100%',
+    },
+    nowPlayingPanel: {
+      position: 'relative',
+      width: '100%',
+      maxWidth: 600,
+      margin: '0 auto',
+      padding: theme.spacing(4),
+      borderRadius: theme.shape.borderRadius * 2,
+      backgroundColor: theme.palette.background.paper,
+      border: `1px solid ${theme.palette.divider}`,
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      gap: theme.spacing(3),
+      [theme.breakpoints.down('sm')]: {
+        padding: theme.spacing(3),
+      },
+    },
+    nowPlayingPanelHeader: {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      gap: theme.spacing(0.5),
+      textAlign: 'center',
+    },
+    nowPlayingPanelTitle: {
+      fontSize: theme.typography.pxToRem(32),
+      fontWeight: theme.typography.fontWeightBold,
+      textAlign: 'center',
+    },
+    nowPlayingPanelArtist: {
+      color: theme.palette.text.secondary,
+      fontSize: theme.typography.pxToRem(18),
+    },
+    nowPlayingPanelAlbum: {
+      fontStyle: 'italic',
+      color: theme.palette.text.secondary,
+      fontSize: theme.typography.pxToRem(16),
+    },
+    nowPlayingPanelClose: {
+      position: 'absolute',
+      top: theme.spacing(2),
+      right: theme.spacing(2),
+      borderRadius: theme.shape.borderRadius,
+      padding: theme.spacing(0.5),
+      '&:hover, &:focus-visible': {
+        backgroundColor: theme.palette.action.hover,
+      },
+    },
+    nowPlayingPanelArtwork: {
+      width: 180,
+      height: 180,
+      borderRadius: '50%',
+      objectFit: 'cover',
+      border: `2px solid ${theme.palette.divider}`,
+    },
+    nowPlayingPanelArtworkPlaceholder: {
+      width: 180,
+      height: 180,
+      borderRadius: '50%',
+      backgroundColor: theme.palette.action.hover,
+      border: `2px solid ${theme.palette.divider}`,
+    },
+    nowPlayingPanelControls: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: theme.spacing(3),
+      flexWrap: 'wrap',
+    },
+    nowPlayingPanelButton: {
+      borderRadius: theme.shape.borderRadius * 2,
+      padding: theme.spacing(1.5),
+      border: `1px solid ${theme.palette.divider}`,
+      '&:hover, &:focus-visible': {
+        backgroundColor: theme.palette.action.hover,
+      },
+    },
+    nowPlayingPanelButtonMuted: {
+      color: dangerMain,
+    },
+    nowPlayingPanelButtonUnmuted: {
+      color: successMain,
+    },
+    nowPlayingPanelButtonIcon: {
+      fontSize: theme.typography.pxToRem(28),
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    nowPlayingPanelVolume: {
+      width: '100%',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(1),
+    },
+    nowPlayingPanelVolumeRow: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(2),
+    },
+    nowPlayingPanelToast: {
+      fontSize: theme.typography.pxToRem(14),
+      color: theme.palette.text.secondary,
+      minHeight: theme.spacing(2),
+    },
   }
 })
 
@@ -315,6 +437,12 @@ const RetailPlayerDashboard = () => {
   const [device, setDevice] = useState(null)
   const [artworkUrl, setArtworkUrl] = useState(null)
   const [currentTime, setCurrentTime] = useState(() => formatTime(new Date()))
+  const [isPanelOpen, setIsPanelOpen] = useState(false)
+  const [panelMuted, setPanelMuted] = useState(false)
+  const [panelVolume, setPanelVolume] = useState(0)
+  const [panelTrack, setPanelTrack] = useState(null)
+  const [showDislikedToast, setShowDislikedToast] = useState(false)
+  const dislikeTimeoutRef = useRef(null)
 
   const refreshDevice = useCallback(() => {
     if (!deviceId) {
@@ -339,7 +467,59 @@ const RetailPlayerDashboard = () => {
     return () => window.clearInterval(intervalId)
   }, [])
 
+  useEffect(() => {
+    if (!device) {
+      setPanelTrack(null)
+      setPanelMuted(false)
+      setPanelVolume(0)
+      setIsPanelOpen(false)
+      return
+    }
+
+    const total = trackList.length
+    if (total > 0) {
+      const index =
+        typeof device.currentTrackIndex === 'number' ? device.currentTrackIndex : 0
+      const normalizedIndex = ((index % total) + total) % total
+      setPanelTrack(trackList[normalizedIndex])
+    } else {
+      setPanelTrack(null)
+    }
+    setPanelMuted(Boolean(device.isMuted))
+    setPanelVolume(typeof device.volume === 'number' ? device.volume : 0)
+  }, [device, trackList])
+
+  useEffect(() => {
+    if (!showDislikedToast) {
+      return
+    }
+
+    if (dislikeTimeoutRef.current) {
+      window.clearTimeout(dislikeTimeoutRef.current)
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setShowDislikedToast(false)
+      dislikeTimeoutRef.current = null
+    }, 2000)
+
+    dislikeTimeoutRef.current = timeoutId
+
+    return () => {
+      window.clearTimeout(timeoutId)
+    }
+  }, [showDislikedToast])
+
+  useEffect(() => {
+    return () => {
+      if (dislikeTimeoutRef.current) {
+        window.clearTimeout(dislikeTimeoutRef.current)
+      }
+    }
+  }, [])
+
   const schedules = useMemo(() => device?.schedules || [], [device])
+  const trackList = useMemo(() => (device?.tracks && Array.isArray(device.tracks) ? device.tracks : []), [device])
 
   const activeChannelKey = useMemo(() => {
     const activeSchedule = schedules.find((schedule) => schedule.isActive)
@@ -383,7 +563,16 @@ const RetailPlayerDashboard = () => {
       if (!device) {
         return
       }
-      RetailPlayerMockService.setActiveChannel(deviceId, schedule.key)
+      const updatedDevice = RetailPlayerMockService.setActiveChannel(deviceId, schedule.key)
+      if (updatedDevice && Array.isArray(updatedDevice.tracks)) {
+        const nextTrack = updatedDevice.tracks[
+          ((updatedDevice.currentTrackIndex || 0) % updatedDevice.tracks.length +
+            updatedDevice.tracks.length) %
+            updatedDevice.tracks.length
+        ]
+        setPanelTrack(nextTrack || null)
+      }
+      setShowDislikedToast(false)
       refreshDevice()
     },
     [device, deviceId, refreshDevice],
@@ -393,7 +582,9 @@ const RetailPlayerDashboard = () => {
     if (!device) {
       return
     }
-    RetailPlayerMockService.setMute(deviceId, !device.isMuted)
+    const nextMuted = !device.isMuted
+    setPanelMuted(nextMuted)
+    RetailPlayerMockService.setMute(deviceId, nextMuted)
     refreshDevice()
   }, [device, deviceId, refreshDevice])
 
@@ -408,7 +599,9 @@ const RetailPlayerDashboard = () => {
         return
       }
 
-      RetailPlayerMockService.setVolume(deviceId, resolvedValue)
+      const nextValue = Math.min(Math.max(Math.round(resolvedValue), 0), 100)
+      setPanelVolume(nextValue)
+      RetailPlayerMockService.setVolume(deviceId, nextValue)
       refreshDevice()
     },
     [device, deviceId, refreshDevice],
@@ -423,23 +616,13 @@ const RetailPlayerDashboard = () => {
       if (!device) {
         return
       }
-      const nextVolume = device.volume + delta
+      const currentVolume = typeof device.volume === 'number' ? device.volume : 0
+      const nextVolume = Math.min(Math.max(Math.round(currentVolume + delta), 0), 100)
+      setPanelVolume(nextVolume)
       RetailPlayerMockService.setVolume(deviceId, nextVolume)
       refreshDevice()
     },
     [device, deviceId, refreshDevice],
-  )
-
-  const handleShortcutChannel = useCallback(
-    (index) => {
-      const schedule = schedules[index]
-      if (!schedule) {
-        return
-      }
-      RetailPlayerMockService.setActiveChannel(deviceId, schedule.key)
-      refreshDevice()
-    },
-    [deviceId, refreshDevice, schedules],
   )
 
   useEffect(() => {
@@ -462,8 +645,7 @@ const RetailPlayerDashboard = () => {
         case 'm':
         case 'M':
           event.preventDefault()
-          RetailPlayerMockService.setMute(deviceId, !device.isMuted)
-          refreshDevice()
+          handleToggleMute()
           break
         case '+':
         case '=':
@@ -476,15 +658,15 @@ const RetailPlayerDashboard = () => {
           break
         case '1':
           event.preventDefault()
-          handleShortcutChannel(0)
+          handleSelectChannel(schedules[0])
           break
         case '2':
           event.preventDefault()
-          handleShortcutChannel(1)
+          handleSelectChannel(schedules[1])
           break
         case '3':
           event.preventDefault()
-          handleShortcutChannel(2)
+          handleSelectChannel(schedules[2])
           break
         default:
           break
@@ -493,7 +675,56 @@ const RetailPlayerDashboard = () => {
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [device, deviceId, handleAdjustVolume, handleShortcutChannel, refreshDevice])
+  }, [device, handleAdjustVolume, handleSelectChannel, handleToggleMute, schedules])
+
+  const handleClosePanel = useCallback(() => {
+    setIsPanelOpen(false)
+    setShowDislikedToast(false)
+  }, [])
+
+  const handleOpenPanel = useCallback(() => {
+    if (!device) {
+      return
+    }
+    setIsPanelOpen(true)
+  }, [device])
+
+  useEffect(() => {
+    if (!isPanelOpen) {
+      return
+    }
+
+    const handleEsc = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        handleClosePanel()
+      }
+    }
+
+    window.addEventListener('keydown', handleEsc)
+    return () => window.removeEventListener('keydown', handleEsc)
+  }, [handleClosePanel, isPanelOpen])
+
+  const handleDislike = useCallback(() => {
+    setShowDislikedToast(true)
+  }, [])
+
+  const handleSkipTrack = useCallback(() => {
+    if (!device) {
+      return
+    }
+    const nextDevice = RetailPlayerMockService.skipTrack(deviceId)
+    if (nextDevice && Array.isArray(nextDevice.tracks)) {
+      const total = nextDevice.tracks.length
+      const index =
+        typeof nextDevice.currentTrackIndex === 'number'
+          ? nextDevice.currentTrackIndex
+          : 0
+      const normalizedIndex = ((index % total) + total) % total
+      setPanelTrack(nextDevice.tracks[normalizedIndex] || null)
+    }
+    refreshDevice()
+  }, [device, deviceId, refreshDevice])
 
   if (!device) {
     return (
@@ -605,16 +836,147 @@ const RetailPlayerDashboard = () => {
       </section>
 
       <div className={classes.artworkWrapper}>
-        {artworkUrl ? (
-          <img
-            src={artworkUrl}
-            alt="Album artwork"
-            className={classes.artworkImage}
-          />
-        ) : (
-          <div className={classes.artworkPlaceholder} role="img" aria-label="Album artwork placeholder" />
-        )}
+        <ButtonBase
+          className={classes.artworkButton}
+          onClick={handleOpenPanel}
+          aria-label="Open Now Playing panel"
+          focusRipple
+        >
+          {artworkUrl ? (
+            <img
+              src={artworkUrl}
+              alt="Album artwork"
+              className={classes.artworkImage}
+            />
+          ) : (
+            <div
+              className={classes.artworkPlaceholder}
+              role="img"
+              aria-label="Album artwork placeholder"
+            />
+          )}
+        </ButtonBase>
       </div>
+
+      {isPanelOpen && (
+        <div className={classes.nowPlayingPanelContainer}>
+          <section
+            className={classes.nowPlayingPanel}
+            role="dialog"
+            aria-modal="false"
+            aria-labelledby="now-playing-panel-title"
+          >
+            <ButtonBase
+              className={classes.nowPlayingPanelClose}
+              onClick={handleClosePanel}
+              aria-label="Close"
+              focusRipple
+            >
+              <CloseIcon fontSize="small" />
+            </ButtonBase>
+            <div className={classes.nowPlayingPanelHeader}>
+              <Typography
+                id="now-playing-panel-title"
+                className={classes.nowPlayingPanelTitle}
+              >
+                {panelTrack?.title || 'Now Playing'}
+              </Typography>
+              {panelTrack?.artist ? (
+                <Typography className={classes.nowPlayingPanelArtist}>
+                  {panelTrack.artist}
+                </Typography>
+              ) : null}
+              {panelTrack?.album ? (
+                <Typography className={classes.nowPlayingPanelAlbum}>
+                  {panelTrack.album}
+                </Typography>
+              ) : null}
+            </div>
+
+            {panelTrack?.artwork ? (
+              <img
+                src={panelTrack.artwork}
+                alt={`${panelTrack.title} artwork`}
+                className={classes.nowPlayingPanelArtwork}
+              />
+            ) : (
+              <div
+                className={classes.nowPlayingPanelArtworkPlaceholder}
+                role="img"
+                aria-label="Album artwork placeholder"
+              />
+            )}
+
+            <div className={classes.nowPlayingPanelControls}>
+              <ButtonBase
+                className={classes.nowPlayingPanelButton}
+                onClick={handleDislike}
+                aria-label="Dislike"
+                focusRipple
+              >
+                <span className={classes.nowPlayingPanelButtonIcon}>
+                  <ThumbDownIcon fontSize="inherit" />
+                </span>
+              </ButtonBase>
+              <ButtonBase
+                className={combineClasses(
+                  classes.nowPlayingPanelButton,
+                  panelMuted
+                    ? classes.nowPlayingPanelButtonMuted
+                    : classes.nowPlayingPanelButtonUnmuted,
+                )}
+                onClick={handleToggleMute}
+                aria-label="Mute/Unmute"
+                focusRipple
+              >
+                <span className={classes.nowPlayingPanelButtonIcon}>
+                  {panelMuted ? (
+                    <VolumeOffIcon fontSize="inherit" />
+                  ) : (
+                    <VolumeUpIcon fontSize="inherit" />
+                  )}
+                </span>
+              </ButtonBase>
+              <ButtonBase
+                className={classes.nowPlayingPanelButton}
+                onClick={handleSkipTrack}
+                aria-label="Skip"
+                focusRipple
+              >
+                <span className={classes.nowPlayingPanelButtonIcon}>
+                  <SkipNextIcon fontSize="inherit" />
+                </span>
+              </ButtonBase>
+            </div>
+
+            <Typography className={classes.nowPlayingPanelToast} aria-live="polite">
+              {showDislikedToast ? 'Marked as disliked' : '\u00a0'}
+            </Typography>
+
+            <div className={classes.nowPlayingPanelVolume}>
+              <Typography className={classes.volumeLabel}>volume</Typography>
+              <div className={classes.nowPlayingPanelVolumeRow}>
+                <Slider
+                  classes={{
+                    root: classes.slider,
+                    track: classes.sliderTrack,
+                    thumb: classes.sliderThumb,
+                    rail: classes.sliderRail,
+                  }}
+                  value={panelVolume}
+                  min={0}
+                  max={100}
+                  aria-label="Volume"
+                  onChange={handleVolumeChange}
+                />
+                <Typography className={classes.volumeValue} aria-live="polite">
+                  {panelVolume}
+                </Typography>
+              </div>
+            </div>
+          </section>
+        </div>
+      )}
 
       <Typography component="h2" className={classes.nowPlaying}>
         {nowPlaying}

--- a/ui/src/retailPlayer/RetailPlayerDevicesList.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDevicesList.jsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, { useMemo, useState } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
-import { Typography, ButtonBase } from '@material-ui/core'
+import { Typography, ButtonBase, TextField } from '@material-ui/core'
 import { Title } from 'react-admin'
 import ChevronRightIcon from '@material-ui/icons/ChevronRight'
 import { useHistory } from 'react-router-dom'
@@ -33,6 +33,14 @@ const useStyles = makeStyles((theme) => ({
     [theme.breakpoints.down('sm')]: {
       fontSize: theme.typography.pxToRem(26),
     },
+  },
+  searchRow: {
+    display: 'flex',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+  },
+  searchField: {
+    maxWidth: 360,
   },
   table: {
     borderRadius: theme.shape.borderRadius,
@@ -139,15 +147,32 @@ const useStyles = makeStyles((theme) => ({
   chevron: {
     fontSize: theme.typography.pxToRem(20),
   },
+  noResults: {
+    padding: `${theme.spacing(3)}px ${theme.spacing(3)}px ${theme.spacing(4)}px`,
+    color: theme.palette.text.secondary,
+    fontStyle: 'italic',
+  },
 }))
 
 const RetailPlayerDevicesList = () => {
   const classes = useStyles()
   const history = useHistory()
+  const [searchTerm, setSearchTerm] = useState('')
 
   const handleNavigate = (deviceId) => {
     history.push(`/retailplayer/${deviceId}`)
   }
+
+  const filteredDevices = useMemo(() => {
+    const normalizedTerm = searchTerm.trim().toLowerCase()
+    if (!normalizedTerm) {
+      return retailDevices
+    }
+
+    return retailDevices.filter((device) =>
+      device.name.toLowerCase().includes(normalizedTerm),
+    )
+  }, [searchTerm])
 
   return (
     <div className={classes.root}>
@@ -155,6 +180,17 @@ const RetailPlayerDevicesList = () => {
       <Typography component="h1" className={classes.heading}>
         Retail Player Devices
       </Typography>
+      <div className={classes.searchRow}>
+        <TextField
+          className={classes.searchField}
+          variant="outlined"
+          size="small"
+          placeholder="Search devices…"
+          value={searchTerm}
+          onChange={(event) => setSearchTerm(event.target.value)}
+          inputProps={{ 'aria-label': 'Search devices' }}
+        />
+      </div>
       <div className={classes.table}>
         <div className={classes.headerRow}>
           <span className={classes.headerCell} data-area="actions">
@@ -173,34 +209,38 @@ const RetailPlayerDevicesList = () => {
             Organization
           </span>
         </div>
-        {retailDevices.map((device) => (
-          <ButtonBase
-            key={device.id}
-            className={classes.buttonBase}
-            onClick={() => handleNavigate(device.id)}
-            focusRipple
-            aria-label={`Open ${device.name}`}
-          >
-            <span className={classes.rowButton}>
-              <span className={`${classes.cell} ${classes.actionCell}`} data-area="actions">
-                View
-                <ChevronRightIcon className={classes.chevron} aria-hidden="true" />
+        {filteredDevices.length > 0 ? (
+          filteredDevices.map((device) => (
+            <ButtonBase
+              key={device.id}
+              className={classes.buttonBase}
+              onClick={() => handleNavigate(device.id)}
+              focusRipple
+              aria-label={`Open ${device.name}`}
+            >
+              <span className={classes.rowButton}>
+                <span className={`${classes.cell} ${classes.actionCell}`} data-area="actions">
+                  View
+                  <ChevronRightIcon className={classes.chevron} aria-hidden="true" />
+                </span>
+                <span className={classes.cell} data-area="name">
+                  {device.name}
+                </span>
+                <span className={classes.cell} data-area="channel">
+                  {device.channel}
+                </span>
+                <span className={classes.cell} data-area="channelList">
+                  {device.channelList}
+                </span>
+                <span className={classes.cell} data-area="organization">
+                  {device.organization}
+                </span>
               </span>
-              <span className={classes.cell} data-area="name">
-                {device.name}
-              </span>
-              <span className={classes.cell} data-area="channel">
-                {device.channel}
-              </span>
-              <span className={classes.cell} data-area="channelList">
-                {device.channelList}
-              </span>
-              <span className={classes.cell} data-area="organization">
-                {device.organization}
-              </span>
-            </span>
-          </ButtonBase>
-        ))}
+            </ButtonBase>
+          ))
+        ) : (
+          <div className={classes.noResults}>No devices match this search.</div>
+        )}
       </div>
     </div>
   )

--- a/ui/src/retailPlayer/RetailPlayerDevicesList.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDevicesList.jsx
@@ -4,7 +4,7 @@ import { Typography, ButtonBase, TextField } from '@material-ui/core'
 import { Title } from 'react-admin'
 import ChevronRightIcon from '@material-ui/icons/ChevronRight'
 import { useHistory } from 'react-router-dom'
-import { retailDevices } from './deviceData'
+import RetailPlayerMockService from './RetailPlayerMockService'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -158,6 +158,10 @@ const RetailPlayerDevicesList = () => {
   const classes = useStyles()
   const history = useHistory()
   const [searchTerm, setSearchTerm] = useState('')
+  const devices = useMemo(
+    () => RetailPlayerMockService.listDevices(),
+    [],
+  )
 
   const handleNavigate = (deviceId) => {
     history.push(`/retailplayer/${deviceId}`)
@@ -166,13 +170,13 @@ const RetailPlayerDevicesList = () => {
   const filteredDevices = useMemo(() => {
     const normalizedTerm = searchTerm.trim().toLowerCase()
     if (!normalizedTerm) {
-      return retailDevices
+      return devices
     }
 
-    return retailDevices.filter((device) =>
+    return devices.filter((device) =>
       device.name.toLowerCase().includes(normalizedTerm),
     )
-  }, [searchTerm])
+  }, [devices, searchTerm])
 
   return (
     <div className={classes.root}>

--- a/ui/src/retailPlayer/RetailPlayerDevicesList.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDevicesList.jsx
@@ -1,0 +1,209 @@
+import React from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+import { Typography, ButtonBase } from '@material-ui/core'
+import { Title } from 'react-admin'
+import ChevronRightIcon from '@material-ui/icons/ChevronRight'
+import { useHistory } from 'react-router-dom'
+import { retailDevices } from './deviceData'
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(5),
+    padding: theme.spacing(5),
+    maxWidth: 1200,
+    width: '100%',
+    margin: '0 auto',
+    [theme.breakpoints.down('md')]: {
+      padding: theme.spacing(4),
+      gap: theme.spacing(4),
+    },
+    [theme.breakpoints.down('sm')]: {
+      padding: theme.spacing(2.5),
+      gap: theme.spacing(3),
+    },
+  },
+  heading: {
+    fontWeight: theme.typography.fontWeightBold,
+    fontSize: theme.typography.pxToRem(48),
+    [theme.breakpoints.down('md')]: {
+      fontSize: theme.typography.pxToRem(36),
+    },
+    [theme.breakpoints.down('sm')]: {
+      fontSize: theme.typography.pxToRem(26),
+    },
+  },
+  table: {
+    borderRadius: theme.shape.borderRadius,
+    border: `1px solid ${theme.palette.divider}`,
+    overflow: 'hidden',
+    backgroundColor: theme.palette.background.paper,
+  },
+  headerRow: {
+    display: 'grid',
+    gridTemplateColumns: '160px 1.5fr 1fr 1fr 1fr',
+    padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`,
+    backgroundColor: theme.palette.action.hover,
+    gap: theme.spacing(2),
+    [theme.breakpoints.down('sm')]: {
+      gridTemplateColumns: '120px 1.2fr 1fr',
+      gridTemplateAreas: "'actions name name' 'channel channelList org'",
+      rowGap: theme.spacing(1),
+    },
+  },
+  headerCell: {
+    fontSize: theme.typography.pxToRem(14),
+    fontWeight: theme.typography.fontWeightMedium,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    color: theme.palette.text.secondary,
+    [theme.breakpoints.down('sm')]: {
+      '&[data-area="actions"]': {
+        gridArea: 'actions',
+      },
+      '&[data-area="name"]': {
+        gridArea: 'name',
+      },
+      '&[data-area="channel"]': {
+        gridArea: 'channel',
+      },
+      '&[data-area="channelList"]': {
+        gridArea: 'channelList',
+      },
+      '&[data-area="organization"]': {
+        gridArea: 'org',
+      },
+    },
+  },
+  buttonBase: {
+    display: 'block',
+    width: '100%',
+    justifyContent: 'flex-start',
+    textAlign: 'left',
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    '&:last-child': {
+      borderBottom: 'none',
+    },
+    '&:hover $rowButton, &:focus-visible $rowButton': {
+      backgroundColor: theme.palette.action.hover,
+    },
+  },
+  rowButton: {
+    display: 'grid',
+    gridTemplateColumns: '160px 1.5fr 1fr 1fr 1fr',
+    padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`,
+    textAlign: 'left',
+    gap: theme.spacing(2),
+    width: '100%',
+    alignItems: 'center',
+    transition: theme.transitions.create(['background-color'], {
+      duration: theme.transitions.duration.shortest,
+    }),
+    [theme.breakpoints.down('sm')]: {
+      gridTemplateColumns: '120px 1.2fr 1fr',
+      gridTemplateAreas: "'actions name name' 'channel channelList org'",
+      rowGap: theme.spacing(1.5),
+    },
+  },
+  cell: {
+    fontSize: theme.typography.pxToRem(16),
+    color: theme.palette.text.primary,
+    [theme.breakpoints.down('sm')]: {
+      '&[data-area="actions"]': {
+        gridArea: 'actions',
+      },
+      '&[data-area="name"]': {
+        gridArea: 'name',
+      },
+      '&[data-area="channel"]': {
+        gridArea: 'channel',
+      },
+      '&[data-area="channelList"]': {
+        gridArea: 'channelList',
+      },
+      '&[data-area="organization"]': {
+        gridArea: 'org',
+      },
+    },
+  },
+  actionCell: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    color:
+      (theme.palette.primary && theme.palette.primary.main) ||
+      theme.palette.text.primary,
+    fontWeight: theme.typography.fontWeightMedium,
+  },
+  chevron: {
+    fontSize: theme.typography.pxToRem(20),
+  },
+}))
+
+const RetailPlayerDevicesList = () => {
+  const classes = useStyles()
+  const history = useHistory()
+
+  const handleNavigate = (deviceId) => {
+    history.push(`/retailplayer/${deviceId}`)
+  }
+
+  return (
+    <div className={classes.root}>
+      <Title title="Retail Player Devices" />
+      <Typography component="h1" className={classes.heading}>
+        Retail Player Devices
+      </Typography>
+      <div className={classes.table}>
+        <div className={classes.headerRow}>
+          <span className={classes.headerCell} data-area="actions">
+            Actions
+          </span>
+          <span className={classes.headerCell} data-area="name">
+            Name
+          </span>
+          <span className={classes.headerCell} data-area="channel">
+            Channel
+          </span>
+          <span className={classes.headerCell} data-area="channelList">
+            Channel List
+          </span>
+          <span className={classes.headerCell} data-area="organization">
+            Organization
+          </span>
+        </div>
+        {retailDevices.map((device) => (
+          <ButtonBase
+            key={device.id}
+            className={classes.buttonBase}
+            onClick={() => handleNavigate(device.id)}
+            focusRipple
+            aria-label={`Open ${device.name}`}
+          >
+            <span className={classes.rowButton}>
+              <span className={`${classes.cell} ${classes.actionCell}`} data-area="actions">
+                View
+                <ChevronRightIcon className={classes.chevron} aria-hidden="true" />
+              </span>
+              <span className={classes.cell} data-area="name">
+                {device.name}
+              </span>
+              <span className={classes.cell} data-area="channel">
+                {device.channel}
+              </span>
+              <span className={classes.cell} data-area="channelList">
+                {device.channelList}
+              </span>
+              <span className={classes.cell} data-area="organization">
+                {device.organization}
+              </span>
+            </span>
+          </ButtonBase>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default RetailPlayerDevicesList

--- a/ui/src/retailPlayer/RetailPlayerMockService.js
+++ b/ui/src/retailPlayer/RetailPlayerMockService.js
@@ -1,40 +1,13 @@
-export const retailDevices = [
-  {
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max)
+
+const initialDevices = {
+  'thompson-chicago-lobby': {
     id: 'thompson-chicago-lobby',
     name: 'ThompsonChicago_Lobby',
     channel: 'Lobby Channel',
     channelList: 'Chicago Rotation',
     organization: 'Thompson Hotels',
-  },
-  {
-    id: 'thompson-chicago-rooftop',
-    name: 'ThompsonChicago_Rooftop',
-    channel: 'Rooftop Beats',
-    channelList: 'Evening Mix',
-    organization: 'Thompson Hotels',
-  },
-  {
-    id: 'thompson-miami-pool',
-    name: 'ThompsonMiami_Pool',
-    channel: 'Poolside Chill',
-    channelList: 'Daytime Flow',
-    organization: 'Thompson Resorts',
-  },
-  {
-    id: 'thompson-denver-lounge',
-    name: 'ThompsonDenver_Lounge',
-    channel: 'Lounge Sessions',
-    channelList: 'Mountain Nights',
-    organization: 'Thompson Collective',
-  },
-]
-
-export const retailDeviceDetails = {
-  'thompson-chicago-lobby': {
-    id: 'thompson-chicago-lobby',
-    name: 'ThompsonChicago_Lobby',
     isConnected: true,
-    time: '16:40',
     hasSignal: true,
     isMuted: true,
     schedules: [
@@ -61,8 +34,10 @@ export const retailDeviceDetails = {
   'thompson-chicago-rooftop': {
     id: 'thompson-chicago-rooftop',
     name: 'ThompsonChicago_Rooftop',
+    channel: 'Rooftop Beats',
+    channelList: 'Evening Mix',
+    organization: 'Thompson Hotels',
     isConnected: true,
-    time: '18:20',
     hasSignal: true,
     isMuted: false,
     schedules: [
@@ -89,8 +64,10 @@ export const retailDeviceDetails = {
   'thompson-miami-pool': {
     id: 'thompson-miami-pool',
     name: 'ThompsonMiami_Pool',
+    channel: 'Poolside Chill',
+    channelList: 'Daytime Flow',
+    organization: 'Thompson Resorts',
     isConnected: true,
-    time: '14:05',
     hasSignal: true,
     isMuted: false,
     schedules: [
@@ -117,8 +94,10 @@ export const retailDeviceDetails = {
   'thompson-denver-lounge': {
     id: 'thompson-denver-lounge',
     name: 'ThompsonDenver_Lounge',
+    channel: 'Lounge Sessions',
+    channelList: 'Mountain Nights',
+    organization: 'Thompson Collective',
     isConnected: false,
-    time: '10:12',
     hasSignal: false,
     isMuted: true,
     schedules: [
@@ -143,3 +122,78 @@ export const retailDeviceDetails = {
     volume: 40,
   },
 }
+
+const deepClone = (value) => JSON.parse(JSON.stringify(value))
+
+class RetailPlayerMockService {
+  constructor() {
+    this.devices = deepClone(initialDevices)
+  }
+
+  listDevices() {
+    return Object.values(this.devices).map((device) => ({
+      id: device.id,
+      name: device.name,
+      channel: device.channel,
+      channelList: device.channelList,
+      organization: device.organization,
+    }))
+  }
+
+  getDevice(deviceId) {
+    const device = this.devices[deviceId]
+    if (!device) {
+      return null
+    }
+    return deepClone(device)
+  }
+
+  setMute(deviceId, muted) {
+    const device = this.devices[deviceId]
+    if (!device) {
+      return null
+    }
+    device.isMuted = Boolean(muted)
+    return this.getDevice(deviceId)
+  }
+
+  setVolume(deviceId, volume) {
+    const device = this.devices[deviceId]
+    if (!device) {
+      return null
+    }
+    device.volume = clamp(Math.round(volume), 0, 100)
+    return this.getDevice(deviceId)
+  }
+
+  setActiveChannel(deviceId, channelKey) {
+    const device = this.devices[deviceId]
+    if (!device) {
+      return null
+    }
+
+    let nextNowPlaying = device.nowPlaying
+    device.schedules = device.schedules.map((schedule) => {
+      const isActive = schedule.key === channelKey
+      if (isActive) {
+        nextNowPlaying = `${schedule.label} | ${schedule.artist}`
+      }
+      return { ...schedule, isActive }
+    })
+
+    device.nowPlaying = nextNowPlaying
+    return this.getDevice(deviceId)
+  }
+
+  getArtwork(deviceId) {
+    const device = this.devices[deviceId]
+    if (!device) {
+      return null
+    }
+    return null
+  }
+}
+
+const retailPlayerMockService = new RetailPlayerMockService()
+
+export default retailPlayerMockService

--- a/ui/src/retailPlayer/RetailPlayerMockService.js
+++ b/ui/src/retailPlayer/RetailPlayerMockService.js
@@ -1,5 +1,16 @@
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max)
 
+const parseNowPlaying = (value) => {
+  if (typeof value !== 'string') {
+    return { label: '', artist: '' }
+  }
+  const [label = '', artist = ''] = value.split('|').map((part) => part.trim())
+  return { label, artist }
+}
+
+const scheduleLabelFromNowPlaying = (value) => parseNowPlaying(value).label
+const scheduleArtistFromNowPlaying = (value) => parseNowPlaying(value).artist
+
 const initialDevices = {
   'thompson-chicago-lobby': {
     id: 'thompson-chicago-lobby',
@@ -30,6 +41,30 @@ const initialDevices = {
     ],
     nowPlaying: 'The Kids | Dog Trainer',
     volume: 75,
+    currentTrackIndex: 0,
+    tracks: [
+      {
+        id: 'kids-dog-trainer',
+        title: 'The Kids',
+        artist: 'Dog Trainer',
+        album: 'Lobby Rotation Vol. 1',
+        artwork: null,
+      },
+      {
+        id: 'evening-hush',
+        title: 'Evening Hush',
+        artist: 'Late Night Riders',
+        album: 'Chicago After Hours',
+        artwork: null,
+      },
+      {
+        id: 'midday-march',
+        title: 'Midday March',
+        artist: 'Midday Parade',
+        album: 'City Strolls',
+        artwork: null,
+      },
+    ],
   },
   'thompson-chicago-rooftop': {
     id: 'thompson-chicago-rooftop',
@@ -60,6 +95,30 @@ const initialDevices = {
     ],
     nowPlaying: 'Skyline Drift | Moon District',
     volume: 62,
+    currentTrackIndex: 1,
+    tracks: [
+      {
+        id: 'sunrise-sessions',
+        title: 'Sunrise Sessions',
+        artist: 'Sunrise Syndicate',
+        album: 'Rooftop Dawn',
+        artwork: null,
+      },
+      {
+        id: 'skyline-drift',
+        title: 'Skyline Drift',
+        artist: 'Moon District',
+        album: 'Moonlit Mixes',
+        artwork: null,
+      },
+      {
+        id: 'night-spark',
+        title: 'Night Spark',
+        artist: 'Skyline Ensemble',
+        album: 'City Lights',
+        artwork: null,
+      },
+    ],
   },
   'thompson-miami-pool': {
     id: 'thompson-miami-pool',
@@ -90,6 +149,30 @@ const initialDevices = {
     ],
     nowPlaying: 'Sea Breeze | Sunrunners',
     volume: 68,
+    currentTrackIndex: 0,
+    tracks: [
+      {
+        id: 'sea-breeze',
+        title: 'Sea Breeze',
+        artist: 'Sunrunners',
+        album: 'Poolside Flow',
+        artwork: null,
+      },
+      {
+        id: 'twilight-currents',
+        title: 'Twilight Currents',
+        artist: 'Twilight Current',
+        album: 'Evening Reflections',
+        artwork: null,
+      },
+      {
+        id: 'harbor-glide',
+        title: 'Harbor Glide',
+        artist: 'Harbor Crew',
+        album: 'Beachline',
+        artwork: null,
+      },
+    ],
   },
   'thompson-denver-lounge': {
     id: 'thompson-denver-lounge',
@@ -120,6 +203,30 @@ const initialDevices = {
     ],
     nowPlaying: 'Quiet Hours | Alpine Echo',
     volume: 40,
+    currentTrackIndex: 1,
+    tracks: [
+      {
+        id: 'summit-glow',
+        title: 'Summit Glow',
+        artist: 'Morning Summit',
+        album: 'Mountain Dawn',
+        artwork: null,
+      },
+      {
+        id: 'quiet-hours',
+        title: 'Quiet Hours',
+        artist: 'Alpine Echo',
+        album: 'Twilight Peak',
+        artwork: null,
+      },
+      {
+        id: 'lounge-lines',
+        title: 'Lounge Lines',
+        artist: 'Denver Collective',
+        album: 'City Mountains',
+        artwork: null,
+      },
+    ],
   },
 }
 
@@ -182,6 +289,19 @@ class RetailPlayerMockService {
     })
 
     device.nowPlaying = nextNowPlaying
+    device.currentTrackIndex = 0
+    if (Array.isArray(device.tracks) && device.tracks.length > 0) {
+      device.tracks = device.tracks.map((track, index) => {
+        if (index === 0) {
+          return {
+            ...track,
+            title: scheduleLabelFromNowPlaying(nextNowPlaying),
+            artist: scheduleArtistFromNowPlaying(nextNowPlaying),
+          }
+        }
+        return track
+      })
+    }
     return this.getDevice(deviceId)
   }
 
@@ -191,6 +311,42 @@ class RetailPlayerMockService {
       return null
     }
     return null
+  }
+
+  setCurrentTrack(deviceId, trackIndex) {
+    const device = this.devices[deviceId]
+    if (!device || !Array.isArray(device.tracks) || device.tracks.length === 0) {
+      return null
+    }
+
+    const total = device.tracks.length
+    const normalizedIndex = ((trackIndex % total) + total) % total
+    device.currentTrackIndex = normalizedIndex
+    const track = device.tracks[normalizedIndex]
+    device.nowPlaying = `${track.title} | ${track.artist}`
+    return this.getDevice(deviceId)
+  }
+
+  skipTrack(deviceId) {
+    const device = this.devices[deviceId]
+    if (!device) {
+      return null
+    }
+
+    const nextIndex =
+      typeof device.currentTrackIndex === 'number' ? device.currentTrackIndex + 1 : 0
+    return this.setCurrentTrack(deviceId, nextIndex)
+  }
+
+  getCurrentTrack(deviceId) {
+    const device = this.devices[deviceId]
+    if (!device || !Array.isArray(device.tracks) || device.tracks.length === 0) {
+      return null
+    }
+
+    const index =
+      typeof device.currentTrackIndex === 'number' ? device.currentTrackIndex : 0
+    return deepClone(device.tracks[index % device.tracks.length])
   }
 }
 

--- a/ui/src/retailPlayer/deviceData.js
+++ b/ui/src/retailPlayer/deviceData.js
@@ -1,0 +1,93 @@
+export const retailDevices = [
+  {
+    id: 'thompson-chicago-lobby',
+    name: 'ThompsonChicago_Lobby',
+    channel: 'Lobby Channel',
+    channelList: 'Chicago Rotation',
+    organization: 'Thompson Hotels',
+  },
+  {
+    id: 'thompson-chicago-rooftop',
+    name: 'ThompsonChicago_Rooftop',
+    channel: 'Rooftop Beats',
+    channelList: 'Evening Mix',
+    organization: 'Thompson Hotels',
+  },
+  {
+    id: 'thompson-miami-pool',
+    name: 'ThompsonMiami_Pool',
+    channel: 'Poolside Chill',
+    channelList: 'Daytime Flow',
+    organization: 'Thompson Resorts',
+  },
+  {
+    id: 'thompson-denver-lounge',
+    name: 'ThompsonDenver_Lounge',
+    channel: 'Lounge Sessions',
+    channelList: 'Mountain Nights',
+    organization: 'Thompson Collective',
+  },
+]
+
+export const retailDeviceDetails = {
+  'thompson-chicago-lobby': {
+    id: 'thompson-chicago-lobby',
+    name: 'ThompsonChicago_Lobby',
+    isConnected: true,
+    time: '16:40',
+    hasSignal: true,
+    isMuted: true,
+    schedules: [
+      { key: 'early', label: 'ThompsonChicago_LobbyEarly', isActive: true },
+      { key: 'late', label: 'ThompsonChicago_LobbyLate', isDisabled: true },
+      { key: 'mid', label: 'ThompsonChicago_LobbyMid', isDisabled: true },
+    ],
+    nowPlaying: 'The Kids | Dog Trainer',
+    volume: 75,
+  },
+  'thompson-chicago-rooftop': {
+    id: 'thompson-chicago-rooftop',
+    name: 'ThompsonChicago_Rooftop',
+    isConnected: true,
+    time: '18:20',
+    hasSignal: true,
+    isMuted: false,
+    schedules: [
+      { key: 'early', label: 'ThompsonChicago_RooftopEarly', isDisabled: true },
+      { key: 'late', label: 'ThompsonChicago_RooftopLate', isActive: true },
+      { key: 'mid', label: 'ThompsonChicago_RooftopMid', isDisabled: true },
+    ],
+    nowPlaying: 'Skyline Drift | Moon District',
+    volume: 62,
+  },
+  'thompson-miami-pool': {
+    id: 'thompson-miami-pool',
+    name: 'ThompsonMiami_Pool',
+    isConnected: true,
+    time: '14:05',
+    hasSignal: true,
+    isMuted: false,
+    schedules: [
+      { key: 'early', label: 'ThompsonMiami_PoolEarly', isActive: true },
+      { key: 'late', label: 'ThompsonMiami_PoolLate', isDisabled: true },
+      { key: 'mid', label: 'ThompsonMiami_PoolMid', isDisabled: true },
+    ],
+    nowPlaying: 'Sea Breeze | Sunrunners',
+    volume: 68,
+  },
+  'thompson-denver-lounge': {
+    id: 'thompson-denver-lounge',
+    name: 'ThompsonDenver_Lounge',
+    isConnected: false,
+    time: '10:12',
+    hasSignal: false,
+    isMuted: true,
+    schedules: [
+      { key: 'early', label: 'ThompsonDenver_LoungeEarly', isDisabled: true },
+      { key: 'late', label: 'ThompsonDenver_LoungeLate', isActive: true },
+      { key: 'mid', label: 'ThompsonDenver_LoungeMid', isDisabled: true },
+    ],
+    nowPlaying: 'Quiet Hours | Alpine Echo',
+    volume: 40,
+  },
+}

--- a/ui/src/retailPlayer/deviceData.js
+++ b/ui/src/retailPlayer/deviceData.js
@@ -38,9 +38,22 @@ export const retailDeviceDetails = {
     hasSignal: true,
     isMuted: true,
     schedules: [
-      { key: 'early', label: 'ThompsonChicago_LobbyEarly', isActive: true },
-      { key: 'late', label: 'ThompsonChicago_LobbyLate', isDisabled: true },
-      { key: 'mid', label: 'ThompsonChicago_LobbyMid', isDisabled: true },
+      {
+        key: 'early',
+        label: 'ThompsonChicago_LobbyEarly',
+        artist: 'Dog Trainer',
+        isActive: true,
+      },
+      {
+        key: 'late',
+        label: 'ThompsonChicago_LobbyLate',
+        artist: 'Late Night Riders',
+      },
+      {
+        key: 'mid',
+        label: 'ThompsonChicago_LobbyMid',
+        artist: 'Midday Parade',
+      },
     ],
     nowPlaying: 'The Kids | Dog Trainer',
     volume: 75,
@@ -53,9 +66,22 @@ export const retailDeviceDetails = {
     hasSignal: true,
     isMuted: false,
     schedules: [
-      { key: 'early', label: 'ThompsonChicago_RooftopEarly', isDisabled: true },
-      { key: 'late', label: 'ThompsonChicago_RooftopLate', isActive: true },
-      { key: 'mid', label: 'ThompsonChicago_RooftopMid', isDisabled: true },
+      {
+        key: 'early',
+        label: 'ThompsonChicago_RooftopEarly',
+        artist: 'Sunrise Syndicate',
+      },
+      {
+        key: 'late',
+        label: 'ThompsonChicago_RooftopLate',
+        artist: 'Moon District',
+        isActive: true,
+      },
+      {
+        key: 'mid',
+        label: 'ThompsonChicago_RooftopMid',
+        artist: 'Skyline Ensemble',
+      },
     ],
     nowPlaying: 'Skyline Drift | Moon District',
     volume: 62,
@@ -68,9 +94,22 @@ export const retailDeviceDetails = {
     hasSignal: true,
     isMuted: false,
     schedules: [
-      { key: 'early', label: 'ThompsonMiami_PoolEarly', isActive: true },
-      { key: 'late', label: 'ThompsonMiami_PoolLate', isDisabled: true },
-      { key: 'mid', label: 'ThompsonMiami_PoolMid', isDisabled: true },
+      {
+        key: 'early',
+        label: 'ThompsonMiami_PoolEarly',
+        artist: 'Sunrunners',
+        isActive: true,
+      },
+      {
+        key: 'late',
+        label: 'ThompsonMiami_PoolLate',
+        artist: 'Twilight Current',
+      },
+      {
+        key: 'mid',
+        label: 'ThompsonMiami_PoolMid',
+        artist: 'Harbor Crew',
+      },
     ],
     nowPlaying: 'Sea Breeze | Sunrunners',
     volume: 68,
@@ -83,9 +122,22 @@ export const retailDeviceDetails = {
     hasSignal: false,
     isMuted: true,
     schedules: [
-      { key: 'early', label: 'ThompsonDenver_LoungeEarly', isDisabled: true },
-      { key: 'late', label: 'ThompsonDenver_LoungeLate', isActive: true },
-      { key: 'mid', label: 'ThompsonDenver_LoungeMid', isDisabled: true },
+      {
+        key: 'early',
+        label: 'ThompsonDenver_LoungeEarly',
+        artist: 'Morning Summit',
+      },
+      {
+        key: 'late',
+        label: 'ThompsonDenver_LoungeLate',
+        artist: 'Alpine Echo',
+        isActive: true,
+      },
+      {
+        key: 'mid',
+        label: 'ThompsonDenver_LoungeMid',
+        artist: 'Denver Collective',
+      },
     ],
     nowPlaying: 'Quiet Hours | Alpine Echo',
     volume: 40,

--- a/ui/src/routes.jsx
+++ b/ui/src/routes.jsx
@@ -1,15 +1,28 @@
 import React from 'react'
-import { Route } from 'react-router-dom'
+import { Redirect, Route } from 'react-router-dom'
 import Personal from './personal/Personal'
 import RetailPlayerDashboard from './retailPlayer/RetailPlayerDashboard'
+import RetailPlayerDevicesList from './retailPlayer/RetailPlayerDevicesList'
 
 const routes = [
   <Route exact path="/personal" render={() => <Personal />} key={'personal'} />,
   <Route
     exact
     path="/retailplayer"
+    render={() => <Redirect to="/retailplayer/devices" />}
+    key={'retailplayer-redirect'}
+  />,
+  <Route
+    exact
+    path="/retailplayer/devices"
+    render={() => <RetailPlayerDevicesList />}
+    key={'retailplayer-devices'}
+  />,
+  <Route
+    exact
+    path="/retailplayer/:deviceId"
     render={() => <RetailPlayerDashboard />}
-    key={'retailplayer'}
+    key={'retailplayer-device'}
   />,
 ]
 


### PR DESCRIPTION
## Summary
- replace the retail player dashboard with the static layout shown in the mock while keeping Navidrome theme tokens
- ensure the device status, playlist list, now playing line, and control bar use accessible labels and theme-aware colors

## Testing
- npm --prefix ui run lint

------
https://chatgpt.com/codex/tasks/task_e_68fbf5dc441c8330acdf9b3876e1b098