### PR TITLE
Fix retail player track display updates

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -859,7 +859,11 @@ const RetailPlayerDashboard = () => {
     if (typeof device.nowPlaying === 'object' && device.nowPlaying !== null) {
       return {
         title: device.nowPlaying.title || 'Now Playing',
-        artist: device.nowPlaying.artist || device.channel || 'Retail Player',
+        artist:
+          device.nowPlaying.artist ||
+          device.channelName ||
+          device.channel ||
+          'Retail Player',
         artworkUrl: device.nowPlaying.artworkUrl || null,
       }
     }
@@ -867,7 +871,9 @@ const RetailPlayerDashboard = () => {
       const [titlePart, artistPart] = device.nowPlaying.split('|')
       return {
         title: titlePart ? titlePart.trim() : device.nowPlaying,
-        artist: artistPart ? artistPart.trim() : device.channel || 'Retail Player',
+        artist: artistPart
+          ? artistPart.trim()
+          : device.channelName || device.channel || 'Retail Player',
         artworkUrl: null,
       }
     }
@@ -877,7 +883,7 @@ const RetailPlayerDashboard = () => {
   const fallbackTrack = useMemo(() => {
     const activeScheduleLabel = normalizeValue(activeSchedule?.label)
     const activeScheduleArtist = normalizeValue(activeSchedule?.artist)
-    const channelName = normalizeValue(device?.channel)
+    const channelName = normalizeValue(device?.channelName) || normalizeValue(device?.channel)
     const deviceName = normalizeValue(device?.name)
     const organizationName = normalizeValue(device?.organization)
 
@@ -886,7 +892,14 @@ const RetailPlayerDashboard = () => {
       artist: activeScheduleArtist || channelName || organizationName || 'Retail Player',
       artworkUrl: null,
     }
-  }, [activeSchedule?.artist, activeSchedule?.label, device?.channel, device?.name, device?.organization])
+  }, [
+    activeSchedule?.artist,
+    activeSchedule?.label,
+    device?.channel,
+    device?.channelName,
+    device?.name,
+    device?.organization,
+  ])
 
   const currentTrack = useMemo(
     () => normalizedDeviceTrack || fallbackTrack,
@@ -990,6 +1003,22 @@ const RetailPlayerDashboard = () => {
         return
       }
 
+      const channelNameCandidates = [
+        metadata.channelName,
+        metadata.channel_name,
+        metadata.name,
+        schedule.label,
+        schedule.name,
+        schedule.key,
+        rawSchedule.name,
+        rawSchedule.channelName,
+        rawSchedule.channel_name,
+      ]
+
+      const selectedChannelName = channelNameCandidates
+        .map((candidate) => normalizeValue(candidate))
+        .find((value) => value)
+
       if (!canControlDevice || !deviceApiId) {
         return
       }
@@ -1026,6 +1055,8 @@ const RetailPlayerDashboard = () => {
 
             return {
               ...previous,
+              channel: selectedChannelId || previous.channel,
+              channelName: selectedChannelName || previous.channelName || previous.channel,
               schedules: nextSchedules,
             }
           })

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -558,25 +558,6 @@ const useStyles = makeStyles((theme) => {
   }
 })
 
-const dummyTracks = [
-  {
-    title: 'Neon Skyline',
-    artist: 'City Echo',
-    artworkUrl: null,
-  },
-  {
-    title: 'Golden Hours',
-    artist: 'Harbor Lights',
-    artworkUrl:
-      'https://images.unsplash.com/photo-1526285840434-67ff3760c121?auto=format&fit=crop&w=400&q=80',
-  },
-  {
-    title: 'Velvet Static',
-    artist: 'Analog Dream',
-    artworkUrl: null,
-  },
-]
-
 const RetailPlayerDashboard = () => {
   const classes = useStyles()
   const { deviceSlug } = useParams()
@@ -604,7 +585,6 @@ const RetailPlayerDashboard = () => {
   const dislikeRequestControllerRef = useRef(null)
   const channelRequestControllerRef = useRef(null)
   const [showDislikeMessage, setShowDislikeMessage] = useState(false)
-  const [currentTrackIndex, setCurrentTrackIndex] = useState(0)
   const [isScheduleMenuOpen, setScheduleMenuOpen] = useState(false)
   const scheduleDropdownRef = useRef(null)
   const isBusy = retailLoading || statusLoading
@@ -894,24 +874,24 @@ const RetailPlayerDashboard = () => {
     return null
   }, [device])
 
-  const trackPool = useMemo(() => {
-    if (normalizedDeviceTrack) {
-      return [normalizedDeviceTrack, ...dummyTracks]
-    }
-    return dummyTracks
-  }, [normalizedDeviceTrack])
+  const fallbackTrack = useMemo(() => {
+    const activeScheduleLabel = normalizeValue(activeSchedule?.label)
+    const activeScheduleArtist = normalizeValue(activeSchedule?.artist)
+    const channelName = normalizeValue(device?.channel)
+    const deviceName = normalizeValue(device?.name)
+    const organizationName = normalizeValue(device?.organization)
 
-  useEffect(() => {
-    setCurrentTrackIndex(0)
-  }, [normalizedDeviceTrack])
-
-  const currentTrack = useMemo(() => {
-    if (!trackPool.length) {
-      return { title: 'Now Playing', artist: 'Retail Player', artworkUrl: null }
+    return {
+      title: activeScheduleLabel || channelName || deviceName || 'Now Playing',
+      artist: activeScheduleArtist || channelName || organizationName || 'Retail Player',
+      artworkUrl: null,
     }
-    const index = ((currentTrackIndex % trackPool.length) + trackPool.length) % trackPool.length
-    return trackPool[index]
-  }, [currentTrackIndex, trackPool])
+  }, [activeSchedule?.artist, activeSchedule?.label, device?.channel, device?.name, device?.organization])
+
+  const currentTrack = useMemo(
+    () => normalizedDeviceTrack || fallbackTrack,
+    [fallbackTrack, normalizedDeviceTrack],
+  )
 
   const artworkUrl = device?.nowPlaying?.artworkUrl || null
   const resolvedArtworkUrl = artworkUrl || currentTrack?.artworkUrl || null
@@ -1150,11 +1130,8 @@ const RetailPlayerDashboard = () => {
   }, [sendDislikeNotification])
 
   const handleSkip = useCallback(() => {
-    if (!trackPool.length) {
-      return
-    }
-    setCurrentTrackIndex((previous) => (previous + 1) % trackPool.length)
-  }, [trackPool])
+    refreshStatus()
+  }, [refreshStatus])
 
   const handleShortcutChannel = useCallback(
     (index) => {

--- a/ui/src/retailPlayer/RetailPlayerDevicesList.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDevicesList.jsx
@@ -246,7 +246,7 @@ const RetailPlayerDevicesList = () => {
                   {device.name}
                 </span>
                 <span className={classes.cell} data-area="channel">
-                  {device.channel}
+                  {device.channelName || device.channel}
                 </span>
                 <span className={classes.cell} data-area="channelList">
                   {device.channelList}

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -245,14 +245,17 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
     }
   })
 
+  const baseChannelId = normalizeValue(baseDevice.channel)
+  const baseChannelName = normalizeValue(baseDevice.channelName)
+
   const fallbackSchedule = {
     key: buildDeviceSlug(baseDevice) || baseDevice.id,
-    label: normalizeValue(baseDevice.channel) || baseDevice.name,
+    label: baseChannelName || baseChannelId || baseDevice.name,
     artist: normalizeValue(baseDevice.organization) || baseDevice.name,
     isActive: true,
     metadata: {
-      channelId: normalizeValue(baseDevice.channel),
-      channelName: normalizeValue(baseDevice.channel) || baseDevice.name,
+      channelId: baseChannelId,
+      channelName: baseChannelName || baseChannelId || baseDevice.name,
     },
   }
 
@@ -394,6 +397,8 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
     'title',
   ])
   const scheduleLabel = normalizeValue(activeSchedule?.label)
+  const metadataChannelId = normalizeValue(metadata.channelId)
+  const metadataChannelName = normalizeValue(metadata.channelName)
   const useStreamTitleFallback =
     !metadataTitle && !statusTitle && Boolean(streamTitleFallback)
   const nowPlayingTitle =
@@ -442,8 +447,26 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
     statusArtist ||
     (useStreamArtistFallback ? streamArtistFallback : '') ||
     scheduleArtist ||
-    normalizeValue(baseDevice.channel) ||
+    metadataChannelName ||
+    baseChannelName ||
+    baseChannelId ||
     'Retail Player'
+
+  const activeChannelId =
+    metadataChannelId || normalizeValue(status.channelId) || baseChannelId
+
+  const activeChannelName =
+    metadataChannelName ||
+    scheduleLabel ||
+    normalizeValue(status.activeStreamName) ||
+    streamName ||
+    baseChannelName ||
+    baseChannelId ||
+    baseDevice.name
+
+  const nextChannelId = activeChannelId || baseChannelId
+  const nextChannelName =
+    activeChannelName || baseChannelName || nextChannelId || baseDevice.name
 
   const volume = metadata.volume ?? parseVolume(status.volume)
 
@@ -470,6 +493,8 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
 
   return {
     ...baseDevice,
+    channel: nextChannelId || baseDevice.channel,
+    channelName: nextChannelName,
     isConnected,
     hasSignal,
     isMuted: volume === 0,

--- a/ui/src/retailPlayer/useRetailPlayerDevices.js
+++ b/ui/src/retailPlayer/useRetailPlayerDevices.js
@@ -20,6 +20,8 @@ const mapDevice = (device) => {
 
   const slug = buildDeviceSlug(device) || fallbackId
   const name = normalizeValue(device.name) || fallbackId
+  const channel = normalizeValue(device.channel)
+  const channelName = normalizeValue(device.channelName)
 
   return {
     id: fallbackId,
@@ -27,7 +29,8 @@ const mapDevice = (device) => {
     name,
     slug,
     slugKey: deviceSlugKey(slug),
-    channel: normalizeValue(device.channel),
+    channel,
+    channelName: channelName || channel,
     channelList: normalizeValue(device.channelList),
     organization:
       normalizeValue(device.organization) ||


### PR DESCRIPTION
## Summary
- remove the dummy track rotation used by the retail player dashboard so the UI always reflects backend now playing data
- derive a fallback now playing label from the active schedule or device metadata and trigger a status refresh when skipping tracks

## Testing
- npm test *(fails: existing react-admin mock lacks useNotify export during AppBar tests)*

------
https://chatgpt.com/codex/tasks/task_e_6903c7c25ba08330a521abfdc4fcd552