### PR TITLE
Add retail player device folder management UI

### DIFF
--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -594,9 +594,35 @@
       "allDevices": "All Devices",
       "loading": "Loading devices…",
       "error": "Unable to load devices",
-      "empty": "No devices available"
+      "empty": "No devices available",
+      "manage": "Manage device folders"
     },
     "about": "About"
+  },
+  "retailPlayer": {
+    "folders": {
+      "title": "Retail Player Device Folders",
+      "create": "Create folder",
+      "rename": "Rename folder",
+      "delete": "Delete folder",
+      "deleteMessage": "Deleting \"%{name}\" will move any nested items back to the parent folder.",
+      "searchPlaceholder": "Search folders or devices",
+      "empty": "No folders or devices in this location yet.",
+      "loadError": "Unable to load retail player devices. Please try again later.",
+      "moveFolder": "Move folder",
+      "moveDevice": "Move device",
+      "destination": "Destination folder",
+      "root": "Root",
+      "viewDevice": "View device",
+      "columns": {
+        "type": "Type",
+        "name": "Name",
+        "ownerName": "Owner Name",
+        "updatedAt": "Updated",
+        "public": "Public",
+        "actions": "Actions"
+      }
+    }
   },
   "player": {
     "playListsText": "Play Queue",

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { Divider, makeStyles } from '@material-ui/core'
 import clsx from 'clsx'
@@ -15,6 +15,8 @@ import DiscoverySubMenu from './DiscoverySubMenu'
 import LibrarySelector from '../common/LibrarySelector'
 import config from '../config'
 import useRetailPlayerDevices from '../retailPlayer/useRetailPlayerDevices'
+import { BiCog } from 'react-icons/bi'
+import { useHistory } from 'react-router-dom'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -66,6 +68,7 @@ const Menu = ({ dense = false }) => {
   const resources = useSelector(getResources).filter(
     (r) => r.name !== 'radio' && r.name !== 'share',
   )
+  const history = useHistory()
 
   // TODO State is not persisted in mobile when you close the sidebar menu. Move to redux?
   const [state, setState] = useState({
@@ -127,6 +130,10 @@ const Menu = ({ dense = false }) => {
     isLoading: retailDevicesLoading,
   } = useRetailPlayerDevices()
 
+  const onRetailPlayerConfig = useCallback(() => {
+    history.push('/retailplayer/folders')
+  }, [history])
+
   const renderRetailPlayerDevices = () => {
     if (retailDevicesLoading) {
       return (
@@ -180,6 +187,8 @@ const Menu = ({ dense = false }) => {
       name="menu.retailPlayer.name"
       icon={<SpeakerGroupIcon />}
       dense={dense}
+      actionIcon={<BiCog />}
+      onAction={onRetailPlayerConfig}
     >
       {renderRetailPlayerDevices()}
     </SubMenu>

--- a/ui/src/retailPlayerFolder/ConfirmDialog.jsx
+++ b/ui/src/retailPlayerFolder/ConfirmDialog.jsx
@@ -1,0 +1,37 @@
+import PropTypes from 'prop-types'
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from '@material-ui/core'
+
+const ConfirmDialog = ({ open, title, message, confirmLabel, onClose, onConfirm }) => (
+  <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+    <DialogTitle>{title}</DialogTitle>
+    <DialogContent>
+      <Typography>{message}</Typography>
+    </DialogContent>
+    <DialogActions>
+      <Button onClick={onClose} color="primary">
+        Cancel
+      </Button>
+      <Button onClick={onConfirm} color="secondary" variant="contained">
+        {confirmLabel}
+      </Button>
+    </DialogActions>
+  </Dialog>
+)
+
+ConfirmDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  title: PropTypes.string.isRequired,
+  message: PropTypes.string.isRequired,
+  confirmLabel: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+}
+
+export default ConfirmDialog

--- a/ui/src/retailPlayerFolder/FolderFormDialog.jsx
+++ b/ui/src/retailPlayerFolder/FolderFormDialog.jsx
@@ -1,0 +1,89 @@
+import PropTypes from 'prop-types'
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+} from '@material-ui/core'
+import { useState, useEffect } from 'react'
+
+const FolderFormDialog = ({
+  open,
+  title,
+  label,
+  initialName = '',
+  onClose,
+  onSubmit,
+}) => {
+  const [name, setName] = useState(initialName)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (open) {
+      setName(initialName)
+      setError('')
+    }
+  }, [open, initialName])
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    const trimmed = name.trim()
+    if (!trimmed) {
+      setError('Name is required')
+      return
+    }
+    onSubmit(trimmed)
+  }
+
+  const handleClose = () => {
+    setName(initialName)
+    setError('')
+    onClose()
+  }
+
+  return (
+    <Dialog open={open} onClose={handleClose} fullWidth maxWidth="xs">
+      <form onSubmit={handleSubmit}>
+        <DialogTitle>{title}</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            fullWidth
+            margin="dense"
+            label={label}
+            value={name}
+            onChange={(event) => {
+              setName(event.target.value)
+              if (error) {
+                setError('')
+              }
+            }}
+            error={Boolean(error)}
+            helperText={error}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} color="primary">
+            Cancel
+          </Button>
+          <Button type="submit" color="primary" variant="contained">
+            Save
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  )
+}
+
+FolderFormDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  title: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  initialName: PropTypes.string,
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+}
+
+export default FolderFormDialog

--- a/ui/src/retailPlayerFolder/MoveItemDialog.jsx
+++ b/ui/src/retailPlayerFolder/MoveItemDialog.jsx
@@ -1,0 +1,115 @@
+import PropTypes from 'prop-types'
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+} from '@material-ui/core'
+import { useEffect, useMemo, useState } from 'react'
+
+const formatLabel = (folder, currentId) => {
+  const prefix = folder.depth > 0 ? `${'\u00A0'.repeat(folder.depth * 2)}• ` : ''
+  const name = folder.name || 'Untitled folder'
+  if (folder.id === currentId) {
+    return `${prefix}${name} (current)`
+  }
+  return `${prefix}${name}`
+}
+
+const MoveItemDialog = ({
+  open,
+  title,
+  folders,
+  currentId,
+  initialParentId,
+  forbiddenIds = [],
+  destinationLabel = 'Destination folder',
+  rootLabel = 'Root',
+  onClose,
+  onSubmit,
+}) => {
+  const [selected, setSelected] = useState(initialParentId ?? '')
+
+  useEffect(() => {
+    if (open) {
+      setSelected(initialParentId ?? '')
+    }
+  }, [open, initialParentId])
+
+  const availableFolders = useMemo(() => {
+    const forbidden = new Set(forbiddenIds)
+    if (currentId) {
+      forbidden.add(currentId)
+    }
+    return folders.filter((folder) => !forbidden.has(folder.id))
+  }, [folders, forbiddenIds, currentId])
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    const payload = selected === '' ? null : selected
+    onSubmit(payload)
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      <form onSubmit={handleSubmit}>
+        <DialogTitle>{title}</DialogTitle>
+        <DialogContent>
+          <FormControl variant="outlined" fullWidth margin="dense">
+            <InputLabel id="retail-player-move-folder-label">
+              {destinationLabel}
+            </InputLabel>
+            <Select
+              labelId="retail-player-move-folder-label"
+              value={selected}
+              onChange={(event) => setSelected(event.target.value)}
+              label={destinationLabel}
+            >
+              <MenuItem value="">{rootLabel}</MenuItem>
+              {availableFolders.map((folder) => (
+                <MenuItem key={folder.id} value={folder.id}>
+                  {formatLabel(folder, currentId)}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} color="primary">
+            Cancel
+          </Button>
+          <Button type="submit" color="primary" variant="contained">
+            Move
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  )
+}
+
+MoveItemDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  title: PropTypes.string.isRequired,
+  folders: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      parentId: PropTypes.string,
+      depth: PropTypes.number,
+    }),
+  ).isRequired,
+  currentId: PropTypes.string,
+  initialParentId: PropTypes.string,
+  forbiddenIds: PropTypes.arrayOf(PropTypes.string),
+  destinationLabel: PropTypes.string,
+  rootLabel: PropTypes.string,
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+}
+
+export default MoveItemDialog

--- a/ui/src/retailPlayerFolder/RetailPlayerFolderPage.jsx
+++ b/ui/src/retailPlayerFolder/RetailPlayerFolderPage.jsx
@@ -26,7 +26,7 @@ import SpeakerGroupIcon from '@material-ui/icons/SpeakerGroup'
 import EditIcon from '@material-ui/icons/Edit'
 import DeleteIcon from '@material-ui/icons/Delete'
 import OpenInNewIcon from '@material-ui/icons/OpenInNew'
-import DriveFileMoveIcon from '@material-ui/icons/DriveFileMove'
+import MoveToInboxIcon from '@material-ui/icons/MoveToInbox'
 import Switch from '@material-ui/core/Switch'
 import { useHistory } from 'react-router-dom'
 import { Title, useTranslate } from 'react-admin'
@@ -413,7 +413,7 @@ const RetailPlayerFolderPage = () => {
                                   })
                                 }
                               >
-                                <DriveFileMoveIcon fontSize="small" />
+                                <MoveToInboxIcon fontSize="small" />
                               </IconButton>
                             </Tooltip>
                             {item.type === 'folder' ? (

--- a/ui/src/retailPlayerFolder/RetailPlayerFolderPage.jsx
+++ b/ui/src/retailPlayerFolder/RetailPlayerFolderPage.jsx
@@ -1,0 +1,506 @@
+import { useCallback, useMemo, useState } from 'react'
+import {
+  Box,
+  Breadcrumbs,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  IconButton,
+  Link,
+  makeStyles,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TableSortLabel,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@material-ui/core'
+import FolderIcon from '@material-ui/icons/Folder'
+import SpeakerGroupIcon from '@material-ui/icons/SpeakerGroup'
+import EditIcon from '@material-ui/icons/Edit'
+import DeleteIcon from '@material-ui/icons/Delete'
+import OpenInNewIcon from '@material-ui/icons/OpenInNew'
+import DriveFileMoveIcon from '@material-ui/icons/DriveFileMove'
+import Switch from '@material-ui/core/Switch'
+import { useHistory } from 'react-router-dom'
+import { Title, useTranslate } from 'react-admin'
+import useRetailPlayerDevices from '../retailPlayer/useRetailPlayerDevices'
+import FolderFormDialog from './FolderFormDialog'
+import MoveItemDialog from './MoveItemDialog'
+import ConfirmDialog from './ConfirmDialog'
+import useRetailPlayerFolderState from './useRetailPlayerFolderState'
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    padding: theme.spacing(3),
+    [theme.breakpoints.down('sm')]: {
+      padding: theme.spacing(2),
+    },
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: theme.spacing(3),
+    flexWrap: 'wrap',
+    gap: theme.spacing(2),
+  },
+  breadcrumbs: {
+    '& a': {
+      color: theme.palette.primary.main,
+    },
+  },
+  actionsRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+  },
+  tableHead: {
+    backgroundColor: theme.palette.background.paper,
+  },
+  typeCell: {
+    width: theme.spacing(6),
+  },
+  nameCell: {
+    minWidth: 220,
+  },
+  ownerCell: {
+    minWidth: 160,
+  },
+  updatedCell: {
+    minWidth: 160,
+  },
+  publicCell: {
+    width: theme.spacing(10),
+  },
+  actionsCell: {
+    width: theme.spacing(18),
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+  },
+  emptyState: {
+    padding: theme.spacing(4),
+    textAlign: 'center',
+    color: theme.palette.text.secondary,
+  },
+  loadingWrapper: {
+    display: 'flex',
+    justifyContent: 'center',
+    padding: theme.spacing(4),
+  },
+}))
+
+const HEADERS = [
+  { id: 'type', labelKey: 'retailPlayer.folders.columns.type', defaultLabel: 'Type', sortable: false },
+  { id: 'name', labelKey: 'retailPlayer.folders.columns.name', defaultLabel: 'Name', sortable: true },
+  {
+    id: 'ownerName',
+    labelKey: 'retailPlayer.folders.columns.ownerName',
+    defaultLabel: 'Owner Name',
+    sortable: true,
+  },
+  {
+    id: 'updatedAt',
+    labelKey: 'retailPlayer.folders.columns.updatedAt',
+    defaultLabel: 'Updated',
+    sortable: true,
+  },
+  {
+    id: 'public',
+    labelKey: 'retailPlayer.folders.columns.public',
+    defaultLabel: 'Public',
+    sortable: true,
+  },
+  {
+    id: 'actions',
+    labelKey: 'retailPlayer.folders.columns.actions',
+    defaultLabel: 'Actions',
+    sortable: false,
+  },
+]
+
+const formatDate = (value) => {
+  if (!value) {
+    return '—'
+  }
+  try {
+    return new Date(value).toLocaleString()
+  } catch (err) {
+    return value
+  }
+}
+
+const RetailPlayerFolderPage = () => {
+  const classes = useStyles()
+  const history = useHistory()
+  const [currentFolderId, setCurrentFolderId] = useState(null)
+  const [searchTerm, setSearchTerm] = useState('')
+  const [orderBy, setOrderBy] = useState('name')
+  const [orderDirection, setOrderDirection] = useState('asc')
+  const [isCreateOpen, setIsCreateOpen] = useState(false)
+  const [editFolderId, setEditFolderId] = useState(null)
+  const [moveContext, setMoveContext] = useState(null)
+  const [confirmContext, setConfirmContext] = useState(null)
+
+  const { devices, isLoading, error } = useRetailPlayerDevices()
+
+  const folderState = useRetailPlayerFolderState(devices)
+  const translate = useTranslate()
+
+  const items = useMemo(
+    () =>
+      folderState.getItems(currentFolderId, searchTerm, orderBy, orderDirection),
+    [folderState, currentFolderId, searchTerm, orderBy, orderDirection],
+  )
+
+  const breadcrumbTrail = useMemo(() => folderState.getBreadcrumb(currentFolderId), [folderState, currentFolderId])
+
+  const handleSortChange = (columnId) => {
+    if (orderBy === columnId) {
+      setOrderDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setOrderBy(columnId)
+      setOrderDirection('asc')
+    }
+  }
+
+  const handleCreateFolder = useCallback(
+    (name) => {
+      folderState.createFolder(name, currentFolderId)
+      setIsCreateOpen(false)
+    },
+    [folderState, currentFolderId],
+  )
+
+  const handleRenameFolder = useCallback(
+    (name) => {
+      if (!editFolderId) return
+      folderState.updateFolder(editFolderId, { name })
+      setEditFolderId(null)
+    },
+    [folderState, editFolderId],
+  )
+
+  const handleDeleteFolder = useCallback(() => {
+    if (!confirmContext) return
+    folderState.deleteFolder(confirmContext.id)
+    setConfirmContext(null)
+    if (confirmContext.id === currentFolderId) {
+      setCurrentFolderId(null)
+    }
+  }, [folderState, confirmContext, currentFolderId])
+
+  const handleMove = useCallback(
+    (targetParentId) => {
+      if (!moveContext) return
+      if (moveContext.type === 'folder') {
+        folderState.moveFolder(moveContext.id, targetParentId)
+      } else if (moveContext.type === 'device') {
+        folderState.moveDevice(moveContext.id, targetParentId)
+      }
+      setMoveContext(null)
+    },
+    [folderState, moveContext],
+  )
+
+  const openFolder = (folderId) => {
+    setCurrentFolderId(folderId)
+    setSearchTerm('')
+  }
+
+  const moveDialogInitialParent = useMemo(() => {
+    if (!moveContext) return null
+    if (moveContext.type === 'folder') {
+      return folderState.getFolderById(moveContext.id)?.parentId ?? null
+    }
+    return folderState.assignments[moveContext.id] ?? null
+  }, [moveContext, folderState])
+
+  const forbiddenFolderTargets = useMemo(() => {
+    if (!moveContext || moveContext.type !== 'folder') {
+      return []
+    }
+    return Array.from(folderState.getDescendantIds(moveContext.id))
+  }, [moveContext, folderState])
+
+  return (
+    <Box className={classes.root}>
+      <Title title={translate('retailPlayer.folders.title', { _: 'Retail Player Device Folders' })} />
+      <div className={classes.header}>
+        <Typography variant="h4" component="h1">
+          {translate('retailPlayer.folders.title', { _: 'Retail Player Device Folders' })}
+        </Typography>
+        <Button color="primary" variant="contained" onClick={() => setIsCreateOpen(true)}>
+          {translate('retailPlayer.folders.create', { _: 'Create folder' })}
+        </Button>
+      </div>
+      <Card>
+        <CardContent>
+          <div className={classes.actionsRow}>
+            <Breadcrumbs aria-label="breadcrumb" className={classes.breadcrumbs}>
+              <Link
+                component="button"
+                onClick={() => {
+                  setCurrentFolderId(null)
+                  setSearchTerm('')
+                }}
+              >
+                {translate('retailPlayer.folders.root', { _: 'Root' })}
+              </Link>
+              {breadcrumbTrail.map((folder) => (
+                <Link
+                  key={folder.id}
+                  component="button"
+                  onClick={() => openFolder(folder.id)}
+                >
+                  {folder.name}
+                </Link>
+              ))}
+            </Breadcrumbs>
+            <TextField
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              variant="outlined"
+              size="small"
+              placeholder={translate('retailPlayer.folders.searchPlaceholder', {
+                _: 'Search folders or devices',
+              })}
+              InputProps={{
+                'aria-label': translate('retailPlayer.folders.searchPlaceholder', {
+                  _: 'Search folders or devices',
+                }),
+              }}
+            />
+          </div>
+          {isLoading ? (
+            <div className={classes.loadingWrapper}>
+              <CircularProgress size={24} />
+            </div>
+          ) : error ? (
+            <Typography color="error">
+              {translate('retailPlayer.folders.loadError', {
+                _: 'Unable to load retail player devices. Please try again later.',
+              })}
+            </Typography>
+          ) : (
+            <TableContainer component={Paper}>
+              <Table size="small">
+                <TableHead className={classes.tableHead}>
+                  <TableRow>
+                    {HEADERS.map((column) => (
+                      <TableCell
+                        key={column.id}
+                        className={
+                          column.id === 'type'
+                            ? classes.typeCell
+                            : column.id === 'name'
+                            ? classes.nameCell
+                            : column.id === 'ownerName'
+                            ? classes.ownerCell
+                            : column.id === 'updatedAt'
+                            ? classes.updatedCell
+                            : column.id === 'public'
+                            ? classes.publicCell
+                            : undefined
+                        }
+                      >
+                        {column.sortable ? (
+                          <TableSortLabel
+                            active={orderBy === column.id}
+                            direction={orderBy === column.id ? orderDirection : 'asc'}
+                            onClick={() => handleSortChange(column.id)}
+                          >
+                            {translate(column.labelKey, { _: column.defaultLabel })}
+                          </TableSortLabel>
+                        ) : (
+                          translate(column.labelKey, { _: column.defaultLabel })
+                        )}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {items.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={HEADERS.length} className={classes.emptyState}>
+                        {translate('retailPlayer.folders.empty', {
+                          _: 'No folders or devices in this location yet.',
+                        })}
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    items.map((item) => (
+                      <TableRow key={`${item.type}-${item.id}`} hover>
+                        <TableCell className={classes.typeCell}>
+                          {item.type === 'folder' ? (
+                            <FolderIcon color="primary" />
+                          ) : (
+                            <SpeakerGroupIcon color="action" />
+                          )}
+                        </TableCell>
+                        <TableCell className={classes.nameCell}>
+                          {item.type === 'folder' ? (
+                            <Link component="button" onClick={() => openFolder(item.id)}>
+                              {item.name}
+                            </Link>
+                          ) : (
+                            item.name
+                          )}
+                        </TableCell>
+                        <TableCell className={classes.ownerCell}>
+                          {item.ownerName || '—'}
+                        </TableCell>
+                        <TableCell className={classes.updatedCell}>{formatDate(item.updatedAt)}</TableCell>
+                        <TableCell className={classes.publicCell}>
+                          {item.type === 'folder' ? (
+                            <Switch
+                              color="primary"
+                              size="small"
+                              checked={Boolean(item.public)}
+                              onClick={(event) => event.stopPropagation()}
+                              onChange={() => folderState.toggleFolderPublic(item.id)}
+                            />
+                          ) : (
+                            '—'
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <div className={classes.actionsCell}>
+                            {item.type === 'folder' ? (
+                              <Tooltip title="Open">
+                              <IconButton size="small" onClick={() => openFolder(item.id)}>
+                                <OpenInNewIcon fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                          ) : (
+                              <Tooltip
+                                title={translate('retailPlayer.folders.viewDevice', { _: 'View device' })}
+                              >
+                                <IconButton
+                                  size="small"
+                                  onClick={() => {
+                                    const slug = item.data.slug || item.data.name || item.data.id
+                                    history.push(`/retailplayer/${encodeURIComponent(slug)}`)
+                                  }}
+                                >
+                                  <OpenInNewIcon fontSize="small" />
+                                </IconButton>
+                              </Tooltip>
+                            )}
+                            <Tooltip
+                              title={
+                                item.type === 'folder'
+                                  ? translate('retailPlayer.folders.moveFolder', { _: 'Move folder' })
+                                  : translate('retailPlayer.folders.moveDevice', { _: 'Move device' })
+                              }
+                            >
+                              <IconButton
+                                size="small"
+                                onClick={() =>
+                                  setMoveContext({
+                                    id: item.id,
+                                    type: item.type,
+                                  })
+                                }
+                              >
+                                <DriveFileMoveIcon fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                            {item.type === 'folder' ? (
+                              <>
+                                <Tooltip
+                                  title={translate('retailPlayer.folders.rename', { _: 'Rename folder' })}
+                                >
+                                  <IconButton size="small" onClick={() => setEditFolderId(item.id)}>
+                                    <EditIcon fontSize="small" />
+                                  </IconButton>
+                                </Tooltip>
+                                <Tooltip
+                                  title={translate('retailPlayer.folders.delete', { _: 'Delete folder' })}
+                                >
+                                  <IconButton
+                                    size="small"
+                                    onClick={() =>
+                                      setConfirmContext({
+                                        id: item.id,
+                                        name: item.name,
+                                      })
+                                    }
+                                  >
+                                    <DeleteIcon fontSize="small" />
+                                  </IconButton>
+                                </Tooltip>
+                              </>
+                            ) : null}
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </CardContent>
+      </Card>
+      <FolderFormDialog
+        open={isCreateOpen}
+        title={translate('retailPlayer.folders.create', { _: 'Create folder' })}
+        label={translate('retailPlayer.folders.create', { _: 'Create folder' })}
+        onClose={() => setIsCreateOpen(false)}
+        onSubmit={handleCreateFolder}
+      />
+      <FolderFormDialog
+        open={Boolean(editFolderId)}
+        title={translate('retailPlayer.folders.rename', { _: 'Rename folder' })}
+        label={translate('retailPlayer.folders.rename', { _: 'Rename folder' })}
+        initialName={editFolderId ? folderState.getFolderById(editFolderId)?.name || '' : ''}
+        onClose={() => setEditFolderId(null)}
+        onSubmit={handleRenameFolder}
+      />
+      <MoveItemDialog
+        open={Boolean(moveContext)}
+        title={
+          moveContext?.type === 'folder'
+            ? translate('retailPlayer.folders.moveFolder', { _: 'Move folder' })
+            : translate('retailPlayer.folders.moveDevice', { _: 'Move device' })
+        }
+        folders={folderState.folderOptions}
+        currentId={moveContext?.type === 'folder' ? moveContext.id : undefined}
+        initialParentId={moveDialogInitialParent || undefined}
+        forbiddenIds={forbiddenFolderTargets}
+        destinationLabel={translate('retailPlayer.folders.destination', { _: 'Destination folder' })}
+        rootLabel={translate('retailPlayer.folders.root', { _: 'Root' })}
+        onClose={() => setMoveContext(null)}
+        onSubmit={handleMove}
+      />
+      <ConfirmDialog
+        open={Boolean(confirmContext)}
+        title={translate('retailPlayer.folders.delete', { _: 'Delete folder' })}
+        message={
+          confirmContext
+            ? translate('retailPlayer.folders.deleteMessage', {
+                name: confirmContext.name,
+                _: `Deleting "${confirmContext.name}" will move any nested items back to the parent folder.`,
+              })
+            : ''
+        }
+        confirmLabel={translate('retailPlayer.folders.delete', { _: 'Delete folder' })}
+        onClose={() => setConfirmContext(null)}
+        onConfirm={handleDeleteFolder}
+      />
+    </Box>
+  )
+}
+
+export default RetailPlayerFolderPage

--- a/ui/src/retailPlayerFolder/index.jsx
+++ b/ui/src/retailPlayerFolder/index.jsx
@@ -1,0 +1,1 @@
+export { default as RetailPlayerFolderPage } from './RetailPlayerFolderPage'

--- a/ui/src/retailPlayerFolder/useRetailPlayerFolderState.js
+++ b/ui/src/retailPlayerFolder/useRetailPlayerFolderState.js
@@ -1,0 +1,354 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { v4 as uuidv4 } from 'uuid'
+
+const STORAGE_KEY = 'retailPlayerFolderState'
+
+const normalizeParentId = (parentId) => (parentId === undefined ? null : parentId)
+
+const loadInitialState = (devices) => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      const parsed = JSON.parse(stored)
+      return ensureStateShape(parsed, devices)
+    }
+  } catch (err) {
+    // ignore storage parsing issues and fall back to defaults
+  }
+
+  return createInitialState(devices)
+}
+
+const createInitialState = (devices) => ({
+  folders: [],
+  assignments: devices.reduce((acc, device) => {
+    acc[device.id] = null
+    return acc
+  }, {}),
+})
+
+const ensureStateShape = (state, devices) => {
+  const safeState = {
+    folders: Array.isArray(state?.folders) ? state.folders : [],
+    assignments: typeof state?.assignments === 'object' && state.assignments
+      ? { ...state.assignments }
+      : {},
+  }
+
+  const knownDeviceIds = new Set(devices.map((device) => device.id))
+
+  devices.forEach((device) => {
+    if (!(device.id in safeState.assignments)) {
+      safeState.assignments[device.id] = null
+    }
+  })
+
+  Object.keys(safeState.assignments).forEach((deviceId) => {
+    if (!knownDeviceIds.has(deviceId)) {
+      delete safeState.assignments[deviceId]
+    }
+  })
+
+  const folderIds = new Set(safeState.folders.map((folder) => folder.id))
+  Object.entries(safeState.assignments).forEach(([deviceId, folderId]) => {
+    if (folderId && !folderIds.has(folderId)) {
+      safeState.assignments[deviceId] = null
+    }
+  })
+
+  return safeState
+}
+
+const persistState = (state) => {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  } catch (err) {
+    // ignore storage errors
+  }
+}
+
+const buildFolderMap = (folders) => {
+  const map = new Map()
+  folders.forEach((folder) => {
+    map.set(folder.id, folder)
+  })
+  return map
+}
+
+const collectDescendantIds = (folderId, folders) => {
+  const descendants = new Set()
+  const toVisit = [folderId]
+
+  while (toVisit.length > 0) {
+    const current = toVisit.pop()
+    descendants.add(current)
+
+    folders.forEach((folder) => {
+      const parentId = normalizeParentId(folder.parentId)
+      if (parentId === current && !descendants.has(folder.id)) {
+        toVisit.push(folder.id)
+      }
+    })
+  }
+
+  return descendants
+}
+
+const buildFolderOptions = (folders) => {
+  const childrenMap = new Map()
+  folders.forEach((folder) => {
+    const parentId = normalizeParentId(folder.parentId)
+    if (!childrenMap.has(parentId)) {
+      childrenMap.set(parentId, [])
+    }
+    childrenMap.get(parentId).push(folder)
+  })
+
+  const walk = (parentId = null, depth = 0, acc = []) => {
+    const siblings = childrenMap.get(parentId) || []
+    const sorted = [...siblings].sort((a, b) => a.name.localeCompare(b.name))
+    sorted.forEach((folder) => {
+      acc.push({ ...folder, depth })
+      walk(folder.id, depth + 1, acc)
+    })
+    return acc
+  }
+
+  return walk()
+}
+
+const useRetailPlayerFolderState = (devices) => {
+  const [state, setState] = useState(() => loadInitialState(devices))
+
+  useEffect(() => {
+    setState((prev) => {
+      const next = ensureStateShape(prev, devices)
+      if (next !== prev) {
+        persistState(next)
+      }
+      return next
+    })
+  }, [devices])
+
+  const updateState = useCallback((updater) => {
+    setState((prev) => {
+      const next = typeof updater === 'function' ? updater(prev) : updater
+      persistState(next)
+      return next
+    })
+  }, [])
+
+  const createFolder = useCallback((name, parentId = null) => {
+    const now = new Date().toISOString()
+    const ownerName = localStorage.getItem('username') || 'admin'
+    updateState((prev) => ({
+      folders: [
+        ...prev.folders,
+        {
+          id: uuidv4(),
+          name: name.trim(),
+          parentId: normalizeParentId(parentId),
+          ownerName,
+          public: false,
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+      assignments: { ...prev.assignments },
+    }))
+  }, [updateState])
+
+  const updateFolder = useCallback((folderId, updates) => {
+    updateState((prev) => ({
+      folders: prev.folders.map((folder) =>
+        folder.id === folderId
+          ? {
+              ...folder,
+              ...updates,
+              updatedAt: updates.updatedAt || new Date().toISOString(),
+            }
+          : folder,
+      ),
+      assignments: { ...prev.assignments },
+    }))
+  }, [updateState])
+
+  const toggleFolderPublic = useCallback((folderId) => {
+    updateState((prev) => ({
+      folders: prev.folders.map((folder) =>
+        folder.id === folderId
+          ? { ...folder, public: !folder.public, updatedAt: new Date().toISOString() }
+          : folder,
+      ),
+      assignments: { ...prev.assignments },
+    }))
+  }, [updateState])
+
+  const moveFolder = useCallback((folderId, targetParentId = null) => {
+    updateState((prev) => {
+      const normalizedTarget = normalizeParentId(targetParentId)
+      const invalidTargets = collectDescendantIds(folderId, prev.folders)
+      if (invalidTargets.has(normalizedTarget)) {
+        return prev
+      }
+      return {
+        folders: prev.folders.map((folder) =>
+          folder.id === folderId
+            ? { ...folder, parentId: normalizedTarget, updatedAt: new Date().toISOString() }
+            : folder,
+        ),
+        assignments: { ...prev.assignments },
+      }
+    })
+  }, [updateState])
+
+  const moveDevice = useCallback((deviceId, targetParentId = null) => {
+    updateState((prev) => ({
+      folders: prev.folders,
+      assignments: {
+        ...prev.assignments,
+        [deviceId]: normalizeParentId(targetParentId),
+      },
+    }))
+  }, [updateState])
+
+  const deleteFolder = useCallback((folderId) => {
+    updateState((prev) => {
+      const descendants = collectDescendantIds(folderId, prev.folders)
+      const folderMap = buildFolderMap(prev.folders)
+      const folder = folderMap.get(folderId)
+      const parentId = normalizeParentId(folder?.parentId)
+
+      const remainingFolders = prev.folders.filter((item) => !descendants.has(item.id))
+      const assignments = { ...prev.assignments }
+      Object.entries(assignments).forEach(([deviceId, assignedFolder]) => {
+        if (assignedFolder && descendants.has(assignedFolder)) {
+          assignments[deviceId] = parentId
+        }
+      })
+
+      return {
+        folders: remainingFolders,
+        assignments,
+      }
+    })
+  }, [updateState])
+
+  const foldersMap = useMemo(() => buildFolderMap(state.folders), [state.folders])
+
+  const getBreadcrumb = useCallback((folderId) => {
+    if (!folderId) {
+      return []
+    }
+    const path = []
+    let current = foldersMap.get(folderId)
+    const safetyCounter = state.folders.length + 1
+    let guard = 0
+    while (current && guard < safetyCounter) {
+      path.unshift(current)
+      const parentId = normalizeParentId(current.parentId)
+      current = parentId ? foldersMap.get(parentId) : null
+      guard += 1
+    }
+    return path
+  }, [foldersMap, state.folders.length])
+
+  const folderOptions = useMemo(() => buildFolderOptions(state.folders), [state.folders])
+
+  const getItems = useCallback(
+    (parentId = null, searchTerm = '', sortField = 'name', sortOrder = 'asc') => {
+      const normalizedParent = normalizeParentId(parentId)
+      const folders = state.folders
+        .filter((folder) => normalizeParentId(folder.parentId) === normalizedParent)
+        .map((folder) => ({
+          id: folder.id,
+          type: 'folder',
+          name: folder.name,
+          ownerName: folder.ownerName,
+          updatedAt: folder.updatedAt,
+          public: folder.public,
+          data: folder,
+        }))
+
+      const devicesInFolder = devices
+        .filter((device) => normalizeParentId(state.assignments[device.id]) === normalizedParent)
+        .map((device) => ({
+          id: device.id,
+          type: 'device',
+          name: device.name,
+          ownerName: device.organization || '',
+          updatedAt: null,
+          public: null,
+          data: device,
+        }))
+
+      const merged = [...folders, ...devicesInFolder]
+      const term = searchTerm.trim().toLowerCase()
+      const filtered = term
+        ? merged.filter((item) =>
+            item.name.toLowerCase().includes(term) ||
+            (item.ownerName || '').toLowerCase().includes(term),
+          )
+        : merged
+
+      const direction = sortOrder.toLowerCase() === 'desc' ? -1 : 1
+
+      filtered.sort((a, b) => {
+        const resolveValue = (item) => {
+          switch (sortField) {
+            case 'ownerName':
+              return (item.ownerName || '').toLowerCase()
+            case 'updatedAt':
+              return item.updatedAt || ''
+            case 'public':
+              return item.type === 'folder' ? (item.public ? 1 : 0) : -1
+            case 'type':
+              return item.type
+            default:
+              return item.name.toLowerCase()
+          }
+        }
+
+        const valueA = resolveValue(a)
+        const valueB = resolveValue(b)
+
+        if (valueA < valueB) return -1 * direction
+        if (valueA > valueB) return 1 * direction
+        return 0
+      })
+
+      return filtered
+    },
+    [devices, state.assignments, state.folders],
+  )
+
+  const getFolderById = useCallback((folderId) => foldersMap.get(folderId) || null, [foldersMap])
+
+  const getDescendantIds = useCallback(
+    (folderId) => {
+      if (!folderId) {
+        return new Set()
+      }
+      return collectDescendantIds(folderId, state.folders)
+    },
+    [state.folders],
+  )
+
+  return {
+    folders: state.folders,
+    assignments: state.assignments,
+    createFolder,
+    updateFolder,
+    toggleFolderPublic,
+    deleteFolder,
+    moveFolder,
+    moveDevice,
+    getBreadcrumb,
+    getItems,
+    folderOptions,
+    getFolderById,
+    getDescendantIds,
+  }
+}
+
+export default useRetailPlayerFolderState

--- a/ui/src/routes.jsx
+++ b/ui/src/routes.jsx
@@ -3,6 +3,7 @@ import { Redirect, Route } from 'react-router-dom'
 import Personal from './personal/Personal'
 import RetailPlayerDashboard from './retailPlayer/RetailPlayerDashboard'
 import RetailPlayerDevicesList from './retailPlayer/RetailPlayerDevicesList'
+import { RetailPlayerFolderPage } from './retailPlayerFolder'
 
 const routes = [
   <Route exact path="/personal" render={() => <Personal />} key={'personal'} />,
@@ -17,6 +18,12 @@ const routes = [
     path="/retailplayer/devices"
     render={() => <RetailPlayerDevicesList />}
     key={'retailplayer-devices'}
+  />,
+  <Route
+    exact
+    path="/retailplayer/folders"
+    render={() => <RetailPlayerFolderPage />}
+    key={'retailplayer-folders'}
   />,
   <Route
     exact


### PR DESCRIPTION
## Summary
- add a dedicated Retail Player device folder page with search, sorting, and folder/device actions
- persist folder structure locally and reuse translations for the new management workflow
- update the sidebar to expose the folder manager via a gear action and register the new route

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6909183afdcc833081bd3a871f634615