### PR TITLE
Allow dragging multi-selected songs into playlists

### DIFF
--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -1,4 +1,12 @@
-import React, { isValidElement, useMemo, useCallback, forwardRef } from 'react'
+import React, {
+  isValidElement,
+  useMemo,
+  useCallback,
+  forwardRef,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import {
   Datagrid,
@@ -34,7 +42,8 @@ const useStyles = makeStyles((theme) => ({
     marginRight: '4px',
   },
   row: {
-    cursor: 'pointer',
+    cursor: 'grab',
+    WebkitUserDrag: 'element',
     // ↓ shrink row height by reducing vertical padding on all table cells
     '& td, & th, & .MuiTableCell-root': {
       paddingTop: 3,
@@ -73,6 +82,10 @@ const useStyles = makeStyles((theme) => ({
       pointerEvents: 'none',
     },
   },
+  rowDragging: {
+    cursor: 'grabbing',
+    userSelect: 'none',
+  },
   headerStyle: {
     '& thead': {
       boxShadow: '0px 3px 3px rgba(0, 0, 0, 0.15)',
@@ -85,6 +98,20 @@ const useStyles = makeStyles((theme) => ({
   contextMenu: (props) => ({
     visibility: props?.isDesktop ? 'hidden' : 'visible',
   }),
+  dragPreview: {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    zIndex: 99999,
+    padding: '8px 12px',
+    borderRadius: 8,
+    background: 'rgba(40, 40, 40, 0.92)',
+    color: '#fff',
+    fontSize: 13,
+    lineHeight: 1,
+    boxShadow: '0 6px 24px rgba(0, 0, 0, 0.25)',
+    pointerEvents: 'none',
+  },
 }))
 
 const DiscSubtitleRow = forwardRef(
@@ -149,6 +176,9 @@ export const SongDatagridRow = ({
   const fields = React.Children.toArray(children).filter((c) =>
     isValidElement(c),
   )
+  const [isDragging, setIsDragging] = useState(false)
+  const rowRef = useRef(null)
+  const dragPreviewRef = useRef(null)
 
   const [, dragDiscRef] = useDrag(
     () => ({
@@ -218,8 +248,38 @@ export const SongDatagridRow = ({
     [getDragTrackIds],
   )
 
+  useEffect(() => {
+    const node = rowRef.current
+    if (!node) {
+      return undefined
+    }
+    const interactiveSelector =
+      'button,input,textarea,select,a,[data-no-drag]'
+    const interactiveElements = Array.from(
+      node.querySelectorAll(interactiveSelector),
+    )
+    if (!interactiveElements.length) {
+      return undefined
+    }
+    const handleChildDragStart = (event) => {
+      event.stopPropagation()
+    }
+    interactiveElements.forEach((element) => {
+      element.setAttribute('draggable', 'false')
+      element.addEventListener('dragstart', handleChildDragStart)
+    })
+    return () => {
+      interactiveElements.forEach((element) => {
+        element.removeEventListener('dragstart', handleChildDragStart)
+      })
+    }
+  }, [record?.id])
+
   const handleDragStart = useCallback(
     (event) => {
+      if (event?.target?.closest('button,input,textarea,select,a,[data-no-drag]')) {
+        return
+      }
       if (!event?.dataTransfer) {
         return
       }
@@ -239,8 +299,45 @@ export const SongDatagridRow = ({
       event.dataTransfer.setData('text/plain', ids.join(','))
       // multi-select drag payload: include all selected track IDs
       event.dataTransfer.effectAllowed = 'copy'
+
+      const label =
+        ids.length > 1 ? `${ids.length} items` : record?.title || '1 item'
+      const ghost = document.createElement('div')
+      ghost.className = classes.dragPreview
+      ghost.textContent = label
+      document.body.appendChild(ghost)
+      dragPreviewRef.current = ghost
+      if (typeof event.dataTransfer.setDragImage === 'function') {
+        const { width, height } = ghost.getBoundingClientRect()
+        event.dataTransfer.setDragImage(ghost, width / 2, height / 2)
+      }
+      setTimeout(() => {
+        if (dragPreviewRef.current === ghost) {
+          ghost.remove()
+          dragPreviewRef.current = null
+        }
+      }, 0)
+      setIsDragging(true)
     },
-    [getDragTrackIds],
+    [classes.dragPreview, getDragTrackIds, record?.title],
+  )
+
+  const handleDragEnd = useCallback(() => {
+    if (dragPreviewRef.current) {
+      dragPreviewRef.current.remove()
+      dragPreviewRef.current = null
+    }
+    setIsDragging(false)
+  }, [dragPreviewRef])
+
+  const setRowRef = useCallback(
+    (node) => {
+      rowRef.current = node
+      if (!record?.missing) {
+        dragSongRef(node)
+      }
+    },
+    [dragSongRef, record?.missing],
   )
 
   if (!record || !record.title) {
@@ -257,6 +354,7 @@ export const SongDatagridRow = ({
     classes.row,
     record.missing && classes.missingRow,
     isCurrent && classes.currentRow,
+    isDragging && classes.rowDragging,
   )
   const childCount = fields.length
   return (
@@ -271,12 +369,14 @@ export const SongDatagridRow = ({
         />
       )}
       <PureDatagridRow
-        ref={record?.missing ? undefined : dragSongRef}
+        ref={setRowRef}
         record={record}
         {...rest}
         rowClick={rowClick}
         className={computedClasses}
         onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        draggable={!record?.missing}
       >
         {fields}
       </PureDatagridRow>

--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -86,6 +86,16 @@ const useStyles = makeStyles((theme) => ({
     cursor: 'grabbing',
     userSelect: 'none',
   },
+  // drag-arming state: temporarily block pointer events so the row owns the gesture
+  dragArmed: {
+    userSelect: 'none',
+    '& *': {
+      pointerEvents: 'none',
+    },
+    '& [data-no-drag], & button, & a, & input, & textarea, & select, & [role="menu"], & [role="button"]': {
+      pointerEvents: 'auto',
+    },
+  },
   headerStyle: {
     '& thead': {
       boxShadow: '0px 3px 3px rgba(0, 0, 0, 0.15)',
@@ -112,7 +122,16 @@ const useStyles = makeStyles((theme) => ({
     boxShadow: '0 6px 24px rgba(0, 0, 0, 0.25)',
     pointerEvents: 'none',
   },
+  '@global': {
+    '.nd-global-drag-armed': {
+      userSelect: 'none',
+      WebkitUserSelect: 'none',
+    },
+  },
 }))
+
+const INTERACTIVE_SELECTOR =
+  'button,input,textarea,select,a,[data-no-drag],[role="menu"],[role="button"]'
 
 const DiscSubtitleRow = forwardRef(
   ({ record, onClick, colSpan, contextAlwaysVisible }, ref) => {
@@ -177,8 +196,11 @@ export const SongDatagridRow = ({
     isValidElement(c),
   )
   const [isDragging, setIsDragging] = useState(false)
+  const [isDragArmed, setIsDragArmed] = useState(false)
   const rowRef = useRef(null)
   const dragPreviewRef = useRef(null)
+  const dragArmTimerRef = useRef(null)
+  const mouseUpHandlerRef = useRef(null)
 
   const [, dragDiscRef] = useDrag(
     () => ({
@@ -253,10 +275,8 @@ export const SongDatagridRow = ({
     if (!node) {
       return undefined
     }
-    const interactiveSelector =
-      'button,input,textarea,select,a,[data-no-drag]'
     const interactiveElements = Array.from(
-      node.querySelectorAll(interactiveSelector),
+      node.querySelectorAll(INTERACTIVE_SELECTOR),
     )
     if (!interactiveElements.length) {
       return undefined
@@ -275,14 +295,86 @@ export const SongDatagridRow = ({
     }
   }, [record?.id])
 
+  const clearArmTimer = useCallback(() => {
+    if (dragArmTimerRef.current) {
+      clearTimeout(dragArmTimerRef.current)
+      dragArmTimerRef.current = null
+    }
+  }, [])
+
+  const disarmDrag = useCallback(() => {
+    clearArmTimer()
+    if (mouseUpHandlerRef.current) {
+      window.removeEventListener('mouseup', mouseUpHandlerRef.current, true)
+      mouseUpHandlerRef.current = null
+    }
+    setIsDragArmed((prev) => (prev ? false : prev))
+  }, [clearArmTimer])
+
+  const armDrag = useCallback(() => {
+    clearArmTimer()
+    setIsDragArmed(true)
+    dragArmTimerRef.current = window.setTimeout(() => {
+      disarmDrag()
+    }, 1000)
+  }, [clearArmTimer, disarmDrag])
+
+  useEffect(() => {
+    if (!isDragArmed) {
+      return undefined
+    }
+    document.body.classList.add('nd-global-drag-armed')
+    return () => {
+      document.body.classList.remove('nd-global-drag-armed')
+    }
+  }, [isDragArmed])
+
+  useEffect(
+    () => () => {
+      clearArmTimer()
+      if (mouseUpHandlerRef.current) {
+        window.removeEventListener('mouseup', mouseUpHandlerRef.current, true)
+        mouseUpHandlerRef.current = null
+      }
+      document.body.classList.remove('nd-global-drag-armed')
+    },
+    [clearArmTimer],
+  )
+
+  const isInteractiveTarget = useCallback(
+    (target) => target && target.closest(INTERACTIVE_SELECTOR),
+    [],
+  )
+
+  const handleMouseDown = useCallback(
+    (event) => {
+      if (record?.missing || isInteractiveTarget(event?.target)) {
+        return
+      }
+      // Arm the drag so a light motion immediately starts dragging the row
+      armDrag()
+      if (mouseUpHandlerRef.current) {
+        window.removeEventListener('mouseup', mouseUpHandlerRef.current, true)
+        mouseUpHandlerRef.current = null
+      }
+      const handleMouseUp = () => {
+        disarmDrag()
+      }
+      mouseUpHandlerRef.current = handleMouseUp
+      window.addEventListener('mouseup', handleMouseUp, true)
+    },
+    [armDrag, disarmDrag, isInteractiveTarget, record?.missing],
+  )
+
   const handleDragStart = useCallback(
     (event) => {
-      if (event?.target?.closest('button,input,textarea,select,a,[data-no-drag]')) {
+      if (isInteractiveTarget(event?.target)) {
         return
       }
       if (!event?.dataTransfer) {
         return
       }
+      clearArmTimer()
       const ids = Array.from(new Set(getDragTrackIds()?.filter(Boolean) || []))
       if (!ids.length) {
         return
@@ -319,7 +411,13 @@ export const SongDatagridRow = ({
       }, 0)
       setIsDragging(true)
     },
-    [classes.dragPreview, getDragTrackIds, record?.title],
+    [
+      classes.dragPreview,
+      clearArmTimer,
+      getDragTrackIds,
+      isInteractiveTarget,
+      record?.title,
+    ],
   )
 
   const handleDragEnd = useCallback(() => {
@@ -328,7 +426,8 @@ export const SongDatagridRow = ({
       dragPreviewRef.current = null
     }
     setIsDragging(false)
-  }, [dragPreviewRef])
+    disarmDrag()
+  }, [disarmDrag])
 
   const setRowRef = useCallback(
     (node) => {
@@ -355,6 +454,7 @@ export const SongDatagridRow = ({
     record.missing && classes.missingRow,
     isCurrent && classes.currentRow,
     isDragging && classes.rowDragging,
+    isDragArmed && classes.dragArmed,
   )
   const childCount = fields.length
   return (
@@ -374,6 +474,7 @@ export const SongDatagridRow = ({
         {...rest}
         rowClick={rowClick}
         className={computedClasses}
+        onMouseDown={handleMouseDown}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
         draggable={!record?.missing}

--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -166,13 +166,81 @@ export const SongDatagridRow = ({
     [record],
   )
 
+  const resourceName = rest?.resource
+  const selectedIds = useSelector(
+    (state) =>
+      (resourceName &&
+        state?.admin?.resources?.[resourceName]?.list?.selectedIds) ||
+      [],
+  )
+  const resourceRecords = useSelector(
+    (state) =>
+      (resourceName && state?.admin?.resources?.[resourceName]?.data) || {},
+  )
+
+  const recordId = record?.id
+  const trackId = record?.mediaFileId || recordId
+
+  const getDragTrackIds = useCallback(() => {
+    const selection = Array.isArray(selectedIds) ? selectedIds : []
+    const isSelected = recordId != null && selection.includes(recordId)
+    const baseIds = isSelected ? selection : [recordId]
+    const seen = new Set()
+    const ids = []
+
+    baseIds.forEach((id) => {
+      if (id == null) {
+        return
+      }
+      const dataRecord = resourceRecords?.[id]
+      const value =
+        dataRecord?.mediaFileId || dataRecord?.id || (id === recordId ? trackId : id)
+      if (!value || seen.has(value)) {
+        return
+      }
+      seen.add(value)
+      ids.push(value)
+    })
+
+    if (!ids.length && trackId && !seen.has(trackId)) {
+      ids.push(trackId)
+    }
+
+    return ids
+  }, [selectedIds, recordId, resourceRecords, trackId])
+
   const [, dragSongRef] = useDrag(
     () => ({
       type: DraggableTypes.SONG,
-      item: { ids: [record?.mediaFileId || record?.id] },
+      item: () => ({ ids: getDragTrackIds() }),
       options: { dropEffect: 'copy' },
     }),
-    [record],
+    [getDragTrackIds],
+  )
+
+  const handleDragStart = useCallback(
+    (event) => {
+      if (!event?.dataTransfer) {
+        return
+      }
+      const ids = Array.from(new Set(getDragTrackIds()?.filter(Boolean) || []))
+      if (!ids.length) {
+        return
+      }
+      const payload = { kind: 'tracks', ids }
+      try {
+        event.dataTransfer.setData(
+          'application/x-navidrome-tracks',
+          JSON.stringify(payload),
+        )
+      } catch (error) {
+        // Ignore serialization errors and fall back to text/plain
+      }
+      event.dataTransfer.setData('text/plain', ids.join(','))
+      // multi-select drag payload: include all selected track IDs
+      event.dataTransfer.effectAllowed = 'copy'
+    },
+    [getDragTrackIds],
   )
 
   if (!record || !record.title) {
@@ -208,6 +276,7 @@ export const SongDatagridRow = ({
         {...rest}
         rowClick={rowClick}
         className={computedClasses}
+        onDragStart={handleDragStart}
       >
         {fields}
       </PureDatagridRow>

--- a/ui/src/layout/PlaylistsSubMenu.jsx
+++ b/ui/src/layout/PlaylistsSubMenu.jsx
@@ -158,28 +158,162 @@ const PlaylistMenuItemLink = memo(({ pls, depth = 0 }) => {
 
   const parentIdForDnD = pls.parent_id ?? ''
 
+  const handledNativeTracksRef = useRef(null)
+
+  const submitAddPayload = useCallback(
+    async (payload) => {
+      return dataProvider
+        .addToPlaylist(pls.id, payload)
+        .then((res) =>
+          notify('message.songsAddedToPlaylist', 'info', {
+            smart_count: res?.data?.added,
+          }),
+        )
+        .catch(() => notify('ra.page.error', 'warning'))
+    },
+    [dataProvider, notify, pls.id],
+  )
+
+  const addTrackIdsToPlaylist = useCallback(
+    async (ids) => {
+      const normalized = Array.from(
+        new Set((Array.isArray(ids) ? ids : []).filter(Boolean)),
+      )
+      if (!normalized.length) {
+        return
+      }
+
+      let payload = { ids: normalized }
+      try {
+        const filtered = await filterSongDropPayload(pls.id, payload)
+        if (!filtered) {
+          notify('Skipped duplicate song.', { type: 'info' })
+          return
+        }
+        payload = filtered
+      } catch (error) {
+        // Ignore filter errors and let the backend handle any duplicates
+      }
+
+      return submitAddPayload(payload)
+    },
+    [notify, pls.id, submitAddPayload],
+  )
+
+  const hasTrackData = useCallback((dt) => {
+    const types = Array.from(dt?.types || [])
+    return (
+      types.includes('application/x-navidrome-tracks') || types.includes('text/plain')
+    )
+  }, [])
+
+  const extractTrackIdsFromDataTransfer = useCallback((dt) => {
+    if (!dt) {
+      return []
+    }
+
+    let parsedIds = []
+    const jsonPayload = dt.getData('application/x-navidrome-tracks')
+    if (jsonPayload) {
+      try {
+        const parsed = JSON.parse(jsonPayload)
+        if (parsed?.kind === 'tracks' && Array.isArray(parsed?.ids)) {
+          parsedIds = parsed.ids
+        }
+      } catch (error) {
+        // Ignore malformed JSON payloads and fall back to text/plain
+      }
+    }
+
+    if (!parsedIds.length) {
+      const textPayload = dt.getData('text/plain')
+      if (textPayload) {
+        parsedIds = textPayload
+          .split(',')
+          .map((id) => id.trim())
+          .filter(Boolean)
+      }
+    }
+
+    const seen = new Set()
+    const deduped = []
+    parsedIds.forEach((id) => {
+      if (!id || seen.has(id)) {
+        return
+      }
+      seen.add(id)
+      deduped.push(id)
+    })
+
+    return deduped
+  }, [])
+
+  const handleNativeDragOver = useCallback(
+    (event) => {
+      if (!hasTrackData(event?.dataTransfer)) {
+        return
+      }
+      event.preventDefault()
+      event.dataTransfer.dropEffect = 'copy'
+    },
+    [hasTrackData],
+  )
+
+  const handleNativeDrop = useCallback(
+    async (event) => {
+      const dt = event?.dataTransfer
+      if (!dt || !hasTrackData(dt)) {
+        return
+      }
+
+      const ids = extractTrackIdsFromDataTransfer(dt)
+      if (!ids.length) {
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+      dt.dropEffect = 'copy'
+      // playlist drop: parse JSON payload of track IDs and add in batch
+      handledNativeTracksRef.current = ids
+      try {
+        await addTrackIdsToPlaylist(ids)
+      } finally {
+        // Keep reference for React DnD drop handler to avoid duplicate inserts
+      }
+    },
+    [addTrackIdsToPlaylist, extractTrackIdsFromDataTransfer, hasTrackData],
+  )
+
   const handleDrop = useCallback(
-    async (item) => {
-      let payload = item
-      if (Array.isArray(item?.ids) && item.ids.length) {
-        try {
-          const filtered = await filterSongDropPayload(pls.id, item)
-          if (!filtered) {
-            notify('Skipped duplicate song.', { type: 'info' })
-            return
-          }
-          payload = filtered
-        } catch (error) {
-          // Ignore filter errors and let the backend handle any duplicates
+    async (item, monitor) => {
+      const itemType = monitor?.getItemType?.()
+
+      if (itemType === DraggableTypes.SONG) {
+        const handledIds = handledNativeTracksRef.current
+        if (
+          handledIds &&
+          Array.isArray(item?.ids) &&
+          handledIds.length === item.ids.length &&
+          handledIds.every((id, index) => id === item.ids[index])
+        ) {
+          handledNativeTracksRef.current = null
+          return
+        }
+        handledNativeTracksRef.current = null
+
+        if (Array.isArray(item?.ids) && item.ids.length) {
+          return addTrackIdsToPlaylist(item.ids)
         }
       }
 
-      return dataProvider
-        .addToPlaylist(pls.id, payload)
-        .then((res) => notify('message.songsAddedToPlaylist', 'info', { smart_count: res?.data?.added }))
-        .catch(() => notify('ra.page.error', 'warning'))
+      if (Array.isArray(item?.ids) && item.ids.length) {
+        return addTrackIdsToPlaylist(item.ids)
+      }
+
+      return submitAddPayload(item)
     },
-    [dataProvider, notify, pls.id]
+    [addTrackIdsToPlaylist, submitAddPayload],
   )
 
   const { dragDropRef, isDragging } = useDragAndDrop(
@@ -196,6 +330,8 @@ const PlaylistMenuItemLink = memo(({ pls, depth = 0 }) => {
       className={`${classes.listItem} ${classes.depth}`}
       ref={dragDropRef}
       style={{ opacity: isDragging ? 0.5 : 1 }}
+      onDragOver={handleNativeDragOver}
+      onDrop={handleNativeDrop}
     >
       <span className={classes.spacer} />
       <ListItemIcon className={classes.listItemIcon}><RiPlayListFill /></ListItemIcon>


### PR DESCRIPTION
## Summary
- include the full song selection when starting a drag from the songs datagrid and expose the IDs via HTML5 dataTransfer
- update playlist drop targets to read the custom drag payload, batch add all tracks, and avoid duplicate additions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd4540a6a483309461557b3cca3606