### PR TITLE
Fix retail player channel dropdown to reflect selection

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -603,6 +603,8 @@ const RetailPlayerDashboard = () => {
   const dislikeTimeoutRef = useRef(null)
   const dislikeRequestControllerRef = useRef(null)
   const channelRequestControllerRef = useRef(null)
+  const pendingScheduleKeyRef = useRef(null)
+  const latestResolvedDeviceRef = useRef(null)
   const [showDislikeMessage, setShowDislikeMessage] = useState(false)
   const [currentTrackIndex, setCurrentTrackIndex] = useState(0)
   const [isScheduleMenuOpen, setScheduleMenuOpen] = useState(false)
@@ -685,7 +687,41 @@ const RetailPlayerDashboard = () => {
   }, [])
 
   useEffect(() => {
-    setDevice(resolvedDevice || null)
+    latestResolvedDeviceRef.current = resolvedDevice || null
+    setDevice(() => {
+      const nextDevice = resolvedDevice || null
+      if (!nextDevice) {
+        pendingScheduleKeyRef.current = null
+        return nextDevice
+      }
+
+      const pendingKey = pendingScheduleKeyRef.current
+      if (!pendingKey) {
+        return nextDevice
+      }
+
+      const schedules = Array.isArray(nextDevice.schedules)
+        ? nextDevice.schedules
+        : []
+
+      const pendingSchedule = schedules.find((schedule) => schedule.key === pendingKey)
+      if (!pendingSchedule) {
+        pendingScheduleKeyRef.current = null
+        return nextDevice
+      }
+
+      if (pendingSchedule.isActive) {
+        pendingScheduleKeyRef.current = null
+        return nextDevice
+      }
+
+      const patchedSchedules = schedules.map((schedule) => ({
+        ...schedule,
+        isActive: schedule.key === pendingKey,
+      }))
+
+      return { ...nextDevice, schedules: patchedSchedules }
+    })
     setDeviceTime(resolveDeviceTime(resolvedDevice))
   }, [resolvedDevice, resolveDeviceTime])
 
@@ -1023,6 +1059,7 @@ const RetailPlayerDashboard = () => {
 
       const headers = new Headers({ 'Content-Type': 'application/json' })
       const selectedKey = schedule.key
+      pendingScheduleKeyRef.current = selectedKey
 
       httpClient(`/api/retailplayer/devices/${encodeURIComponent(deviceApiId)}/channel`, {
         method: 'POST',
@@ -1055,6 +1092,8 @@ const RetailPlayerDashboard = () => {
           if (err?.name !== 'AbortError') {
             // eslint-disable-next-line no-console
             console.error('Failed to update retail player channel', err)
+            pendingScheduleKeyRef.current = null
+            setDevice(latestResolvedDeviceRef.current)
           }
         })
         .finally(() => {

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -577,6 +577,9 @@ const dummyTracks = [
   },
 ]
 
+const CHANNEL_STATUS_REFRESH_ATTEMPTS = 3
+const CHANNEL_STATUS_REFRESH_DELAY_MS = 1000
+
 const RetailPlayerDashboard = () => {
   const classes = useStyles()
   const { deviceSlug } = useParams()
@@ -605,6 +608,8 @@ const RetailPlayerDashboard = () => {
   const channelRequestControllerRef = useRef(null)
   const pendingScheduleKeyRef = useRef(null)
   const latestResolvedDeviceRef = useRef(null)
+  const statusRefreshTimeoutRef = useRef(null)
+  const statusRefreshRemainingRef = useRef(0)
   const [showDislikeMessage, setShowDislikeMessage] = useState(false)
   const [currentTrackIndex, setCurrentTrackIndex] = useState(0)
   const [isScheduleMenuOpen, setScheduleMenuOpen] = useState(false)
@@ -686,12 +691,52 @@ const RetailPlayerDashboard = () => {
     return new Date()
   }, [])
 
+  const clearStatusRefreshRetry = useCallback(() => {
+    if (statusRefreshTimeoutRef.current) {
+      window.clearTimeout(statusRefreshTimeoutRef.current)
+      statusRefreshTimeoutRef.current = null
+    }
+    statusRefreshRemainingRef.current = 0
+  }, [])
+
+  const scheduleStatusRefreshRetry = useCallback(
+    (
+      attempts = CHANNEL_STATUS_REFRESH_ATTEMPTS,
+      delayMs = CHANNEL_STATUS_REFRESH_DELAY_MS,
+    ) => {
+      clearStatusRefreshRetry()
+
+      if (!attempts || delayMs <= 0) {
+        return
+      }
+
+      statusRefreshRemainingRef.current = attempts
+
+      const scheduleNextAttempt = () => {
+        if (statusRefreshRemainingRef.current <= 0) {
+          statusRefreshTimeoutRef.current = null
+          return
+        }
+
+        statusRefreshTimeoutRef.current = window.setTimeout(() => {
+          refreshStatus()
+          statusRefreshRemainingRef.current -= 1
+          scheduleNextAttempt()
+        }, delayMs)
+      }
+
+      scheduleNextAttempt()
+    },
+    [clearStatusRefreshRetry, refreshStatus],
+  )
+
   useEffect(() => {
     latestResolvedDeviceRef.current = resolvedDevice || null
     setDevice(() => {
       const nextDevice = resolvedDevice || null
       if (!nextDevice) {
         pendingScheduleKeyRef.current = null
+        clearStatusRefreshRetry()
         return nextDevice
       }
 
@@ -707,11 +752,13 @@ const RetailPlayerDashboard = () => {
       const pendingSchedule = schedules.find((schedule) => schedule.key === pendingKey)
       if (!pendingSchedule) {
         pendingScheduleKeyRef.current = null
+        clearStatusRefreshRetry()
         return nextDevice
       }
 
       if (pendingSchedule.isActive) {
         pendingScheduleKeyRef.current = null
+        clearStatusRefreshRetry()
         return nextDevice
       }
 
@@ -723,7 +770,7 @@ const RetailPlayerDashboard = () => {
       return { ...nextDevice, schedules: patchedSchedules }
     })
     setDeviceTime(resolveDeviceTime(resolvedDevice))
-  }, [resolvedDevice, resolveDeviceTime])
+  }, [clearStatusRefreshRetry, resolvedDevice, resolveDeviceTime])
 
   useEffect(() => {
     const intervalId = window.setInterval(() => {
@@ -1087,12 +1134,14 @@ const RetailPlayerDashboard = () => {
             }
           })
           refreshStatus()
+          scheduleStatusRefreshRetry()
         })
         .catch((err) => {
           if (err?.name !== 'AbortError') {
             // eslint-disable-next-line no-console
             console.error('Failed to update retail player channel', err)
             pendingScheduleKeyRef.current = null
+            clearStatusRefreshRetry()
             setDevice(latestResolvedDeviceRef.current)
           }
         })
@@ -1102,7 +1151,13 @@ const RetailPlayerDashboard = () => {
           }
         })
     },
-    [canControlDevice, deviceApiId, refreshStatus],
+    [
+      canControlDevice,
+      clearStatusRefreshRetry,
+      deviceApiId,
+      refreshStatus,
+      scheduleStatusRefreshRetry,
+    ],
   )
 
   const handleSelectFromDropdown = useCallback(
@@ -1271,7 +1326,8 @@ const RetailPlayerDashboard = () => {
       channelRequestControllerRef.current.abort()
       channelRequestControllerRef.current = null
     }
-  }, [clearVolumeTimeout])
+    clearStatusRefreshRetry()
+  }, [clearStatusRefreshRetry, clearVolumeTimeout])
 
   if (!device) {
     const heading = notFound

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -114,8 +114,6 @@ const mapChannelListResponse = (payload) =>
     })
     .filter(Boolean)
 
-const STATUS_REFRESH_INTERVAL_MS = 5000
-
 const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
   if (!baseDevice) {
     return null
@@ -554,29 +552,6 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
   const refresh = useCallback(() => {
     setRefreshIndex((previous) => previous + 1)
   }, [])
-
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return undefined
-    }
-
-    if (!isApiEnabled || devicesLoading) {
-      return undefined
-    }
-
-    const deviceId = normalizeValue(baseDevice?.apiId)
-    if (!deviceId) {
-      return undefined
-    }
-
-    const intervalId = window.setInterval(() => {
-      refresh()
-    }, STATUS_REFRESH_INTERVAL_MS)
-
-    return () => {
-      window.clearInterval(intervalId)
-    }
-  }, [baseDevice?.apiId, devicesLoading, isApiEnabled, refresh])
 
   useEffect(() => {
     if (!isApiEnabled) {

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -114,6 +114,8 @@ const mapChannelListResponse = (payload) =>
     })
     .filter(Boolean)
 
+const STATUS_REFRESH_INTERVAL_MS = 5000
+
 const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
   if (!baseDevice) {
     return null
@@ -552,6 +554,29 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
   const refresh = useCallback(() => {
     setRefreshIndex((previous) => previous + 1)
   }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined
+    }
+
+    if (!isApiEnabled || devicesLoading) {
+      return undefined
+    }
+
+    const deviceId = normalizeValue(baseDevice?.apiId)
+    if (!deviceId) {
+      return undefined
+    }
+
+    const intervalId = window.setInterval(() => {
+      refresh()
+    }, STATUS_REFRESH_INTERVAL_MS)
+
+    return () => {
+      window.clearInterval(intervalId)
+    }
+  }, [baseDevice?.apiId, devicesLoading, isApiEnabled, refresh])
 
   useEffect(() => {
     if (!isApiEnabled) {


### PR DESCRIPTION
## Summary
- keep track of a pending retail player schedule selection and reuse it while waiting for status updates
- patch the local device state so the newly selected schedule stays active in the dropdown until the backend confirms it
- reset the pending selection when new data reflects the change or when the update request fails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69033dc216448330a22dc7ae5ee39147