### PR TITLE
Convert retail player playlists list to dropdown

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -51,14 +51,15 @@ const useStyles = makeStyles((theme) => {
     root: {
       display: 'flex',
       flexDirection: 'column',
-      gap: theme.spacing(5),
-      padding: theme.spacing(5),
-      maxWidth: 960,
-      width: '100%',
+      gap: theme.spacing(4),
+      padding: theme.spacing(4.5),
+      width: 'min(100%, 1200px)',
       margin: '0 auto',
+      boxSizing: 'border-box',
+      minHeight: '100vh',
       [theme.breakpoints.down('md')]: {
-        padding: theme.spacing(4),
-        gap: theme.spacing(4),
+        padding: theme.spacing(3.5),
+        gap: theme.spacing(3.5),
       },
       [theme.breakpoints.down('sm')]: {
         padding: theme.spacing(2.5),
@@ -130,15 +131,11 @@ const useStyles = makeStyles((theme) => {
       overflow: 'hidden',
       border: `1px solid ${theme.palette.divider}`,
     },
-    contentGrid: {
-      display: 'grid',
-      gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)',
-      gap: theme.spacing(5),
-      alignItems: 'flex-start',
+    mainContent: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(4),
       width: '100%',
-      [theme.breakpoints.down('md')]: {
-        gridTemplateColumns: 'minmax(0, 1fr)',
-      },
     },
     nowPlayingCard: {
       borderRadius: theme.shape.borderRadius,
@@ -146,20 +143,37 @@ const useStyles = makeStyles((theme) => {
       border: `1px solid ${theme.palette.divider}`,
       padding: theme.spacing(4),
       display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      gap: theme.spacing(3),
+      flexDirection: 'row',
+      alignItems: 'stretch',
+      gap: theme.spacing(4),
+      width: '100%',
+      [theme.breakpoints.down('md')]: {
+        flexDirection: 'column',
+        padding: theme.spacing(3.5),
+        gap: theme.spacing(3),
+      },
       [theme.breakpoints.down('sm')]: {
         padding: theme.spacing(3),
-        gap: theme.spacing(2.5),
       },
+    },
+    nowPlayingBody: {
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'flex-start',
+      gap: theme.spacing(3),
+      flex: 1,
+      minWidth: 0,
     },
     nowPlayingStack: {
       display: 'flex',
       flexDirection: 'column',
-      alignItems: 'center',
-      gap: theme.spacing(2),
+      alignItems: 'flex-start',
+      gap: theme.spacing(1.5),
       width: '100%',
+      [theme.breakpoints.down('md')]: {
+        alignItems: 'center',
+        textAlign: 'center',
+      },
     },
     listItemButton: {
       display: 'block',
@@ -248,8 +262,16 @@ const useStyles = makeStyles((theme) => {
       fontWeight: theme.typography.fontWeightMedium,
     },
     artworkWrapper: {
-      width: 'min(180px, 100%)',
-      maxWidth: 200,
+      width: 220,
+      maxWidth: '100%',
+      flexShrink: 0,
+      alignSelf: 'center',
+      [theme.breakpoints.down('md')]: {
+        width: 'min(200px, 70%)',
+      },
+      [theme.breakpoints.down('sm')]: {
+        width: 'min(180px, 80%)',
+      },
     },
     artworkCircle: {
       position: 'relative',
@@ -301,11 +323,13 @@ const useStyles = makeStyles((theme) => {
       opacity: 0.2,
     },
     nowPlayingTitle: {
-      fontSize: theme.typography.pxToRem(36),
+      fontSize: theme.typography.pxToRem(34),
       fontWeight: theme.typography.fontWeightBold,
-      textAlign: 'center',
+      textAlign: 'left',
+      overflowWrap: 'anywhere',
       [theme.breakpoints.down('md')]: {
         fontSize: theme.typography.pxToRem(30),
+        textAlign: 'center',
       },
       [theme.breakpoints.down('sm')]: {
         fontSize: theme.typography.pxToRem(22),
@@ -313,8 +337,12 @@ const useStyles = makeStyles((theme) => {
     },
     nowPlayingArtist: {
       fontSize: theme.typography.pxToRem(18),
-      textAlign: 'center',
+      textAlign: 'left',
       color: theme.palette.text.secondary,
+      overflowWrap: 'anywhere',
+      [theme.breakpoints.down('md')]: {
+        textAlign: 'center',
+      },
       [theme.breakpoints.down('sm')]: {
         fontSize: theme.typography.pxToRem(15),
       },
@@ -322,9 +350,12 @@ const useStyles = makeStyles((theme) => {
     controlsRow: {
       display: 'flex',
       alignItems: 'center',
-      justifyContent: 'center',
+      justifyContent: 'flex-start',
       gap: theme.spacing(4),
       flexWrap: 'wrap',
+      [theme.breakpoints.down('md')]: {
+        justifyContent: 'center',
+      },
     },
     controlButton: {
       display: 'inline-flex',
@@ -354,7 +385,10 @@ const useStyles = makeStyles((theme) => {
       gap: theme.spacing(1.5),
       width: '100%',
       maxWidth: 360,
-      alignSelf: 'center',
+      alignSelf: 'flex-start',
+      [theme.breakpoints.down('md')]: {
+        alignSelf: 'center',
+      },
     },
     volumeLabelRow: {
       display: 'flex',
@@ -853,7 +887,7 @@ const RetailPlayerDashboard = () => {
         </div>
       </header>
 
-      <div className={classes.contentGrid}>
+      <div className={classes.mainContent}>
         <section
           className={classes.list}
           aria-label="Available schedules"
@@ -985,76 +1019,78 @@ const RetailPlayerDashboard = () => {
             </div>
           </div>
 
-          <div className={classes.nowPlayingStack}>
-            <Typography component="h2" className={classes.nowPlayingTitle}>
-              {currentTrack.title}
-            </Typography>
-            <Typography className={classes.nowPlayingArtist}>{currentTrack.artist}</Typography>
-          </div>
-
-          <section className={classes.controlsRow} aria-label="Now playing controls">
-            <ButtonBase
-              className={classes.controlButton}
-              aria-label="Dislike"
-              onClick={handleDislike}
-              focusRipple
-            >
-              <span className={classes.controlIcon} role="img" aria-hidden="true">
-                <BiDislike fontSize="inherit" />
-              </span>
-            </ButtonBase>
-            <ButtonBase
-              className={combineClasses(
-                classes.controlButton,
-                isMuted ? classes.controlButtonMuted : null,
-              )}
-              aria-label="Mute/Unmute"
-              onClick={handleToggleMute}
-              focusRipple
-            >
-              <span className={classes.controlIcon} role="img" aria-hidden="true">
-                {isMuted ? <VolumeOffIcon fontSize="inherit" /> : <VolumeUpIcon fontSize="inherit" />}
-              </span>
-            </ButtonBase>
-            <ButtonBase
-              className={classes.controlButton}
-              aria-label="Skip"
-              onClick={handleSkip}
-              focusRipple
-            >
-              <span className={classes.controlIcon} role="img" aria-hidden="true">
-                <MdSkipNext fontSize="inherit" />
-              </span>
-            </ButtonBase>
-          </section>
-
-          {showDislikeMessage ? (
-            <Typography className={classes.dislikeMessage} aria-live="polite">
-              Marked as disliked
-            </Typography>
-          ) : null}
-
-          <section className={classes.volumeSection} aria-label="Volume">
-            <div className={classes.volumeLabelRow}>
-              <Typography component="span">volume</Typography>
-              <Typography className={classes.volumeValue} aria-live="polite">
-                {displayVolume}
+          <div className={classes.nowPlayingBody}>
+            <div className={classes.nowPlayingStack}>
+              <Typography component="h2" className={classes.nowPlayingTitle}>
+                {currentTrack.title}
               </Typography>
+              <Typography className={classes.nowPlayingArtist}>{currentTrack.artist}</Typography>
             </div>
-            <Slider
-              classes={{
-                root: classes.slider,
-                track: classes.sliderTrack,
-                thumb: classes.sliderThumb,
-                rail: classes.sliderRail,
-              }}
-              value={displayVolume}
-              min={0}
-              max={100}
-              aria-label="Volume"
-              onChange={handleVolumeChange}
-            />
-          </section>
+
+            <section className={classes.controlsRow} aria-label="Now playing controls">
+              <ButtonBase
+                className={classes.controlButton}
+                aria-label="Dislike"
+                onClick={handleDislike}
+                focusRipple
+              >
+                <span className={classes.controlIcon} role="img" aria-hidden="true">
+                  <BiDislike fontSize="inherit" />
+                </span>
+              </ButtonBase>
+              <ButtonBase
+                className={combineClasses(
+                  classes.controlButton,
+                  isMuted ? classes.controlButtonMuted : null,
+                )}
+                aria-label="Mute/Unmute"
+                onClick={handleToggleMute}
+                focusRipple
+              >
+                <span className={classes.controlIcon} role="img" aria-hidden="true">
+                  {isMuted ? <VolumeOffIcon fontSize="inherit" /> : <VolumeUpIcon fontSize="inherit" />}
+                </span>
+              </ButtonBase>
+              <ButtonBase
+                className={classes.controlButton}
+                aria-label="Skip"
+                onClick={handleSkip}
+                focusRipple
+              >
+                <span className={classes.controlIcon} role="img" aria-hidden="true">
+                  <MdSkipNext fontSize="inherit" />
+                </span>
+              </ButtonBase>
+            </section>
+
+            {showDislikeMessage ? (
+              <Typography className={classes.dislikeMessage} aria-live="polite">
+                Marked as disliked
+              </Typography>
+            ) : null}
+
+            <section className={classes.volumeSection} aria-label="Volume">
+              <div className={classes.volumeLabelRow}>
+                <Typography component="span">volume</Typography>
+                <Typography className={classes.volumeValue} aria-live="polite">
+                  {displayVolume}
+                </Typography>
+              </div>
+              <Slider
+                classes={{
+                  root: classes.slider,
+                  track: classes.sliderTrack,
+                  thumb: classes.sliderThumb,
+                  rail: classes.sliderRail,
+                }}
+                value={displayVolume}
+                min={0}
+                max={100}
+                aria-label="Volume"
+                onChange={handleVolumeChange}
+              />
+            </section>
+          </div>
         </section>
       </div>
     </div>

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -51,19 +51,21 @@ const useStyles = makeStyles((theme) => {
     root: {
       display: 'flex',
       flexDirection: 'column',
-      gap: theme.spacing(4),
-      padding: theme.spacing(4.5),
-      width: 'min(100%, 1200px)',
+      gap: theme.spacing(3.5),
+      padding: `${theme.spacing(5)}px ${theme.spacing(4)}px`,
+      width: '100%',
+      maxWidth: 1200,
       margin: '0 auto',
       boxSizing: 'border-box',
       minHeight: '100vh',
+      alignItems: 'center',
       [theme.breakpoints.down('md')]: {
-        padding: theme.spacing(3.5),
-        gap: theme.spacing(3.5),
+        padding: `${theme.spacing(4)}px ${theme.spacing(3)}px`,
+        gap: theme.spacing(3),
       },
       [theme.breakpoints.down('sm')]: {
-        padding: theme.spacing(2.5),
-        gap: theme.spacing(3),
+        padding: `${theme.spacing(3)}px ${theme.spacing(2.5)}px`,
+        gap: theme.spacing(2.5),
       },
     },
     header: {
@@ -72,6 +74,12 @@ const useStyles = makeStyles((theme) => {
       justifyContent: 'space-between',
       gap: theme.spacing(2),
       flexWrap: 'wrap',
+      width: '100%',
+      maxWidth: 960,
+      [theme.breakpoints.down('sm')]: {
+        justifyContent: 'center',
+        textAlign: 'center',
+      },
     },
     backLinkTop: {
       alignSelf: 'flex-start',
@@ -81,9 +89,10 @@ const useStyles = makeStyles((theme) => {
     },
     title: {
       fontWeight: theme.typography.fontWeightBold,
-      fontSize: theme.typography.pxToRem(60),
+      fontSize: theme.typography.pxToRem(52),
+      letterSpacing: '-0.01em',
       [theme.breakpoints.down('md')]: {
-        fontSize: theme.typography.pxToRem(44),
+        fontSize: theme.typography.pxToRem(40),
       },
       [theme.breakpoints.down('sm')]: {
         fontSize: theme.typography.pxToRem(28),
@@ -126,49 +135,72 @@ const useStyles = makeStyles((theme) => {
       fontSize: theme.typography.pxToRem(18),
     },
     list: {
-      borderRadius: theme.shape.borderRadius,
+      borderRadius: theme.shape.borderRadius * 1.5,
       backgroundColor: theme.palette.background.paper,
       overflow: 'hidden',
       border: `1px solid ${theme.palette.divider}`,
+      width: '100%',
+      maxWidth: 960,
+      boxShadow: '0 22px 45px rgba(0, 0, 0, 0.28)',
+      transition: theme.transitions.create(['box-shadow'], {
+        duration: theme.transitions.duration.shorter,
+      }),
+      '&:hover, &:focus-within': {
+        boxShadow: '0 30px 60px rgba(0, 0, 0, 0.36)',
+      },
     },
     mainContent: {
       display: 'flex',
       flexDirection: 'column',
-      gap: theme.spacing(4),
+      gap: theme.spacing(3),
       width: '100%',
+      maxWidth: 960,
+      margin: '0 auto',
     },
     nowPlayingCard: {
-      borderRadius: theme.shape.borderRadius,
+      borderRadius: theme.shape.borderRadius * 1.5,
       backgroundColor: theme.palette.background.paper,
       border: `1px solid ${theme.palette.divider}`,
-      padding: theme.spacing(4),
+      padding: theme.spacing(3),
       display: 'flex',
       flexDirection: 'row',
-      alignItems: 'stretch',
-      gap: theme.spacing(4),
+      alignItems: 'center',
+      gap: theme.spacing(3),
       width: '100%',
+      maxWidth: 960,
+      boxShadow: '0 26px 55px rgba(0, 0, 0, 0.32)',
+      transition: theme.transitions.create(['box-shadow', 'transform'], {
+        duration: theme.transitions.duration.shorter,
+        easing: theme.transitions.easing.easeInOut,
+      }),
+      '&:hover, &:focus-within': {
+        boxShadow: '0 36px 70px rgba(0, 0, 0, 0.38)',
+        transform: 'translateY(-2px)',
+      },
       [theme.breakpoints.down('md')]: {
         flexDirection: 'column',
-        padding: theme.spacing(3.5),
+        alignItems: 'center',
+        padding: theme.spacing(3),
         gap: theme.spacing(3),
       },
       [theme.breakpoints.down('sm')]: {
-        padding: theme.spacing(3),
+        padding: theme.spacing(2.5),
       },
     },
     nowPlayingBody: {
       display: 'flex',
       flexDirection: 'column',
-      justifyContent: 'flex-start',
+      justifyContent: 'center',
       gap: theme.spacing(3),
       flex: 1,
       minWidth: 0,
+      width: '100%',
     },
-    nowPlayingStack: {
+    nowPlayingHeader: {
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'flex-start',
-      gap: theme.spacing(1.5),
+      gap: theme.spacing(1),
       width: '100%',
       [theme.breakpoints.down('md')]: {
         alignItems: 'center',
@@ -190,7 +222,7 @@ const useStyles = makeStyles((theme) => {
       display: 'flex',
       alignItems: 'center',
       gap: theme.spacing(2),
-      padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`,
+      padding: `${theme.spacing(2.25)}px ${theme.spacing(3)}px`,
       borderBottom: `1px solid ${theme.palette.divider}`,
       transition: theme.transitions.create(['background-color'], {
         duration: theme.transitions.duration.shortest,
@@ -220,9 +252,16 @@ const useStyles = makeStyles((theme) => {
       display: 'flex',
       flexDirection: 'column',
       width: '100%',
+      backgroundColor: theme.palette.background.paper,
     },
     dropdownTriggerButton: {
       borderBottom: `1px solid ${theme.palette.divider}`,
+      display: 'flex',
+      alignItems: 'center',
+      width: '100%',
+      transition: theme.transitions.create(['background-color'], {
+        duration: theme.transitions.duration.shorter,
+      }),
     },
     dropdownCaret: {
       marginLeft: 'auto',
@@ -246,6 +285,8 @@ const useStyles = makeStyles((theme) => {
       opacity: 0,
       pointerEvents: 'none',
       overflow: 'hidden',
+      boxShadow: '0 20px 40px rgba(0, 0, 0, 0.3)',
+      borderTop: `1px solid ${theme.palette.divider}`,
     },
     dropdownMenuOpen: {
       maxHeight: 320,
@@ -258,19 +299,20 @@ const useStyles = makeStyles((theme) => {
       },
     },
     listText: {
-      fontSize: theme.typography.pxToRem(20),
+      fontSize: theme.typography.pxToRem(18),
       fontWeight: theme.typography.fontWeightMedium,
+      letterSpacing: 0.2,
     },
     artworkWrapper: {
-      width: 220,
+      width: 'clamp(120px, 20vw, 180px)',
       maxWidth: '100%',
       flexShrink: 0,
       alignSelf: 'center',
       [theme.breakpoints.down('md')]: {
-        width: 'min(200px, 70%)',
+        width: 'clamp(120px, 32vw, 200px)',
       },
       [theme.breakpoints.down('sm')]: {
-        width: 'min(180px, 80%)',
+        width: 'min(160px, 70%)',
       },
     },
     artworkCircle: {
@@ -285,6 +327,7 @@ const useStyles = makeStyles((theme) => {
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
+      boxShadow: 'inset 0 0 0 2px rgba(255, 255, 255, 0.04)',
     },
     artworkContent: {
       position: 'absolute',
@@ -323,12 +366,15 @@ const useStyles = makeStyles((theme) => {
       opacity: 0.2,
     },
     nowPlayingTitle: {
-      fontSize: theme.typography.pxToRem(34),
-      fontWeight: theme.typography.fontWeightBold,
+      fontSize: theme.typography.pxToRem(32),
+      fontWeight: 600,
       textAlign: 'left',
-      overflowWrap: 'anywhere',
+      width: '100%',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
       [theme.breakpoints.down('md')]: {
-        fontSize: theme.typography.pxToRem(30),
+        fontSize: theme.typography.pxToRem(28),
         textAlign: 'center',
       },
       [theme.breakpoints.down('sm')]: {
@@ -339,7 +385,11 @@ const useStyles = makeStyles((theme) => {
       fontSize: theme.typography.pxToRem(18),
       textAlign: 'left',
       color: theme.palette.text.secondary,
-      overflowWrap: 'anywhere',
+      width: '100%',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      letterSpacing: 0.2,
       [theme.breakpoints.down('md')]: {
         textAlign: 'center',
       },
@@ -347,11 +397,27 @@ const useStyles = makeStyles((theme) => {
         fontSize: theme.typography.pxToRem(15),
       },
     },
+    nowPlayingFooter: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: theme.spacing(3),
+      flexWrap: 'wrap',
+      width: '100%',
+      [theme.breakpoints.down('md')]: {
+        justifyContent: 'center',
+      },
+      [theme.breakpoints.down('sm')]: {
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: theme.spacing(2.5),
+      },
+    },
     controlsRow: {
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'flex-start',
-      gap: theme.spacing(4),
+      gap: theme.spacing(3),
       flexWrap: 'wrap',
       [theme.breakpoints.down('md')]: {
         justifyContent: 'center',
@@ -383,11 +449,16 @@ const useStyles = makeStyles((theme) => {
       display: 'flex',
       flexDirection: 'column',
       gap: theme.spacing(1.5),
-      width: '100%',
+      flex: 1,
+      minWidth: 220,
       maxWidth: 360,
-      alignSelf: 'flex-start',
+      alignSelf: 'stretch',
       [theme.breakpoints.down('md')]: {
         alignSelf: 'center',
+      },
+      [theme.breakpoints.down('sm')]: {
+        width: '100%',
+        minWidth: 'auto',
       },
     },
     volumeLabelRow: {
@@ -420,6 +491,7 @@ const useStyles = makeStyles((theme) => {
       textAlign: 'center',
       color: theme.palette.text.secondary,
       fontSize: theme.typography.pxToRem(14),
+      width: '100%',
     },
     notFoundWrapper: {
       display: 'flex',
@@ -1020,76 +1092,89 @@ const RetailPlayerDashboard = () => {
           </div>
 
           <div className={classes.nowPlayingBody}>
-            <div className={classes.nowPlayingStack}>
-              <Typography component="h2" className={classes.nowPlayingTitle}>
+            <div className={classes.nowPlayingHeader}>
+              <Typography
+                component="h2"
+                className={classes.nowPlayingTitle}
+                noWrap
+                title={currentTrack.title}
+              >
                 {currentTrack.title}
               </Typography>
-              <Typography className={classes.nowPlayingArtist}>{currentTrack.artist}</Typography>
+              <Typography
+                className={classes.nowPlayingArtist}
+                noWrap
+                title={currentTrack.artist}
+              >
+                {currentTrack.artist}
+              </Typography>
             </div>
 
-            <section className={classes.controlsRow} aria-label="Now playing controls">
-              <ButtonBase
-                className={classes.controlButton}
-                aria-label="Dislike"
-                onClick={handleDislike}
-                focusRipple
-              >
-                <span className={classes.controlIcon} role="img" aria-hidden="true">
-                  <BiDislike fontSize="inherit" />
-                </span>
-              </ButtonBase>
-              <ButtonBase
-                className={combineClasses(
-                  classes.controlButton,
-                  isMuted ? classes.controlButtonMuted : null,
-                )}
-                aria-label="Mute/Unmute"
-                onClick={handleToggleMute}
-                focusRipple
-              >
-                <span className={classes.controlIcon} role="img" aria-hidden="true">
-                  {isMuted ? <VolumeOffIcon fontSize="inherit" /> : <VolumeUpIcon fontSize="inherit" />}
-                </span>
-              </ButtonBase>
-              <ButtonBase
-                className={classes.controlButton}
-                aria-label="Skip"
-                onClick={handleSkip}
-                focusRipple
-              >
-                <span className={classes.controlIcon} role="img" aria-hidden="true">
-                  <MdSkipNext fontSize="inherit" />
-                </span>
-              </ButtonBase>
-            </section>
+            <div className={classes.nowPlayingFooter}>
+              <section className={classes.controlsRow} aria-label="Now playing controls">
+                <ButtonBase
+                  className={classes.controlButton}
+                  aria-label="Dislike"
+                  onClick={handleDislike}
+                  focusRipple
+                >
+                  <span className={classes.controlIcon} role="img" aria-hidden="true">
+                    <BiDislike fontSize="inherit" />
+                  </span>
+                </ButtonBase>
+                <ButtonBase
+                  className={combineClasses(
+                    classes.controlButton,
+                    isMuted ? classes.controlButtonMuted : null,
+                  )}
+                  aria-label="Mute/Unmute"
+                  onClick={handleToggleMute}
+                  focusRipple
+                >
+                  <span className={classes.controlIcon} role="img" aria-hidden="true">
+                    {isMuted ? <VolumeOffIcon fontSize="inherit" /> : <VolumeUpIcon fontSize="inherit" />}
+                  </span>
+                </ButtonBase>
+                <ButtonBase
+                  className={classes.controlButton}
+                  aria-label="Skip"
+                  onClick={handleSkip}
+                  focusRipple
+                >
+                  <span className={classes.controlIcon} role="img" aria-hidden="true">
+                    <MdSkipNext fontSize="inherit" />
+                  </span>
+                </ButtonBase>
+              </section>
+
+              <section className={classes.volumeSection} aria-label="Volume">
+                <div className={classes.volumeLabelRow}>
+                  <Typography component="span">volume</Typography>
+                  <Typography className={classes.volumeValue} aria-live="polite">
+                    {displayVolume}
+                  </Typography>
+                </div>
+                <Slider
+                  classes={{
+                    root: classes.slider,
+                    track: classes.sliderTrack,
+                    thumb: classes.sliderThumb,
+                    rail: classes.sliderRail,
+                  }}
+                  value={displayVolume}
+                  min={0}
+                  max={100}
+                  aria-label="Volume"
+                  onChange={handleVolumeChange}
+                />
+              </section>
+            </div>
 
             {showDislikeMessage ? (
               <Typography className={classes.dislikeMessage} aria-live="polite">
                 Marked as disliked
               </Typography>
             ) : null}
-
-            <section className={classes.volumeSection} aria-label="Volume">
-              <div className={classes.volumeLabelRow}>
-                <Typography component="span">volume</Typography>
-                <Typography className={classes.volumeValue} aria-live="polite">
-                  {displayVolume}
-                </Typography>
-              </div>
-              <Slider
-                classes={{
-                  root: classes.slider,
-                  track: classes.sliderTrack,
-                  thumb: classes.sliderThumb,
-                  rail: classes.sliderRail,
-                }}
-                value={displayVolume}
-                min={0}
-                max={100}
-                aria-label="Volume"
-                onChange={handleVolumeChange}
-              />
-            </section>
           </div>
         </section>
       </div>

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -8,6 +8,7 @@ import VolumeOffIcon from '@material-ui/icons/VolumeOff'
 import VolumeUpIcon from '@material-ui/icons/VolumeUp'
 import DescriptionIcon from '@material-ui/icons/Description'
 import CachedIcon from '@material-ui/icons/Cached'
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import { Link as RouterLink, useParams } from 'react-router-dom'
 import { BiDislike } from 'react-icons/bi'
 import { MdSkipNext } from 'react-icons/md'
@@ -40,6 +41,8 @@ const useStyles = makeStyles((theme) => {
     theme.palette.primary.main
   const sliderMain =
     (theme.palette.secondary && theme.palette.secondary.main) || theme.palette.primary.main
+  const accentColor =
+    (theme.palette.secondary && theme.palette.secondary.main) || '#ff6f9f'
   const disabledBackground =
     (theme.palette.action && theme.palette.action.disabledBackground) ||
     theme.palette.background.paper
@@ -179,25 +182,70 @@ const useStyles = makeStyles((theme) => {
         duration: theme.transitions.duration.shortest,
       }),
     },
-    listItemActive: {
-      backgroundColor: theme.palette.action.selected,
-    },
-    listItemInactive: {
-      backgroundColor: disabledBackground,
-    },
     listIcon: {
       color: theme.palette.text.secondary,
       fontSize: theme.typography.pxToRem(24),
     },
-    listIconInactive: {
-      color: theme.palette.text.disabled,
+    playlistLabel: {
+      flex: 1,
+      minWidth: 0,
+    },
+    playlistLabelActive: {
+      color: accentColor,
+    },
+    playlistLabelInactive: {
+      color: theme.palette.text.secondary,
+    },
+    playlistIconActive: {
+      color: accentColor,
+    },
+    playlistIconInactive: {
+      color: theme.palette.text.secondary,
+    },
+    dropdownWrapper: {
+      display: 'flex',
+      flexDirection: 'column',
+      width: '100%',
+    },
+    dropdownTriggerButton: {
+      borderBottom: `1px solid ${theme.palette.divider}`,
+    },
+    dropdownCaret: {
+      marginLeft: 'auto',
+      transition: theme.transitions.create(['transform'], {
+        duration: theme.transitions.duration.shortest,
+      }),
+      color: accentColor,
+    },
+    dropdownCaretOpen: {
+      transform: 'rotate(180deg)',
+    },
+    dropdownMenu: {
+      display: 'grid',
+      gridAutoRows: 'min-content',
+      backgroundColor: theme.palette.background.paper,
+      transition: theme.transitions.create(['max-height', 'opacity'], {
+        duration: theme.transitions.duration.short,
+        easing: theme.transitions.easing.easeInOut,
+      }),
+      maxHeight: 0,
+      opacity: 0,
+      pointerEvents: 'none',
+      overflow: 'hidden',
+    },
+    dropdownMenuOpen: {
+      maxHeight: 320,
+      opacity: 1,
+      pointerEvents: 'auto',
+    },
+    dropdownOptionButton: {
+      '&:last-child $listItem': {
+        borderBottom: 'none',
+      },
     },
     listText: {
       fontSize: theme.typography.pxToRem(20),
       fontWeight: theme.typography.fontWeightMedium,
-    },
-    listTextInactive: {
-      color: theme.palette.text.disabled,
     },
     artworkWrapper: {
       width: 'min(180px, 100%)',
@@ -411,6 +459,8 @@ const RetailPlayerDashboard = () => {
   const dislikeTimeoutRef = useRef(null)
   const [showDislikeMessage, setShowDislikeMessage] = useState(false)
   const [currentTrackIndex, setCurrentTrackIndex] = useState(0)
+  const [isScheduleMenuOpen, setScheduleMenuOpen] = useState(false)
+  const scheduleDropdownRef = useRef(null)
 
   const refreshDevice = useCallback(() => {
     if (!deviceId) {
@@ -434,11 +484,61 @@ const RetailPlayerDashboard = () => {
   }, [])
 
   const schedules = useMemo(() => device?.schedules || [], [device])
+  const schedulesCount = schedules.length
 
   const activeChannelKey = useMemo(() => {
     const activeSchedule = schedules.find((schedule) => schedule.isActive)
     return activeSchedule ? activeSchedule.key : null
   }, [schedules])
+
+  useEffect(() => {
+    if (!isScheduleMenuOpen) {
+      return undefined
+    }
+
+    const handleClickOutside = (event) => {
+      if (
+        scheduleDropdownRef.current &&
+        !scheduleDropdownRef.current.contains(event.target)
+      ) {
+        setScheduleMenuOpen(false)
+      }
+    }
+
+    const handleEscape = (event) => {
+      if (event.key === 'Escape') {
+        setScheduleMenuOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keydown', handleEscape)
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleEscape)
+    }
+  }, [isScheduleMenuOpen])
+
+  useEffect(() => {
+    setScheduleMenuOpen(false)
+  }, [activeChannelKey])
+
+  useEffect(() => {
+    if (schedulesCount === 0) {
+      setScheduleMenuOpen(false)
+    }
+  }, [schedulesCount])
+
+  const activeSchedule = useMemo(() => {
+    if (!schedulesCount) {
+      return null
+    }
+    const matched = schedules.find((schedule) => schedule.key === activeChannelKey)
+    return matched || schedules[0]
+  }, [activeChannelKey, schedules, schedulesCount])
+
+  const dropdownLabel = activeSchedule ? activeSchedule.label : 'No playlists available'
 
   useEffect(() => {
     setIsMuted(Boolean(device?.isMuted))
@@ -522,6 +622,13 @@ const RetailPlayerDashboard = () => {
     ]
   }, [currentTime, device, isMuted])
 
+  const handleToggleScheduleMenu = useCallback(() => {
+    if (!schedulesCount) {
+      return
+    }
+    setScheduleMenuOpen((prev) => !prev)
+  }, [schedulesCount])
+
   const handleSelectChannel = useCallback(
     (schedule) => {
       if (!device) {
@@ -531,6 +638,14 @@ const RetailPlayerDashboard = () => {
       refreshDevice()
     },
     [device, deviceId, refreshDevice],
+  )
+
+  const handleSelectFromDropdown = useCallback(
+    (schedule) => {
+      setScheduleMenuOpen(false)
+      handleSelectChannel(schedule)
+    },
+    [handleSelectChannel],
   )
 
   const clearVolumeTimeout = useCallback(() => {
@@ -739,43 +854,106 @@ const RetailPlayerDashboard = () => {
       </header>
 
       <div className={classes.contentGrid}>
-        <section className={classes.list} aria-label="Available schedules">
-          {device.schedules.map((schedule) => {
-            const isActive = schedule.key === activeChannelKey
-            return (
-              <ButtonBase
-                key={schedule.key}
-                className={classes.listItemButton}
-                onClick={() => handleSelectChannel(schedule)}
-                focusRipple
-                aria-label={`Select channel: ${schedule.label}`}
-                aria-pressed={isActive}
-              >
-                <div
+        <section
+          className={classes.list}
+          aria-label="Available schedules"
+          ref={scheduleDropdownRef}
+        >
+          <div className={classes.dropdownWrapper}>
+            <ButtonBase
+              className={combineClasses(
+                classes.listItemButton,
+                classes.dropdownTriggerButton,
+              )}
+              onClick={handleToggleScheduleMenu}
+              focusRipple
+              aria-haspopup="listbox"
+              aria-expanded={isScheduleMenuOpen && Boolean(schedulesCount)}
+              aria-controls="schedule-menu"
+              disabled={!schedulesCount}
+            >
+              <div className={classes.listItem}>
+                <DescriptionIcon
                   className={combineClasses(
-                    classes.listItem,
-                    isActive ? classes.listItemActive : classes.listItemInactive,
+                    classes.listIcon,
+                    activeSchedule
+                      ? classes.playlistIconActive
+                      : classes.playlistIconInactive,
                   )}
+                  aria-hidden="true"
+                />
+                <Typography
+                  className={combineClasses(
+                    classes.listText,
+                    classes.playlistLabel,
+                    activeSchedule
+                      ? classes.playlistLabelActive
+                      : classes.playlistLabelInactive,
+                  )}
+                  noWrap
                 >
-                  <DescriptionIcon
+                  {dropdownLabel}
+                </Typography>
+                <ExpandMoreIcon
+                  className={combineClasses(
+                    classes.dropdownCaret,
+                    isScheduleMenuOpen ? classes.dropdownCaretOpen : null,
+                  )}
+                  aria-hidden="true"
+                />
+              </div>
+            </ButtonBase>
+            <div
+              className={combineClasses(
+                classes.dropdownMenu,
+                isScheduleMenuOpen ? classes.dropdownMenuOpen : null,
+              )}
+              role="listbox"
+              id="schedule-menu"
+              aria-hidden={!isScheduleMenuOpen}
+            >
+              {schedules.map((schedule) => {
+                const isActive = schedule.key === activeChannelKey
+                return (
+                  <ButtonBase
+                    key={schedule.key}
                     className={combineClasses(
-                      classes.listIcon,
-                      !isActive ? classes.listIconInactive : null,
+                      classes.listItemButton,
+                      classes.dropdownOptionButton,
                     )}
-                    aria-hidden="true"
-                  />
-                  <Typography
-                    className={combineClasses(
-                      classes.listText,
-                      !isActive ? classes.listTextInactive : null,
-                    )}
+                    onClick={() => handleSelectFromDropdown(schedule)}
+                    focusRipple
+                    role="option"
+                    aria-selected={isActive}
                   >
-                    {schedule.label}
-                  </Typography>
-                </div>
-              </ButtonBase>
-            )
-          })}
+                    <div className={classes.listItem}>
+                      <DescriptionIcon
+                        className={combineClasses(
+                          classes.listIcon,
+                          isActive
+                            ? classes.playlistIconActive
+                            : classes.playlistIconInactive,
+                        )}
+                        aria-hidden="true"
+                      />
+                      <Typography
+                        className={combineClasses(
+                          classes.listText,
+                          classes.playlistLabel,
+                          isActive
+                            ? classes.playlistLabelActive
+                            : classes.playlistLabelInactive,
+                        )}
+                        noWrap
+                      >
+                        {schedule.label}
+                      </Typography>
+                    </div>
+                  </ButtonBase>
+                )
+              })}
+            </div>
+          </div>
         </section>
 
         <section className={classes.nowPlayingCard} aria-label="Now playing">


### PR DESCRIPTION
## Summary
- replace the retail player schedule list with a dropdown that defaults to the active playlist
- add dropdown state management, outside click dismissal, and animations while keeping existing styling cues
- update styling helpers to highlight the active playlist in pink and inactive playlists in gray

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ffe659f0fc8330948cba2b8be092e1