### PR TITLE
Fix retail player dashboard channel state sync

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -13,7 +13,7 @@ import { useParams } from 'react-router-dom'
 import { BiDislike } from 'react-icons/bi'
 import { MdSkipNext } from 'react-icons/md'
 import useRetailPlayerDeviceStatus from './useRetailPlayerDeviceStatus'
-import { normalizeValue } from './deviceUtils'
+import { deviceSlugKey, normalizeValue } from './deviceUtils'
 import httpClient from '../dataProvider/httpClient'
 
 const combineClasses = (...classNames) => classNames.filter(Boolean).join(' ')
@@ -704,9 +704,136 @@ const RetailPlayerDashboard = () => {
 
   const schedules = useMemo(() => device?.schedules || [], [device])
 
+  const resolvedActiveChannelKey = useMemo(() => {
+    if (!schedules.length) {
+      return null
+    }
+
+    const flaggedActive = schedules.find((schedule) => schedule.isActive)
+    if (flaggedActive) {
+      return flaggedActive.key
+    }
+
+    const status =
+      device?.status && typeof device.status === 'object' ? device.status : {}
+
+    const nowPlayingMetadata =
+      device?.nowPlaying && typeof device.nowPlaying === 'object'
+        ? device.nowPlaying.metadata && typeof device.nowPlaying.metadata === 'object'
+          ? device.nowPlaying.metadata
+          : {}
+        : {}
+
+    const collectUnique = (values, transform) => {
+      const result = []
+      const seen = new Set()
+      values.forEach((value) => {
+        const normalized = transform ? transform(value) : value
+        if (normalized) {
+          const token = String(normalized)
+          if (!seen.has(token)) {
+            seen.add(token)
+            result.push(token)
+          }
+        }
+      })
+      return result
+    }
+
+    const candidateIds = collectUnique(
+      [
+        nowPlayingMetadata.channelId,
+        nowPlayingMetadata.channel_id,
+        nowPlayingMetadata.channel,
+        status.channelId,
+        status.channel_id,
+        status.currentChannelId,
+        status.current_channel_id,
+        status.channel,
+        status.currentChannel,
+        status.current_channel,
+        device?.channel,
+      ],
+      (value) => normalizeValue(value),
+    )
+
+    if (candidateIds.length) {
+      const matchById = schedules.find((schedule) => {
+        const metadata = schedule?.metadata && typeof schedule.metadata === 'object' ? schedule.metadata : {}
+        const scheduleId = normalizeValue(metadata.channelId)
+        return scheduleId && candidateIds.includes(scheduleId)
+      })
+      if (matchById) {
+        return matchById.key
+      }
+    }
+
+    const candidateResources = collectUnique(
+      [
+        status.activeResource,
+        status.active_resource,
+        nowPlayingMetadata.activeResource,
+        nowPlayingMetadata.active_resource,
+        nowPlayingMetadata.resource,
+      ],
+      (value) => normalizeValue(value),
+    )
+
+    if (candidateResources.length) {
+      const matchByResource = schedules.find((schedule) => {
+        const metadata = schedule?.metadata && typeof schedule.metadata === 'object' ? schedule.metadata : {}
+        const resource = normalizeValue(metadata.activeResource)
+        return resource && candidateResources.includes(resource)
+      })
+      if (matchByResource) {
+        return matchByResource.key
+      }
+    }
+
+    const candidateNameKeys = collectUnique(
+      [
+        nowPlayingMetadata.channelName,
+        nowPlayingMetadata.channel_name,
+        nowPlayingMetadata.channel,
+        nowPlayingMetadata.playlistName,
+        nowPlayingMetadata.playlist_name,
+        status.channelName,
+        status.channel_name,
+        status.currentChannelName,
+        status.current_channel_name,
+        status.currentChannel,
+        status.current_channel,
+        status.activeStreamName,
+        status.active_stream_name,
+        status.activeStream,
+        status.active_stream,
+        device?.channel,
+      ],
+      (value) => deviceSlugKey(value),
+    )
+
+    if (candidateNameKeys.length) {
+      const matchByName = schedules.find((schedule) => {
+        const metadata = schedule?.metadata && typeof schedule.metadata === 'object' ? schedule.metadata : {}
+        const scheduleNameKey =
+          deviceSlugKey(metadata.channelName) ||
+          deviceSlugKey(metadata.channel_name) ||
+          deviceSlugKey(metadata.channel) ||
+          deviceSlugKey(schedule.label) ||
+          deviceSlugKey(schedule.key)
+        return scheduleNameKey && candidateNameKeys.includes(scheduleNameKey)
+      })
+      if (matchByName) {
+        return matchByName.key
+      }
+    }
+
+    return schedules[0].key
+  }, [device?.channel, device?.nowPlaying, device?.status, schedules])
+
   const activeChannelKey = useMemo(
-    () => pendingChannelKey || (schedules.find((schedule) => schedule.isActive)?.key ?? null),
-    [pendingChannelKey, schedules],
+    () => pendingChannelKey || resolvedActiveChannelKey,
+    [pendingChannelKey, resolvedActiveChannelKey],
   )
 
   const availableSchedules = useMemo(
@@ -1056,14 +1183,16 @@ const RetailPlayerDashboard = () => {
       return
     }
 
-    const pendingSchedule = schedules.find(
-      (schedule) => schedule.key === pendingChannelKey,
-    )
+    const hasPending = schedules.some((schedule) => schedule.key === pendingChannelKey)
+    if (!hasPending) {
+      setPendingChannelKey(null)
+      return
+    }
 
-    if (!pendingSchedule || pendingSchedule.isActive) {
+    if (pendingChannelKey === resolvedActiveChannelKey) {
       setPendingChannelKey(null)
     }
-  }, [pendingChannelKey, schedules])
+  }, [pendingChannelKey, resolvedActiveChannelKey, schedules])
 
   const handleSelectFromDropdown = useCallback(
     (schedule) => {

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -592,7 +592,7 @@ const RetailPlayerDashboard = () => {
     notFound,
     isApiEnabled,
   } = useRetailPlayerDeviceStatus(deviceSlug)
-  const [device, setDevice] = useState(resolvedDevice)
+  const device = resolvedDevice
   const [deviceTime, setDeviceTime] = useState(() => new Date())
   const [isMuted, setIsMuted] = useState(false)
   const [volume, setVolume] = useState(50)
@@ -606,6 +606,7 @@ const RetailPlayerDashboard = () => {
   const [showDislikeMessage, setShowDislikeMessage] = useState(false)
   const [currentTrackIndex, setCurrentTrackIndex] = useState(0)
   const [isScheduleMenuOpen, setScheduleMenuOpen] = useState(false)
+  const [pendingChannelKey, setPendingChannelKey] = useState(null)
   const scheduleDropdownRef = useRef(null)
   const isBusy = retailLoading || statusLoading
   const combinedError = integrationError || statusError || devicesError
@@ -685,9 +686,8 @@ const RetailPlayerDashboard = () => {
   }, [])
 
   useEffect(() => {
-    setDevice(resolvedDevice || null)
-    setDeviceTime(resolveDeviceTime(resolvedDevice))
-  }, [resolvedDevice, resolveDeviceTime])
+    setDeviceTime(resolveDeviceTime(device))
+  }, [device, resolveDeviceTime])
 
   useEffect(() => {
     const intervalId = window.setInterval(() => {
@@ -704,10 +704,10 @@ const RetailPlayerDashboard = () => {
 
   const schedules = useMemo(() => device?.schedules || [], [device])
 
-  const activeChannelKey = useMemo(() => {
-    const activeSchedule = schedules.find((schedule) => schedule.isActive)
-    return activeSchedule ? activeSchedule.key : null
-  }, [schedules])
+  const activeChannelKey = useMemo(
+    () => pendingChannelKey || (schedules.find((schedule) => schedule.isActive)?.key ?? null),
+    [pendingChannelKey, schedules],
+  )
 
   const availableSchedules = useMemo(
     () => schedules.filter((schedule) => schedule.key !== activeChannelKey),
@@ -974,6 +974,7 @@ const RetailPlayerDashboard = () => {
 
   const handleSelectChannel = useCallback(
     (schedule) => {
+      setPendingChannelKey(schedule?.key || null)
       if (!schedule) {
         return
       }
@@ -1007,10 +1008,12 @@ const RetailPlayerDashboard = () => {
       if (!selectedChannelId) {
         // eslint-disable-next-line no-console
         console.error('Unable to determine channel id for selection', schedule)
+        setPendingChannelKey(null)
         return
       }
 
       if (!canControlDevice || !deviceApiId) {
+        setPendingChannelKey(null)
         return
       }
 
@@ -1022,7 +1025,6 @@ const RetailPlayerDashboard = () => {
       channelRequestControllerRef.current = abortController
 
       const headers = new Headers({ 'Content-Type': 'application/json' })
-      const selectedKey = schedule.key
 
       httpClient(`/api/retailplayer/devices/${encodeURIComponent(deviceApiId)}/channel`, {
         method: 'POST',
@@ -1031,24 +1033,6 @@ const RetailPlayerDashboard = () => {
         signal: abortController.signal,
       })
         .then(() => {
-          setDevice((previous) => {
-            if (!previous) {
-              return previous
-            }
-
-            const previousSchedules = Array.isArray(previous.schedules)
-              ? previous.schedules
-              : []
-            const nextSchedules = previousSchedules.map((item) => ({
-              ...item,
-              isActive: item.key === selectedKey,
-            }))
-
-            return {
-              ...previous,
-              schedules: nextSchedules,
-            }
-          })
           refreshStatus()
         })
         .catch((err) => {
@@ -1061,6 +1045,7 @@ const RetailPlayerDashboard = () => {
           if (channelRequestControllerRef.current === abortController) {
             channelRequestControllerRef.current = null
           }
+          setPendingChannelKey(null)
         })
     },
     [canControlDevice, deviceApiId, refreshStatus],

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1039,17 +1039,31 @@ const RetailPlayerDashboard = () => {
           if (err?.name !== 'AbortError') {
             // eslint-disable-next-line no-console
             console.error('Failed to update retail player channel', err)
+            setPendingChannelKey(null)
           }
         })
         .finally(() => {
           if (channelRequestControllerRef.current === abortController) {
             channelRequestControllerRef.current = null
           }
-          setPendingChannelKey(null)
         })
     },
     [canControlDevice, deviceApiId, refreshStatus],
   )
+
+  useEffect(() => {
+    if (!pendingChannelKey) {
+      return
+    }
+
+    const pendingSchedule = schedules.find(
+      (schedule) => schedule.key === pendingChannelKey,
+    )
+
+    if (!pendingSchedule || pendingSchedule.isActive) {
+      setPendingChannelKey(null)
+    }
+  }, [pendingChannelKey, schedules])
 
   const handleSelectFromDropdown = useCallback(
     (schedule) => {

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -717,11 +717,12 @@ const RetailPlayerDashboard = () => {
     const status =
       device?.status && typeof device.status === 'object' ? device.status : {}
 
+    const nowPlaying =
+      device?.nowPlaying && typeof device.nowPlaying === 'object' ? device.nowPlaying : {}
+
     const nowPlayingMetadata =
-      device?.nowPlaying && typeof device.nowPlaying === 'object'
-        ? device.nowPlaying.metadata && typeof device.nowPlaying.metadata === 'object'
-          ? device.nowPlaying.metadata
-          : {}
+      nowPlaying.metadata && typeof nowPlaying.metadata === 'object'
+        ? nowPlaying.metadata
         : {}
 
     const collectUnique = (values, transform) => {
@@ -754,13 +755,13 @@ const RetailPlayerDashboard = () => {
         status.current_channel,
         device?.channel,
       ],
-      (value) => normalizeValue(value),
+      (value) => normalizeValue(value).toLowerCase(),
     )
 
     if (candidateIds.length) {
       const matchById = schedules.find((schedule) => {
         const metadata = schedule?.metadata && typeof schedule.metadata === 'object' ? schedule.metadata : {}
-        const scheduleId = normalizeValue(metadata.channelId)
+        const scheduleId = normalizeValue(metadata.channelId).toLowerCase()
         return scheduleId && candidateIds.includes(scheduleId)
       })
       if (matchById) {
@@ -772,17 +773,20 @@ const RetailPlayerDashboard = () => {
       [
         status.activeResource,
         status.active_resource,
+        status.resource,
         nowPlayingMetadata.activeResource,
         nowPlayingMetadata.active_resource,
         nowPlayingMetadata.resource,
+        nowPlayingMetadata.filename,
+        nowPlaying.streamName,
       ],
-      (value) => normalizeValue(value),
+      (value) => normalizeValue(value).toLowerCase(),
     )
 
     if (candidateResources.length) {
       const matchByResource = schedules.find((schedule) => {
         const metadata = schedule?.metadata && typeof schedule.metadata === 'object' ? schedule.metadata : {}
-        const resource = normalizeValue(metadata.activeResource)
+        const resource = normalizeValue(metadata.activeResource).toLowerCase()
         return resource && candidateResources.includes(resource)
       })
       if (matchByResource) {

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -213,19 +213,22 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
     })
     .filter(Boolean)
 
-  const activeResource = normalizeValue(status.activeResource)
+  const activeResource = normalizeValue(status.activeResource).toLowerCase()
   const activeStreamName = normalizeValue(status.activeStreamName)
   const activeStream = normalizeValue(status.activeStream)
   const streamName = activeStreamName || activeStream
+  const activeStreamNameKey = deviceSlugKey(activeStreamName || activeStream)
   const { artist: streamArtistFallback, title: streamTitleFallback } =
     parseStreamArtistTitle(activeStream || activeStreamName)
 
   const schedulesWithActive = normalizedSchedules.map((schedule, index) => {
     const metadata = schedule.metadata ? { ...schedule.metadata } : {}
     const matchesResource =
-      activeResource && normalizeValue(metadata.activeResource) === activeResource
+      activeResource &&
+      normalizeValue(metadata.activeResource).toLowerCase() === activeResource
     const matchesChannel =
-      activeStreamName && normalizeValue(metadata.channelName) === activeStreamName
+      activeStreamNameKey &&
+      deviceSlugKey(metadata.channelName) === activeStreamNameKey
     const isActive =
       matchesResource ||
       matchesChannel ||
@@ -268,7 +271,7 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
 
     metadataSchedules.forEach((schedule) => {
       const scheduleMetadata = schedule.metadata || {}
-      const idKey = normalizeValue(scheduleMetadata.channelId)
+      const idKey = normalizeValue(scheduleMetadata.channelId).toLowerCase()
       const nameKey = deviceSlugKey(
         normalizeValue(scheduleMetadata.channelName) || schedule.label || schedule.key,
       )
@@ -282,7 +285,8 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
 
     const activeMetadata = metadataSchedules.find((schedule) => schedule.isActive) || null
     const activeId =
-      normalizeValue(activeMetadata?.metadata?.channelId) || normalizeValue(baseDevice.channel)
+      normalizeValue(activeMetadata?.metadata?.channelId).toLowerCase() ||
+      normalizeValue(baseDevice.channel).toLowerCase()
     const activeNameKey = activeMetadata
       ? deviceSlugKey(
           normalizeValue(activeMetadata.metadata?.channelName) ||
@@ -292,7 +296,7 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
       : ''
 
     let mergedSchedules = normalizedChannelList.map((schedule, index) => {
-      const channelId = normalizeValue(schedule.metadata.channelId)
+      const channelId = normalizeValue(schedule.metadata.channelId).toLowerCase()
       const channelName = normalizeValue(schedule.metadata.channelName) || schedule.label
       const nameKey = deviceSlugKey(channelName)
       const metadataMatch =
@@ -333,7 +337,7 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
 
     const identifierSet = new Set()
     mergedSchedules.forEach((schedule) => {
-      const idValue = normalizeValue(schedule.metadata?.channelId)
+      const idValue = normalizeValue(schedule.metadata?.channelId).toLowerCase()
       const nameKey = deviceSlugKey(
         normalizeValue(schedule.metadata?.channelName) || schedule.label || schedule.key,
       )
@@ -346,7 +350,7 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
     })
 
     metadataSchedules.forEach((schedule) => {
-      const idValue = normalizeValue(schedule.metadata?.channelId)
+      const idValue = normalizeValue(schedule.metadata?.channelId).toLowerCase()
       const nameKey = deviceSlugKey(
         normalizeValue(schedule.metadata?.channelName) || schedule.label || schedule.key,
       )


### PR DESCRIPTION
## Summary
- rely on the retail player status hook as the single device source of truth
- drop local schedule mutations and refresh after channel changes while tracking pending selection
- keep the dashboard clock derived from the shared device state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69035858544483308ea802d71546adef