### PR TITLE
Add retail player channel toggle endpoint

### DIFF
--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -105,6 +105,7 @@ func (n *Router) addRetailPlayerRoute(r chi.Router) {
 		r.Get("/channel-lists/{channelListID}/channels", n.handleRetailPlayerChannelListChannels())
 		r.Post("/devices/{deviceID}/volume", n.handleRetailPlayerDeviceVolume())
 		r.Post("/devices/{deviceID}/channel", n.handleRetailPlayerDeviceChannel())
+		r.Post("/devices/{deviceID}/channel/toggle", n.handleRetailPlayerDeviceToggleChannel())
 		r.Post("/devices/{deviceID}/dislike", n.handleRetailPlayerDeviceDislike())
 	})
 }
@@ -343,6 +344,156 @@ func (n *Router) handleRetailPlayerDeviceChannel() http.HandlerFunc {
 	}
 }
 
+func (n *Router) handleRetailPlayerDeviceToggleChannel() http.HandlerFunc {
+	type toggleRequest struct {
+		Channel          string `json:"channel,omitempty"`
+		ChannelList      string `json:"channelList,omitempty"`
+		AlternateChannel string `json:"alternateChannel,omitempty"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		deviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		if deviceID == "" {
+			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
+			return
+		}
+
+		var payload toggleRequest
+		if r.Body != nil {
+			decoder := json.NewDecoder(r.Body)
+			decoder.DisallowUnknownFields()
+			if err := decoder.Decode(&payload); err != nil {
+				if !errors.Is(err, io.EOF) {
+					http.Error(w, "Invalid toggle channel payload", http.StatusBadRequest)
+					return
+				}
+			}
+		}
+
+		currentChannelID := strings.TrimSpace(payload.Channel)
+		channelListID := strings.TrimSpace(payload.ChannelList)
+		alternateChannelID := strings.TrimSpace(payload.AlternateChannel)
+
+		if currentChannelID == "" || channelListID == "" {
+			device, err := fetchRetailPlayerDevice(ctx, deviceID)
+			if err != nil {
+				if errors.Is(err, errRetailPlayerDeviceNotFound) {
+					http.Error(w, "Retail player device not found", http.StatusNotFound)
+					return
+				}
+
+				log.Error(ctx, "Unable to fetch retail player device", "deviceID", deviceID, "err", err)
+				http.Error(w, "Unable to fetch device information", http.StatusBadGateway)
+				return
+			}
+
+			if currentChannelID == "" {
+				currentChannelID = strings.TrimSpace(device.Channel)
+			}
+			if channelListID == "" {
+				channelListID = strings.TrimSpace(device.ChannelList)
+			}
+		}
+
+		if currentChannelID == "" {
+			http.Error(w, "Channel id is required", http.StatusBadRequest)
+			return
+		}
+
+		if alternateChannelID != "" && strings.EqualFold(alternateChannelID, currentChannelID) {
+			alternateChannelID = ""
+		}
+
+		if alternateChannelID == "" {
+			if channelListID == "" {
+				http.Error(w, "Channel list id is required to toggle channel", http.StatusBadRequest)
+				return
+			}
+
+			response, err := fetchRetailPlayerChannelListChannels(ctx, channelListID)
+			if err != nil {
+				log.Error(ctx, "Unable to fetch retail player channel list", "deviceID", deviceID, "channelListID", channelListID, "err", err)
+				http.Error(w, "Unable to fetch channel list", http.StatusBadGateway)
+				return
+			}
+
+			for _, channel := range response.Channels {
+				candidate := strings.TrimSpace(channel.ID)
+				if candidate == "" {
+					candidate = strings.TrimSpace(channel.Name)
+				}
+				if candidate == "" {
+					continue
+				}
+				if strings.EqualFold(candidate, currentChannelID) {
+					continue
+				}
+				alternateChannelID = candidate
+				break
+			}
+		}
+
+		if alternateChannelID == "" {
+			http.Error(w, "No alternate channel available to toggle", http.StatusBadRequest)
+			return
+		}
+
+		log.Info(ctx, "Toggling retail player channel", "deviceID", deviceID, "currentChannelID", currentChannelID, "alternateChannelID", alternateChannelID)
+
+		alternateCommand := retailPlayerCommandRequest{
+			Type: "set_channel",
+			Payload: map[string]any{
+				"channel": alternateChannelID,
+			},
+		}
+
+		alternateResponse, err := n.sendRetailPlayerDeviceCommand(ctx, deviceID, alternateCommand)
+		if err != nil {
+			log.Error(ctx, "Unable to send retail player alternate channel command", "deviceID", deviceID, "alternateChannelID", alternateChannelID, "err", err)
+			http.Error(w, "Unable to toggle device channel", http.StatusBadGateway)
+			return
+		}
+
+		restoreCommand := retailPlayerCommandRequest{
+			Type: "set_channel",
+			Payload: map[string]any{
+				"channel": currentChannelID,
+			},
+		}
+
+		restoreResponse, err := n.sendRetailPlayerDeviceCommand(ctx, deviceID, restoreCommand)
+		if err != nil {
+			log.Error(ctx, "Unable to restore retail player channel", "deviceID", deviceID, "currentChannelID", currentChannelID, "err", err)
+			http.Error(w, "Unable to restore device channel", http.StatusBadGateway)
+			return
+		}
+
+		response := map[string]any{
+			"success":          true,
+			"channel":          currentChannelID,
+			"alternateChannel": alternateChannelID,
+			"alternateMessage": strings.TrimSpace(alternateResponse),
+			"restoreMessage":   strings.TrimSpace(restoreResponse),
+		}
+
+		if response["alternateMessage"] == "" {
+			delete(response, "alternateMessage")
+		}
+		if response["restoreMessage"] == "" {
+			delete(response, "restoreMessage")
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusOK, response)
+	}
+}
+
 func (n *Router) handleRetailPlayerDeviceDislike() http.HandlerFunc {
 	type dislikeRequest struct {
 		TrackTitle   string `json:"trackTitle"`
@@ -452,6 +603,67 @@ func fetchRetailPlayerDevices(ctx context.Context) (retailPlayerDevicesResponse,
 		Page:  apiPayload.Page,
 		Total: apiPayload.Total,
 	}, nil
+}
+
+func fetchRetailPlayerDevice(ctx context.Context, deviceID string) (retailPlayerDevice, error) {
+	cfg := conf.Server.RetailPlayer
+	if cfg.BaseURL == "" || cfg.OrgID == "" {
+		return retailPlayerDevice{}, errors.New("retail player API not configured")
+	}
+
+	trimmedID := strings.TrimSpace(deviceID)
+	if trimmedID == "" {
+		return retailPlayerDevice{}, errors.New("retail player device id is empty")
+	}
+
+	requestConfig := retailPlayerConfig{
+		BaseURL:           cfg.BaseURL,
+		OrgID:             cfg.OrgID,
+		APIKey:            cfg.APIKey,
+		APIKeyHeader:      cfg.APIKeyHeader,
+		AdditionalHeaders: cfg.AdditionalHeaders,
+	}
+
+	req, err := buildRetailPlayerRequest(ctx, requestConfig, trimmedID)
+	if err != nil {
+		return retailPlayerDevice{}, err
+	}
+
+	resp, err := retailPlayerHTTPClient.Do(req)
+	if err != nil {
+		return retailPlayerDevice{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return retailPlayerDevice{}, errRetailPlayerDeviceNotFound
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return retailPlayerDevice{}, fmt.Errorf("retail player API request failed with status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return retailPlayerDevice{}, err
+	}
+
+	var apiDevice retailPlayerAPIDevice
+	if err := json.Unmarshal(body, &apiDevice); err != nil || isRetailPlayerAPIDeviceEmpty(apiDevice) {
+		var wrapped struct {
+			Data retailPlayerAPIDevice `json:"data"`
+		}
+		if err := json.Unmarshal(body, &wrapped); err != nil || isRetailPlayerAPIDeviceEmpty(wrapped.Data) {
+			return retailPlayerDevice{}, errors.New("unable to parse retail player device response")
+		}
+		apiDevice = wrapped.Data
+	}
+
+	device, ok := simplifyRetailPlayerDevice(apiDevice)
+	if !ok {
+		return retailPlayerDevice{}, errors.New("unable to simplify retail player device")
+	}
+
+	return device, nil
 }
 
 func fetchRetailPlayerChannelListChannels(ctx context.Context, channelListID string) (retailPlayerChannelsResponse, error) {
@@ -905,6 +1117,42 @@ func applyRetailPlayerHeaders(req *http.Request, cfg retailPlayerConfig) {
 			req.Header.Set(trimmedKey, trimmedValue)
 		}
 	}
+}
+
+func isRetailPlayerAPIDeviceEmpty(device retailPlayerAPIDevice) bool {
+	if device.Ordinal != nil {
+		return false
+	}
+
+	if strings.TrimSpace(device.ID) != "" {
+		return false
+	}
+	if strings.TrimSpace(device.MacAddress) != "" {
+		return false
+	}
+	if strings.TrimSpace(device.Name) != "" {
+		return false
+	}
+	if strings.TrimSpace(device.Location) != "" {
+		return false
+	}
+	if strings.TrimSpace(device.OrgUnit) != "" {
+		return false
+	}
+	if strings.TrimSpace(device.Organization) != "" {
+		return false
+	}
+	if strings.TrimSpace(device.Channel) != "" {
+		return false
+	}
+	if strings.TrimSpace(device.ChannelList) != "" {
+		return false
+	}
+	if strings.TrimSpace(device.TimeZone) != "" {
+		return false
+	}
+
+	return true
 }
 
 func simplifyRetailPlayerDevice(device retailPlayerAPIDevice) (retailPlayerDevice, bool) {

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -365,12 +365,15 @@ func (n *Router) handleRetailPlayerDeviceToggleChannel() http.HandlerFunc {
 			return
 		}
 
+		log.Info(ctx, "Retail player channel toggle requested", "deviceID", deviceID)
+
 		var payload toggleRequest
 		if r.Body != nil {
 			decoder := json.NewDecoder(r.Body)
 			decoder.DisallowUnknownFields()
 			if err := decoder.Decode(&payload); err != nil {
 				if !errors.Is(err, io.EOF) {
+					log.Error(ctx, "Invalid toggle channel payload", "deviceID", deviceID, "err", err)
 					http.Error(w, "Invalid toggle channel payload", http.StatusBadRequest)
 					return
 				}
@@ -381,10 +384,14 @@ func (n *Router) handleRetailPlayerDeviceToggleChannel() http.HandlerFunc {
 		channelListID := strings.TrimSpace(payload.ChannelList)
 		alternateChannelID := strings.TrimSpace(payload.AlternateChannel)
 
+		log.Info(ctx, "Retail player toggle payload received", "deviceID", deviceID, "channel", currentChannelID, "channelList", channelListID, "alternateChannel", alternateChannelID)
+
 		if currentChannelID == "" || channelListID == "" {
+			log.Info(ctx, "Fetching device metadata for toggle", "deviceID", deviceID)
 			device, err := fetchRetailPlayerDevice(ctx, deviceID)
 			if err != nil {
 				if errors.Is(err, errRetailPlayerDeviceNotFound) {
+					log.Info(ctx, "Retail player device not found during toggle", "deviceID", deviceID)
 					http.Error(w, "Retail player device not found", http.StatusNotFound)
 					return
 				}
@@ -393,6 +400,8 @@ func (n *Router) handleRetailPlayerDeviceToggleChannel() http.HandlerFunc {
 				http.Error(w, "Unable to fetch device information", http.StatusBadGateway)
 				return
 			}
+
+			log.Info(ctx, "Retail player device metadata fetched for toggle", "deviceID", deviceID, "channel", device.Channel, "channelList", device.ChannelList)
 
 			if currentChannelID == "" {
 				currentChannelID = strings.TrimSpace(device.Channel)
@@ -403,20 +412,24 @@ func (n *Router) handleRetailPlayerDeviceToggleChannel() http.HandlerFunc {
 		}
 
 		if currentChannelID == "" {
+			log.Error(ctx, "Missing channel id for toggle", "deviceID", deviceID)
 			http.Error(w, "Channel id is required", http.StatusBadRequest)
 			return
 		}
 
 		if alternateChannelID != "" && strings.EqualFold(alternateChannelID, currentChannelID) {
+			log.Info(ctx, "Ignoring alternate channel identical to current", "deviceID", deviceID, "channel", currentChannelID)
 			alternateChannelID = ""
 		}
 
 		if alternateChannelID == "" {
 			if channelListID == "" {
+				log.Error(ctx, "Missing channel list for toggle", "deviceID", deviceID)
 				http.Error(w, "Channel list id is required to toggle channel", http.StatusBadRequest)
 				return
 			}
 
+			log.Info(ctx, "Fetching channel list for toggle", "deviceID", deviceID, "channelListID", channelListID)
 			response, err := fetchRetailPlayerChannelListChannels(ctx, channelListID)
 			if err != nil {
 				log.Error(ctx, "Unable to fetch retail player channel list", "deviceID", deviceID, "channelListID", channelListID, "err", err)
@@ -436,11 +449,13 @@ func (n *Router) handleRetailPlayerDeviceToggleChannel() http.HandlerFunc {
 					continue
 				}
 				alternateChannelID = candidate
+				log.Info(ctx, "Selected alternate channel for toggle", "deviceID", deviceID, "alternateChannelID", alternateChannelID)
 				break
 			}
 		}
 
 		if alternateChannelID == "" {
+			log.Error(ctx, "No alternate channel found for toggle", "deviceID", deviceID, "channelListID", channelListID)
 			http.Error(w, "No alternate channel available to toggle", http.StatusBadRequest)
 			return
 		}
@@ -454,12 +469,14 @@ func (n *Router) handleRetailPlayerDeviceToggleChannel() http.HandlerFunc {
 			},
 		}
 
+		log.Info(ctx, "Sending alternate channel command", "deviceID", deviceID, "alternateChannelID", alternateChannelID)
 		alternateResponse, err := n.sendRetailPlayerDeviceCommand(ctx, deviceID, alternateCommand)
 		if err != nil {
 			log.Error(ctx, "Unable to send retail player alternate channel command", "deviceID", deviceID, "alternateChannelID", alternateChannelID, "err", err)
 			http.Error(w, "Unable to toggle device channel", http.StatusBadGateway)
 			return
 		}
+		log.Info(ctx, "Alternate channel command acknowledged", "deviceID", deviceID, "alternateChannelID", alternateChannelID, "response", strings.TrimSpace(alternateResponse))
 
 		restoreCommand := retailPlayerCommandRequest{
 			Type: "set_channel",
@@ -468,12 +485,14 @@ func (n *Router) handleRetailPlayerDeviceToggleChannel() http.HandlerFunc {
 			},
 		}
 
+		log.Info(ctx, "Restoring original channel", "deviceID", deviceID, "currentChannelID", currentChannelID)
 		restoreResponse, err := n.sendRetailPlayerDeviceCommand(ctx, deviceID, restoreCommand)
 		if err != nil {
 			log.Error(ctx, "Unable to restore retail player channel", "deviceID", deviceID, "currentChannelID", currentChannelID, "err", err)
 			http.Error(w, "Unable to restore device channel", http.StatusBadGateway)
 			return
 		}
+		log.Info(ctx, "Original channel restored", "deviceID", deviceID, "currentChannelID", currentChannelID, "response", strings.TrimSpace(restoreResponse))
 
 		response := map[string]any{
 			"success":          true,
@@ -490,6 +509,7 @@ func (n *Router) handleRetailPlayerDeviceToggleChannel() http.HandlerFunc {
 			delete(response, "restoreMessage")
 		}
 
+		log.Info(ctx, "Retail player toggle completed", "deviceID", deviceID, "channel", currentChannelID, "alternateChannel", alternateChannelID)
 		writeRetailPlayerJSON(ctx, w, http.StatusOK, response)
 	}
 }

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1152,8 +1152,83 @@ const RetailPlayerDashboard = () => {
     if (!trackPool.length) {
       return
     }
+
     setCurrentTrackIndex((previous) => (previous + 1) % trackPool.length)
-  }, [trackPool])
+
+    if (!canControlDevice || !deviceApiId) {
+      return
+    }
+
+    const activeMetadata =
+      activeSchedule && typeof activeSchedule === 'object' && activeSchedule.metadata
+        ? activeSchedule.metadata
+        : {}
+
+    const channelIdCandidates = [
+      normalizeValue(activeMetadata?.channelId),
+      normalizeValue(activeMetadata?.channel_id),
+      normalizeValue(activeMetadata?.channel),
+      normalizeValue(device?.channel),
+    ]
+    const channelListCandidates = [
+      normalizeValue(baseDevice?.channelList),
+      normalizeValue(device?.channelList),
+    ]
+
+    const resolvedChannelId = channelIdCandidates.find((candidate) => candidate) || ''
+    const resolvedChannelListId = channelListCandidates.find((candidate) => candidate) || ''
+
+    if (!resolvedChannelId && !resolvedChannelListId) {
+      return
+    }
+
+    if (channelRequestControllerRef.current) {
+      channelRequestControllerRef.current.abort()
+    }
+
+    const abortController = new AbortController()
+    channelRequestControllerRef.current = abortController
+
+    const headers = new Headers({ 'Content-Type': 'application/json' })
+    const body = {}
+
+    if (resolvedChannelId) {
+      body.channel = resolvedChannelId
+    }
+    if (resolvedChannelListId) {
+      body.channelList = resolvedChannelListId
+    }
+
+    httpClient(`/api/retailplayer/devices/${encodeURIComponent(deviceApiId)}/channel/toggle`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: abortController.signal,
+    })
+      .then(() => {
+        refreshStatus()
+      })
+      .catch((err) => {
+        if (err?.name !== 'AbortError') {
+          // eslint-disable-next-line no-console
+          console.error('Failed to toggle retail player channel', err)
+        }
+      })
+      .finally(() => {
+        if (channelRequestControllerRef.current === abortController) {
+          channelRequestControllerRef.current = null
+        }
+      })
+  }, [
+    activeSchedule,
+    baseDevice?.channelList,
+    canControlDevice,
+    device?.channel,
+    device?.channelList,
+    deviceApiId,
+    refreshStatus,
+    trackPool,
+  ])
 
   const handleShortcutChannel = useCallback(
     (index) => {


### PR DESCRIPTION
## Summary
- add a /retailplayer/devices/{deviceID}/channel/toggle endpoint that briefly switches to another channel and restores the original one
- fetch device and channel list metadata to resolve an alternate channel before issuing the toggle commands

## Testing
- go test ./... *(fails: taglib development files are not available in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_6907dcc498e883309fecf5c61851b9f8