### PR TITLE
Fix multi-track drag from playlists

### DIFF
--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -363,6 +363,10 @@ const PlaylistSongs = ({
     [dispatch, data, ids],
   )
 
+  // Disable playlist reordering when multiple tracks are selected so the
+  // native drag events can be handled by React DnD for multi-track moves.
+  const isReorderEnabled = !readOnly && selectedIds.length <= 1
+
   return (
     <>
       <ListContextProvider value={filteredListContext}>
@@ -387,7 +391,7 @@ const PlaylistSongs = ({
             </BulkActionsToolbar>
             {showDuplicatesOnly && listContext.loading && <LinearProgress />}
             <ReorderableList
-              readOnly={readOnly}
+              readOnly={!isReorderEnabled}
               onDragEnd={handleDragEnd}
               nodeSelector={'tr'}
               handleSelector={'.draggable'}


### PR DESCRIPTION
## Summary
- disable playlist reordering while multiple playlist tracks are selected so React DnD can handle the drag payload
- keep single-track reorder functionality by re-enabling the drag list view when only one item is selected

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe893dbb3c8330bfde4da0844d8786