### PR TITLE
Refine mobile song and playlist views

### DIFF
--- a/ui/src/common/SongSimpleList.jsx
+++ b/ui/src/common/SongSimpleList.jsx
@@ -40,6 +40,9 @@ const useStyles = makeStyles(
       paddingRight: '10px',
       width: '80%',
     },
+    mobileTitle: {
+      width: '100%',
+    },
     secondary: {
       marginTop: '-3px',
       width: '96%',
@@ -64,13 +67,13 @@ const useStyles = makeStyles(
     mobilePrimary: {
       fontWeight: theme.typography.fontWeightMedium,
       color: theme.palette.text.primary,
-      display: 'block',
+      display: 'inline',
     },
     mobileArtist: {
-      display: 'block',
+      display: 'inline',
       color: theme.palette.text.secondary,
       fontSize: '0.875rem',
-      marginTop: theme.spacing(0.5),
+      marginLeft: theme.spacing(1),
     },
   }),
   { name: 'RaSongSimpleList' },
@@ -166,18 +169,25 @@ export const SongSimpleList = ({
                       <div
                         className={clsx(
                           classes.title,
-                          isMobile && classes.mobilePrimary,
+                          isMobile && classes.mobileTitle,
                         )}
                       >
-                        {data[id].title}
+                        {isMobile ? (
+                          <>
+                            <span className={classes.mobilePrimary}>
+                              {data[id].title}
+                            </span>
+                            <span className={classes.mobileArtist}>
+                              {data[id].artist}
+                            </span>
+                          </>
+                        ) : (
+                          data[id].title
+                        )}
                       </div>
                     }
                     secondary={
-                      isMobile ? (
-                        <span className={classes.mobileArtist}>
-                          {data[id].artist}
-                        </span>
-                      ) : (
+                      isMobile ? undefined : (
                         <>
                           <span className={classes.secondary}>
                             <span className={classes.artist}>

--- a/ui/src/common/SongSimpleList.jsx
+++ b/ui/src/common/SongSimpleList.jsx
@@ -5,6 +5,7 @@ import ListItem from '@material-ui/core/ListItem'
 import ListItemIcon from '@material-ui/core/ListItemIcon'
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
 import ListItemText from '@material-ui/core/ListItemText'
+import clsx from 'clsx'
 import { makeStyles } from '@material-ui/core/styles'
 import { sanitizeListRestProps } from 'react-admin'
 import { DurationField, SongContextMenu, RatingField } from './index'
@@ -20,6 +21,7 @@ const useStyles = makeStyles(
     },
     listItem: {
       padding: '10px',
+      alignItems: 'flex-start',
     },
     currentRowMobile: {
       backgroundColor: theme.palette.action.hover,
@@ -58,6 +60,17 @@ const useStyles = makeStyles(
     },
     rightIcon: {
       top: '26px',
+    },
+    mobilePrimary: {
+      fontWeight: theme.typography.fontWeightMedium,
+      color: theme.palette.text.primary,
+      display: 'block',
+    },
+    mobileArtist: {
+      display: 'block',
+      color: theme.palette.text.secondary,
+      fontSize: '0.875rem',
+      marginTop: theme.spacing(0.5),
     },
   }),
   { name: 'RaSongSimpleList' },
@@ -150,37 +163,52 @@ export const SongSimpleList = ({
                 >
                   <ListItemText
                     primary={
-                      <div className={classes.title}>{data[id].title}</div>
+                      <div
+                        className={clsx(
+                          classes.title,
+                          isMobile && classes.mobilePrimary,
+                        )}
+                      >
+                        {data[id].title}
+                      </div>
                     }
                     secondary={
-                      <>
-                        <span className={classes.secondary}>
-                          <span className={classes.artist}>
-                            {data[id].artist}
-                          </span>
-                          <span className={classes.timeStamp}>
-                            <DurationField
-                              record={data[id]}
-                              source={'duration'}
-                            />
-                          </span>
+                      isMobile ? (
+                        <span className={classes.mobileArtist}>
+                          {data[id].artist}
                         </span>
-                        {config.enableStarRating && (
-                          <RatingField
-                            record={data[id]}
-                            source={'rating'}
-                            resource={'song'}
-                            size={'small'}
-                          />
-                        )}
-                      </>
+                      ) : (
+                        <>
+                          <span className={classes.secondary}>
+                            <span className={classes.artist}>
+                              {data[id].artist}
+                            </span>
+                            <span className={classes.timeStamp}>
+                              <DurationField
+                                record={data[id]}
+                                source={'duration'}
+                              />
+                            </span>
+                          </span>
+                          {config.enableStarRating && (
+                            <RatingField
+                              record={data[id]}
+                              source={'rating'}
+                              resource={'song'}
+                              size={'small'}
+                            />
+                          )}
+                        </>
+                      )
                     }
                   />
-                  <ListItemSecondaryAction className={classes.rightIcon}>
-                    <ListItemIcon>
-                      <SongContextMenu record={data[id]} visible={true} />
-                    </ListItemIcon>
-                  </ListItemSecondaryAction>
+                  {!isMobile && (
+                    <ListItemSecondaryAction className={classes.rightIcon}>
+                      <ListItemIcon>
+                        <SongContextMenu record={data[id]} visible={true} />
+                      </ListItemIcon>
+                    </ListItemSecondaryAction>
+                  )}
                 </ListItem>
               </span>
             ),

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -21,6 +21,7 @@ import {
   SongInfo,
   SongContextMenu,
   SongDatagrid,
+  SongSimpleList,
   SongTitleField,
   QualityInfo,
   useSelectedFields,
@@ -114,6 +115,7 @@ const PlaylistSongs = ({
   const ids = contextIds
   const data = contextData
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
+  const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
   const classes = useStyles({ isDesktop })
   const dispatch = useDispatch()
   const dataProvider = useDataProvider()
@@ -386,27 +388,31 @@ const PlaylistSongs = ({
               />
             </BulkActionsToolbar>
             {showDuplicatesOnly && listContext.loading && <LinearProgress />}
-            <ReorderableList
-              readOnly={readOnly}
-              onDragEnd={handleDragEnd}
-              nodeSelector={'tr'}
-              handleSelector={'.draggable'}
-            >
-              <SongDatagrid
-                rowClick={handleRowClick}
-                {...filteredListContext}
-                hasBulkActions={!readOnly}
-                contextAlwaysVisible={!isDesktop}
-                classes={{ row: classes.row }}
+            {isXsmall ? (
+              <SongSimpleList />
+            ) : (
+              <ReorderableList
+                readOnly={readOnly}
+                onDragEnd={handleDragEnd}
+                nodeSelector={'tr'}
+                handleSelector={'.draggable'}
               >
-                {columns}
-                <SongContextMenu
-                  onAddToPlaylist={onAddToPlaylist}
-                  showLove={true}
-                  className={classes.contextMenu}
-                />
-              </SongDatagrid>
-            </ReorderableList>
+                <SongDatagrid
+                  rowClick={handleRowClick}
+                  {...filteredListContext}
+                  hasBulkActions={!readOnly}
+                  contextAlwaysVisible={!isDesktop}
+                  classes={{ row: classes.row }}
+                >
+                  {columns}
+                  <SongContextMenu
+                    onAddToPlaylist={onAddToPlaylist}
+                    showLove={true}
+                    className={classes.contextMenu}
+                  />
+                </SongDatagrid>
+              </ReorderableList>
+            )}
           </Card>
         </div>
       </ListContextProvider>


### PR DESCRIPTION
## Summary
- simplify the mobile SongSimpleList layout to only show track titles and artists
- render the same simplified list for playlists on extra-small screens while keeping the desktop datagrid unchanged

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fd6a963e6083308078274810c2945e