### PR TITLE
Prevent text selection from interfering with song drag

### DIFF
--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -213,7 +213,23 @@ export const SongDatagridRow = ({
   )
 
   const recordId = record?.id
-  const trackId = record?.mediaFileId || recordId
+  const resolveTrackId = useCallback((maybeRecord, fallbackId) => {
+    if (!maybeRecord) {
+      return fallbackId
+    }
+
+    const mediaFile = maybeRecord.mediaFile || {}
+
+    return (
+      maybeRecord.mediaFileId ||
+      maybeRecord.mediaFileID ||
+      mediaFile.id ||
+      maybeRecord.songId ||
+      fallbackId
+    )
+  }, [])
+
+  const trackId = resolveTrackId(record, recordId)
 
   const getDragTrackIds = useCallback(() => {
     const selection = Array.isArray(selectedIds) ? selectedIds : []
@@ -227,8 +243,10 @@ export const SongDatagridRow = ({
         return
       }
       const dataRecord = resourceRecords?.[id]
-      const value =
-        dataRecord?.mediaFileId || dataRecord?.id || (id === recordId ? trackId : id)
+      const value = resolveTrackId(
+        dataRecord,
+        id === recordId ? trackId : resolveTrackId(record, id),
+      )
       if (!value || seen.has(value)) {
         return
       }
@@ -241,7 +259,14 @@ export const SongDatagridRow = ({
     }
 
     return ids
-  }, [selectedIds, recordId, resourceRecords, trackId])
+  }, [
+    selectedIds,
+    recordId,
+    resourceRecords,
+    trackId,
+    resolveTrackId,
+    record,
+  ])
 
   const [, dragSongRef] = useDrag(
     () => ({

--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -44,6 +44,10 @@ const useStyles = makeStyles((theme) => ({
   row: {
     cursor: 'grab',
     WebkitUserDrag: 'element',
+    userSelect: 'none',
+    WebkitUserSelect: 'none',
+    MozUserSelect: 'none',
+    msUserSelect: 'none',
     // ↓ shrink row height by reducing vertical padding on all table cells
     '& td, & th, & .MuiTableCell-root': {
       paddingTop: 3,
@@ -253,14 +257,23 @@ export const SongDatagridRow = ({
     if (!node) {
       return undefined
     }
+    const preventTextSelection = (event) => {
+      if (
+        event?.target?.closest(
+          'button,input,textarea,select,a,[data-no-drag]',
+        )
+      ) {
+        return
+      }
+      event.preventDefault()
+    }
+    node.addEventListener('selectstart', preventTextSelection)
+
     const interactiveSelector =
       'button,input,textarea,select,a,[data-no-drag]'
     const interactiveElements = Array.from(
       node.querySelectorAll(interactiveSelector),
     )
-    if (!interactiveElements.length) {
-      return undefined
-    }
     const handleChildDragStart = (event) => {
       event.stopPropagation()
     }
@@ -269,6 +282,7 @@ export const SongDatagridRow = ({
       element.addEventListener('dragstart', handleChildDragStart)
     })
     return () => {
+      node.removeEventListener('selectstart', preventTextSelection)
       interactiveElements.forEach((element) => {
         element.removeEventListener('dragstart', handleChildDragStart)
       })


### PR DESCRIPTION
## Summary
- add vendor-specific user-select fallbacks to draggable song rows
- block selectstart on song rows to keep multi-selection drags responsive

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd618bfea08330834c678e8a5f35a0