### PR TITLE
Refresh missing track notifications when data changes

### DIFF
--- a/ui/src/layout/MissingTracksPanel.jsx
+++ b/ui/src/layout/MissingTracksPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import {
   Badge,
   Card,
@@ -82,13 +82,26 @@ const MissingTracksPanel = () => {
   const [totalCount, setTotalCount] = useState(0)
   const [hasMore, setHasMore] = useState(false)
   const [nextOffset, setNextOffset] = useState(0)
+  const activeRequestRef = useRef({ id: 0, controller: null })
 
   const open = Boolean(anchorEl)
   const classes = useStyles({ open })
 
   const fetchEntries = useCallback(
     (offset = 0, append = false) => {
+      const controller = new AbortController()
       const setLoadingState = append ? setLoadingMore : setLoading
+      const nextRequestId = activeRequestRef.current.id + 1
+
+      if (!append && activeRequestRef.current.controller) {
+        activeRequestRef.current.controller.abort()
+      }
+
+      activeRequestRef.current = {
+        id: nextRequestId,
+        controller: append ? activeRequestRef.current.controller : controller,
+      }
+
       setLoadingState(true)
       const params = new URLSearchParams({
         limit: PAGE_SIZE.toString(),
@@ -98,6 +111,7 @@ const MissingTracksPanel = () => {
       return httpClient(`/api/notifications/missing-tracks?${params.toString()}`,
         {
           cache: 'no-store',
+          signal: controller.signal,
           headers: new Headers({
             Accept: 'application/json',
             'Cache-Control': 'no-cache',
@@ -106,6 +120,9 @@ const MissingTracksPanel = () => {
         },
       )
         .then(({ json, headers }) => {
+          if (activeRequestRef.current.id !== nextRequestId) {
+            return
+          }
           const list = Array.isArray(json) ? json : []
           const totalHeader = headers && headers.get ? headers.get('X-Total-Count') : null
           const parsedTotal = totalHeader ? parseInt(totalHeader, 10) : NaN
@@ -119,6 +136,12 @@ const MissingTracksPanel = () => {
           })
         })
         .catch((error) => {
+          if (error?.name === 'AbortError') {
+            return
+          }
+          if (activeRequestRef.current.id !== nextRequestId) {
+            return
+          }
           notify('ra.notification.http_error', 'warning', {
             messageArgs: { error: error.message || 'Unknown error' },
           })
@@ -129,7 +152,15 @@ const MissingTracksPanel = () => {
             setHasMore(false)
           }
         })
-        .finally(() => setLoadingState(false))
+        .finally(() => {
+          if (activeRequestRef.current.id !== nextRequestId) {
+            return
+          }
+          setLoadingState(false)
+          if (!append && activeRequestRef.current.controller === controller) {
+            activeRequestRef.current.controller = null
+          }
+        })
     },
     [notify],
   )
@@ -170,6 +201,16 @@ const MissingTracksPanel = () => {
   useEffect(() => {
     fetchEntries(0, false)
   }, [fetchEntries])
+
+  useEffect(
+    () => () => {
+      if (activeRequestRef.current.controller) {
+        activeRequestRef.current.controller.abort()
+        activeRequestRef.current.controller = null
+      }
+    },
+    [],
+  )
 
   useRefreshOnEvents({
     events: ['*'],

--- a/ui/src/layout/MissingTracksPanel.jsx
+++ b/ui/src/layout/MissingTracksPanel.jsx
@@ -88,6 +88,27 @@ const MissingTracksPanel = () => {
   const open = Boolean(anchorEl)
   const classes = useStyles({ open })
 
+  const mergeEntries = useCallback((base, incoming) => {
+    if (!incoming) {
+      return base
+    }
+    const merged = { ...base }
+    Object.keys(incoming).forEach((key) => {
+      const value = incoming[key]
+      if (value === undefined || value === null) {
+        return
+      }
+      if (typeof value === 'string' && value.trim() === '') {
+        return
+      }
+      const existing = merged[key]
+      if (existing === undefined || existing === null || (typeof existing === 'string' && existing.trim() === '')) {
+        merged[key] = value
+      }
+    })
+    return merged
+  }, [])
+
   const fetchEntries = useCallback(
     (offset = 0, append = false) => {
       const controller = new AbortController()
@@ -107,15 +128,21 @@ const MissingTracksPanel = () => {
 
       setLoadingState(true)
 
-      const params = new URLSearchParams({
+      const missingParams = new URLSearchParams({
         _sort: 'updated_at',
         _order: 'DESC',
         _start: start.toString(),
         _end: end.toString(),
       })
-      params.set('_', Date.now().toString())
+      missingParams.set('_', Date.now().toString())
 
-      return httpClient(`${REST_URL}/missing?${params.toString()}`, {
+      const notificationsParams = new URLSearchParams({
+        limit: PAGE_SIZE.toString(),
+        offset: start.toString(),
+      })
+      notificationsParams.set('_', Date.now().toString())
+
+      const requestOptions = {
         cache: 'no-store',
         signal: controller.signal,
         headers: new Headers({
@@ -123,22 +150,77 @@ const MissingTracksPanel = () => {
           'Cache-Control': 'no-cache',
           Pragma: 'no-cache',
         }),
-      })
-        .then(({ json, headers }) => {
+      }
+
+      const requests = [
+        httpClient(`/api/notifications/missing-tracks?${notificationsParams.toString()}`, requestOptions),
+        httpClient(`${REST_URL}/missing?${missingParams.toString()}`, requestOptions),
+      ]
+
+      return Promise.allSettled(requests)
+        .then((results) => {
           if (activeRequestRef.current.id !== nextRequestId) {
             return
           }
 
-          const list = Array.isArray(json) ? json : []
-          const rawTotal = headers && headers.get ? headers.get('X-Total-Count') : null
-          const totalValue = (() => {
-            if (!rawTotal) {
-              return list.length + (append ? start : 0)
+          const [notificationsResult, missingResult] = results
+          const notificationsSuccess =
+            notificationsResult.status === 'fulfilled' ? notificationsResult.value : null
+          const missingSuccess = missingResult.status === 'fulfilled' ? missingResult.value : null
+
+          const isNotificationsError =
+            notificationsResult.status === 'rejected' && notificationsResult.reason?.name !== 'AbortError'
+          const isMissingError =
+            missingResult.status === 'rejected' && missingResult.reason?.name !== 'AbortError'
+
+          if (!notificationsSuccess && !missingSuccess) {
+            if (isNotificationsError || isMissingError) {
+              const error = isMissingError ? missingResult.reason : notificationsResult.reason
+              notify('ra.notification.http_error', 'warning', {
+                messageArgs: { error: (error && error.message) || 'Unknown error' },
+              })
             }
-            const segments = rawTotal.split('/')
+            if (!append) {
+              setEntries([])
+              setTotalCount(0)
+              setNextOffset(0)
+              setHasMore(false)
+            }
+            return
+          }
+
+          if (isNotificationsError || isMissingError) {
+            const error = isMissingError ? missingResult.reason : notificationsResult.reason
+            if (error?.name !== 'AbortError') {
+              notify('ra.notification.http_error', 'warning', {
+                messageArgs: { error: (error && error.message) || 'Unknown error' },
+              })
+            }
+          }
+
+          const notificationList = Array.isArray(notificationsSuccess?.json)
+            ? notificationsSuccess.json
+            : []
+          const missingList = Array.isArray(missingSuccess?.json) ? missingSuccess.json : []
+
+          const notificationsHeader = notificationsSuccess?.headers?.get
+            ? notificationsSuccess.headers.get('X-Total-Count')
+            : null
+          const parsedNotificationsTotal = notificationsHeader
+            ? parseInt(notificationsHeader, 10)
+            : NaN
+
+          const missingHeader = missingSuccess?.headers?.get
+            ? missingSuccess.headers.get('X-Total-Count')
+            : null
+          const parsedMissingTotal = (() => {
+            if (!missingHeader) {
+              return missingList.length + (append ? start : 0)
+            }
+            const segments = missingHeader.split('/')
             const parsed = parseInt(segments[segments.length - 1], 10)
             if (Number.isNaN(parsed)) {
-              return list.length + (append ? start : 0)
+              return missingList.length + (append ? start : 0)
             }
             return parsed
           })()
@@ -146,37 +228,59 @@ const MissingTracksPanel = () => {
           setEntries((prev) => {
             const previous = append ? prev : []
             const nextEntriesMap = new Map()
-            previous.forEach((entry) => {
-              const key = entry?.id || entry?.path || `${entry?.title || ''}-${entry?.artist || ''}`
-              nextEntriesMap.set(key, entry)
-            })
-            list.forEach((entry) => {
-              const key = entry?.id || entry?.path || `${entry?.title || ''}-${entry?.artist || ''}`
-              nextEntriesMap.set(key, entry)
-            })
+            const getKey = (entry, fallbackIndex) => {
+              if (!entry) {
+                return `unknown-${fallbackIndex}`
+              }
+              return (
+                entry.id ||
+                entry.path ||
+                entry.trackPath ||
+                `${entry.title || ''}-${entry.artist || ''}` ||
+                `unknown-${fallbackIndex}`
+              )
+            }
+
+            const addEntry = (entry, indexOffset = 0) => {
+              if (!entry) {
+                return
+              }
+              const key = getKey(entry, indexOffset)
+              const existing = nextEntriesMap.get(key)
+              if (existing) {
+                nextEntriesMap.set(key, mergeEntries(existing, entry))
+              } else {
+                nextEntriesMap.set(key, { ...entry })
+              }
+            }
+
+            previous.forEach((entry, index) => addEntry(entry, index))
+            missingList.forEach((entry, index) => addEntry(entry, start + index))
+            notificationList.forEach((entry, index) => addEntry(entry, start + index + missingList.length))
+
             const nextEntries = Array.from(nextEntriesMap.values())
-            setTotalCount(totalValue)
-            setNextOffset(start + list.length)
-            setHasMore(start + list.length < totalValue && list.length > 0)
+
+            const hasMoreMissing =
+              Number.isFinite(parsedMissingTotal) && start + missingList.length < parsedMissingTotal
+            const hasMoreNotifications =
+              Number.isFinite(parsedNotificationsTotal) &&
+              start + notificationList.length < parsedNotificationsTotal
+
+            const computedTotal = Math.max(
+              nextEntries.length,
+              Number.isFinite(parsedMissingTotal) ? parsedMissingTotal : 0,
+              Number.isFinite(parsedNotificationsTotal) ? parsedNotificationsTotal : 0,
+            )
+
+            setTotalCount(computedTotal)
+            setNextOffset(start + Math.max(missingList.length, notificationList.length))
+            setHasMore(
+              (hasMoreMissing || hasMoreNotifications) &&
+              (missingList.length > 0 || notificationList.length > 0),
+            )
+
             return nextEntries
           })
-        })
-        .catch((error) => {
-          if (error?.name === 'AbortError') {
-            return
-          }
-          if (activeRequestRef.current.id !== nextRequestId) {
-            return
-          }
-          notify('ra.notification.http_error', 'warning', {
-            messageArgs: { error: error.message || 'Unknown error' },
-          })
-          if (!append) {
-            setEntries([])
-            setTotalCount(0)
-            setNextOffset(0)
-            setHasMore(false)
-          }
         })
         .finally(() => {
           if (activeRequestRef.current.id !== nextRequestId) {
@@ -188,7 +292,7 @@ const MissingTracksPanel = () => {
           }
         })
     },
-    [notify],
+    [mergeEntries, notify],
   )
 
   const refreshEntries = useCallback(() => fetchEntries(0, false), [fetchEntries])

--- a/ui/src/layout/MissingTracksPanel.jsx
+++ b/ui/src/layout/MissingTracksPanel.jsx
@@ -17,6 +17,7 @@ import { MdOutlineNotifications } from 'react-icons/md'
 import { useTranslate, useNotify } from 'react-admin'
 import { useRefreshOnEvents } from '../common'
 import { httpClient } from '../dataProvider'
+import { REST_URL } from '../consts'
 
 const PAGE_SIZE = 100
 
@@ -92,46 +93,71 @@ const MissingTracksPanel = () => {
       const controller = new AbortController()
       const setLoadingState = append ? setLoadingMore : setLoading
       const nextRequestId = activeRequestRef.current.id + 1
+      const start = Math.max(offset, 0)
+      const end = start + PAGE_SIZE
 
-      if (!append && activeRequestRef.current.controller) {
+      if (activeRequestRef.current.controller) {
         activeRequestRef.current.controller.abort()
       }
 
       activeRequestRef.current = {
         id: nextRequestId,
-        controller: append ? activeRequestRef.current.controller : controller,
+        controller,
       }
 
       setLoadingState(true)
+
       const params = new URLSearchParams({
-        limit: PAGE_SIZE.toString(),
-        offset: Math.max(offset, 0).toString(),
+        _sort: 'updated_at',
+        _order: 'DESC',
+        _start: start.toString(),
+        _end: end.toString(),
       })
       params.set('_', Date.now().toString())
-      return httpClient(`/api/notifications/missing-tracks?${params.toString()}`,
-        {
-          cache: 'no-store',
-          signal: controller.signal,
-          headers: new Headers({
-            Accept: 'application/json',
-            'Cache-Control': 'no-cache',
-            Pragma: 'no-cache',
-          }),
-        },
-      )
+
+      return httpClient(`${REST_URL}/missing?${params.toString()}`, {
+        cache: 'no-store',
+        signal: controller.signal,
+        headers: new Headers({
+          Accept: 'application/json',
+          'Cache-Control': 'no-cache',
+          Pragma: 'no-cache',
+        }),
+      })
         .then(({ json, headers }) => {
           if (activeRequestRef.current.id !== nextRequestId) {
             return
           }
+
           const list = Array.isArray(json) ? json : []
-          const totalHeader = headers && headers.get ? headers.get('X-Total-Count') : null
-          const parsedTotal = totalHeader ? parseInt(totalHeader, 10) : NaN
+          const rawTotal = headers && headers.get ? headers.get('X-Total-Count') : null
+          const totalValue = (() => {
+            if (!rawTotal) {
+              return list.length + (append ? start : 0)
+            }
+            const segments = rawTotal.split('/')
+            const parsed = parseInt(segments[segments.length - 1], 10)
+            if (Number.isNaN(parsed)) {
+              return list.length + (append ? start : 0)
+            }
+            return parsed
+          })()
+
           setEntries((prev) => {
-            const nextEntries = append ? [...prev, ...list] : list
-            const totalValue = Number.isNaN(parsedTotal) ? nextEntries.length : parsedTotal
+            const previous = append ? prev : []
+            const nextEntriesMap = new Map()
+            previous.forEach((entry) => {
+              const key = entry?.id || entry?.path || `${entry?.title || ''}-${entry?.artist || ''}`
+              nextEntriesMap.set(key, entry)
+            })
+            list.forEach((entry) => {
+              const key = entry?.id || entry?.path || `${entry?.title || ''}-${entry?.artist || ''}`
+              nextEntriesMap.set(key, entry)
+            })
+            const nextEntries = Array.from(nextEntriesMap.values())
             setTotalCount(totalValue)
-            setNextOffset(nextEntries.length)
-            setHasMore(nextEntries.length < totalValue && list.length > 0)
+            setNextOffset(start + list.length)
+            setHasMore(start + list.length < totalValue && list.length > 0)
             return nextEntries
           })
         })
@@ -157,7 +183,7 @@ const MissingTracksPanel = () => {
             return
           }
           setLoadingState(false)
-          if (!append && activeRequestRef.current.controller === controller) {
+          if (activeRequestRef.current.controller === controller) {
             activeRequestRef.current.controller = null
           }
         })
@@ -187,9 +213,13 @@ const MissingTracksPanel = () => {
       if (!entry) {
         return ''
       }
-      const rawTitle = (entry.title || '').trim()
-      const rawArtist = (entry.artist || '').trim()
-      const title = rawTitle || translate('notifications.missingTracksUnknownTitle')
+      const rawTitle = (entry.title || entry.name || '').trim()
+      const rawArtist = (entry.artist || entry.artistName || '').trim()
+      const fallbackTitle = (entry.path || '').split(/[/\\]/).pop() || ''
+      const title =
+        rawTitle ||
+        fallbackTitle ||
+        translate('notifications.missingTracksUnknownTitle')
       const unknownArtist = translate('notifications.missingTracksUnknownArtist').trim()
       const hasArtist =
         rawArtist && rawArtist.toLocaleLowerCase() !== unknownArtist.toLocaleLowerCase()
@@ -197,6 +227,16 @@ const MissingTracksPanel = () => {
     },
     [translate],
   )
+
+  const getEntrySecondaryLabel = useCallback((entry) => {
+    if (!entry) {
+      return ''
+    }
+    const details = [entry.libraryName, entry.album || entry.albumName]
+      .map((value) => (typeof value === 'string' ? value.trim() : ''))
+      .filter(Boolean)
+    return details.join(' • ')
+  }, [])
 
   useEffect(() => {
     fetchEntries(0, false)
@@ -260,11 +300,18 @@ const MissingTracksPanel = () => {
               </Typography>
             ) : (
               <List className={classes.list} dense>
-                {entries.map((entry, index) => (
-                  <ListItem key={`${entry.title || 'missing'}-${entry.artist || index}-${index}`} className={classes.listItem}>
-                    <ListItemText primary={getEntryLabel(entry)} />
-                  </ListItem>
-                ))}
+                {entries.map((entry, index) => {
+                  const key = entry?.id || entry?.path || `${index}-${entry?.title || 'missing'}`
+                  return (
+                    <ListItem key={key} className={classes.listItem}>
+                      <ListItemText
+                        primary={getEntryLabel(entry)}
+                        secondary={getEntrySecondaryLabel(entry)}
+                        secondaryTypographyProps={{ variant: 'body2', color: 'textSecondary' }}
+                      />
+                    </ListItem>
+                  )
+                })}
                 {hasMore && (
                   <ListItem
                     button

--- a/ui/src/layout/MissingTracksPanel.jsx
+++ b/ui/src/layout/MissingTracksPanel.jsx
@@ -15,6 +15,7 @@ import {
 } from '@material-ui/core'
 import { MdOutlineNotifications } from 'react-icons/md'
 import { useTranslate, useNotify } from 'react-admin'
+import { useRefreshOnEvents } from '../common'
 import { httpClient } from '../dataProvider'
 
 const PAGE_SIZE = 100
@@ -93,7 +94,7 @@ const MissingTracksPanel = () => {
         limit: PAGE_SIZE.toString(),
         offset: Math.max(offset, 0).toString(),
       })
-      httpClient(`/api/notifications/missing-tracks?${params.toString()}`)
+      return httpClient(`/api/notifications/missing-tracks?${params.toString()}`)
         .then(({ json, headers }) => {
           const list = Array.isArray(json) ? json : []
           const totalHeader = headers && headers.get ? headers.get('X-Total-Count') : null
@@ -122,6 +123,8 @@ const MissingTracksPanel = () => {
     },
     [notify],
   )
+
+  const refreshEntries = useCallback(() => fetchEntries(0, false), [fetchEntries])
 
   const handleOpen = useCallback(
     (event) => {
@@ -157,6 +160,11 @@ const MissingTracksPanel = () => {
   useEffect(() => {
     fetchEntries(0, false)
   }, [fetchEntries])
+
+  useRefreshOnEvents({
+    events: ['*'],
+    onRefresh: refreshEntries,
+  })
 
   return (
     <div>

--- a/ui/src/layout/MissingTracksPanel.jsx
+++ b/ui/src/layout/MissingTracksPanel.jsx
@@ -94,7 +94,17 @@ const MissingTracksPanel = () => {
         limit: PAGE_SIZE.toString(),
         offset: Math.max(offset, 0).toString(),
       })
-      return httpClient(`/api/notifications/missing-tracks?${params.toString()}`)
+      params.set('_', Date.now().toString())
+      return httpClient(`/api/notifications/missing-tracks?${params.toString()}`,
+        {
+          cache: 'no-store',
+          headers: new Headers({
+            Accept: 'application/json',
+            'Cache-Control': 'no-cache',
+            Pragma: 'no-cache',
+          }),
+        },
+      )
         .then(({ json, headers }) => {
           const list = Array.isArray(json) ? json : []
           const totalHeader = headers && headers.get ? headers.get('X-Total-Count') : null


### PR DESCRIPTION
## Summary
- ensure the missing track notification fetch helper returns a promise so it can be reused
- listen for refresh events over SSE and refetch missing track entries so the badge updates promptly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6901d0b889708330ab2147a5270cafb6