### PR TITLE
Retail Player: add base API service for devices

### DIFF
--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -67,15 +67,17 @@ func (n *Router) routes() http.Handler {
 		n.addSongPlaylistsRoute(r)
 		n.addSongDiscoveriesRoute(r)
 		n.addQueueRoute(r)
-		n.addMissingFilesRoute(r)
-		n.addNotificationsRoute(r)
-		n.addKeepAliveRoute(r)
-		n.addInsightsRoute(r)
+                n.addMissingFilesRoute(r)
+                n.addNotificationsRoute(r)
+                n.addKeepAliveRoute(r)
+                n.addInsightsRoute(r)
 
-		r.With(adminOnlyMiddleware).Group(func(r chi.Router) {
-			n.addInspectRoute(r)
-			n.addConfigRoute(r)
-			n.addUserLibraryRoute(r)
+                server.NewRetailPlayerProxy().Mount(r)
+
+                r.With(adminOnlyMiddleware).Group(func(r chi.Router) {
+                        n.addInspectRoute(r)
+                        n.addConfigRoute(r)
+                        n.addUserLibraryRoute(r)
 			n.addSyncRoute(r)
 			n.RX(r, "/library", n.libs.NewRepository, true)
 		})

--- a/server/retailplayer_proxy.go
+++ b/server/retailplayer_proxy.go
@@ -1,0 +1,148 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/log"
+)
+
+const (
+	retailPlayerDefaultBaseURL = "https://rpp.jareddietch.com/broad/api/v1"
+	retailPlayerDefaultAPIKey  = "f3894t28-aghj-cv50-453e-9dfr1s9h73s5"
+	retailPlayerDefaultOrgID   = "1aa59b04-5365-4efe-afb3-deb23c414add"
+)
+
+// RetailPlayerProxy handles forwarding requests from the Navidrome server to the
+// Retail Player Broad API, adding the required authentication headers and
+// returning the upstream response to the client.
+type RetailPlayerProxy struct {
+	client  *http.Client
+	baseURL string
+	apiKey  string
+	orgID   string
+}
+
+// NewRetailPlayerProxy creates a RetailPlayerProxy configured using environment
+// variables with sensible defaults for development.
+func NewRetailPlayerProxy() *RetailPlayerProxy {
+	return &RetailPlayerProxy{
+		client:  &http.Client{Timeout: 10 * time.Second},
+		baseURL: getEnvDefault("RETAILPLAYER_BASE_URL", retailPlayerDefaultBaseURL),
+		apiKey:  getEnvDefault("RETAILPLAYER_API_KEY", retailPlayerDefaultAPIKey),
+		orgID:   getEnvDefault("RETAILPLAYER_ORG_ID", retailPlayerDefaultOrgID),
+	}
+}
+
+func getEnvDefault(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+// Mount registers the Retail Player proxy endpoints in the provided router.
+func (p *RetailPlayerProxy) Mount(r chi.Router) {
+	r.Route("/retailplayer", func(r chi.Router) {
+		r.Get("/devices", p.handleDevices)
+		r.Get("/devices/{id}/status", p.handleDeviceStatus)
+		r.Post("/devices/{id}/command", p.handleDeviceCommand)
+	})
+}
+
+func (p *RetailPlayerProxy) handleDevices(w http.ResponseWriter, r *http.Request) {
+	endpoint := fmt.Sprintf("/orgs/%s/devices", p.orgID)
+	p.forward(w, r, http.MethodGet, endpoint, nil)
+}
+
+func (p *RetailPlayerProxy) handleDeviceStatus(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	endpoint := fmt.Sprintf("/orgs/%s/devices/%s/status", p.orgID, id)
+	p.forward(w, r, http.MethodGet, endpoint, nil)
+}
+
+func (p *RetailPlayerProxy) handleDeviceCommand(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	endpoint := fmt.Sprintf("/orgs/%s/devices/%s/command", p.orgID, id)
+	defer func() { _ = r.Body.Close() }()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeRetailPlayerError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	p.forward(w, r, http.MethodPost, endpoint, body)
+}
+
+func (p *RetailPlayerProxy) forward(w http.ResponseWriter, r *http.Request, method, endpoint string, body []byte) {
+	url := p.baseURL + endpoint
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(r.Context(), method, url, bodyReader)
+	if err != nil {
+		writeRetailPlayerError(w, http.StatusInternalServerError, "failed to build upstream request")
+		return
+	}
+
+	req.Header.Set("x-retailplayer-apikey", p.apiKey)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			log.Warn(r.Context(), "Retail Player proxy request cancelled or timed out", "endpoint", endpoint, err)
+			writeRetailPlayerError(w, http.StatusGatewayTimeout, "upstream request timeout")
+			return
+		}
+		log.Error(r.Context(), "Retail Player proxy request failed", "endpoint", endpoint, err)
+		writeRetailPlayerError(w, http.StatusBadGateway, "upstream request failed")
+		return
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Error(r.Context(), "Retail Player proxy failed to read upstream response", "endpoint", endpoint, err)
+		writeRetailPlayerError(w, http.StatusBadGateway, "failed to read upstream response")
+		return
+	}
+
+	for key, values := range resp.Header {
+		if key == "Content-Length" {
+			continue
+		}
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+	if w.Header().Get("Content-Type") == "" {
+		w.Header().Set("Content-Type", "application/json")
+	}
+
+	w.WriteHeader(resp.StatusCode)
+	if _, err := w.Write(responseBody); err != nil {
+		log.Warn(r.Context(), "Retail Player proxy failed to write response", "endpoint", endpoint, err)
+	}
+}
+
+func writeRetailPlayerError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+}

--- a/server/retailplayer_proxy.go
+++ b/server/retailplayer_proxy.go
@@ -53,6 +53,7 @@ func getEnvDefault(key, defaultValue string) string {
 func (p *RetailPlayerProxy) Mount(r chi.Router) {
 	r.Route("/retailplayer", func(r chi.Router) {
 		r.Get("/devices", p.handleDevices)
+		r.Get("/devices/{id}", p.handleDevice)
 		r.Get("/devices/{id}/status", p.handleDeviceStatus)
 		r.Post("/devices/{id}/command", p.handleDeviceCommand)
 	})
@@ -60,6 +61,12 @@ func (p *RetailPlayerProxy) Mount(r chi.Router) {
 
 func (p *RetailPlayerProxy) handleDevices(w http.ResponseWriter, r *http.Request) {
 	endpoint := fmt.Sprintf("/orgs/%s/devices", p.orgID)
+	p.forward(w, r, http.MethodGet, endpoint, nil)
+}
+
+func (p *RetailPlayerProxy) handleDevice(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	endpoint := fmt.Sprintf("/orgs/%s/devices/%s", p.orgID, id)
 	p.forward(w, r, http.MethodGet, endpoint, nil)
 }
 

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
-import { ButtonBase, Slider, Typography } from '@material-ui/core'
+import { Button, ButtonBase, Slider, Typography } from '@material-ui/core'
 import { Title } from 'react-admin'
 import LinkIcon from '@material-ui/icons/Link'
 import SignalWifi4BarIcon from '@material-ui/icons/SignalWifi4Bar'
@@ -10,7 +10,11 @@ import DescriptionIcon from '@material-ui/icons/Description'
 import GetAppIcon from '@material-ui/icons/GetApp'
 import CachedIcon from '@material-ui/icons/Cached'
 import { Link as RouterLink, useParams } from 'react-router-dom'
-import RetailPlayerMockService from './RetailPlayerMockService'
+import {
+  getDevice,
+  getDeviceStatus,
+  postDeviceCommand,
+} from '../services/retailPlayerService'
 
 const combineClasses = (...classNames) => classNames.filter(Boolean).join(' ')
 
@@ -22,6 +26,355 @@ const formatTime = (date) =>
       hour12: false,
     })
     .replace(/^24:/, '00:')
+
+const uuidRegex = /^[0-9a-fA-F-]{36}$/
+
+const clampVolume = (value) => {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) {
+    return 0
+  }
+  return Math.min(Math.max(Math.round(numeric), 0), 100)
+}
+
+const toStringValue = (value) => {
+  if (value === null || value === undefined) {
+    return null
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed || null
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value)
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false'
+  }
+  return String(value)
+}
+
+const toBooleanValue = (value) => {
+  if (typeof value === 'boolean') {
+    return value
+  }
+  if (typeof value === 'number') {
+    if (Number.isNaN(value)) {
+      return undefined
+    }
+    return value !== 0
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (!normalized) {
+      return undefined
+    }
+    if (['true', 'yes', 'on', '1'].includes(normalized)) {
+      return true
+    }
+    if (['false', 'no', 'off', '0'].includes(normalized)) {
+      return false
+    }
+  }
+  return undefined
+}
+
+const getValue = (source, path) => {
+  if (!source || !path) {
+    return undefined
+  }
+  const segments = Array.isArray(path) ? path : String(path).split('.')
+  let current = source
+  for (const segment of segments) {
+    if (current === null || current === undefined) {
+      return undefined
+    }
+    current = current[segment]
+  }
+  return current
+}
+
+const firstValue = (source, paths) => {
+  if (!source) {
+    return undefined
+  }
+  for (const path of paths) {
+    const value = getValue(source, path)
+    if (value !== undefined && value !== null) {
+      return value
+    }
+  }
+  return undefined
+}
+
+const extractArtworkUrl = (value) => {
+  const stringValue = toStringValue(value)
+  if (stringValue) {
+    return stringValue
+  }
+  if (value && typeof value === 'object') {
+    const nested =
+      toStringValue(firstValue(value, [['url'], ['href'], ['link'], ['source']])) || null
+    return nested
+  }
+  return null
+}
+
+const normalizeDevice = (deviceData, statusData, fallbackId) => {
+  const idPaths = [
+    ['id'],
+    ['deviceId'],
+    ['device', 'id'],
+    ['device', 'deviceId'],
+  ]
+  const namePaths = [
+    ['name'],
+    ['displayName'],
+    ['deviceName'],
+    ['title'],
+    ['device', 'name'],
+    ['device', 'displayName'],
+  ]
+  const connectedPaths = [
+    ['isConnected'],
+    ['connected'],
+    ['online'],
+    ['isOnline'],
+    ['status', 'connected'],
+    ['device', 'isConnected'],
+    ['device', 'connected'],
+    ['device', 'online'],
+  ]
+  const signalPaths = [
+    ['hasSignal'],
+    ['signal'],
+    ['signalStatus'],
+    ['device', 'hasSignal'],
+    ['network', 'hasSignal'],
+  ]
+  const mutedPaths = [
+    ['isMuted'],
+    ['muted'],
+    ['audio', 'muted'],
+    ['device', 'isMuted'],
+    ['device', 'muted'],
+  ]
+  const volumePaths = [
+    ['volume'],
+    ['device', 'volume'],
+    ['audio', 'volume'],
+    ['settings', 'volume'],
+  ]
+  const activeKeyPaths = [
+    ['activeChannelKey'],
+    ['currentChannelKey'],
+    ['channelKey'],
+    ['channel', 'key'],
+    ['channel', 'id'],
+    ['currentChannel', 'key'],
+    ['currentChannel', 'id'],
+    ['activeChannel', 'key'],
+    ['activeChannel', 'id'],
+  ]
+  const activeNamePaths = [
+    ['currentChannel', 'name'],
+    ['channel', 'name'],
+    ['activeChannel', 'name'],
+    ['currentChannelName'],
+    ['channelName'],
+  ]
+  const schedulePaths = [
+    ['schedules'],
+    ['channels'],
+    ['channelList'],
+    ['availableChannels'],
+    ['device', 'schedules'],
+    ['device', 'channels'],
+    ['status', 'channels'],
+  ]
+  const nowPlayingPaths = [
+    ['nowPlaying'],
+    ['currentTrack'],
+    ['track'],
+    ['playback', 'nowPlaying'],
+  ]
+
+  const resolvedId =
+    toStringValue(firstValue(deviceData, idPaths)) ||
+    toStringValue(firstValue(statusData, idPaths)) ||
+    toStringValue(fallbackId)
+  if (!resolvedId) {
+    return null
+  }
+
+  const resolvedName =
+    toStringValue(firstValue(deviceData, namePaths)) ||
+    toStringValue(firstValue(statusData, namePaths)) ||
+    resolvedId
+
+  const isConnected =
+    toBooleanValue(firstValue(statusData, connectedPaths)) ?? false
+  const hasSignal =
+    toBooleanValue(firstValue(statusData, signalPaths)) ?? isConnected
+  const isMuted = toBooleanValue(firstValue(statusData, mutedPaths)) ?? false
+
+  const volumeRaw = firstValue(statusData, volumePaths)
+  const volume =
+    typeof volumeRaw === 'number'
+      ? clampVolume(volumeRaw)
+      : clampVolume(Number(volumeRaw))
+
+  const activeKey = toStringValue(firstValue(statusData, activeKeyPaths))
+  const activeName = toStringValue(firstValue(statusData, activeNamePaths))
+
+  const scheduleCandidates = []
+  for (const path of schedulePaths) {
+    const fromDevice = getValue(deviceData, path)
+    if (Array.isArray(fromDevice)) {
+      scheduleCandidates.push(fromDevice)
+    }
+    const fromStatus = getValue(statusData, path)
+    if (Array.isArray(fromStatus)) {
+      scheduleCandidates.push(fromStatus)
+    }
+  }
+
+  const normalizedSchedules = []
+  const seenKeys = new Set()
+  scheduleCandidates.forEach((collection) => {
+    collection.forEach((item, index) => {
+      if (item === null || item === undefined) {
+        return
+      }
+
+      let key = null
+      let label = null
+      let isActive = false
+
+      if (typeof item === 'string') {
+        key = item
+        label = item
+      } else if (typeof item === 'object') {
+        key =
+          toStringValue(
+            firstValue(item, [
+              ['key'],
+              ['id'],
+              ['uuid'],
+              ['channelId'],
+              ['channel', 'id'],
+              ['channel', 'key'],
+            ]),
+          ) || `schedule-${normalizedSchedules.length}`
+        label =
+          toStringValue(
+            firstValue(item, [
+              ['label'],
+              ['name'],
+              ['title'],
+              ['description'],
+            ]),
+          ) || key || `Channel ${normalizedSchedules.length + 1}`
+        const activeCandidate =
+          toBooleanValue(firstValue(item, [['isActive'], ['active'], ['selected']])) ?? false
+        isActive =
+          activeCandidate ||
+          (key && activeKey && key === activeKey) ||
+          (label && activeName && label === activeName)
+      } else {
+        key = `schedule-${normalizedSchedules.length}`
+        label = toStringValue(item) || key
+      }
+
+      const resolvedKey = key || `schedule-${normalizedSchedules.length}`
+      const resolvedLabel = label || resolvedKey
+
+      if (seenKeys.has(resolvedKey)) {
+        const existing = normalizedSchedules.find((schedule) => schedule.key === resolvedKey)
+        if (existing) {
+          existing.isActive =
+            existing.isActive ||
+            isActive ||
+            (resolvedKey && activeKey && resolvedKey === activeKey) ||
+            (resolvedLabel && activeName && resolvedLabel === activeName)
+        }
+        return
+      }
+
+      normalizedSchedules.push({
+        key: resolvedKey,
+        label: resolvedLabel,
+        isActive:
+          isActive ||
+          (resolvedKey && activeKey && resolvedKey === activeKey) ||
+          (resolvedLabel && activeName && resolvedLabel === activeName),
+      })
+      seenKeys.add(resolvedKey)
+    })
+  })
+
+  const nowPlayingSource = firstValue(statusData, nowPlayingPaths)
+  let nowPlaying = ''
+  let artworkUrl =
+    extractArtworkUrl(
+      firstValue(statusData, [
+        ['artworkUrl'],
+        ['artwork'],
+        ['channel', 'artworkUrl'],
+        ['channel', 'artwork'],
+      ]),
+    ) || null
+
+  if (typeof nowPlayingSource === 'string') {
+    nowPlaying = nowPlayingSource.trim()
+  } else if (nowPlayingSource && typeof nowPlayingSource === 'object') {
+    const nowPlayingTitle =
+      toStringValue(
+        firstValue(nowPlayingSource, [
+          ['title'],
+          ['name'],
+          ['track'],
+          ['song'],
+          ['description'],
+        ]),
+      ) || ''
+    const nowPlayingArtist =
+      toStringValue(
+        firstValue(nowPlayingSource, [
+          ['artist'],
+          ['artistName'],
+          ['artist', 'name'],
+          ['artists', 0, 'name'],
+          ['artists', 0],
+        ]),
+      ) || ''
+    const combined = [nowPlayingTitle, nowPlayingArtist].filter(Boolean).join(' | ')
+    nowPlaying = combined || nowPlayingTitle || nowPlayingArtist || ''
+    artworkUrl =
+      extractArtworkUrl(
+        firstValue(nowPlayingSource, [
+          ['artworkUrl'],
+          ['artwork'],
+          ['artwork', 'url'],
+          ['image'],
+          ['imageUrl'],
+        ]),
+      ) || artworkUrl
+  }
+
+  return {
+    id: resolvedId,
+    name: resolvedName,
+    isConnected,
+    hasSignal,
+    isMuted,
+    volume,
+    schedules: normalizedSchedules,
+    nowPlaying,
+    activeChannelKey: activeKey || null,
+    artworkUrl,
+  }
+}
 
 const useStyles = makeStyles((theme) => {
   const successMain =
@@ -123,6 +476,32 @@ const useStyles = makeStyles((theme) => {
       color: successContrast,
       fontWeight: theme.typography.fontWeightMedium,
       fontSize: theme.typography.pxToRem(18),
+    },
+    inlineError: {
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: theme.spacing(1.5),
+      padding: `${theme.spacing(1)}px ${theme.spacing(1.5)}px`,
+      borderRadius: theme.shape.borderRadius,
+      backgroundColor: theme.palette.action.hover,
+      color: theme.palette.error.main,
+      fontSize: theme.typography.pxToRem(14),
+    },
+    inlineErrorButton: {
+      padding: `${theme.spacing(0.25)}px ${theme.spacing(1.5)}px`,
+    },
+    compactErrorWrapper: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(1.5),
+      padding: theme.spacing(3),
+      maxWidth: 480,
+      width: '100%',
+      margin: '0 auto',
+    },
+    compactErrorMessage: {
+      color: theme.palette.error.main,
+      fontWeight: theme.typography.fontWeightMedium,
     },
     list: {
       borderRadius: theme.shape.borderRadius,
@@ -312,26 +691,75 @@ const useStyles = makeStyles((theme) => {
 const RetailPlayerDashboard = () => {
   const classes = useStyles()
   const { deviceId } = useParams()
+  const deviceInfoRef = useRef(null)
   const [device, setDevice] = useState(null)
-  const [artworkUrl, setArtworkUrl] = useState(null)
   const [currentTime, setCurrentTime] = useState(() => formatTime(new Date()))
+  const [isLoading, setIsLoading] = useState(true)
+  const [loadError, setLoadError] = useState(null)
 
-  const refreshDevice = useCallback(() => {
-    if (!deviceId) {
-      setDevice(null)
-      setArtworkUrl(null)
-      return
-    }
-
-    const nextDevice = RetailPlayerMockService.getDevice(deviceId)
-    setDevice(nextDevice)
-    setArtworkUrl(RetailPlayerMockService.getArtwork(deviceId))
-    setCurrentTime(formatTime(new Date()))
-  }, [deviceId])
+  const isValidDeviceId = useMemo(
+    () => Boolean(deviceId) && uuidRegex.test(deviceId),
+    [deviceId],
+  )
 
   useEffect(() => {
+    console.log('[RetailPlayerDashboard] deviceId:', deviceId)
+  }, [deviceId])
+
+  const refreshStatusOnly = useCallback(async () => {
+    if (!isValidDeviceId) {
+      return
+    }
+    try {
+      const statusResponse = await getDeviceStatus(deviceId)
+      setDevice((previous) => {
+        const normalized = normalizeDevice(deviceInfoRef.current, statusResponse, deviceId)
+        return normalized ?? previous
+      })
+      setCurrentTime(formatTime(new Date()))
+      setLoadError(null)
+    } catch (error) {
+      console.error(`[RetailPlayerDashboard] Failed to refresh status for ${deviceId}`, error)
+      setLoadError("Couldn't load device details.")
+    }
+  }, [deviceId, isValidDeviceId])
+
+  const refreshDevice = useCallback(async () => {
+    if (!isValidDeviceId) {
+      return
+    }
+    console.log(`[RetailPlayerDashboard] Refreshing device ${deviceId}`)
+    setIsLoading(true)
+    setLoadError(null)
+    try {
+      const [deviceResponse, statusResponse] = await Promise.all([
+        getDevice(deviceId),
+        getDeviceStatus(deviceId),
+      ])
+      deviceInfoRef.current = deviceResponse || null
+      const normalized = normalizeDevice(deviceResponse, statusResponse, deviceId)
+      setDevice(normalized)
+      setCurrentTime(formatTime(new Date()))
+    } catch (error) {
+      console.error(`[RetailPlayerDashboard] Failed to load device ${deviceId}`, error)
+      deviceInfoRef.current = null
+      setDevice(null)
+      setLoadError("Couldn't load device details.")
+    } finally {
+      setIsLoading(false)
+    }
+  }, [deviceId, isValidDeviceId])
+
+  useEffect(() => {
+    if (!isValidDeviceId) {
+      deviceInfoRef.current = null
+      setDevice(null)
+      setIsLoading(false)
+      setLoadError(null)
+      return
+    }
     refreshDevice()
-  }, [refreshDevice])
+  }, [isValidDeviceId, refreshDevice])
 
   useEffect(() => {
     const updateTime = () => setCurrentTime(formatTime(new Date()))
@@ -342,13 +770,17 @@ const RetailPlayerDashboard = () => {
   const schedules = useMemo(() => device?.schedules || [], [device])
 
   const activeChannelKey = useMemo(() => {
+    if (device?.activeChannelKey) {
+      return device.activeChannelKey
+    }
     const activeSchedule = schedules.find((schedule) => schedule.isActive)
     return activeSchedule ? activeSchedule.key : null
-  }, [schedules])
+  }, [device, schedules])
 
   const isMuted = Boolean(device?.isMuted)
   const volume = typeof device?.volume === 'number' ? device.volume : 0
   const nowPlaying = device?.nowPlaying || ''
+  const artworkUrl = device?.artworkUrl || null
 
   const statusItems = useMemo(() => {
     if (!device) {
@@ -378,24 +810,52 @@ const RetailPlayerDashboard = () => {
     ]
   }, [currentTime, device, isMuted])
 
-  const handleSelectChannel = useCallback(
-    (schedule) => {
-      if (!device) {
+  const sendCommand = useCallback(
+    async (payload) => {
+      if (!isValidDeviceId) {
         return
       }
-      RetailPlayerMockService.setActiveChannel(deviceId, schedule.key)
-      refreshDevice()
+      try {
+        await postDeviceCommand(deviceId, payload)
+        await refreshStatusOnly()
+      } catch (error) {
+        console.error(`[RetailPlayerDashboard] Command failed for ${deviceId}`, error)
+      }
     },
-    [device, deviceId, refreshDevice],
+    [deviceId, isValidDeviceId, refreshStatusOnly],
+  )
+
+  const handleSelectChannel = useCallback(
+    (schedule) => {
+      if (!device || !schedule) {
+        return
+      }
+      setDevice((previous) => {
+        if (!previous) {
+          return previous
+        }
+        return {
+          ...previous,
+          activeChannelKey: schedule.key,
+          schedules: previous.schedules.map((item) => ({
+            ...item,
+            isActive: item.key === schedule.key,
+          })),
+        }
+      })
+      void sendCommand({ type: 'channel', channel: schedule.key })
+    },
+    [device, sendCommand],
   )
 
   const handleToggleMute = useCallback(() => {
     if (!device) {
       return
     }
-    RetailPlayerMockService.setMute(deviceId, !device.isMuted)
-    refreshDevice()
-  }, [device, deviceId, refreshDevice])
+    const nextMuted = !device.isMuted
+    setDevice((previous) => (previous ? { ...previous, isMuted: nextMuted } : previous))
+    void sendCommand({ type: 'mute', value: nextMuted })
+  }, [device, sendCommand])
 
   const handleVolumeChange = useCallback(
     (_, newValue) => {
@@ -408,26 +868,32 @@ const RetailPlayerDashboard = () => {
         return
       }
 
-      RetailPlayerMockService.setVolume(deviceId, resolvedValue)
-      refreshDevice()
+      const clampedValue = clampVolume(resolvedValue)
+      setDevice((previous) =>
+        previous ? { ...previous, volume: clampedValue } : previous,
+      )
+      void sendCommand({ type: 'volume', value: clampedValue })
     },
-    [device, deviceId, refreshDevice],
+    [device, sendCommand],
   )
 
   const handleRefresh = useCallback(() => {
-    refreshDevice()
-  }, [refreshDevice])
+    if (!isValidDeviceId) {
+      return
+    }
+    void refreshDevice()
+  }, [isValidDeviceId, refreshDevice])
 
   const handleAdjustVolume = useCallback(
     (delta) => {
       if (!device) {
         return
       }
-      const nextVolume = device.volume + delta
-      RetailPlayerMockService.setVolume(deviceId, nextVolume)
-      refreshDevice()
+      const nextVolume = clampVolume((device.volume ?? 0) + delta)
+      setDevice((previous) => (previous ? { ...previous, volume: nextVolume } : previous))
+      void sendCommand({ type: 'volume', value: nextVolume })
     },
-    [device, deviceId, refreshDevice],
+    [device, sendCommand],
   )
 
   const handleShortcutChannel = useCallback(
@@ -436,10 +902,9 @@ const RetailPlayerDashboard = () => {
       if (!schedule) {
         return
       }
-      RetailPlayerMockService.setActiveChannel(deviceId, schedule.key)
-      refreshDevice()
+      handleSelectChannel(schedule)
     },
-    [deviceId, refreshDevice, schedules],
+    [handleSelectChannel, schedules],
   )
 
   useEffect(() => {
@@ -462,8 +927,7 @@ const RetailPlayerDashboard = () => {
         case 'm':
         case 'M':
           event.preventDefault()
-          RetailPlayerMockService.setMute(deviceId, !device.isMuted)
-          refreshDevice()
+          handleToggleMute()
           break
         case '+':
         case '=':
@@ -493,9 +957,51 @@ const RetailPlayerDashboard = () => {
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [device, deviceId, handleAdjustVolume, handleShortcutChannel, refreshDevice])
+  }, [device, handleAdjustVolume, handleShortcutChannel, handleToggleMute])
+
+  if (!isValidDeviceId) {
+    return (
+      <div className={classes.compactErrorWrapper}>
+        <Title title="Retail Player" />
+        <Typography className={classes.compactErrorMessage}>Invalid device id</Typography>
+        <RouterLink to="/retailplayer/devices" className={classes.backLink}>
+          ← Back to devices
+        </RouterLink>
+      </div>
+    )
+  }
+
+  if (!device && isLoading) {
+    return (
+      <div className={classes.notFoundWrapper}>
+        <Title title="Retail Player" />
+        <Typography className={classes.notFoundMessage}>Loading device…</Typography>
+      </div>
+    )
+  }
 
   if (!device) {
+    if (loadError) {
+      return (
+        <div className={classes.compactErrorWrapper}>
+          <Title title="Retail Player" />
+          <Typography className={classes.compactErrorMessage}>{loadError}</Typography>
+          <Button
+            className={classes.inlineErrorButton}
+            variant="outlined"
+            size="small"
+            onClick={handleRefresh}
+            disabled={isLoading}
+          >
+            Retry
+          </Button>
+          <RouterLink to="/retailplayer/devices" className={classes.backLink}>
+            ← Back to devices
+          </RouterLink>
+        </div>
+      )
+    }
+
     return (
       <div className={classes.notFoundWrapper}>
         <Title title="Retail Player" />
@@ -519,6 +1025,20 @@ const RetailPlayerDashboard = () => {
       <RouterLink to="/retailplayer/devices" className={`${classes.backLink} ${classes.backLinkTop}`}>
         ← Back to Devices
       </RouterLink>
+      {loadError && (
+        <div className={classes.inlineError} role="alert">
+          <span>{loadError}</span>
+          <Button
+            className={classes.inlineErrorButton}
+            variant="outlined"
+            size="small"
+            onClick={handleRefresh}
+            disabled={isLoading}
+          >
+            Retry
+          </Button>
+        </div>
+      )}
       <header className={classes.header}>
         <Typography component="h1" className={classes.title}>
           {device.name}
@@ -529,6 +1049,7 @@ const RetailPlayerDashboard = () => {
             onClick={handleRefresh}
             aria-label="Refresh"
             focusRipple
+            disabled={isLoading}
           >
             <CachedIcon fontSize="inherit" />
           </ButtonBase>
@@ -617,7 +1138,7 @@ const RetailPlayerDashboard = () => {
       </div>
 
       <Typography component="h2" className={classes.nowPlaying}>
-        {nowPlaying}
+        {nowPlaying || '—'}
       </Typography>
 
       <section className={classes.controls}>

--- a/ui/src/retailPlayer/RetailPlayerDevicesList.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDevicesList.jsx
@@ -1,10 +1,18 @@
-import React, { useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
-import { Typography, ButtonBase, TextField } from '@material-ui/core'
+import {
+  Typography,
+  Button,
+  ButtonBase,
+  CircularProgress,
+  IconButton,
+  TextField,
+} from '@material-ui/core'
 import { Title } from 'react-admin'
 import ChevronRightIcon from '@material-ui/icons/ChevronRight'
 import { useHistory } from 'react-router-dom'
-import RetailPlayerMockService from './RetailPlayerMockService'
+import RefreshIcon from '@material-ui/icons/Refresh'
+import { getDevices } from '../services/retailPlayerService'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -38,9 +46,17 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     justifyContent: 'flex-start',
     alignItems: 'center',
+    gap: theme.spacing(2),
   },
   searchField: {
     maxWidth: 360,
+  },
+  refreshButton: {
+    padding: theme.spacing(1),
+  },
+  lastUpdated: {
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.pxToRem(13),
   },
   table: {
     borderRadius: theme.shape.borderRadius,
@@ -152,20 +168,141 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.text.secondary,
     fontStyle: 'italic',
   },
+  statusRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+    padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`,
+    color: theme.palette.text.secondary,
+  },
+  statusActions: {
+    display: 'flex',
+    gap: theme.spacing(1),
+  },
 }))
 
 const RetailPlayerDevicesList = () => {
   const classes = useStyles()
   const history = useHistory()
   const [searchTerm, setSearchTerm] = useState('')
-  const devices = useMemo(
-    () => RetailPlayerMockService.listDevices(),
-    [],
-  )
+  const [devices, setDevices] = useState([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [hasError, setHasError] = useState(false)
+  const [lastUpdated, setLastUpdated] = useState(null)
+
+  const normalizeDevices = useCallback((response) => {
+    if (!response) {
+      return []
+    }
+
+    if (Array.isArray(response)) {
+      return response
+    }
+
+    if (Array.isArray(response.devices)) {
+      return response.devices
+    }
+
+    if (Array.isArray(response.items)) {
+      return response.items
+    }
+
+    if (Array.isArray(response.data)) {
+      return response.data
+    }
+
+    return []
+  }, [])
+
+  const loadDevices = useCallback(async () => {
+    setIsLoading(true)
+    setHasError(false)
+
+    try {
+      const response = await getDevices()
+      const fetchedDevices = normalizeDevices(response)
+      setDevices(fetchedDevices)
+      setLastUpdated(new Date())
+    } catch (error) {
+      setHasError(true)
+      setDevices([])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [normalizeDevices])
+
+  useEffect(() => {
+    loadDevices()
+  }, [loadDevices])
 
   const handleNavigate = (deviceId) => {
     history.push(`/retailplayer/${deviceId}`)
   }
+
+  const getDeviceDisplayName = useCallback((device) => {
+    return (
+      (device?.name && device.name.trim()) ||
+      (device?.displayName && device.displayName.trim()) ||
+      (device?.deviceName && device.deviceName.trim()) ||
+      (device?.id && String(device.id)) ||
+      '—'
+    )
+  }, [])
+
+  const getDeviceId = (device) => {
+    return (
+      device?.id ||
+      device?.deviceId ||
+      device?.device_id ||
+      device?.uuid ||
+      null
+    )
+  }
+
+  const getDeviceChannel = (device) => {
+    return (
+      device?.channel?.name ||
+      device?.currentChannel?.name ||
+      device?.assignedChannel?.name ||
+      device?.channelName ||
+      device?.currentChannelName ||
+      '—'
+    )
+  }
+
+  const getDeviceOrganization = (device) => {
+    const organizationName =
+      device?.organization?.name ||
+      device?.orgName ||
+      device?.organizationName
+
+    if (organizationName) {
+      return organizationName
+    }
+
+    const organizationId =
+      device?.organization?.id ||
+      device?.orgId ||
+      device?.org_id ||
+      device?.organizationId
+
+    if (organizationId) {
+      return String(organizationId).slice(0, 8)
+    }
+
+    return '—'
+  }
+
+  const formattedLastUpdated = useMemo(() => {
+    if (!lastUpdated) {
+      return null
+    }
+
+    return lastUpdated.toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }, [lastUpdated])
 
   const filteredDevices = useMemo(() => {
     const normalizedTerm = searchTerm.trim().toLowerCase()
@@ -174,9 +311,9 @@ const RetailPlayerDevicesList = () => {
     }
 
     return devices.filter((device) =>
-      device.name.toLowerCase().includes(normalizedTerm),
+      getDeviceDisplayName(device).toLowerCase().includes(normalizedTerm),
     )
-  }, [devices, searchTerm])
+  }, [devices, getDeviceDisplayName, searchTerm])
 
   return (
     <div className={classes.root}>
@@ -194,6 +331,19 @@ const RetailPlayerDevicesList = () => {
           onChange={(event) => setSearchTerm(event.target.value)}
           inputProps={{ 'aria-label': 'Search devices' }}
         />
+        <IconButton
+          className={classes.refreshButton}
+          aria-label="Refresh devices"
+          onClick={loadDevices}
+          disabled={isLoading}
+        >
+          <RefreshIcon fontSize="small" />
+        </IconButton>
+        {formattedLastUpdated && (
+          <Typography variant="caption" className={classes.lastUpdated}>
+            Last updated {formattedLastUpdated}
+          </Typography>
+        )}
       </div>
       <div className={classes.table}>
         <div className={classes.headerRow}>
@@ -213,35 +363,56 @@ const RetailPlayerDevicesList = () => {
             Organization
           </span>
         </div>
-        {filteredDevices.length > 0 ? (
-          filteredDevices.map((device) => (
-            <ButtonBase
-              key={device.id}
-              className={classes.buttonBase}
-              onClick={() => handleNavigate(device.id)}
-              focusRipple
-              aria-label={`Open ${device.name}`}
-            >
-              <span className={classes.rowButton}>
-                <span className={`${classes.cell} ${classes.actionCell}`} data-area="actions">
-                  View
-                  <ChevronRightIcon className={classes.chevron} aria-hidden="true" />
+        {isLoading ? (
+          <div className={classes.statusRow}>
+            <CircularProgress size={18} thickness={4} />
+            <span>Loading devices…</span>
+          </div>
+        ) : hasError ? (
+          <div className={classes.statusRow}>
+            <span>Couldn't load devices.</span>
+            <span className={classes.statusActions}>
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={loadDevices}
+              >
+                Retry
+              </Button>
+            </span>
+          </div>
+        ) : filteredDevices.length > 0 ? (
+          filteredDevices.map((device) => {
+            const deviceId = getDeviceId(device)
+            return (
+              <ButtonBase
+                key={deviceId || getDeviceDisplayName(device)}
+                className={classes.buttonBase}
+                onClick={() => deviceId && handleNavigate(deviceId)}
+                focusRipple
+                aria-label={`Open ${getDeviceDisplayName(device)}`}
+              >
+                <span className={classes.rowButton}>
+                  <span className={`${classes.cell} ${classes.actionCell}`} data-area="actions">
+                    View
+                    <ChevronRightIcon className={classes.chevron} aria-hidden="true" />
+                  </span>
+                  <span className={classes.cell} data-area="name">
+                    {getDeviceDisplayName(device)}
+                  </span>
+                  <span className={classes.cell} data-area="channel">
+                    {getDeviceChannel(device)}
+                  </span>
+                  <span className={classes.cell} data-area="channelList">
+                    {'—'}
+                  </span>
+                  <span className={classes.cell} data-area="organization">
+                    {getDeviceOrganization(device)}
+                  </span>
                 </span>
-                <span className={classes.cell} data-area="name">
-                  {device.name}
-                </span>
-                <span className={classes.cell} data-area="channel">
-                  {device.channel}
-                </span>
-                <span className={classes.cell} data-area="channelList">
-                  {device.channelList}
-                </span>
-                <span className={classes.cell} data-area="organization">
-                  {device.organization}
-                </span>
-              </span>
-            </ButtonBase>
-          ))
+              </ButtonBase>
+            )
+          })
         ) : (
           <div className={classes.noResults}>No devices match this search.</div>
         )}

--- a/ui/src/retailPlayer/RetailPlayerDevicesList.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDevicesList.jsx
@@ -240,13 +240,20 @@ const RetailPlayerDevicesList = () => {
   }
 
   const getDeviceDisplayName = useCallback((device) => {
-    return (
-      (device?.name && device.name.trim()) ||
-      (device?.displayName && device.displayName.trim()) ||
-      (device?.deviceName && device.deviceName.trim()) ||
-      (device?.id && String(device.id)) ||
-      '—'
-    )
+    if (!device) {
+      return '—'
+    }
+
+    if (typeof device.name === 'string' && device.name.trim()) {
+      return device.name.trim()
+    }
+
+    const id = getDeviceId(device)
+    if (id) {
+      return String(id)
+    }
+
+    return '—'
   }, [])
 
   const getDeviceId = (device) => {
@@ -398,7 +405,9 @@ const RetailPlayerDevicesList = () => {
                     <ChevronRightIcon className={classes.chevron} aria-hidden="true" />
                   </span>
                   <span className={classes.cell} data-area="name">
-                    {getDeviceDisplayName(device)}
+                    {typeof device?.name === 'string' && device.name.trim()
+                      ? device.name.trim()
+                      : '—'}
                   </span>
                   <span className={classes.cell} data-area="channel">
                     {getDeviceChannel(device)}

--- a/ui/src/services/retailPlayerService.js
+++ b/ui/src/services/retailPlayerService.js
@@ -1,18 +1,14 @@
-const BASE_URL = "https://rpp.jareddietch.com/broad/api/v1";
-const API_KEY = "f3894t28-aghj-cv50-453e-9dfr1s9h73s5";
-const ORG_ID = "1aa59b04-5365-4efe-afb3-deb23c414add";
+const BASE_URL = "";
 
 async function fetchFromRetail(endpoint, method = "GET", body = null) {
   const url = `${BASE_URL}${endpoint}`;
   const options = {
     method,
-    headers: {
-      "x-retailplayer-apikey": API_KEY,
-      "Content-Type": "application/json",
-    },
+    headers: {},
   };
 
   if (body !== null) {
+    options.headers["Content-Type"] = "application/json";
     options.body = JSON.stringify(body);
   }
 
@@ -48,15 +44,15 @@ async function fetchFromRetail(endpoint, method = "GET", body = null) {
 }
 
 export function getDevices() {
-  return fetchFromRetail(`/orgs/${ORG_ID}/devices`);
+  return fetchFromRetail(`/api/retailplayer/devices`);
 }
 
 export function getDeviceStatus(id) {
-  return fetchFromRetail(`/orgs/${ORG_ID}/devices/${id}/status`);
+  return fetchFromRetail(`/api/retailplayer/devices/${id}/status`);
 }
 
 export function postDeviceCommand(id, payload) {
-  return fetchFromRetail(`/orgs/${ORG_ID}/devices/${id}/command`, "POST", payload);
+  return fetchFromRetail(`/api/retailplayer/devices/${id}/command`, "POST", payload);
 }
 
 export default {

--- a/ui/src/services/retailPlayerService.js
+++ b/ui/src/services/retailPlayerService.js
@@ -47,6 +47,10 @@ export function getDevices() {
   return fetchFromRetail(`/api/retailplayer/devices`);
 }
 
+export function getDevice(id) {
+  return fetchFromRetail(`/api/retailplayer/devices/${id}`);
+}
+
 export function getDeviceStatus(id) {
   return fetchFromRetail(`/api/retailplayer/devices/${id}/status`);
 }
@@ -57,6 +61,7 @@ export function postDeviceCommand(id, payload) {
 
 export default {
   getDevices,
+  getDevice,
   getDeviceStatus,
   postDeviceCommand,
 };

--- a/ui/src/services/retailPlayerService.js
+++ b/ui/src/services/retailPlayerService.js
@@ -1,0 +1,69 @@
+const BASE_URL = "https://rpp.jareddietch.com/broad/api/v1";
+const API_KEY = "f3894t28-aghj-cv50-453e-9dfr1s9h73s5";
+const ORG_ID = "1aa59b04-5365-4efe-afb3-deb23c414add";
+
+async function fetchFromRetail(endpoint, method = "GET", body = null) {
+  const url = `${BASE_URL}${endpoint}`;
+  const options = {
+    method,
+    headers: {
+      "x-retailplayer-apikey": API_KEY,
+      "Content-Type": "application/json",
+    },
+  };
+
+  if (body !== null) {
+    options.body = JSON.stringify(body);
+  }
+
+  try {
+    const response = await fetch(url, options);
+
+    if (!response.ok) {
+      console.warn(
+        `[RetailPlayerService] Request to ${endpoint} failed with status ${response.status} ${response.statusText}`
+      );
+
+      let errorDetail;
+      try {
+        errorDetail = await response.json();
+      } catch (jsonError) {
+        errorDetail = await response.text();
+      }
+
+      console.warn("Response detail:", errorDetail);
+      throw new Error(`RetailPlayer API error: ${response.status}`);
+    }
+
+    const contentType = response.headers.get("content-type");
+    if (contentType && contentType.includes("application/json")) {
+      return response.json();
+    }
+
+    return null;
+  } catch (error) {
+    console.warn(`[RetailPlayerService] Network error while accessing ${endpoint}`, error);
+    throw error;
+  }
+}
+
+export function getDevices() {
+  return fetchFromRetail(`/orgs/${ORG_ID}/devices`);
+}
+
+export function getDeviceStatus(id) {
+  return fetchFromRetail(`/orgs/${ORG_ID}/devices/${id}/status`);
+}
+
+export function postDeviceCommand(id, payload) {
+  return fetchFromRetail(`/orgs/${ORG_ID}/devices/${id}/command`, "POST", payload);
+}
+
+export default {
+  getDevices,
+  getDeviceStatus,
+  postDeviceCommand,
+};
+
+// Example usage for sanity checking device responses:
+// getDevices().then(console.log);


### PR DESCRIPTION
## Summary
- add a reusable Retail Player API helper with shared headers and error handling
- expose device management helpers for listing devices, fetching status, and posting commands with an inline example

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fc245a1f648330b4b37a294347b705