### PR TITLE
Allow dragging multi-selected songs into playlists

### DIFF
--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -166,13 +166,81 @@ export const SongDatagridRow = ({
     [record],
   )
 
+  const resourceName = rest?.resource
+  const selectedIds = useSelector(
+    (state) =>
+      (resourceName &&
+        state?.admin?.resources?.[resourceName]?.list?.selectedIds) ||
+      [],
+  )
+  const resourceRecords = useSelector(
+    (state) =>
+      (resourceName && state?.admin?.resources?.[resourceName]?.data) || {},
+  )
+
+  const recordId = record?.id
+  const trackId = record?.mediaFileId || recordId
+
+  const getDragTrackIds = useCallback(() => {
+    const selection = Array.isArray(selectedIds) ? selectedIds : []
+    const isSelected = recordId != null && selection.includes(recordId)
+    const baseIds = isSelected ? selection : [recordId]
+    const seen = new Set()
+    const ids = []
+
+    baseIds.forEach((id) => {
+      if (id == null) {
+        return
+      }
+      const dataRecord = resourceRecords?.[id]
+      const value =
+        dataRecord?.mediaFileId || dataRecord?.id || (id === recordId ? trackId : id)
+      if (!value || seen.has(value)) {
+        return
+      }
+      seen.add(value)
+      ids.push(value)
+    })
+
+    if (!ids.length && trackId && !seen.has(trackId)) {
+      ids.push(trackId)
+    }
+
+    return ids
+  }, [selectedIds, recordId, resourceRecords, trackId])
+
   const [, dragSongRef] = useDrag(
     () => ({
       type: DraggableTypes.SONG,
-      item: { ids: [record?.mediaFileId || record?.id] },
+      item: () => ({ ids: getDragTrackIds() }),
       options: { dropEffect: 'copy' },
     }),
-    [record],
+    [getDragTrackIds],
+  )
+
+  const handleDragStart = useCallback(
+    (event) => {
+      if (!event?.dataTransfer) {
+        return
+      }
+      const ids = Array.from(new Set(getDragTrackIds()?.filter(Boolean) || []))
+      if (!ids.length) {
+        return
+      }
+      const payload = { kind: 'tracks', ids }
+      try {
+        event.dataTransfer.setData(
+          'application/x-navidrome-tracks',
+          JSON.stringify(payload),
+        )
+      } catch (error) {
+        // Ignore serialization errors and fall back to text/plain
+      }
+      event.dataTransfer.setData('text/plain', ids.join(','))
+      // multi-select drag payload: include all selected track IDs
+      event.dataTransfer.effectAllowed = 'copy'
+    },
+    [getDragTrackIds],
   )
 
   if (!record || !record.title) {
@@ -208,6 +276,7 @@ export const SongDatagridRow = ({
         {...rest}
         rowClick={rowClick}
         className={computedClasses}
+        onDragStart={handleDragStart}
       >
         {fields}
       </PureDatagridRow>

--- a/ui/src/layout/PlaylistsSubMenu.jsx
+++ b/ui/src/layout/PlaylistsSubMenu.jsx
@@ -158,28 +158,162 @@ const PlaylistMenuItemLink = memo(({ pls, depth = 0 }) => {
 
   const parentIdForDnD = pls.parent_id ?? ''
 
+  const handledNativeTracksRef = useRef(null)
+
+  const submitAddPayload = useCallback(
+    async (payload) => {
+      return dataProvider
+        .addToPlaylist(pls.id, payload)
+        .then((res) =>
+          notify('message.songsAddedToPlaylist', 'info', {
+            smart_count: res?.data?.added,
+          }),
+        )
+        .catch(() => notify('ra.page.error', 'warning'))
+    },
+    [dataProvider, notify, pls.id],
+  )
+
+  const addTrackIdsToPlaylist = useCallback(
+    async (ids) => {
+      const normalized = Array.from(
+        new Set((Array.isArray(ids) ? ids : []).filter(Boolean)),
+      )
+      if (!normalized.length) {
+        return
+      }
+
+      let payload = { ids: normalized }
+      try {
+        const filtered = await filterSongDropPayload(pls.id, payload)
+        if (!filtered) {
+          notify('Skipped duplicate song.', { type: 'info' })
+          return
+        }
+        payload = filtered
+      } catch (error) {
+        // Ignore filter errors and let the backend handle any duplicates
+      }
+
+      return submitAddPayload(payload)
+    },
+    [notify, pls.id, submitAddPayload],
+  )
+
+  const hasTrackData = useCallback((dt) => {
+    const types = Array.from(dt?.types || [])
+    return (
+      types.includes('application/x-navidrome-tracks') || types.includes('text/plain')
+    )
+  }, [])
+
+  const extractTrackIdsFromDataTransfer = useCallback((dt) => {
+    if (!dt) {
+      return []
+    }
+
+    let parsedIds = []
+    const jsonPayload = dt.getData('application/x-navidrome-tracks')
+    if (jsonPayload) {
+      try {
+        const parsed = JSON.parse(jsonPayload)
+        if (parsed?.kind === 'tracks' && Array.isArray(parsed?.ids)) {
+          parsedIds = parsed.ids
+        }
+      } catch (error) {
+        // Ignore malformed JSON payloads and fall back to text/plain
+      }
+    }
+
+    if (!parsedIds.length) {
+      const textPayload = dt.getData('text/plain')
+      if (textPayload) {
+        parsedIds = textPayload
+          .split(',')
+          .map((id) => id.trim())
+          .filter(Boolean)
+      }
+    }
+
+    const seen = new Set()
+    const deduped = []
+    parsedIds.forEach((id) => {
+      if (!id || seen.has(id)) {
+        return
+      }
+      seen.add(id)
+      deduped.push(id)
+    })
+
+    return deduped
+  }, [])
+
+  const handleNativeDragOver = useCallback(
+    (event) => {
+      if (!hasTrackData(event?.dataTransfer)) {
+        return
+      }
+      event.preventDefault()
+      event.dataTransfer.dropEffect = 'copy'
+    },
+    [hasTrackData],
+  )
+
+  const handleNativeDrop = useCallback(
+    async (event) => {
+      const dt = event?.dataTransfer
+      if (!dt || !hasTrackData(dt)) {
+        return
+      }
+
+      const ids = extractTrackIdsFromDataTransfer(dt)
+      if (!ids.length) {
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+      dt.dropEffect = 'copy'
+      // playlist drop: parse JSON payload of track IDs and add in batch
+      handledNativeTracksRef.current = ids
+      try {
+        await addTrackIdsToPlaylist(ids)
+      } finally {
+        // Keep reference for React DnD drop handler to avoid duplicate inserts
+      }
+    },
+    [addTrackIdsToPlaylist, extractTrackIdsFromDataTransfer, hasTrackData],
+  )
+
   const handleDrop = useCallback(
-    async (item) => {
-      let payload = item
-      if (Array.isArray(item?.ids) && item.ids.length) {
-        try {
-          const filtered = await filterSongDropPayload(pls.id, item)
-          if (!filtered) {
-            notify('Skipped duplicate song.', { type: 'info' })
-            return
-          }
-          payload = filtered
-        } catch (error) {
-          // Ignore filter errors and let the backend handle any duplicates
+    async (item, monitor) => {
+      const itemType = monitor?.getItemType?.()
+
+      if (itemType === DraggableTypes.SONG) {
+        const handledIds = handledNativeTracksRef.current
+        if (
+          handledIds &&
+          Array.isArray(item?.ids) &&
+          handledIds.length === item.ids.length &&
+          handledIds.every((id, index) => id === item.ids[index])
+        ) {
+          handledNativeTracksRef.current = null
+          return
+        }
+        handledNativeTracksRef.current = null
+
+        if (Array.isArray(item?.ids) && item.ids.length) {
+          return addTrackIdsToPlaylist(item.ids)
         }
       }
 
-      return dataProvider
-        .addToPlaylist(pls.id, payload)
-        .then((res) => notify('message.songsAddedToPlaylist', 'info', { smart_count: res?.data?.added }))
-        .catch(() => notify('ra.page.error', 'warning'))
+      if (Array.isArray(item?.ids) && item.ids.length) {
+        return addTrackIdsToPlaylist(item.ids)
+      }
+
+      return submitAddPayload(item)
     },
-    [dataProvider, notify, pls.id]
+    [addTrackIdsToPlaylist, submitAddPayload],
   )
 
   const { dragDropRef, isDragging } = useDragAndDrop(
@@ -196,6 +330,8 @@ const PlaylistMenuItemLink = memo(({ pls, depth = 0 }) => {
       className={`${classes.listItem} ${classes.depth}`}
       ref={dragDropRef}
       style={{ opacity: isDragging ? 0.5 : 1 }}
+      onDragOver={handleNativeDragOver}
+      onDrop={handleNativeDrop}
     >
       <span className={classes.spacer} />
       <ListItemIcon className={classes.listItemIcon}><RiPlayListFill /></ListItemIcon>


### PR DESCRIPTION
## Summary
- include the full song selection when starting a drag from the songs datagrid and expose the IDs via HTML5 dataTransfer
- update playlist drop targets to read the custom drag payload, batch add all tracks, and avoid duplicate additions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd4540a6a483309461557b3cca3606