### PR TITLE
Fetch missing track notifications on load

### DIFF
--- a/ui/src/layout/MissingTracksPanel.jsx
+++ b/ui/src/layout/MissingTracksPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import {
   Badge,
   Card,
@@ -153,6 +153,10 @@ const MissingTracksPanel = () => {
     },
     [translate],
   )
+
+  useEffect(() => {
+    fetchEntries(0, false)
+  }, [fetchEntries])
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- fetch missing track notifications when the app loads so the badge count is visible without opening the panel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd43f44704833098941fa6860521d4