### PR TITLE
Fix playlist multi-track drag-and-drop payload

### DIFF
--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -201,16 +201,36 @@ export const SongDatagridRow = ({
   )
 
   const resourceName = rest?.resource
-  const selectedIds = useSelector(
+  const storeSelectedIds = useSelector(
     (state) =>
       (resourceName &&
         state?.admin?.resources?.[resourceName]?.list?.selectedIds) ||
       [],
   )
-  const resourceRecords = useSelector(
+  const storeRecords = useSelector(
     (state) =>
       (resourceName && state?.admin?.resources?.[resourceName]?.data) || {},
   )
+
+  const contextSelectedIds = rest?.selectedIds
+  const contextData = rest?.data
+
+  const selectedIds = useMemo(() => {
+    return Array.isArray(contextSelectedIds) && contextSelectedIds.length
+      ? contextSelectedIds
+      : storeSelectedIds
+  }, [contextSelectedIds, storeSelectedIds])
+
+  const resourceRecords = useMemo(() => {
+    if (
+      contextData &&
+      !Array.isArray(contextData) &&
+      typeof contextData === 'object'
+    ) {
+      return { ...storeRecords, ...contextData }
+    }
+    return storeRecords
+  }, [contextData, storeRecords])
 
   const recordId = record?.id
   const trackId = record?.mediaFileId || recordId


### PR DESCRIPTION
## Summary
- merge list context selection/data into the drag payload builder so playlist rows include full track metadata
- ensure multi-select drags from playlists keep every selected media file id in the drop payload

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fe89a1278c8330a0fe66028a2be89d