### PR TITLE
Ensure missing track notifications stay fresh

### DIFF
--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -1,6 +1,7 @@
 import jsonServerProvider from 'ra-data-json-server'
 import httpClient from './httpClient'
 import { REST_URL } from '../consts'
+import { emitLibraryMutated } from '../utils/libraryMutationEvents'
 
 const dataProvider = jsonServerProvider(REST_URL, httpClient)
 
@@ -80,12 +81,33 @@ const mapResource = (resource, params) => {
   }
 }
 
-const callDeleteMany = (resource, params) => {
+const LIBRARY_MUTATION_RESOURCES = new Set([
+  'song',
+  'playlist',
+  'playlistTrack',
+  'missing',
+  'folder',
+])
+
+const shouldEmitLibraryMutation = (resource) => LIBRARY_MUTATION_RESOURCES.has(resource)
+
+const emitMutationEvent = (resource, action, payload) => {
+  if (!shouldEmitLibraryMutation(resource)) {
+    return
+  }
+  emitLibraryMutated({ resource, action, payload })
+}
+
+const callDeleteMany = (resource, params, mappedResource) => {
   const ids = (params.ids || []).map((id) => `id=${id}`)
   const query = ids.length > 0 ? `?${ids.join('&')}` : ''
-  return httpClient(`${REST_URL}/${resource}${query}`, {
+  const targetResource = mappedResource || resource
+  return httpClient(`${REST_URL}/${targetResource}${query}`, {
     method: 'DELETE',
-  }).then((response) => ({ data: response.json.ids || [] }))
+  }).then((response) => {
+    emitMutationEvent(resource, 'deleteMany', { ids: response.json.ids || [] })
+    return { data: response.json.ids || [] }
+  })
 }
 
 // Helper function to handle user-library associations
@@ -95,10 +117,10 @@ const handleUserLibraryAssociation = async (userId, libraryIds) => {
   }
 
   try {
-  await httpClient(`${REST_URL}/user/${userId}/library`, {
-    method: 'PUT',
-    body: JSON.stringify({ libraryIds }),
-  })
+    await httpClient(`${REST_URL}/user/${userId}/library`, {
+      method: 'PUT',
+      body: JSON.stringify({ libraryIds }),
+    })
   } catch (error) {
     console.error('Error setting user libraries:', error) //eslint-disable-line no-console
     throw error
@@ -191,12 +213,16 @@ const wrapperDataProvider = {
           (params?.data?.folderId ?? params?.data?.parentId ?? '') || ''
         emitFoldersChanged({ type: 'create', resource, targetParentId: parentId })
       }
+      emitMutationEvent(resource, 'update', { id: params?.id, data: params?.data })
       return res
     })
   },
   updateMany: (resource, params) => {
     const [r, p] = mapResource(resource, params)
-    return dataProvider.updateMany(r, p)
+    return dataProvider.updateMany(r, p).then((res) => {
+      emitMutationEvent(resource, 'updateMany', { ids: params?.ids, data: params?.data })
+      return res
+    })
   },
   create: (resource, params) => {
     if (resource === 'user') {
@@ -209,6 +235,7 @@ const wrapperDataProvider = {
           (params?.data?.folderId ?? params?.data?.parentId ?? '') || ''
         emitFoldersChanged({ type: 'create', resource, targetParentId: parentId })
       }
+      emitMutationEvent(resource, 'create', { data: params?.data })
       return res
     })
   },
@@ -218,21 +245,28 @@ const wrapperDataProvider = {
       if (resource === 'playlist' || resource === 'folder') {
         emitFoldersChanged({ type: 'delete', resource, targetParentId: '' })
       }
+      emitMutationEvent(resource, 'delete', { id: params?.id })
       return res
     })
   },
   deleteMany: (resource, params) => {
     const [r, p] = mapResource(resource, params)
     if (r.endsWith('/tracks') || resource === 'missing' || resource === 'folder') {
-      return callDeleteMany(r, p)
+      return callDeleteMany(resource, p, r)
     }
-    return dataProvider.deleteMany(r, p)
+    return dataProvider.deleteMany(r, p).then((res) => {
+      emitMutationEvent(resource, 'deleteMany', { ids: params?.ids })
+      return res
+    })
   },
   addToPlaylist: (playlistId, data) => {
     return httpClient(`${REST_URL}/playlist/${playlistId}/tracks`, {
       method: 'POST',
       body: JSON.stringify(data),
-    }).then(({ json }) => ({ data: json }))
+    }).then(({ json }) => {
+      emitMutationEvent('playlistTrack', 'create', { playlistId, data })
+      return { data: json }
+    })
   },
   getPlaylists: (songId) => {
     return httpClient(`${REST_URL}/song/${songId}/playlists`).then(
@@ -258,6 +292,11 @@ const wrapperDataProvider = {
         sourceParentId: sourceParentId ?? '',
         targetParentId: targetFolderId ?? '',
       })
+      emitMutationEvent('playlist', 'move', {
+        id: playlistId,
+        targetFolderId,
+        sourceParentId,
+      })
       return { data: { id: playlistId, folderId: targetFolderId } }
     })
   },
@@ -275,6 +314,11 @@ const wrapperDataProvider = {
         sourceParentId: sourceParentId ?? '',
         targetParentId: targetParentId ?? '',
       })
+      emitMutationEvent('folder', 'move', {
+        id: folderId,
+        targetParentId,
+        sourceParentId,
+      })
       return { data: json }
     })
   },
@@ -291,6 +335,11 @@ const wrapperDataProvider = {
       if ((targetParentId ?? '') === '') {
         emitFoldersChanged({ type: 'bulkMove', targetParentId: '' })
       }
+      emitMutationEvent('folder', 'bulkMove', {
+        playlistIds,
+        folderIds,
+        targetParentId,
+      })
       return { data: json }
     })
   },

--- a/ui/src/layout/MissingTracksPanel.jsx
+++ b/ui/src/layout/MissingTracksPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import {
   Badge,
   Card,
@@ -15,9 +15,36 @@ import {
 } from '@material-ui/core'
 import { MdOutlineNotifications } from 'react-icons/md'
 import { useTranslate, useNotify } from 'react-admin'
+import { useSelector } from 'react-redux'
 import { httpClient } from '../dataProvider'
+import { useInterval } from '../common'
+import { subscribeLibraryMutated } from '../utils/libraryMutationEvents'
 
 const PAGE_SIZE = 100
+const OPEN_POLL_INTERVAL = 20000
+const CLOSED_POLL_INTERVAL = 60000
+const REFRESH_RELEVANT_RESOURCES = [
+  '*',
+  'song',
+  'playlist',
+  'playlistTrack',
+  'missing',
+  'folder',
+]
+
+const buildEntryKey = (entry) => {
+  if (!entry) {
+    return 'missing-entry'
+  }
+  const title = (entry.title || '').toString().trim().toLowerCase()
+  const artist = (entry.artist || '').toString().trim().toLowerCase()
+  const source = `${title}:::${artist}`
+  let hash = 0
+  for (let i = 0; i < source.length; i += 1) {
+    hash = (hash * 31 + source.charCodeAt(i)) | 0
+  }
+  return `missing-${hash.toString(16)}`
+}
 
 const useStyles = makeStyles((theme) => ({
   button: (props) => ({
@@ -74,6 +101,10 @@ const useStyles = makeStyles((theme) => ({
 const MissingTracksPanel = () => {
   const translate = useTranslate()
   const notify = useNotify()
+  const scanStatus = useSelector((state) => state.activity?.scanStatus || {})
+  const refreshEvent = useSelector((state) => state.activity?.refresh)
+  const streamReconnected = useSelector((state) => state.activity?.streamReconnected)
+
   const [anchorEl, setAnchorEl] = useState(null)
   const [entries, setEntries] = useState([])
   const [loading, setLoading] = useState(false)
@@ -84,17 +115,25 @@ const MissingTracksPanel = () => {
 
   const open = Boolean(anchorEl)
   const classes = useStyles({ open })
+  const isMountedRef = useRef(false)
+  const fetchIdRef = useRef(0)
+  const lastRefreshHandledRef = useRef(0)
+  const prevScanningRef = useRef(Boolean(scanStatus?.scanning))
 
   const fetchEntries = useCallback(
     (offset = 0, append = false) => {
       const setLoadingState = append ? setLoadingMore : setLoading
       setLoadingState(true)
+      const requestId = ++fetchIdRef.current
       const params = new URLSearchParams({
         limit: PAGE_SIZE.toString(),
         offset: Math.max(offset, 0).toString(),
       })
       httpClient(`/api/notifications/missing-tracks?${params.toString()}`)
         .then(({ json, headers }) => {
+          if (!isMountedRef.current || requestId !== fetchIdRef.current) {
+            return
+          }
           const list = Array.isArray(json) ? json : []
           const totalHeader = headers && headers.get ? headers.get('X-Total-Count') : null
           const parsedTotal = totalHeader ? parseInt(totalHeader, 10) : NaN
@@ -111,6 +150,9 @@ const MissingTracksPanel = () => {
           notify('ra.notification.http_error', 'warning', {
             messageArgs: { error: error.message || 'Unknown error' },
           })
+          if (!isMountedRef.current || requestId !== fetchIdRef.current) {
+            return
+          }
           if (!append) {
             setEntries([])
             setTotalCount(0)
@@ -118,18 +160,23 @@ const MissingTracksPanel = () => {
             setHasMore(false)
           }
         })
-        .finally(() => setLoadingState(false))
+        .finally(() => {
+          if (!isMountedRef.current || requestId !== fetchIdRef.current) {
+            return
+          }
+          setLoadingState(false)
+        })
     },
     [notify],
   )
 
-  const handleOpen = useCallback(
-    (event) => {
-      setAnchorEl(event.currentTarget)
-      fetchEntries(0, false)
-    },
-    [fetchEntries],
-  )
+  const refetchEntries = useCallback(() => {
+    fetchEntries(0, false)
+  }, [fetchEntries])
+
+  const handleOpen = useCallback((event) => {
+    setAnchorEl(event.currentTarget)
+  }, [])
 
   const handleClose = useCallback(() => {
     setAnchorEl(null)
@@ -138,6 +185,7 @@ const MissingTracksPanel = () => {
   const handleLoadMore = useCallback(() => {
     fetchEntries(nextOffset, true)
   }, [fetchEntries, nextOffset])
+
   const getEntryLabel = useCallback(
     (entry) => {
       if (!entry) {
@@ -155,8 +203,68 @@ const MissingTracksPanel = () => {
   )
 
   useEffect(() => {
+    isMountedRef.current = true
     fetchEntries(0, false)
+    return () => {
+      isMountedRef.current = false
+    }
   }, [fetchEntries])
+
+  useEffect(() => {
+    if (open) {
+      refetchEntries()
+    }
+  }, [open, refetchEntries])
+
+  useEffect(() => {
+    if (streamReconnected) {
+      refetchEntries()
+    }
+  }, [streamReconnected, refetchEntries])
+
+  useEffect(() => {
+    const unsubscribe = subscribeLibraryMutated(refetchEntries)
+    return () => unsubscribe()
+  }, [refetchEntries])
+
+  useEffect(() => {
+    const scanning = Boolean(scanStatus?.scanning)
+    const wasScanning = Boolean(prevScanningRef.current)
+    if (wasScanning && !scanning) {
+      refetchEntries()
+    }
+    prevScanningRef.current = scanning
+  }, [scanStatus, refetchEntries])
+
+  useEffect(() => {
+    const lastReceived = refreshEvent?.lastReceived
+    const resources = refreshEvent?.resources
+    if (!lastReceived || lastReceived <= lastRefreshHandledRef.current) {
+      return
+    }
+
+    const shouldHandle =
+      !resources ||
+      resources['*'] === '*' ||
+      REFRESH_RELEVANT_RESOURCES.some((resourceName) => resources?.[resourceName])
+
+    if (shouldHandle) {
+      lastRefreshHandledRef.current = lastReceived
+      refetchEntries()
+    }
+  }, [refreshEvent, refetchEntries])
+
+  useInterval(() => {
+    if (open) {
+      refetchEntries()
+    }
+  }, open ? OPEN_POLL_INTERVAL : null)
+
+  useInterval(() => {
+    if (!open) {
+      refetchEntries()
+    }
+  }, open ? null : CLOSED_POLL_INTERVAL)
 
   return (
     <div>
@@ -201,8 +309,8 @@ const MissingTracksPanel = () => {
               </Typography>
             ) : (
               <List className={classes.list} dense>
-                {entries.map((entry, index) => (
-                  <ListItem key={`${entry.title || 'missing'}-${entry.artist || index}-${index}`} className={classes.listItem}>
+                {entries.map((entry) => (
+                  <ListItem key={buildEntryKey(entry)} className={classes.listItem}>
                     <ListItemText primary={getEntryLabel(entry)} />
                   </ListItem>
                 ))}

--- a/ui/src/utils/libraryMutationEvents.js
+++ b/ui/src/utils/libraryMutationEvents.js
@@ -1,0 +1,28 @@
+const LIBRARY_MUTATED_EVENT = 'nd:library-mutated'
+
+export const emitLibraryMutated = (detail = {}) => {
+  if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') {
+    return
+  }
+  try {
+    window.dispatchEvent(
+      new CustomEvent(LIBRARY_MUTATED_EVENT, {
+        detail: { timestamp: Date.now(), ...detail },
+      }),
+    )
+  } catch (error) {
+    // Silently ignore errors when dispatching custom events
+  }
+}
+
+export const subscribeLibraryMutated = (handler) => {
+  if (typeof window === 'undefined' || typeof window.addEventListener !== 'function') {
+    return () => {}
+  }
+  window.addEventListener(LIBRARY_MUTATED_EVENT, handler)
+  return () => {
+    window.removeEventListener(LIBRARY_MUTATED_EVENT, handler)
+  }
+}
+
+export const getLibraryMutatedEventName = () => LIBRARY_MUTATED_EVENT


### PR DESCRIPTION
## Summary
- add a reusable library mutation event emitter
- emit mutation events from the wrapped data provider so missing-track queries can refresh
- refresh the missing tracks drawer on visibility changes, server events, and focused polling with stable keys

## Testing
- npm --prefix ui run lint

------
https://chatgpt.com/codex/tasks/task_e_6901f1da5d7c8330acce29c2eb53e703