### PR TITLE
Allow dragging all selected songs

### DIFF
--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -153,16 +153,56 @@ export const SongDatagridRow = ({
 
   const { selectedIds = [], data: listData } = useListContext() || {}
 
+  const getRecordFromList = useCallback(
+    (recordId) => {
+      if (!listData || recordId == null) {
+        return null
+      }
+
+      if (Array.isArray(listData)) {
+        return listData.find((item) => {
+          const itemId = item?.id
+          return itemId === recordId || String(itemId) === String(recordId)
+        })
+      }
+
+      const keysToCheck = [recordId, String(recordId)]
+      if (typeof recordId === 'string' || typeof recordId === 'number') {
+        const numericId = Number(recordId)
+        if (!Number.isNaN(numericId)) {
+          keysToCheck.push(numericId)
+        }
+      }
+
+      for (const key of keysToCheck) {
+        if (key in listData) {
+          return listData[key]
+        }
+      }
+
+      return null
+    },
+    [listData],
+  )
+
   const getRecordTrackId = useCallback(
     (recordId) => {
-      const item = listData?.[recordId]
+      const item = getRecordFromList(recordId)
       if (item?.missing) {
         return null
       }
       return item?.mediaFileId || item?.id || recordId
     },
-    [listData],
+    [getRecordFromList],
   )
+
+  const selectionIncludesRecord = useMemo(() => {
+    if (!Array.isArray(selectedIds) || record?.id == null) {
+      return false
+    }
+
+    return selectedIds.some((id) => String(id) === String(record.id))
+  }, [record?.id, selectedIds])
 
   const draggedSongIds = useMemo(() => {
     const baseId =
@@ -171,11 +211,7 @@ export const SongDatagridRow = ({
       return []
     }
 
-    if (
-      Array.isArray(selectedIds) &&
-      selectedIds.length > 1 &&
-      selectedIds.includes(record?.id)
-    ) {
+    if (Array.isArray(selectedIds) && selectedIds.length > 1 && selectionIncludesRecord) {
       const idsFromSelection = selectedIds
         .map((id) => getRecordTrackId(id))
         .filter(Boolean)
@@ -184,7 +220,7 @@ export const SongDatagridRow = ({
     }
 
     return [baseId]
-  }, [getRecordTrackId, record, selectedIds])
+  }, [getRecordTrackId, record, selectedIds, selectionIncludesRecord])
 
   const [, dragDiscRef] = useDrag(
     () => ({

--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -4,6 +4,7 @@ import {
   Datagrid,
   PureDatagridBody,
   PureDatagridRow,
+  useListContext,
   useTranslate,
 } from 'react-admin'
 import {
@@ -150,6 +151,41 @@ export const SongDatagridRow = ({
     isValidElement(c),
   )
 
+  const { selectedIds = [], data: listData } = useListContext() || {}
+
+  const getRecordTrackId = useCallback(
+    (recordId) => {
+      const item = listData?.[recordId]
+      if (item?.missing) {
+        return null
+      }
+      return item?.mediaFileId || item?.id || recordId
+    },
+    [listData],
+  )
+
+  const draggedSongIds = useMemo(() => {
+    const baseId =
+      getRecordTrackId(record?.id) || record?.mediaFileId || record?.id
+    if (!baseId) {
+      return []
+    }
+
+    if (
+      Array.isArray(selectedIds) &&
+      selectedIds.length > 1 &&
+      selectedIds.includes(record?.id)
+    ) {
+      const idsFromSelection = selectedIds
+        .map((id) => getRecordTrackId(id))
+        .filter(Boolean)
+
+      return Array.from(new Set(idsFromSelection))
+    }
+
+    return [baseId]
+  }, [getRecordTrackId, record, selectedIds])
+
   const [, dragDiscRef] = useDrag(
     () => ({
       type: DraggableTypes.DISC,
@@ -169,10 +205,11 @@ export const SongDatagridRow = ({
   const [, dragSongRef] = useDrag(
     () => ({
       type: DraggableTypes.SONG,
-      item: { ids: [record?.mediaFileId || record?.id] },
+      canDrag: draggedSongIds.length > 0,
+      item: { ids: draggedSongIds },
       options: { dropEffect: 'copy' },
     }),
-    [record],
+    [draggedSongIds],
   )
 
   if (!record || !record.title) {

--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -204,14 +204,18 @@ export const SongDatagridRow = ({
     return selectedIds.some((id) => String(id) === String(record.id))
   }, [record?.id, selectedIds])
 
-  const draggedSongIds = useMemo(() => {
+  const getDraggedSongIds = useCallback(() => {
     const baseId =
       getRecordTrackId(record?.id) || record?.mediaFileId || record?.id
     if (!baseId) {
       return []
     }
 
-    if (Array.isArray(selectedIds) && selectedIds.length > 1 && selectionIncludesRecord) {
+    if (
+      Array.isArray(selectedIds) &&
+      selectedIds.length > 1 &&
+      selectionIncludesRecord
+    ) {
       const idsFromSelection = selectedIds
         .map((id) => getRecordTrackId(id))
         .filter(Boolean)
@@ -220,7 +224,7 @@ export const SongDatagridRow = ({
     }
 
     return [baseId]
-  }, [getRecordTrackId, record, selectedIds, selectionIncludesRecord])
+  }, [getRecordTrackId, record?.id, record?.mediaFileId, selectedIds, selectionIncludesRecord])
 
   const [, dragDiscRef] = useDrag(
     () => ({
@@ -239,13 +243,16 @@ export const SongDatagridRow = ({
   )
 
   const [, dragSongRef] = useDrag(
-    () => ({
-      type: DraggableTypes.SONG,
-      canDrag: draggedSongIds.length > 0,
-      item: { ids: draggedSongIds },
-      options: { dropEffect: 'copy' },
-    }),
-    [draggedSongIds],
+    () => {
+      const draggedSongIds = getDraggedSongIds()
+      return {
+        type: DraggableTypes.SONG,
+        canDrag: draggedSongIds.length > 0,
+        item: { ids: draggedSongIds },
+        options: { dropEffect: 'copy' },
+      }
+    },
+    [getDraggedSongIds],
   )
 
   if (!record || !record.title) {

--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -95,30 +95,13 @@ const toComparableId = (value) => {
   return String(value)
 }
 
-const recordMatchesId = (candidate, value) => {
-  if (!candidate) {
-    return false
-  }
-
-  const comparable = toComparableId(value)
-  if (comparable === null) {
-    return false
-  }
-
-  const candidateIds = [
-    toComparableId(candidate.id),
-    toComparableId(candidate.mediaFileId),
-  ]
-
-  return candidateIds.some((id) => id !== null && id === comparable)
-}
-
 const extractTrackId = (candidate) => {
   if (!candidate || candidate.missing) {
     return null
   }
 
-  return candidate.mediaFileId ?? candidate.id ?? null
+  const id = candidate.mediaFileId ?? candidate.id
+  return id ?? null
 }
 
 const DiscSubtitleRow = forwardRef(
@@ -185,166 +168,124 @@ export const SongDatagridRow = ({
   )
 
   const listContext = useListContext()
-  const selectedIds = listContext?.selectedIds ?? []
-  const listData = listContext?.data
-  const listIds = listContext?.ids ?? []
+  const selectedIds = listContext?.selectedIds ?? rest?.selectedIds ?? []
+  const listData = listContext?.data ?? rest?.data
+  const listIds = listContext?.ids ?? rest?.ids ?? []
 
-  const getRecordFromList = useCallback(
-    (recordId) => {
-      if (!listData || recordId == null) {
-        return null
-      }
-
-      if (Array.isArray(listData)) {
-        return listData.find((item) => recordMatchesId(item, recordId)) || null
-      }
-
-      const comparable = toComparableId(recordId)
-      const keysToCheck = []
-
+  const comparableIdsForRecord = useMemo(() => {
+    const set = new Set()
+    const register = (value) => {
+      const comparable = toComparableId(value)
       if (comparable !== null) {
-        keysToCheck.push(comparable)
+        set.add(comparable)
+      }
+    }
+
+    register(record?.id)
+    register(record?.mediaFileId)
+
+    return set
+  }, [record?.id, record?.mediaFileId])
+
+  const recordLookup = useMemo(() => {
+    const map = new Map()
+
+    const registerRecord = (candidate) => {
+      if (!candidate) {
+        return
       }
 
-      if (typeof recordId === 'string' || typeof recordId === 'number') {
-        const numericId = Number(recordId)
-        if (!Number.isNaN(numericId)) {
-          const numericComparable = toComparableId(numericId)
-          if (numericComparable !== null) {
-            keysToCheck.push(numericComparable)
-          }
+      const attach = (value) => {
+        const comparable = toComparableId(value)
+        if (comparable !== null && !map.has(comparable)) {
+          map.set(comparable, candidate)
         }
       }
 
-      for (const key of keysToCheck) {
-        if (key in listData && listData[key]) {
-          return listData[key]
-        }
-      }
-
-      const values = Object.values(listData)
-      return values.find((item) => recordMatchesId(item, recordId)) || null
-    },
-    [listData],
-  )
-
-  const ensureRecordForId = useCallback(
-    (recordId) => {
-      if (recordId == null) {
-        return null
-      }
-
-      const fromList = getRecordFromList(recordId)
-      if (fromList) {
-        return fromList
-      }
-
-      if (recordMatchesId(record, recordId)) {
-        return record
-      }
-
-      return null
-    },
-    [getRecordFromList, record],
-  )
-
-  const selectionIncludesRecord = useMemo(() => {
-    if (!Array.isArray(selectedIds) || selectedIds.length === 0) {
-      return false
+      attach(candidate.id)
+      attach(candidate.mediaFileId)
     }
 
-    const possibleMatches = new Set()
-
-    const recordComparableId = toComparableId(record?.id)
-    if (recordComparableId !== null) {
-      possibleMatches.add(recordComparableId)
+    if (Array.isArray(listData)) {
+      listData.forEach(registerRecord)
+    } else if (listData && typeof listData === 'object') {
+      Object.values(listData).forEach(registerRecord)
     }
 
-    const recordComparableMediaId = toComparableId(record?.mediaFileId)
-    if (recordComparableMediaId !== null) {
-      possibleMatches.add(recordComparableMediaId)
-    }
+    registerRecord(record)
 
-    if (possibleMatches.size === 0) {
-      return false
-    }
+    return map
+  }, [listData, record])
 
-    return selectedIds.some((id) => {
-      const comparable = toComparableId(id)
-      return comparable !== null && possibleMatches.has(comparable)
-    })
-  }, [record?.id, record?.mediaFileId, selectedIds])
-
-  const resolveDraggedSongIds = useCallback(() => {
+  const draggedSongIds = useMemo(() => {
     const baseTrackId = extractTrackId(record)
-    if (!baseTrackId) {
+    if (baseTrackId == null) {
       return []
     }
 
-    if (
-      !Array.isArray(selectedIds) ||
-      selectedIds.length < 2 ||
-      !selectionIncludesRecord
-    ) {
+    if (!Array.isArray(selectedIds) || selectedIds.length < 2) {
       return [baseTrackId]
     }
 
-    const selectedComparables = new Set(
-      selectedIds
-        .map((id) => toComparableId(id))
-        .filter((id) => id !== null),
+    const selectionComparables = selectedIds
+      .map((id) => toComparableId(id))
+      .filter((id) => id !== null)
+
+    if (selectionComparables.length === 0) {
+      return [baseTrackId]
+    }
+
+    const selectionSet = new Set(selectionComparables)
+    const recordIsInSelection = selectionComparables.some((id) =>
+      comparableIdsForRecord.has(id),
     )
 
-    if (selectedComparables.size === 0) {
+    if (!recordIsInSelection) {
       return [baseTrackId]
     }
 
     const orderSource =
-      Array.isArray(listIds) && listIds.length > 0 ? listIds : selectedIds
+      Array.isArray(listIds) && listIds.length > 0 ? listIds : selectionComparables
 
     const collected = []
-    const seen = new Set()
+    const seenTracks = new Set()
 
-    const pushRecord = (candidate) => {
+    const pushCandidate = (candidate) => {
       const trackId = extractTrackId(candidate)
-      if (!trackId) {
+      if (trackId == null) {
         return
       }
 
-      const comparable = toComparableId(trackId)
-      if (comparable === null || seen.has(comparable)) {
+      const comparableTrack = toComparableId(trackId)
+      if (comparableTrack === null || seenTracks.has(comparableTrack)) {
         return
       }
 
-      seen.add(comparable)
+      seenTracks.add(comparableTrack)
       collected.push(trackId)
     }
 
     orderSource.forEach((id) => {
       const comparable = toComparableId(id)
-      if (comparable === null || !selectedComparables.has(comparable)) {
+      if (comparable === null || !selectionSet.has(comparable)) {
         return
       }
 
-      const candidate = ensureRecordForId(id)
-      pushRecord(candidate)
+      const candidate = recordLookup.get(comparable)
+      pushCandidate(candidate)
     })
 
     if (collected.length === 0) {
-      pushRecord(record)
+      pushCandidate(record)
     }
 
-    if (collected.length === 0) {
-      return [baseTrackId]
-    }
-
-    return collected
+    return collected.length > 0 ? collected : [baseTrackId]
   }, [
-    ensureRecordForId,
+    comparableIdsForRecord,
     listIds,
     record,
+    recordLookup,
     selectedIds,
-    selectionIncludesRecord,
   ])
 
   const [, dragDiscRef] = useDrag(
@@ -366,11 +307,11 @@ export const SongDatagridRow = ({
   const [, dragSongRef] = useDrag(
     () => ({
       type: DraggableTypes.SONG,
-      item: () => ({ ids: resolveDraggedSongIds() }),
-      canDrag: () => resolveDraggedSongIds().length > 0,
+      item: { ids: draggedSongIds },
+      canDrag: draggedSongIds.length > 0,
       options: { dropEffect: 'copy' },
     }),
-    [resolveDraggedSongIds],
+    [draggedSongIds],
   )
 
   if (!record || !record.title) {

--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -5,7 +5,6 @@ import {
   PureDatagridBody,
   PureDatagridRow,
   useListContext,
-  useTranslate,
 } from 'react-admin'
 import {
   TableCell,
@@ -88,6 +87,40 @@ const useStyles = makeStyles((theme) => ({
   }),
 }))
 
+const toComparableId = (value) => {
+  if (value === undefined || value === null) {
+    return null
+  }
+
+  return String(value)
+}
+
+const recordMatchesId = (candidate, value) => {
+  if (!candidate) {
+    return false
+  }
+
+  const comparable = toComparableId(value)
+  if (comparable === null) {
+    return false
+  }
+
+  const candidateIds = [
+    toComparableId(candidate.id),
+    toComparableId(candidate.mediaFileId),
+  ]
+
+  return candidateIds.some((id) => id !== null && id === comparable)
+}
+
+const extractTrackId = (candidate) => {
+  if (!candidate || candidate.missing) {
+    return null
+  }
+
+  return candidate.mediaFileId ?? candidate.id ?? null
+}
+
 const DiscSubtitleRow = forwardRef(
   ({ record, onClick, colSpan, contextAlwaysVisible }, ref) => {
     const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
@@ -151,7 +184,10 @@ export const SongDatagridRow = ({
     isValidElement(c),
   )
 
-  const { selectedIds = [], data: listData } = useListContext() || {}
+  const listContext = useListContext()
+  const selectedIds = listContext?.selectedIds ?? []
+  const listData = listContext?.data
+  const listIds = listContext?.ids ?? []
 
   const getRecordFromList = useCallback(
     (recordId) => {
@@ -160,71 +196,156 @@ export const SongDatagridRow = ({
       }
 
       if (Array.isArray(listData)) {
-        return listData.find((item) => {
-          const itemId = item?.id
-          return itemId === recordId || String(itemId) === String(recordId)
-        })
+        return listData.find((item) => recordMatchesId(item, recordId)) || null
       }
 
-      const keysToCheck = [recordId, String(recordId)]
+      const comparable = toComparableId(recordId)
+      const keysToCheck = []
+
+      if (comparable !== null) {
+        keysToCheck.push(comparable)
+      }
+
       if (typeof recordId === 'string' || typeof recordId === 'number') {
         const numericId = Number(recordId)
         if (!Number.isNaN(numericId)) {
-          keysToCheck.push(numericId)
+          const numericComparable = toComparableId(numericId)
+          if (numericComparable !== null) {
+            keysToCheck.push(numericComparable)
+          }
         }
       }
 
       for (const key of keysToCheck) {
-        if (key in listData) {
+        if (key in listData && listData[key]) {
           return listData[key]
         }
       }
 
-      return null
+      const values = Object.values(listData)
+      return values.find((item) => recordMatchesId(item, recordId)) || null
     },
     [listData],
   )
 
-  const getRecordTrackId = useCallback(
+  const ensureRecordForId = useCallback(
     (recordId) => {
-      const item = getRecordFromList(recordId)
-      if (item?.missing) {
+      if (recordId == null) {
         return null
       }
-      return item?.mediaFileId || item?.id || recordId
+
+      const fromList = getRecordFromList(recordId)
+      if (fromList) {
+        return fromList
+      }
+
+      if (recordMatchesId(record, recordId)) {
+        return record
+      }
+
+      return null
     },
-    [getRecordFromList],
+    [getRecordFromList, record],
   )
 
   const selectionIncludesRecord = useMemo(() => {
-    if (!Array.isArray(selectedIds) || record?.id == null) {
+    if (!Array.isArray(selectedIds) || selectedIds.length === 0) {
       return false
     }
 
-    return selectedIds.some((id) => String(id) === String(record.id))
-  }, [record?.id, selectedIds])
+    const possibleMatches = new Set()
 
-  const getDraggedSongIds = useCallback(() => {
-    const baseId =
-      getRecordTrackId(record?.id) || record?.mediaFileId || record?.id
-    if (!baseId) {
+    const recordComparableId = toComparableId(record?.id)
+    if (recordComparableId !== null) {
+      possibleMatches.add(recordComparableId)
+    }
+
+    const recordComparableMediaId = toComparableId(record?.mediaFileId)
+    if (recordComparableMediaId !== null) {
+      possibleMatches.add(recordComparableMediaId)
+    }
+
+    if (possibleMatches.size === 0) {
+      return false
+    }
+
+    return selectedIds.some((id) => {
+      const comparable = toComparableId(id)
+      return comparable !== null && possibleMatches.has(comparable)
+    })
+  }, [record?.id, record?.mediaFileId, selectedIds])
+
+  const resolveDraggedSongIds = useCallback(() => {
+    const baseTrackId = extractTrackId(record)
+    if (!baseTrackId) {
       return []
     }
 
     if (
-      Array.isArray(selectedIds) &&
-      selectedIds.length > 1 &&
-      selectionIncludesRecord
+      !Array.isArray(selectedIds) ||
+      selectedIds.length < 2 ||
+      !selectionIncludesRecord
     ) {
-      const idsFromSelection = selectedIds
-        .map((id) => getRecordTrackId(id))
-        .filter(Boolean)
-
-      return Array.from(new Set(idsFromSelection))
+      return [baseTrackId]
     }
 
-    return [baseId]
-  }, [getRecordTrackId, record?.id, record?.mediaFileId, selectedIds, selectionIncludesRecord])
+    const selectedComparables = new Set(
+      selectedIds
+        .map((id) => toComparableId(id))
+        .filter((id) => id !== null),
+    )
+
+    if (selectedComparables.size === 0) {
+      return [baseTrackId]
+    }
+
+    const orderSource =
+      Array.isArray(listIds) && listIds.length > 0 ? listIds : selectedIds
+
+    const collected = []
+    const seen = new Set()
+
+    const pushRecord = (candidate) => {
+      const trackId = extractTrackId(candidate)
+      if (!trackId) {
+        return
+      }
+
+      const comparable = toComparableId(trackId)
+      if (comparable === null || seen.has(comparable)) {
+        return
+      }
+
+      seen.add(comparable)
+      collected.push(trackId)
+    }
+
+    orderSource.forEach((id) => {
+      const comparable = toComparableId(id)
+      if (comparable === null || !selectedComparables.has(comparable)) {
+        return
+      }
+
+      const candidate = ensureRecordForId(id)
+      pushRecord(candidate)
+    })
+
+    if (collected.length === 0) {
+      pushRecord(record)
+    }
+
+    if (collected.length === 0) {
+      return [baseTrackId]
+    }
+
+    return collected
+  }, [
+    ensureRecordForId,
+    listIds,
+    record,
+    selectedIds,
+    selectionIncludesRecord,
+  ])
 
   const [, dragDiscRef] = useDrag(
     () => ({
@@ -243,16 +364,13 @@ export const SongDatagridRow = ({
   )
 
   const [, dragSongRef] = useDrag(
-    () => {
-      const draggedSongIds = getDraggedSongIds()
-      return {
-        type: DraggableTypes.SONG,
-        canDrag: draggedSongIds.length > 0,
-        item: { ids: draggedSongIds },
-        options: { dropEffect: 'copy' },
-      }
-    },
-    [getDraggedSongIds],
+    () => ({
+      type: DraggableTypes.SONG,
+      item: () => ({ ids: resolveDraggedSongIds() }),
+      canDrag: () => resolveDraggedSongIds().length > 0,
+      options: { dropEffect: 'copy' },
+    }),
+    [resolveDraggedSongIds],
   )
 
   if (!record || !record.title) {


### PR DESCRIPTION
## Summary
- include the list selection in the song drag payload
- skip missing tracks when preparing dragged ids so only playable songs are dropped

## Testing
- npm --prefix ui test *(fails: existing react-admin mock used by AppBar tests is missing useNotify export)*

------
https://chatgpt.com/codex/tasks/task_e_68fd4497edf4833093da725fd766da95