### PR TITLE
Add retail player device management page and sidebar integration

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -47,6 +47,7 @@ import missing from './missing/index.js'
 import PlaylistCreate from './playlist/PlaylistCreate'
 import PlaylistShow from './playlist/PlaylistShow'
 import PlaylistEdit from './playlist/PlaylistEdit'
+import RetailPlayerDeviceStoreProvider from './retailPlayer/RetailPlayerDeviceStoreContext'
 
 const history = createHashHistory()
 if (!shareInfo && history.location.pathname === '/') history.replace('/song')
@@ -81,7 +82,9 @@ const adminStore = createAdminStore({
 
 const App = () => (
   <Provider store={adminStore}>
-    <Admin />
+    <RetailPlayerDeviceStoreProvider>
+      <Admin />
+    </RetailPlayerDeviceStoreProvider>
   </Provider>
 )
 

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -232,6 +232,25 @@
         "noPlaylists": "No playlists available"
       }
     },
+    "retailDevice": {
+      "fields": {
+        "serial": "#",
+        "name": "Name",
+        "type": "Type",
+        "channel": "Channel",
+        "channelList": "Channel List",
+        "organization": "Organization",
+        "timeZone": "Time Zone",
+        "source": "Source",
+        "actions": "Actions"
+      },
+      "values": {
+        "folder": "Folder",
+        "device": "Device",
+        "local": "Local",
+        "remote": "Remote"
+      }
+    },
     "discovery": {
       "name": "Discovery |||| Discoveries",
       "fields": {

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -77,6 +77,22 @@ const useStyles = makeStyles((theme) => ({
     paddingTop: theme.spacing(0.5),
     paddingBottom: theme.spacing(0.5),
     fontSize: theme.typography.pxToRem(13),
+    '& .MuiListItemIcon-root': {
+      minWidth: theme.spacing(4),
+      color: theme.palette.text.primary,
+    },
+    '& .RaMenuItemLink-primaryText': {
+      fontSize: theme.typography.pxToRem(13),
+      color: theme.palette.text.primary,
+    },
+  },
+  nestedDeviceItem: {
+    '& .MuiListItemIcon-root': {
+      color: theme.palette.secondary.main,
+    },
+    '& .RaMenuItemLink-primaryText': {
+      color: theme.palette.secondary.main,
+    },
   },
 }))
 
@@ -183,21 +199,30 @@ const Menu = ({ dense = false }) => {
       const slug = node.slug || node.name || node.id
       const encodedSlug = encodeURIComponent(slug)
       const padding = theme.spacing(4 + depth * 2)
+      const isNested = depth > 0
       return (
         <MenuItemLink
           key={`retailplayer-${node.apiId || node.id}`}
           to={`/retailplayer/${encodedSlug}`}
           activeClassName={classes.active}
           primaryText={node.name}
+          leftIcon={<SpeakerGroupIcon fontSize="small" />}
           sidebarIsOpen={open}
           dense={dense}
           exact
-          className={classes.deviceItem}
+          className={clsx(classes.deviceItem, isNested && classes.nestedDeviceItem)}
           style={{ paddingLeft: padding }}
         />
       )
     },
-    [classes.active, classes.deviceItem, dense, open, theme],
+    [
+      classes.active,
+      classes.deviceItem,
+      classes.nestedDeviceItem,
+      dense,
+      open,
+      theme,
+    ],
   )
 
   const renderRetailPlayerNodes = useCallback(

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -1,12 +1,24 @@
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { useSelector } from 'react-redux'
-import { Divider, makeStyles } from '@material-ui/core'
+import {
+  Collapse,
+  Divider,
+  ListItemIcon,
+  ListItemText,
+  makeStyles,
+  useTheme,
+} from '@material-ui/core'
 import clsx from 'clsx'
 import { useTranslate, MenuItemLink, getResources } from 'react-admin'
 import ViewListIcon from '@material-ui/icons/ViewList'
 import AlbumIcon from '@material-ui/icons/Album'
 import MenuItem from '@material-ui/core/MenuItem'
 import SpeakerGroupIcon from '@material-ui/icons/SpeakerGroup'
+import ChevronRightIcon from '@material-ui/icons/ChevronRight'
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
+import FolderIcon from '@material-ui/icons/Folder'
+import { useHistory } from 'react-router-dom'
+import { BiCog } from 'react-icons/bi'
 import SubMenu from './SubMenu'
 import { humanize, pluralize } from 'inflection'
 import albumLists from '../album/albumLists'
@@ -14,7 +26,7 @@ import PlaylistsSubMenu from './PlaylistsSubMenu'
 import DiscoverySubMenu from './DiscoverySubMenu'
 import LibrarySelector from '../common/LibrarySelector'
 import config from '../config'
-import useRetailPlayerDevices from '../retailPlayer/useRetailPlayerDevices'
+import { useRetailPlayerDeviceStore } from '../retailPlayer/RetailPlayerDeviceStoreContext'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -44,6 +56,28 @@ const useStyles = makeStyles((theme) => ({
       fontSize: theme.typography.pxToRem(13),
     },
   },
+  folderItem: {
+    paddingTop: theme.spacing(0.5),
+    paddingBottom: theme.spacing(0.5),
+    fontSize: theme.typography.pxToRem(13),
+    '& .MuiListItemIcon-root': {
+      minWidth: theme.spacing(4),
+    },
+    '& .MuiTypography-body1': {
+      fontSize: theme.typography.pxToRem(13),
+      color: theme.palette.text.secondary,
+    },
+  },
+  folderChildren: {
+    '& > *': {
+      width: '100%',
+    },
+  },
+  deviceItem: {
+    paddingTop: theme.spacing(0.5),
+    paddingBottom: theme.spacing(0.5),
+    fontSize: theme.typography.pxToRem(13),
+  },
 }))
 
 const translatedResourceName = (resource, translate) =>
@@ -63,9 +97,11 @@ const Menu = ({ dense = false }) => {
   const translate = useTranslate()
   const queue = useSelector((state) => state.player?.queue)
   const classes = useStyles({ addPadding: queue.length > 0 })
+  const theme = useTheme()
   const resources = useSelector(getResources).filter(
     (r) => r.name !== 'radio' && r.name !== 'share',
   )
+  const history = useHistory()
 
   // TODO State is not persisted in mobile when you close the sidebar menu. Move to redux?
   const [state, setState] = useState({
@@ -122,10 +158,98 @@ const Menu = ({ dense = false }) => {
     resource.hasList && resource.options && resource.options.subMenu === subMenu
 
   const {
-    devices: retailDevices,
-    error: retailDevicesError,
-    isLoading: retailDevicesLoading,
-  } = useRetailPlayerDevices()
+    state: {
+      tree: retailTree,
+      loading: retailDevicesLoading,
+      error: retailDevicesError,
+    },
+  } = useRetailPlayerDeviceStore()
+
+  const [openFolders, setOpenFolders] = useState({})
+
+  const toggleFolder = useCallback((folderId) => {
+    setOpenFolders((prev) => ({
+      ...prev,
+      [folderId]: !prev[folderId],
+    }))
+  }, [])
+
+  const goToRetailPlayerSettings = useCallback(() => {
+    history.push('/retail-player/devices')
+  }, [history])
+
+  const renderDeviceLink = useCallback(
+    (node, depth) => {
+      const slug = node.slug || node.name || node.id
+      const encodedSlug = encodeURIComponent(slug)
+      const padding = theme.spacing(4 + depth * 2)
+      return (
+        <MenuItemLink
+          key={`retailplayer-${node.apiId || node.id}`}
+          to={`/retailplayer/${encodedSlug}`}
+          activeClassName={classes.active}
+          primaryText={node.name}
+          sidebarIsOpen={open}
+          dense={dense}
+          exact
+          className={classes.deviceItem}
+          style={{ paddingLeft: padding }}
+        />
+      )
+    },
+    [classes.active, classes.deviceItem, dense, open, theme],
+  )
+
+  const renderRetailPlayerNodes = useCallback(
+    (nodes, depth = 0) =>
+      nodes.map((node) => {
+        if (node.type === 'folder') {
+          const isOpen = openFolders[node.id] ?? true
+          const padding = theme.spacing(4 + depth * 2)
+          const childPadding = theme.spacing(2)
+          return (
+            <React.Fragment key={`retailfolder-${node.id}`}>
+              <MenuItem
+                dense={dense}
+                className={classes.folderItem}
+                style={{ paddingLeft: padding }}
+                onClick={() => toggleFolder(node.id)}
+              >
+                <ListItemIcon>
+                  {isOpen ? (
+                    <ExpandMoreIcon fontSize="small" />
+                  ) : (
+                    <ChevronRightIcon fontSize="small" />
+                  )}
+                </ListItemIcon>
+                <ListItemIcon>
+                  <FolderIcon fontSize="small" />
+                </ListItemIcon>
+                <ListItemText primary={node.name} />
+              </MenuItem>
+              <Collapse in={isOpen} timeout="auto" unmountOnExit>
+                <div
+                  className={classes.folderChildren}
+                  style={{ paddingLeft: childPadding }}
+                >
+                  {renderRetailPlayerNodes(node.children || [], depth + 1)}
+                </div>
+              </Collapse>
+            </React.Fragment>
+          )
+        }
+        return renderDeviceLink(node, depth)
+      }),
+    [
+      classes.folderChildren,
+      classes.folderItem,
+      dense,
+      openFolders,
+      renderDeviceLink,
+      theme,
+      toggleFolder,
+    ],
+  )
 
   const renderRetailPlayerDevices = () => {
     if (retailDevicesLoading) {
@@ -146,7 +270,7 @@ const Menu = ({ dense = false }) => {
       )
     }
 
-    if (!retailDevices.length) {
+    if (!retailTree.length) {
       return (
         <MenuItem dense={dense} disabled className={classes.retailPlayerSubItem}>
           {translate('menu.retailPlayer.empty', { _: 'No devices available' })}
@@ -154,22 +278,7 @@ const Menu = ({ dense = false }) => {
       )
     }
 
-    return retailDevices.map((device) => {
-      const slug = device.slug || device.name || device.id
-      const encodedSlug = encodeURIComponent(slug)
-      return (
-        <MenuItemLink
-          key={`retailplayer-${device.apiId || device.id}`}
-          to={`/retailplayer/${encodedSlug}`}
-          activeClassName={classes.active}
-          primaryText={device.name}
-          sidebarIsOpen={open}
-          dense={dense}
-          exact
-          className={classes.retailPlayerSubItem}
-        />
-      )
-    })
+    return renderRetailPlayerNodes(retailTree)
   }
 
   const renderRetailPlayerMenu = () => (
@@ -180,6 +289,8 @@ const Menu = ({ dense = false }) => {
       name="menu.retailPlayer.name"
       icon={<SpeakerGroupIcon />}
       dense={dense}
+      actionIcon={<BiCog />}
+      onAction={goToRetailPlayerSettings}
     >
       {renderRetailPlayerDevices()}
     </SubMenu>

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -19,7 +19,7 @@ import {
   Typography,
 } from '@material-ui/core'
 import { makeStyles, useTheme } from '@material-ui/core/styles'
-import { Title } from 'react-admin'
+import { Title, useTranslate } from 'react-admin'
 import AddIcon from '@material-ui/icons/Add'
 import EditIcon from '@material-ui/icons/Edit'
 import FolderIcon from '@material-ui/icons/Folder'
@@ -29,6 +29,8 @@ import Link from '@material-ui/core/Link'
 import clsx from 'clsx'
 import PropTypes from 'prop-types'
 import { useHistory } from 'react-router-dom'
+import { useSelector } from 'react-redux'
+import { ToggleFieldsMenu, useSelectedFields } from '../common'
 import { useRetailPlayerDeviceStore } from './RetailPlayerDeviceStoreContext'
 
 const useStyles = makeStyles((theme) => ({
@@ -68,13 +70,12 @@ const useStyles = makeStyles((theme) => ({
   panel: {
     borderRadius: theme.shape.borderRadius,
     border: `1px solid ${theme.palette.divider}`,
-    overflow: 'hidden',
+    overflowX: 'auto',
+    overflowY: 'hidden',
     backgroundColor: theme.palette.background.paper,
   },
   listHeader: {
     display: 'grid',
-    gridTemplateColumns:
-      'minmax(220px, 2fr) minmax(120px, 1fr) minmax(160px, 1fr) minmax(160px, 1fr) minmax(100px, 0.8fr)',
     padding: theme.spacing(1.5, 2),
     backgroundColor: theme.palette.action.hover,
     color: theme.palette.text.secondary,
@@ -82,50 +83,37 @@ const useStyles = makeStyles((theme) => ({
     textTransform: 'uppercase',
     letterSpacing: 0.8,
     fontWeight: theme.typography.fontWeightMedium,
-    [theme.breakpoints.down('sm')]: {
-      gridTemplateColumns: 'minmax(200px, 2fr) minmax(120px, 1fr) minmax(140px, 1fr)',
-      gridTemplateAreas: "'name type actions' 'channel channelList actions'",
-      rowGap: theme.spacing(1),
-    },
+    alignItems: 'center',
+  },
+  headerSerial: {
+    textAlign: 'center',
+    color: theme.palette.text.secondary,
   },
   headerName: {
-    [theme.breakpoints.down('sm')]: {
-      gridArea: 'name',
-    },
+    display: 'flex',
+    alignItems: 'center',
   },
   headerType: {
-    [theme.breakpoints.down('sm')]: {
-      gridArea: 'type',
-    },
+    display: 'flex',
+    alignItems: 'center',
   },
   headerChannel: {
-    [theme.breakpoints.down('sm')]: {
-      gridArea: 'channel',
-    },
+    display: 'flex',
+    alignItems: 'center',
   },
   headerChannelList: {
-    [theme.breakpoints.down('sm')]: {
-      gridArea: 'channelList',
-    },
+    display: 'flex',
+    alignItems: 'center',
   },
   headerActions: {
-    [theme.breakpoints.down('sm')]: {
-      gridArea: 'actions',
-      justifySelf: 'flex-end',
-    },
+    display: 'flex',
+    justifyContent: 'flex-end',
   },
   row: {
     display: 'grid',
-    gridTemplateColumns:
-      'minmax(220px, 2fr) minmax(120px, 1fr) minmax(160px, 1fr) minmax(160px, 1fr) minmax(100px, 0.8fr)',
     alignItems: 'center',
     padding: theme.spacing(1.5, 2),
     borderTop: `1px solid ${theme.palette.divider}`,
-    [theme.breakpoints.down('sm')]: {
-      gridTemplateColumns: 'minmax(200px, 2fr) minmax(120px, 1fr) minmax(140px, 1fr)',
-      gridTemplateAreas: "'name type actions' 'channel channelList actions'",
-      rowGap: theme.spacing(1),
-    },
   },
   folderRow: {
     backgroundColor: theme.palette.action.selected,
@@ -145,9 +133,6 @@ const useStyles = makeStyles((theme) => ({
     alignItems: 'center',
     gap: theme.spacing(1.5),
     fontWeight: theme.typography.fontWeightMedium,
-    [theme.breakpoints.down('sm')]: {
-      gridArea: 'name',
-    },
   },
   nameIcon: {
     color: theme.palette.text.secondary,
@@ -161,9 +146,6 @@ const useStyles = makeStyles((theme) => ({
   typeCell: {
     fontSize: theme.typography.pxToRem(14),
     color: theme.palette.text.secondary,
-    [theme.breakpoints.down('sm')]: {
-      gridArea: 'type',
-    },
   },
   metaCell: {
     fontSize: theme.typography.pxToRem(14),
@@ -171,22 +153,16 @@ const useStyles = makeStyles((theme) => ({
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
-    [theme.breakpoints.down('sm')]: {
-      gridArea: 'channel',
-    },
-  },
-  metaSecondary: {
-    [theme.breakpoints.down('sm')]: {
-      gridArea: 'channelList',
-    },
   },
   actionsCell: {
     display: 'flex',
     gap: theme.spacing(1),
     justifyContent: 'flex-end',
-    [theme.breakpoints.down('sm')]: {
-      gridArea: 'actions',
-    },
+  },
+  serialCell: {
+    fontVariantNumeric: 'tabular-nums',
+    textAlign: 'center',
+    color: theme.palette.text.secondary,
   },
   breadcrumbBar: {
     display: 'flex',
@@ -236,6 +212,17 @@ const useStyles = makeStyles((theme) => ({
     },
   },
 }))
+
+const RETAIL_DEVICE_RESOURCE = 'retailDevice'
+const RETAIL_DEVICE_COLUMNS = [
+  'type',
+  'channel',
+  'channelList',
+  'organization',
+  'timeZone',
+  'source',
+]
+const RETAIL_DEVICE_DEFAULT_OFF = ['timeZone', 'source']
 
 const FolderDialog = ({
   open,
@@ -480,6 +467,7 @@ const RetailPlayerDeviceManagement = () => {
   const classes = useStyles()
   const theme = useTheme()
   const history = useHistory()
+  const translate = useTranslate()
   const {
     state: { tree, folders, devices, loading, error },
     actions: { createFolder, updateFolder, createDevice, updateDevice },
@@ -565,6 +553,126 @@ const RetailPlayerDeviceManagement = () => {
   }, [activeFolderId, folderMap])
 
   const visibleNodes = activeFolderNode ? activeFolderNode.children || [] : tree
+
+  const columnDefinitions = useMemo(() => {
+    const dash = '—'
+    return {
+      type: {
+        label: translate('resources.retailDevice.fields.type', { _: 'Type' }),
+        cellClass: classes.typeCell,
+        headerClass: classes.headerType,
+        width: 'minmax(120px, 1fr)',
+        render: (node) =>
+          node.type === 'folder'
+            ? translate('resources.retailDevice.values.folder', { _: 'Folder' })
+            : translate('resources.retailDevice.values.device', { _: 'Device' }),
+      },
+      channel: {
+        label: translate('resources.retailDevice.fields.channel', { _: 'Channel' }),
+        cellClass: classes.metaCell,
+        headerClass: classes.headerChannel,
+        width: 'minmax(140px, 1fr)',
+        render: (node) => (node.type === 'device' ? node.channel || dash : dash),
+      },
+      channelList: {
+        label: translate('resources.retailDevice.fields.channelList', {
+          _: 'Channel List',
+        }),
+        cellClass: classes.metaCell,
+        headerClass: classes.headerChannelList,
+        width: 'minmax(160px, 1fr)',
+        render: (node) => (node.type === 'device' ? node.channelList || dash : dash),
+      },
+      organization: {
+        label: translate('resources.retailDevice.fields.organization', {
+          _: 'Organization',
+        }),
+        cellClass: classes.metaCell,
+        headerClass: classes.headerChannelList,
+        width: 'minmax(180px, 1.2fr)',
+        render: (node) => (node.type === 'device' ? node.organization || dash : dash),
+      },
+      timeZone: {
+        label: translate('resources.retailDevice.fields.timeZone', {
+          _: 'Time Zone',
+        }),
+        cellClass: classes.metaCell,
+        headerClass: classes.headerChannelList,
+        width: 'minmax(160px, 1fr)',
+        render: (node) => (node.type === 'device' ? node.timeZone || dash : dash),
+      },
+      source: {
+        label: translate('resources.retailDevice.fields.source', { _: 'Source' }),
+        cellClass: classes.metaCell,
+        headerClass: classes.headerChannelList,
+        width: 'minmax(140px, 1fr)',
+        render: (node) =>
+          node.type === 'device'
+            ? translate(`resources.retailDevice.values.${
+                node.source === 'local' ? 'local' : 'remote'
+              }`, {
+                _: node.source === 'local' ? 'Local' : 'Remote',
+              })
+            : dash,
+      },
+    }
+  }, [classes.headerChannel, classes.headerChannelList, classes.headerType, classes.metaCell, classes.typeCell, translate])
+
+  const placeholderColumns = useMemo(() => {
+    const placeholders = {}
+    RETAIL_DEVICE_COLUMNS.forEach((key) => {
+      placeholders[key] = <span />
+    })
+    return placeholders
+  }, [])
+
+  useSelectedFields({
+    resource: RETAIL_DEVICE_RESOURCE,
+    columns: placeholderColumns,
+    defaultOff: RETAIL_DEVICE_DEFAULT_OFF,
+  })
+
+  const toggleableFields =
+    useSelector((state) => state.settings.toggleableFields?.[RETAIL_DEVICE_RESOURCE]) || {}
+  const columnsOrderSetting =
+    useSelector((state) => state.settings.columnsOrder?.[RETAIL_DEVICE_RESOURCE]) ||
+    RETAIL_DEVICE_COLUMNS
+
+  const visibleColumnKeys = useMemo(() => {
+    const orderedKeys = Array.isArray(columnsOrderSetting)
+      ? columnsOrderSetting.filter((key) => RETAIL_DEVICE_COLUMNS.includes(key))
+      : RETAIL_DEVICE_COLUMNS
+    return orderedKeys.filter((key) => toggleableFields[key])
+  }, [columnsOrderSetting, toggleableFields])
+
+  const gridTemplateColumns = useMemo(() => {
+    const dynamicColumns = visibleColumnKeys.map((key) => {
+      const definition = columnDefinitions[key]
+      return definition?.width || 'minmax(140px, 1fr)'
+    })
+    return [
+      'minmax(56px, 0.4fr)',
+      'minmax(240px, 2.2fr)',
+      ...dynamicColumns,
+      'minmax(120px, 0.8fr)',
+    ].join(' ')
+  }, [columnDefinitions, visibleColumnKeys])
+
+  const gridStyle = useMemo(
+    () => ({ gridTemplateColumns, minWidth: 720 }),
+    [gridTemplateColumns],
+  )
+
+  const showOrganizationCaption = useMemo(
+    () => !visibleColumnKeys.includes('organization'),
+    [visibleColumnKeys],
+  )
+
+  const serialLabel = translate('resources.retailDevice.fields.serial', { _: '#' })
+  const nameLabel = translate('resources.retailDevice.fields.name', { _: 'Name' })
+  const actionsLabel = translate('resources.retailDevice.fields.actions', {
+    _: 'Actions',
+  })
 
   const openMenu = (event) => {
     setMenuAnchor(event.currentTarget)
@@ -664,22 +772,48 @@ const RetailPlayerDeviceManagement = () => {
     }, 0)
   }, [])
 
+  let serialCounter = 0
+
+  const renderColumnCells = (node) =>
+    visibleColumnKeys.map((columnKey) => {
+      const definition = columnDefinitions[columnKey]
+      if (!definition) {
+        return null
+      }
+      return (
+        <div
+          key={`${node.id}-${columnKey}`}
+          className={definition.cellClass || classes.metaCell}
+        >
+          {definition.render(node)}
+        </div>
+      )
+    })
+
+  const getSerial = () => {
+    serialCounter += 1
+    return serialCounter
+  }
+
   const renderRows = (nodes, depth = 0) =>
     nodes.flatMap((node) => {
+      const indentStyle = { paddingLeft: theme.spacing(depth * 2) }
+      const serialValue = getSerial()
       if (node.type === 'folder') {
-        const indentStyle = { paddingLeft: theme.spacing(depth * 2) }
         const folderChildren = renderRows(node.children || [], depth + 1)
         const deviceCount = countDevices(node)
         return [
           <div
             key={`folder-row-${node.id}`}
             className={clsx(classes.row, classes.folderRow, classes.interactiveRow)}
+            style={gridStyle}
             role="button"
             tabIndex={0}
             onClick={() => handleEnterFolder(node.id)}
             onKeyDown={(event) => handleRowKeyDown(event, () => handleEnterFolder(node.id))}
             aria-label={`Open folder ${node.name}`}
           >
+            <div className={classes.serialCell}>{serialValue}</div>
             <div className={classes.nameCell} style={indentStyle}>
               <FolderIcon className={classes.nameIcon} />
               <div className={classes.nameLabel}>
@@ -691,9 +825,7 @@ const RetailPlayerDeviceManagement = () => {
                 </Typography>
               </div>
             </div>
-            <div className={classes.typeCell}>Folder</div>
-            <div className={classes.metaCell}>—</div>
-            <div className={clsx(classes.metaCell, classes.metaSecondary)}>—</div>
+            {renderColumnCells(node)}
             <div className={classes.actionsCell}>
               <Tooltip title="Edit folder">
                 <IconButton
@@ -712,35 +844,32 @@ const RetailPlayerDeviceManagement = () => {
           ...folderChildren,
         ]
       }
-      const indentStyle = { paddingLeft: theme.spacing(depth * 2) }
       return [
         <div
           key={`device-row-${node.id}`}
           className={clsx(classes.row, classes.interactiveRow)}
+          style={gridStyle}
           role="button"
           tabIndex={0}
           onClick={() => handleNavigateToDevice(node)}
           onKeyDown={(event) => handleRowKeyDown(event, () => handleNavigateToDevice(node))}
           aria-label={`Open device ${node.name}`}
         >
+          <div className={classes.serialCell}>{serialValue}</div>
           <div className={classes.nameCell} style={indentStyle}>
             <SpeakerGroupIcon className={classes.nameIcon} />
             <div className={classes.nameLabel}>
               <Typography variant="body1" color="textPrimary">
                 {node.name}
               </Typography>
-              {node.organization ? (
+              {showOrganizationCaption && node.organization ? (
                 <Typography variant="caption" color="textSecondary">
                   {node.organization}
                 </Typography>
               ) : null}
             </div>
           </div>
-          <div className={classes.typeCell}>Device</div>
-          <div className={classes.metaCell}>{node.channel || '—'}</div>
-          <div className={clsx(classes.metaCell, classes.metaSecondary)}>
-            {node.channelList || '—'}
-          </div>
+          {renderColumnCells(node)}
           <div className={classes.actionsCell}>
             <Tooltip title="Edit device">
               <IconButton
@@ -773,6 +902,7 @@ const RetailPlayerDeviceManagement = () => {
           </Typography>
         </div>
         <div className={classes.actions}>
+          <ToggleFieldsMenu resource={RETAIL_DEVICE_RESOURCE} />
           <Button
             color="primary"
             variant="contained"
@@ -835,12 +965,24 @@ const RetailPlayerDeviceManagement = () => {
             </Breadcrumbs>
           </div>
         ) : null}
-        <div className={classes.listHeader}>
-          <span className={classes.headerName}>Name</span>
-          <span className={classes.headerType}>Type</span>
-          <span className={classes.headerChannel}>Channel</span>
-          <span className={classes.headerChannelList}>Channel List</span>
-          <span className={classes.headerActions}>Actions</span>
+        <div className={classes.listHeader} style={gridStyle}>
+          <span className={classes.headerSerial}>{serialLabel}</span>
+          <span className={classes.headerName}>{nameLabel}</span>
+          {visibleColumnKeys.map((columnKey) => {
+            const definition = columnDefinitions[columnKey]
+            if (!definition) {
+              return null
+            }
+            return (
+              <span
+                key={`header-${columnKey}`}
+                className={definition.headerClass || classes.headerChannelList}
+              >
+                {definition.label}
+              </span>
+            )
+          })}
+          <span className={classes.headerActions}>{actionsLabel}</span>
         </div>
         {loading ? (
           <div className={classes.loaderState}>

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -1,0 +1,708 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormHelperText,
+  IconButton,
+  InputLabel,
+  Menu,
+  MenuItem,
+  Paper,
+  Select,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@material-ui/core'
+import { makeStyles, useTheme } from '@material-ui/core/styles'
+import { Title } from 'react-admin'
+import AddIcon from '@material-ui/icons/Add'
+import EditIcon from '@material-ui/icons/Edit'
+import FolderIcon from '@material-ui/icons/Folder'
+import SpeakerGroupIcon from '@material-ui/icons/SpeakerGroup'
+import clsx from 'clsx'
+import PropTypes from 'prop-types'
+import { useRetailPlayerDeviceStore } from './RetailPlayerDeviceStoreContext'
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    padding: theme.spacing(5),
+    maxWidth: 1200,
+    margin: '0 auto',
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(3),
+    [theme.breakpoints.down('md')]: {
+      padding: theme.spacing(4),
+    },
+    [theme.breakpoints.down('sm')]: {
+      padding: theme.spacing(2.5),
+      gap: theme.spacing(2),
+    },
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: theme.spacing(2),
+    flexWrap: 'wrap',
+  },
+  titleBlock: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+  },
+  actions: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+  },
+  panel: {
+    borderRadius: theme.shape.borderRadius,
+    border: `1px solid ${theme.palette.divider}`,
+    overflow: 'hidden',
+    backgroundColor: theme.palette.background.paper,
+  },
+  listHeader: {
+    display: 'grid',
+    gridTemplateColumns:
+      'minmax(220px, 2fr) minmax(120px, 1fr) minmax(160px, 1fr) minmax(160px, 1fr) minmax(100px, 0.8fr)',
+    padding: theme.spacing(1.5, 2),
+    backgroundColor: theme.palette.action.hover,
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.pxToRem(12),
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+    fontWeight: theme.typography.fontWeightMedium,
+    [theme.breakpoints.down('sm')]: {
+      gridTemplateColumns: 'minmax(200px, 2fr) minmax(120px, 1fr) minmax(140px, 1fr)',
+      gridTemplateAreas: "'name type actions' 'channel channelList actions'",
+      rowGap: theme.spacing(1),
+    },
+  },
+  headerName: {
+    [theme.breakpoints.down('sm')]: {
+      gridArea: 'name',
+    },
+  },
+  headerType: {
+    [theme.breakpoints.down('sm')]: {
+      gridArea: 'type',
+    },
+  },
+  headerChannel: {
+    [theme.breakpoints.down('sm')]: {
+      gridArea: 'channel',
+    },
+  },
+  headerChannelList: {
+    [theme.breakpoints.down('sm')]: {
+      gridArea: 'channelList',
+    },
+  },
+  headerActions: {
+    [theme.breakpoints.down('sm')]: {
+      gridArea: 'actions',
+      justifySelf: 'flex-end',
+    },
+  },
+  row: {
+    display: 'grid',
+    gridTemplateColumns:
+      'minmax(220px, 2fr) minmax(120px, 1fr) minmax(160px, 1fr) minmax(160px, 1fr) minmax(100px, 0.8fr)',
+    alignItems: 'center',
+    padding: theme.spacing(1.5, 2),
+    borderTop: `1px solid ${theme.palette.divider}`,
+    [theme.breakpoints.down('sm')]: {
+      gridTemplateColumns: 'minmax(200px, 2fr) minmax(120px, 1fr) minmax(140px, 1fr)',
+      gridTemplateAreas: "'name type actions' 'channel channelList actions'",
+      rowGap: theme.spacing(1),
+    },
+  },
+  folderRow: {
+    backgroundColor: theme.palette.action.selected,
+  },
+  nameCell: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+    fontWeight: theme.typography.fontWeightMedium,
+    [theme.breakpoints.down('sm')]: {
+      gridArea: 'name',
+    },
+  },
+  nameIcon: {
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.pxToRem(18),
+  },
+  nameLabel: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
+  },
+  typeCell: {
+    fontSize: theme.typography.pxToRem(14),
+    color: theme.palette.text.secondary,
+    [theme.breakpoints.down('sm')]: {
+      gridArea: 'type',
+    },
+  },
+  metaCell: {
+    fontSize: theme.typography.pxToRem(14),
+    color: theme.palette.text.secondary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    [theme.breakpoints.down('sm')]: {
+      gridArea: 'channel',
+    },
+  },
+  metaSecondary: {
+    [theme.breakpoints.down('sm')]: {
+      gridArea: 'channelList',
+    },
+  },
+  actionsCell: {
+    display: 'flex',
+    gap: theme.spacing(1),
+    justifyContent: 'flex-end',
+    [theme.breakpoints.down('sm')]: {
+      gridArea: 'actions',
+    },
+  },
+  emptyState: {
+    padding: theme.spacing(4),
+    textAlign: 'center',
+    color: theme.palette.text.secondary,
+  },
+  loaderState: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: theme.spacing(4),
+    gap: theme.spacing(2),
+    color: theme.palette.text.secondary,
+  },
+  errorState: {
+    padding: theme.spacing(4),
+    textAlign: 'center',
+    color: theme.palette.error.main,
+  },
+  dialogFields: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2.5),
+    minWidth: 360,
+    [theme.breakpoints.down('xs')]: {
+      minWidth: 'auto',
+    },
+  },
+}))
+
+const FolderDialog = ({
+  open,
+  onClose,
+  onSubmit,
+  parentOptions,
+  initialValues,
+  disableParent,
+}) => {
+  const classes = useStyles()
+  const [name, setName] = useState(initialValues?.name || '')
+  const [parentId, setParentId] = useState(initialValues?.parentId || '')
+
+  useEffect(() => {
+    setName(initialValues?.name || '')
+    setParentId(initialValues?.parentId || '')
+  }, [initialValues, open])
+
+  const handleSubmit = () => {
+    if (!name.trim()) {
+      return
+    }
+    onSubmit({ name: name.trim(), parentId: parentId || null })
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      <DialogTitle>{initialValues?.id ? 'Edit Folder' : 'Create Folder'}</DialogTitle>
+      <DialogContent>
+        <div className={classes.dialogFields}>
+          <TextField
+            autoFocus
+            label="Folder Name"
+            fullWidth
+            variant="outlined"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+          />
+          <FormControl variant="outlined" fullWidth disabled={disableParent}>
+            <InputLabel id="folder-parent-label">Parent Folder</InputLabel>
+            <Select
+              labelId="folder-parent-label"
+              value={parentId}
+              onChange={(event) => setParentId(event.target.value)}
+              label="Parent Folder"
+            >
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              {parentOptions.map((option) => (
+                <MenuItem key={option.id} value={option.id}>
+                  {option.name}
+                </MenuItem>
+              ))}
+            </Select>
+            {disableParent && (
+              <FormHelperText>
+                Parent folders cannot be changed for existing groups yet.
+              </FormHelperText>
+            )}
+          </FormControl>
+        </div>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button color="primary" variant="contained" onClick={handleSubmit}>
+          {initialValues?.id ? 'Save Changes' : 'Create Folder'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+FolderDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  parentOptions: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  initialValues: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+    parentId: PropTypes.string,
+  }),
+  disableParent: PropTypes.bool,
+}
+
+FolderDialog.defaultProps = {
+  initialValues: null,
+  disableParent: false,
+}
+
+const DeviceDialog = ({
+  open,
+  onClose,
+  onSubmit,
+  parentOptions,
+  initialValues,
+}) => {
+  const [form, setForm] = useState(() => ({
+    name: initialValues?.name || '',
+    channel: initialValues?.channel || '',
+    channelList: initialValues?.channelList || '',
+    organization: initialValues?.organization || '',
+    folderId: initialValues?.folderId || '',
+  }))
+
+  useEffect(() => {
+    setForm({
+      name: initialValues?.name || '',
+      channel: initialValues?.channel || '',
+      channelList: initialValues?.channelList || '',
+      organization: initialValues?.organization || '',
+      folderId: initialValues?.folderId || '',
+    })
+  }, [initialValues, open])
+
+  const isRemote = initialValues?.source !== 'local'
+
+  const handleChange = (field) => (event) => {
+    setForm((prev) => ({ ...prev, [field]: event.target.value }))
+  }
+
+  const handleSubmit = () => {
+    if (!form.name.trim()) {
+      return
+    }
+    onSubmit({
+      ...form,
+      name: form.name.trim(),
+      folderId: form.folderId || null,
+    })
+  }
+
+  const classes = useStyles()
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>
+        {initialValues?.id ? 'Edit Device' : 'Create Device'}
+      </DialogTitle>
+      <DialogContent>
+        <div className={classes.dialogFields}>
+          <TextField
+            autoFocus
+            label="Device Name"
+            fullWidth
+            variant="outlined"
+            value={form.name}
+            onChange={handleChange('name')}
+            disabled={isRemote}
+            helperText={
+              isRemote
+                ? 'Name is managed by the device integration.'
+                : 'Give the device a friendly label for identification.'
+            }
+          />
+          <TextField
+            label="Channel"
+            fullWidth
+            variant="outlined"
+            value={form.channel}
+            onChange={handleChange('channel')}
+          />
+          <TextField
+            label="Channel List"
+            fullWidth
+            variant="outlined"
+            value={form.channelList}
+            onChange={handleChange('channelList')}
+          />
+          <TextField
+            label="Organization"
+            fullWidth
+            variant="outlined"
+            value={form.organization}
+            onChange={handleChange('organization')}
+          />
+          <FormControl variant="outlined" fullWidth>
+            <InputLabel id="device-folder-label">Folder</InputLabel>
+            <Select
+              labelId="device-folder-label"
+              value={form.folderId}
+              onChange={handleChange('folderId')}
+              label="Folder"
+            >
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              {parentOptions.map((option) => (
+                <MenuItem key={option.id} value={option.id}>
+                  {option.name}
+                </MenuItem>
+              ))}
+            </Select>
+            <FormHelperText>
+              Use folders to keep devices grouped by location or usage.
+            </FormHelperText>
+          </FormControl>
+        </div>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button color="primary" variant="contained" onClick={handleSubmit}>
+          {initialValues?.id ? 'Save Changes' : 'Create Device'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+DeviceDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  parentOptions: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  initialValues: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+    channel: PropTypes.string,
+    channelList: PropTypes.string,
+    organization: PropTypes.string,
+    folderId: PropTypes.string,
+    source: PropTypes.string,
+  }),
+}
+
+DeviceDialog.defaultProps = {
+  initialValues: null,
+}
+
+const RetailPlayerDeviceManagement = () => {
+  const classes = useStyles()
+  const theme = useTheme()
+  const {
+    state: { tree, folders, devices, loading, error },
+    actions: { createFolder, updateFolder, createDevice, updateDevice },
+  } = useRetailPlayerDeviceStore()
+  const [menuAnchor, setMenuAnchor] = useState(null)
+  const [folderDialog, setFolderDialog] = useState({ open: false, target: null })
+  const [deviceDialog, setDeviceDialog] = useState({ open: false, target: null })
+
+  const folderOptions = useMemo(
+    () => folders.map((folder) => ({ id: folder.id, name: folder.name })),
+    [folders],
+  )
+
+  const folderMap = useMemo(() => {
+    const map = new Map()
+    folders.forEach((folder) => {
+      map.set(folder.id, folder)
+    })
+    return map
+  }, [folders])
+
+  const deviceMap = useMemo(() => {
+    const map = new Map()
+    devices.forEach((device) => {
+      map.set(device.id, device)
+    })
+    return map
+  }, [devices])
+
+  const openMenu = (event) => {
+    setMenuAnchor(event.currentTarget)
+  }
+
+  const closeMenu = () => {
+    setMenuAnchor(null)
+  }
+
+  const handleCreateFolder = () => {
+    closeMenu()
+    setFolderDialog({ open: true, target: null })
+  }
+
+  const handleCreateDevice = () => {
+    closeMenu()
+    setDeviceDialog({ open: true, target: null })
+  }
+
+  const handleEditFolder = (folderId) => {
+    const folder = folderMap.get(folderId)
+    if (!folder) return
+    setFolderDialog({ open: true, target: folder })
+  }
+
+  const handleEditDevice = (deviceId) => {
+    const device = deviceMap.get(deviceId)
+    if (!device) return
+    setDeviceDialog({ open: true, target: device })
+  }
+
+  const handleFolderDialogClose = () => {
+    setFolderDialog({ open: false, target: null })
+  }
+
+  const handleDeviceDialogClose = () => {
+    setDeviceDialog({ open: false, target: null })
+  }
+
+  const handleFolderSubmit = (values) => {
+    if (folderDialog.target) {
+      updateFolder({ id: folderDialog.target.id, name: values.name })
+    } else {
+      createFolder(values)
+    }
+    handleFolderDialogClose()
+  }
+
+  const handleDeviceSubmit = (values) => {
+    if (deviceDialog.target) {
+      updateDevice({ id: deviceDialog.target.id, ...values })
+    } else {
+      createDevice(values)
+    }
+    handleDeviceDialogClose()
+  }
+
+  const countDevices = useCallback((node) => {
+    if (!node || !Array.isArray(node.children)) {
+      return 0
+    }
+    return node.children.reduce((acc, child) => {
+      if (child.type === 'device') {
+        return acc + 1
+      }
+      return acc + countDevices(child)
+    }, 0)
+  }, [])
+
+  const renderRows = (nodes, depth = 0) =>
+    nodes.flatMap((node) => {
+      if (node.type === 'folder') {
+        const indentStyle = { paddingLeft: theme.spacing(depth * 2) }
+        const folderChildren = renderRows(node.children || [], depth + 1)
+        const deviceCount = countDevices(node)
+        return [
+          <div
+            key={`folder-row-${node.id}`}
+            className={clsx(classes.row, classes.folderRow)}
+          >
+            <div className={classes.nameCell} style={indentStyle}>
+              <FolderIcon className={classes.nameIcon} />
+              <div className={classes.nameLabel}>
+                <Typography variant="body1" color="textPrimary">
+                  {node.name}
+                </Typography>
+                <Typography variant="caption" color="textSecondary">
+                  {`${deviceCount} device${deviceCount === 1 ? '' : 's'}`}
+                </Typography>
+              </div>
+            </div>
+            <div className={classes.typeCell}>Folder</div>
+            <div className={classes.metaCell}>—</div>
+            <div className={clsx(classes.metaCell, classes.metaSecondary)}>—</div>
+            <div className={classes.actionsCell}>
+              <Tooltip title="Edit folder">
+                <IconButton
+                  size="small"
+                  onClick={() => handleEditFolder(node.id)}
+                  aria-label={`Edit folder ${node.name}`}
+                >
+                  <EditIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            </div>
+          </div>,
+          ...folderChildren,
+        ]
+      }
+      const indentStyle = { paddingLeft: theme.spacing(depth * 2) }
+      return [
+        <div key={`device-row-${node.id}`} className={classes.row}>
+          <div className={classes.nameCell} style={indentStyle}>
+            <SpeakerGroupIcon className={classes.nameIcon} />
+            <div className={classes.nameLabel}>
+              <Typography variant="body1" color="textPrimary">
+                {node.name}
+              </Typography>
+              {node.organization ? (
+                <Typography variant="caption" color="textSecondary">
+                  {node.organization}
+                </Typography>
+              ) : null}
+            </div>
+          </div>
+          <div className={classes.typeCell}>Device</div>
+          <div className={classes.metaCell}>{node.channel || '—'}</div>
+          <div className={clsx(classes.metaCell, classes.metaSecondary)}>
+            {node.channelList || '—'}
+          </div>
+          <div className={classes.actionsCell}>
+            <Tooltip title="Edit device">
+              <IconButton
+                size="small"
+                onClick={() => handleEditDevice(node.id)}
+                aria-label={`Edit device ${node.name}`}
+              >
+                <EditIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </div>
+        </div>,
+      ]
+    })
+
+  return (
+    <div className={classes.root}>
+      <Title title="Retail Player Devices" />
+      <div className={classes.header}>
+        <div className={classes.titleBlock}>
+          <Typography component="h1" variant="h4">
+            Retail Player Devices
+          </Typography>
+          <Typography variant="body2" color="textSecondary">
+            Organize retail player endpoints into folders for quick access and future
+            device management.
+          </Typography>
+        </div>
+        <div className={classes.actions}>
+          <Button
+            color="primary"
+            variant="contained"
+            startIcon={<AddIcon />}
+            onClick={openMenu}
+            aria-haspopup="true"
+            aria-controls="retail-device-create-menu"
+          >
+            Create
+          </Button>
+          <Menu
+            id="retail-device-create-menu"
+            anchorEl={menuAnchor}
+            keepMounted
+            open={Boolean(menuAnchor)}
+            onClose={closeMenu}
+          >
+            <MenuItem onClick={handleCreateFolder}>Create Folder</MenuItem>
+            <MenuItem onClick={handleCreateDevice}>Create Device</MenuItem>
+          </Menu>
+        </div>
+      </div>
+      <Paper className={classes.panel} elevation={0}>
+        <div className={classes.listHeader}>
+          <span className={classes.headerName}>Name</span>
+          <span className={classes.headerType}>Type</span>
+          <span className={classes.headerChannel}>Channel</span>
+          <span className={classes.headerChannelList}>Channel List</span>
+          <span className={classes.headerActions}>Actions</span>
+        </div>
+        {loading ? (
+          <div className={classes.loaderState}>
+            <CircularProgress size={20} />
+            <Typography variant="body2">Loading devices…</Typography>
+          </div>
+        ) : error ? (
+          <div className={classes.errorState}>
+            <Typography variant="body2">
+              We could not load retail player devices right now. Please try again.
+            </Typography>
+          </div>
+        ) : tree.length ? (
+          renderRows(tree)
+        ) : (
+          <div className={classes.emptyState}>
+            <Typography variant="body2">
+              No devices found yet. Use the Create menu to add folders or local
+              devices.
+            </Typography>
+          </div>
+        )}
+      </Paper>
+
+      <FolderDialog
+        open={folderDialog.open}
+        onClose={handleFolderDialogClose}
+        onSubmit={handleFolderSubmit}
+        parentOptions={folderOptions}
+        initialValues={folderDialog.target}
+        disableParent={Boolean(folderDialog.target)}
+      />
+      <DeviceDialog
+        open={deviceDialog.open}
+        onClose={handleDeviceDialogClose}
+        onSubmit={handleDeviceSubmit}
+        parentOptions={folderOptions}
+        initialValues={deviceDialog.target}
+      />
+    </div>
+  )
+}
+
+export default RetailPlayerDeviceManagement

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -24,8 +24,11 @@ import AddIcon from '@material-ui/icons/Add'
 import EditIcon from '@material-ui/icons/Edit'
 import FolderIcon from '@material-ui/icons/Folder'
 import SpeakerGroupIcon from '@material-ui/icons/SpeakerGroup'
+import Breadcrumbs from '@material-ui/core/Breadcrumbs'
+import Link from '@material-ui/core/Link'
 import clsx from 'clsx'
 import PropTypes from 'prop-types'
+import { useHistory } from 'react-router-dom'
 import { useRetailPlayerDeviceStore } from './RetailPlayerDeviceStoreContext'
 
 const useStyles = makeStyles((theme) => ({
@@ -127,6 +130,16 @@ const useStyles = makeStyles((theme) => ({
   folderRow: {
     backgroundColor: theme.palette.action.selected,
   },
+  interactiveRow: {
+    cursor: 'pointer',
+    '&:hover': {
+      backgroundColor: theme.palette.action.hover,
+    },
+    '&:focus': {
+      outline: `2px solid ${theme.palette.primary.main}`,
+      outlineOffset: -2,
+    },
+  },
   nameCell: {
     display: 'flex',
     alignItems: 'center',
@@ -174,6 +187,26 @@ const useStyles = makeStyles((theme) => ({
     [theme.breakpoints.down('sm')]: {
       gridArea: 'actions',
     },
+  },
+  breadcrumbBar: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    flexWrap: 'wrap',
+    gap: theme.spacing(1),
+    padding: theme.spacing(1.5, 2),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    backgroundColor: theme.palette.background.default,
+  },
+  breadcrumbs: {
+    '& .MuiBreadcrumbs-separator': {
+      color: theme.palette.text.secondary,
+    },
+  },
+  breadcrumbLink: {
+    color: theme.palette.primary.main,
+    cursor: 'pointer',
+    fontWeight: theme.typography.fontWeightMedium,
   },
   emptyState: {
     padding: theme.spacing(4),
@@ -446,6 +479,7 @@ DeviceDialog.defaultProps = {
 const RetailPlayerDeviceManagement = () => {
   const classes = useStyles()
   const theme = useTheme()
+  const history = useHistory()
   const {
     state: { tree, folders, devices, loading, error },
     actions: { createFolder, updateFolder, createDevice, updateDevice },
@@ -453,6 +487,7 @@ const RetailPlayerDeviceManagement = () => {
   const [menuAnchor, setMenuAnchor] = useState(null)
   const [folderDialog, setFolderDialog] = useState({ open: false, target: null })
   const [deviceDialog, setDeviceDialog] = useState({ open: false, target: null })
+  const [activeFolderId, setActiveFolderId] = useState(null)
 
   const folderOptions = useMemo(
     () => folders.map((folder) => ({ id: folder.id, name: folder.name })),
@@ -474,6 +509,62 @@ const RetailPlayerDeviceManagement = () => {
     })
     return map
   }, [devices])
+
+  const findFolderNode = useCallback((nodes, targetId) => {
+    if (!targetId) {
+      return null
+    }
+    for (let index = 0; index < nodes.length; index += 1) {
+      const node = nodes[index]
+      if (node.type !== 'folder') {
+        // eslint-disable-next-line no-continue
+        continue
+      }
+      if (node.id === targetId) {
+        return node
+      }
+      const childResult = findFolderNode(node.children || [], targetId)
+      if (childResult) {
+        return childResult
+      }
+    }
+    return null
+  }, [])
+
+  const activeFolderNode = useMemo(
+    () => findFolderNode(tree, activeFolderId),
+    [findFolderNode, tree, activeFolderId],
+  )
+
+  useEffect(() => {
+    if (activeFolderId && !activeFolderNode) {
+      setActiveFolderId(null)
+    }
+  }, [activeFolderId, activeFolderNode])
+
+  const activeFolderPath = useMemo(() => {
+    if (!activeFolderId) {
+      return []
+    }
+    const path = []
+    let currentId = activeFolderId
+    const seen = new Set()
+    while (currentId) {
+      if (seen.has(currentId)) {
+        break
+      }
+      seen.add(currentId)
+      const folder = folderMap.get(currentId)
+      if (!folder) {
+        break
+      }
+      path.unshift(folder)
+      currentId = folder.parentId || null
+    }
+    return path
+  }, [activeFolderId, folderMap])
+
+  const visibleNodes = activeFolderNode ? activeFolderNode.children || [] : tree
 
   const openMenu = (event) => {
     setMenuAnchor(event.currentTarget)
@@ -531,6 +622,36 @@ const RetailPlayerDeviceManagement = () => {
     handleDeviceDialogClose()
   }
 
+  const handleNavigateToDevice = useCallback(
+    (device) => {
+      if (!device) {
+        return
+      }
+      const slug = device.slug || device.name || device.id
+      if (!slug) {
+        return
+      }
+      const encodedSlug = encodeURIComponent(slug)
+      history.push(`/retailplayer/${encodedSlug}`)
+    },
+    [history],
+  )
+
+  const handleEnterFolder = useCallback((folderId) => {
+    if (!folderId) {
+      setActiveFolderId(null)
+      return
+    }
+    setActiveFolderId(folderId)
+  }, [])
+
+  const handleRowKeyDown = (event, action) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      action()
+    }
+  }
+
   const countDevices = useCallback((node) => {
     if (!node || !Array.isArray(node.children)) {
       return 0
@@ -552,7 +673,12 @@ const RetailPlayerDeviceManagement = () => {
         return [
           <div
             key={`folder-row-${node.id}`}
-            className={clsx(classes.row, classes.folderRow)}
+            className={clsx(classes.row, classes.folderRow, classes.interactiveRow)}
+            role="button"
+            tabIndex={0}
+            onClick={() => handleEnterFolder(node.id)}
+            onKeyDown={(event) => handleRowKeyDown(event, () => handleEnterFolder(node.id))}
+            aria-label={`Open folder ${node.name}`}
           >
             <div className={classes.nameCell} style={indentStyle}>
               <FolderIcon className={classes.nameIcon} />
@@ -572,7 +698,10 @@ const RetailPlayerDeviceManagement = () => {
               <Tooltip title="Edit folder">
                 <IconButton
                   size="small"
-                  onClick={() => handleEditFolder(node.id)}
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    handleEditFolder(node.id)
+                  }}
                   aria-label={`Edit folder ${node.name}`}
                 >
                   <EditIcon fontSize="small" />
@@ -585,7 +714,15 @@ const RetailPlayerDeviceManagement = () => {
       }
       const indentStyle = { paddingLeft: theme.spacing(depth * 2) }
       return [
-        <div key={`device-row-${node.id}`} className={classes.row}>
+        <div
+          key={`device-row-${node.id}`}
+          className={clsx(classes.row, classes.interactiveRow)}
+          role="button"
+          tabIndex={0}
+          onClick={() => handleNavigateToDevice(node)}
+          onKeyDown={(event) => handleRowKeyDown(event, () => handleNavigateToDevice(node))}
+          aria-label={`Open device ${node.name}`}
+        >
           <div className={classes.nameCell} style={indentStyle}>
             <SpeakerGroupIcon className={classes.nameIcon} />
             <div className={classes.nameLabel}>
@@ -608,7 +745,10 @@ const RetailPlayerDeviceManagement = () => {
             <Tooltip title="Edit device">
               <IconButton
                 size="small"
-                onClick={() => handleEditDevice(node.id)}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  handleEditDevice(node.id)
+                }}
                 aria-label={`Edit device ${node.name}`}
               >
                 <EditIcon fontSize="small" />
@@ -656,6 +796,45 @@ const RetailPlayerDeviceManagement = () => {
         </div>
       </div>
       <Paper className={classes.panel} elevation={0}>
+        {activeFolderNode ? (
+          <div className={classes.breadcrumbBar}>
+            <Breadcrumbs
+              aria-label="Folder navigation"
+              className={classes.breadcrumbs}
+              maxItems={4}
+            >
+              <Link
+                color="inherit"
+                onClick={() => setActiveFolderId(null)}
+                className={classes.breadcrumbLink}
+                component="button"
+              >
+                All devices
+              </Link>
+              {activeFolderPath.map((folder, index) => {
+                const isLast = index === activeFolderPath.length - 1
+                if (isLast) {
+                  return (
+                    <Typography key={folder.id} color="textPrimary">
+                      {folder.name}
+                    </Typography>
+                  )
+                }
+                return (
+                  <Link
+                    key={folder.id}
+                    color="inherit"
+                    onClick={() => setActiveFolderId(folder.id)}
+                    className={classes.breadcrumbLink}
+                    component="button"
+                  >
+                    {folder.name}
+                  </Link>
+                )
+              })}
+            </Breadcrumbs>
+          </div>
+        ) : null}
         <div className={classes.listHeader}>
           <span className={classes.headerName}>Name</span>
           <span className={classes.headerType}>Type</span>
@@ -674,14 +853,20 @@ const RetailPlayerDeviceManagement = () => {
               We could not load retail player devices right now. Please try again.
             </Typography>
           </div>
-        ) : tree.length ? (
-          renderRows(tree)
+        ) : visibleNodes.length ? (
+          renderRows(visibleNodes)
         ) : (
           <div className={classes.emptyState}>
-            <Typography variant="body2">
-              No devices found yet. Use the Create menu to add folders or local
-              devices.
-            </Typography>
+            {activeFolderNode ? (
+              <Typography variant="body2">
+                This folder does not contain any devices yet.
+              </Typography>
+            ) : (
+              <Typography variant="body2">
+                No devices found yet. Use the Create menu to add folders or local
+                devices.
+              </Typography>
+            )}
           </div>
         )}
       </Paper>

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -1,0 +1,351 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+} from 'react'
+import PropTypes from 'prop-types'
+import { v4 as uuidv4 } from 'uuid'
+import useRetailPlayerDevices from './useRetailPlayerDevices'
+import { buildDeviceSlug, deviceSlugKey, normalizeValue } from './deviceUtils'
+
+const RetailPlayerDeviceStoreContext = createContext(null)
+
+const initialState = {
+  folders: [],
+  devices: [],
+  loading: true,
+  error: null,
+  isApiEnabled: false,
+  lastUpdated: null,
+}
+
+const ensureFolderId = (value) => {
+  if (typeof value === 'string' && value.trim() !== '') {
+    return value
+  }
+  return null
+}
+
+const baseDeviceShape = (device, existing) => {
+  const normalizedName = normalizeValue(device?.name)
+  const normalizedSlug = normalizeValue(device?.slug)
+  const normalizedChannel = normalizeValue(device?.channel)
+  const normalizedChannelList = normalizeValue(device?.channelList)
+  const normalizedOrganization = normalizeValue(device?.organization)
+  const normalizedTimeZone = normalizeValue(device?.timeZone)
+
+  const slug =
+    normalizedSlug ||
+    (existing?.slug || buildDeviceSlug(device) || normalizedName || device?.id)
+
+  return {
+    id: existing?.id || device?.id || uuidv4(),
+    apiId: normalizeValue(device?.apiId || device?.id) || null,
+    name: normalizedName || existing?.name || slug || 'Device',
+    slug,
+    slugKey: deviceSlugKey(slug),
+    channel: normalizedChannel || '',
+    channelList: normalizedChannelList || '',
+    organization: normalizedOrganization || '',
+    timeZone: normalizedTimeZone || '',
+    folderId: ensureFolderId(existing?.folderId),
+    source: existing?.source === 'local' ? 'local' : 'remote',
+    attributes: existing?.attributes || {},
+  }
+}
+
+const reducer = (state, action) => {
+  switch (action.type) {
+    case 'SET_LOADING':
+      return { ...state, loading: Boolean(action.payload) }
+    case 'SET_ERROR':
+      return { ...state, error: action.payload || null }
+    case 'SET_API_ENABLED':
+      return { ...state, isApiEnabled: Boolean(action.payload) }
+    case 'SYNC_DEVICES': {
+      const incoming = Array.isArray(action.payload) ? action.payload : []
+      const existingByKey = new Map()
+      state.devices.forEach((device) => {
+        const key = device.apiId || device.id
+        if (key) {
+          existingByKey.set(key, device)
+        }
+      })
+
+      const nextDevices = incoming.map((device) => {
+        const key = normalizeValue(device?.apiId || device?.id)
+        const existing = key ? existingByKey.get(key) : null
+        return {
+          ...baseDeviceShape(device, existing || undefined),
+          folderId: ensureFolderId(existing?.folderId),
+        }
+      })
+
+      const localDevices = state.devices.filter((device) => device.source === 'local')
+
+      return {
+        ...state,
+        devices: [...nextDevices, ...localDevices],
+        lastUpdated: Date.now(),
+      }
+    }
+    case 'CREATE_FOLDER': {
+      const { name, parentId } = action.payload || {}
+      const now = new Date().toISOString()
+      const folder = {
+        id: uuidv4(),
+        name: normalizeValue(name) || 'New Folder',
+        parentId: ensureFolderId(parentId),
+        createdAt: now,
+        updatedAt: now,
+      }
+      return {
+        ...state,
+        folders: [...state.folders, folder],
+        lastUpdated: Date.now(),
+      }
+    }
+    case 'UPDATE_FOLDER': {
+      const { id, name } = action.payload || {}
+      if (!id) {
+        return state
+      }
+      const nextFolders = state.folders.map((folder) => {
+        if (folder.id !== id) {
+          return folder
+        }
+        return {
+          ...folder,
+          name: normalizeValue(name) || folder.name,
+          updatedAt: new Date().toISOString(),
+        }
+      })
+      return { ...state, folders: nextFolders, lastUpdated: Date.now() }
+    }
+    case 'CREATE_DEVICE': {
+      const {
+        name,
+        channel,
+        channelList,
+        organization,
+        folderId,
+        attributes,
+      } = action.payload || {}
+      const normalizedName = normalizeValue(name) || 'New Device'
+      const slug = deviceSlugKey(normalizedName) || uuidv4()
+      const device = {
+        id: uuidv4(),
+        apiId: null,
+        name: normalizedName,
+        slug,
+        slugKey: deviceSlugKey(slug),
+        channel: normalizeValue(channel) || '',
+        channelList: normalizeValue(channelList) || '',
+        organization: normalizeValue(organization) || '',
+        timeZone: '',
+        folderId: ensureFolderId(folderId),
+        source: 'local',
+        attributes: attributes && typeof attributes === 'object' ? { ...attributes } : {},
+      }
+      return {
+        ...state,
+        devices: [...state.devices, device],
+        lastUpdated: Date.now(),
+      }
+    }
+    case 'UPDATE_DEVICE': {
+      const { id, name, channel, channelList, organization, folderId } =
+        action.payload || {}
+      if (!id) {
+        return state
+      }
+      const nextDevices = state.devices.map((device) => {
+        if (device.id !== id) {
+          return device
+        }
+        const isLocal = device.source === 'local'
+        return {
+          ...device,
+          name: isLocal ? normalizeValue(name) || device.name : device.name,
+          channel: normalizeValue(channel) || device.channel,
+          channelList: normalizeValue(channelList) || device.channelList,
+          organization:
+            normalizeValue(organization) || device.organization,
+          folderId:
+            ensureFolderId(folderId) !== undefined
+              ? ensureFolderId(folderId)
+              : device.folderId,
+        }
+      })
+      return { ...state, devices: nextDevices, lastUpdated: Date.now() }
+    }
+    case 'ASSIGN_DEVICE_FOLDER': {
+      const { id, folderId } = action.payload || {}
+      if (!id) {
+        return state
+      }
+      const nextDevices = state.devices.map((device) => {
+        if (device.id !== id) {
+          return device
+        }
+        return { ...device, folderId: ensureFolderId(folderId) }
+      })
+      return { ...state, devices: nextDevices, lastUpdated: Date.now() }
+    }
+    default:
+      return state
+  }
+}
+
+const buildTree = (folders, devices) => {
+  const folderMap = new Map()
+  const rootNodes = []
+
+  folders.forEach((folder) => {
+    folderMap.set(folder.id, {
+      ...folder,
+      type: 'folder',
+      children: [],
+    })
+  })
+
+  folderMap.forEach((folderNode) => {
+    if (folderNode.parentId && folderMap.has(folderNode.parentId)) {
+      const parent = folderMap.get(folderNode.parentId)
+      parent.children.push(folderNode)
+    } else {
+      rootNodes.push(folderNode)
+    }
+  })
+
+  const attachDevice = (device) => {
+    const node = {
+      ...device,
+      type: 'device',
+    }
+    if (device.folderId && folderMap.has(device.folderId)) {
+      folderMap.get(device.folderId).children.push(node)
+    } else {
+      rootNodes.push(node)
+    }
+  }
+
+  devices.forEach(attachDevice)
+
+  const sortNodes = (nodes) =>
+    nodes
+      .slice()
+      .sort((a, b) => {
+        if (a.type === b.type) {
+          return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+        }
+        return a.type === 'folder' ? -1 : 1
+      })
+
+  const normalizeTree = (nodes) =>
+    sortNodes(nodes).map((node) => {
+      if (node.type === 'folder') {
+        return {
+          ...node,
+          children: normalizeTree(node.children || []),
+        }
+      }
+      return node
+    })
+
+  return normalizeTree(rootNodes)
+}
+
+const RetailPlayerDeviceStoreProvider = ({ children }) => {
+  const [state, dispatch] = useReducer(reducer, initialState)
+  const {
+    devices: remoteDevices,
+    error,
+    isLoading,
+    isApiEnabled,
+  } = useRetailPlayerDevices()
+
+  useEffect(() => {
+    dispatch({ type: 'SET_LOADING', payload: isLoading })
+  }, [isLoading])
+
+  useEffect(() => {
+    dispatch({ type: 'SET_ERROR', payload: error })
+  }, [error])
+
+  useEffect(() => {
+    dispatch({ type: 'SET_API_ENABLED', payload: isApiEnabled })
+  }, [isApiEnabled])
+
+  useEffect(() => {
+    if (Array.isArray(remoteDevices)) {
+      dispatch({ type: 'SYNC_DEVICES', payload: remoteDevices })
+    }
+  }, [remoteDevices])
+
+  const tree = useMemo(
+    () => buildTree(state.folders, state.devices),
+    [state.folders, state.devices],
+  )
+
+  const createFolder = useCallback((payload) => {
+    dispatch({ type: 'CREATE_FOLDER', payload })
+  }, [])
+
+  const updateFolder = useCallback((payload) => {
+    dispatch({ type: 'UPDATE_FOLDER', payload })
+  }, [])
+
+  const createDevice = useCallback((payload) => {
+    dispatch({ type: 'CREATE_DEVICE', payload })
+  }, [])
+
+  const updateDevice = useCallback((payload) => {
+    dispatch({ type: 'UPDATE_DEVICE', payload })
+  }, [])
+
+  const assignDeviceToFolder = useCallback((payload) => {
+    dispatch({ type: 'ASSIGN_DEVICE_FOLDER', payload })
+  }, [])
+
+  const value = useMemo(
+    () => ({
+      state: { ...state, tree },
+      actions: {
+        createFolder,
+        updateFolder,
+        createDevice,
+        updateDevice,
+        assignDeviceToFolder,
+      },
+    }),
+    [state, tree, createFolder, updateFolder, createDevice, updateDevice, assignDeviceToFolder],
+  )
+
+  return (
+    <RetailPlayerDeviceStoreContext.Provider value={value}>
+      {children}
+    </RetailPlayerDeviceStoreContext.Provider>
+  )
+}
+
+RetailPlayerDeviceStoreProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+}
+
+const useRetailPlayerDeviceStore = () => {
+  const context = useContext(RetailPlayerDeviceStoreContext)
+  if (!context) {
+    throw new Error(
+      'useRetailPlayerDeviceStore must be used within RetailPlayerDeviceStoreProvider',
+    )
+  }
+  return context
+}
+
+export { RetailPlayerDeviceStoreProvider, useRetailPlayerDeviceStore }
+
+export default RetailPlayerDeviceStoreProvider

--- a/ui/src/routes.jsx
+++ b/ui/src/routes.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Redirect, Route } from 'react-router-dom'
 import Personal from './personal/Personal'
 import RetailPlayerDashboard from './retailPlayer/RetailPlayerDashboard'
-import RetailPlayerDevicesList from './retailPlayer/RetailPlayerDevicesList'
+import RetailPlayerDeviceManagement from './retailPlayer/RetailPlayerDeviceManagement'
 
 const routes = [
   <Route exact path="/personal" render={() => <Personal />} key={'personal'} />,
@@ -15,8 +15,14 @@ const routes = [
   <Route
     exact
     path="/retailplayer/devices"
-    render={() => <RetailPlayerDevicesList />}
+    render={() => <RetailPlayerDeviceManagement />}
     key={'retailplayer-devices'}
+  />,
+  <Route
+    exact
+    path="/retail-player/devices"
+    render={() => <RetailPlayerDeviceManagement />}
+    key={'retailplayer-devices-settings'}
   />,
   <Route
     exact


### PR DESCRIPTION
## Summary
- add a shared retail player device store to keep folders and devices organized
- update the sidebar retail player submenu to show a tree and link to the new settings view
- build a retail player device management page with folder and device dialogs and expose routes for it

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_690917dd3af88330aa1e4c74a739a4e7