### PR TITLE
Add retail player device folder view and sidebar shortcut

### DIFF
--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -1,6 +1,7 @@
 import jsonServerProvider from 'ra-data-json-server'
 import httpClient from './httpClient'
 import { REST_URL } from '../consts'
+import { resolveRetailPlayerDevices } from '../retailPlayer/deviceApi'
 
 const dataProvider = jsonServerProvider(REST_URL, httpClient)
 
@@ -88,6 +89,56 @@ const callDeleteMany = (resource, params) => {
   }).then((response) => ({ data: response.json.ids || [] }))
 }
 
+const getRetailPlayerDeviceList = async (params) => {
+  const { filter = {}, sort = {}, pagination = {} } = params || {}
+  const { devices } = await resolveRetailPlayerDevices()
+  const search = typeof filter.q === 'string' ? filter.q.trim().toLowerCase() : ''
+
+  const filtered = devices.filter((device) => {
+    if (!search) return true
+    const fields = [
+      device.name,
+      device.channel,
+      device.channelList,
+      device.organization,
+      device.timeZone,
+    ]
+    return fields.some((value) =>
+      typeof value === 'string' && value.toLowerCase().includes(search),
+    )
+  })
+
+  const sortField = sort.field || 'name'
+  const sortOrder = String(sort.order || 'ASC').toUpperCase() === 'DESC' ? -1 : 1
+
+  const sorted = filtered.slice().sort((a, b) => {
+    const aValue = a?.[sortField]
+    const bValue = b?.[sortField]
+
+    if (aValue == null && bValue == null) return 0
+    if (aValue == null) return -1 * sortOrder
+    if (bValue == null) return sortOrder
+
+    if (typeof aValue === 'number' && typeof bValue === 'number') {
+      return (aValue - bValue) * sortOrder
+    }
+
+    return String(aValue).localeCompare(String(bValue), undefined, {
+      numeric: true,
+      sensitivity: 'base',
+    }) * sortOrder
+  })
+
+  const { page = 1, perPage = 25 } = pagination
+  const start = (page - 1) * perPage
+  const end = start + perPage
+
+  return {
+    data: sorted.slice(start, end),
+    total: sorted.length,
+  }
+}
+
 // Helper function to handle user-library associations
 const handleUserLibraryAssociation = async (userId, libraryIds) => {
   if (!libraryIds || libraryIds.length === 0) {
@@ -153,6 +204,12 @@ const emitFoldersChanged = (detail) => {
 const wrapperDataProvider = {
   ...dataProvider,
   getList: (resource, params) => {
+    if (resource === 'retailplayerDevice') {
+      return getRetailPlayerDeviceList(params).then((result) => ({
+        data: result.data,
+        total: result.total,
+      }))
+    }
     const [r, p] = mapResource(resource, params)
     return dataProvider.getList(r, p)
   },

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { Divider, makeStyles } from '@material-ui/core'
 import clsx from 'clsx'
@@ -7,6 +7,7 @@ import ViewListIcon from '@material-ui/icons/ViewList'
 import AlbumIcon from '@material-ui/icons/Album'
 import MenuItem from '@material-ui/core/MenuItem'
 import SpeakerGroupIcon from '@material-ui/icons/SpeakerGroup'
+import { BiCog } from 'react-icons/bi'
 import SubMenu from './SubMenu'
 import { humanize, pluralize } from 'inflection'
 import albumLists from '../album/albumLists'
@@ -15,6 +16,7 @@ import DiscoverySubMenu from './DiscoverySubMenu'
 import LibrarySelector from '../common/LibrarySelector'
 import config from '../config'
 import useRetailPlayerDevices from '../retailPlayer/useRetailPlayerDevices'
+import { useHistory } from 'react-router-dom'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -66,6 +68,7 @@ const Menu = ({ dense = false }) => {
   const resources = useSelector(getResources).filter(
     (r) => r.name !== 'radio' && r.name !== 'share',
   )
+  const history = useHistory()
 
   // TODO State is not persisted in mobile when you close the sidebar menu. Move to redux?
   const [state, setState] = useState({
@@ -172,6 +175,10 @@ const Menu = ({ dense = false }) => {
     })
   }
 
+  const handleRetailPlayerSettings = useCallback(() => {
+    history.push('/retailplayer/folder')
+  }, [history])
+
   const renderRetailPlayerMenu = () => (
     <SubMenu
       handleToggle={() => handleToggle('menuRetailPlayer')}
@@ -180,6 +187,8 @@ const Menu = ({ dense = false }) => {
       name="menu.retailPlayer.name"
       icon={<SpeakerGroupIcon />}
       dense={dense}
+      actionIcon={<BiCog />}
+      onAction={handleRetailPlayerSettings}
     >
       {renderRetailPlayerDevices()}
     </SubMenu>

--- a/ui/src/retailPlayer/RetailPlayerFolderList.jsx
+++ b/ui/src/retailPlayer/RetailPlayerFolderList.jsx
@@ -1,0 +1,64 @@
+import { useCallback } from 'react'
+import {
+  Datagrid,
+  Filter,
+  FunctionField,
+  List,
+  SearchInput,
+  TextField,
+} from 'react-admin'
+import { useMediaQuery } from '@material-ui/core'
+
+const RetailPlayerFolderFilter = (props) => (
+  <Filter {...props} variant="outlined">
+    <SearchInput source="q" alwaysOn />
+  </Filter>
+)
+
+const RetailPlayerFolderList = (props) => {
+  const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
+  const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
+  const rowClick = useCallback((id, record) => {
+    const slug = record?.slug || record?.id
+    if (!slug) {
+      return false
+    }
+    return `/retailplayer/${encodeURIComponent(slug)}`
+  }, [])
+
+  return (
+    <List
+      {...props}
+      resource="retailplayerDevice"
+      basePath="/retailplayer/folder"
+      title="RetailPlayer - Devices"
+      exporter={false}
+      filters={<RetailPlayerFolderFilter />}
+      actions={false}
+      bulkActionButtons={false}
+      perPage={isXsmall ? 50 : 50}
+      sort={{ field: 'name', order: 'ASC' }}
+    >
+      <Datagrid rowClick={rowClick}>
+        <TextField source="name" label="Name" />
+        <TextField source="channel" label="Channel" />
+        <TextField source="channelList" label="Channel List" />
+        {isDesktop && <TextField source="organization" label="Organization" />}
+        {isDesktop ? (
+          <TextField source="timeZone" label="Time Zone" />
+        ) : (
+          <FunctionField
+            label="Details"
+            render={(record) =>
+              [record?.organization, record?.timeZone]
+                .filter(Boolean)
+                .join(' \u2022 ')
+            }
+          />
+        )}
+      </Datagrid>
+    </List>
+  )
+}
+
+export default RetailPlayerFolderList

--- a/ui/src/retailPlayer/deviceApi.js
+++ b/ui/src/retailPlayer/deviceApi.js
@@ -1,0 +1,82 @@
+import config from '../config'
+import httpClient from '../dataProvider/httpClient'
+import RetailPlayerMockService from './RetailPlayerMockService'
+import { buildDeviceSlug, deviceSlugKey, normalizeValue } from './deviceUtils'
+
+export const buildDevicesUrl = () => '/api/retailplayer/devices'
+
+export const mapRetailPlayerDevice = (device) => {
+  if (!device || typeof device !== 'object') {
+    return null
+  }
+
+  const rawId = normalizeValue(device.id)
+  const fallbackId = rawId || normalizeValue(device.macAddress) || normalizeValue(device.ordinal)
+
+  if (!fallbackId) {
+    return null
+  }
+
+  const slug = buildDeviceSlug(device) || fallbackId
+  const name = normalizeValue(device.name) || fallbackId
+
+  return {
+    id: fallbackId,
+    apiId: rawId || null,
+    name,
+    slug,
+    slugKey: deviceSlugKey(slug),
+    channel: normalizeValue(device.channel),
+    channelList: normalizeValue(device.channelList),
+    organization:
+      normalizeValue(device.organization) ||
+      normalizeValue(device.orgUnit) ||
+      normalizeValue(device.location),
+    timeZone: normalizeValue(device.timeZone),
+  }
+}
+
+export const fetchRetailPlayerDevices = async ({ signal } = {}) => {
+  const url = buildDevicesUrl()
+  if (!url) {
+    return { devices: null, enabled: false }
+  }
+
+  try {
+    const { json } = await httpClient(url, { signal })
+    const payload = Array.isArray(json?.data) ? json.data : []
+    const devices = payload.map(mapRetailPlayerDevice).filter(Boolean)
+    return { devices, enabled: true }
+  } catch (err) {
+    if (err?.status === 404) {
+      return { devices: null, enabled: false }
+    }
+
+    const status = typeof err?.status === 'number' ? err.status : null
+    if (status) {
+      throw new Error(`Retail player device request failed with status ${status}`)
+    }
+
+    throw err
+  }
+}
+
+export const resolveRetailPlayerDevices = async (options = {}) => {
+  if (!config.retailPlayerDevicesEnabled) {
+    return { devices: RetailPlayerMockService.listDevices(), enabled: false }
+  }
+
+  const result = await fetchRetailPlayerDevices(options)
+  if (!result.enabled || !Array.isArray(result.devices)) {
+    return { devices: RetailPlayerMockService.listDevices(), enabled: false }
+  }
+
+  return result
+}
+
+export const getRetailPlayerDevicesSync = () => {
+  if (!config.retailPlayerDevicesEnabled) {
+    return RetailPlayerMockService.listDevices()
+  }
+  return []
+}

--- a/ui/src/retailPlayer/useRetailPlayerDevices.js
+++ b/ui/src/retailPlayer/useRetailPlayerDevices.js
@@ -1,81 +1,13 @@
 import { useEffect, useState } from 'react'
 import config from '../config'
-import httpClient from '../dataProvider/httpClient'
 import RetailPlayerMockService from './RetailPlayerMockService'
-import { buildDeviceSlug, deviceSlugKey, normalizeValue } from './deviceUtils'
-
-const buildDevicesUrl = () => '/api/retailplayer/devices'
-
-const mapDevice = (device) => {
-  if (!device || typeof device !== 'object') {
-    return null
-  }
-
-  const rawId = normalizeValue(device.id)
-  const fallbackId = rawId || normalizeValue(device.macAddress) || normalizeValue(device.ordinal)
-
-  if (!fallbackId) {
-    return null
-  }
-
-  const slug = buildDeviceSlug(device) || fallbackId
-  const name = normalizeValue(device.name) || fallbackId
-
-  return {
-    id: fallbackId,
-    apiId: rawId || null,
-    name,
-    slug,
-    slugKey: deviceSlugKey(slug),
-    channel: normalizeValue(device.channel),
-    channelList: normalizeValue(device.channelList),
-    organization:
-      normalizeValue(device.organization) ||
-      normalizeValue(device.orgUnit) ||
-      normalizeValue(device.location),
-    timeZone: normalizeValue(device.timeZone),
-  }
-}
-
-const fetchRetailPlayerDevices = async (signal) => {
-  const url = buildDevicesUrl()
-
-  if (!url) {
-    return { devices: null, enabled: false }
-  }
-
-  let payload
-  try {
-    const { json } = await httpClient(url, { signal })
-    payload = json
-  } catch (err) {
-    if (err?.status === 404) {
-      return { devices: null, enabled: false }
-    }
-
-    const status = typeof err?.status === 'number' ? err.status : null
-    if (status) {
-      throw new Error(
-        `Retail player device request failed with status ${status}`,
-      )
-    }
-
-    throw err
-  }
-  const devices = Array.isArray(payload?.data)
-    ? payload.data.map(mapDevice).filter(Boolean)
-    : []
-
-  return { devices, enabled: true }
-}
+import {
+  getRetailPlayerDevicesSync,
+  resolveRetailPlayerDevices,
+} from './deviceApi'
 
 const useRetailPlayerDevices = () => {
-  const [devices, setDevices] = useState(() => {
-    if (config.retailPlayerDevicesEnabled) {
-      return []
-    }
-    return RetailPlayerMockService.listDevices()
-  })
+  const [devices, setDevices] = useState(getRetailPlayerDevicesSync)
   const [error, setError] = useState(null)
   const [isLoading, setIsLoading] = useState(false)
   const [isApiEnabled, setIsApiEnabled] = useState(
@@ -83,17 +15,11 @@ const useRetailPlayerDevices = () => {
   )
 
   useEffect(() => {
-    const url = buildDevicesUrl()
-    if (!url) {
-      setIsApiEnabled(false)
-      return undefined
-    }
-
     const abortController = new AbortController()
     setIsLoading(true)
     setError(null)
 
-    fetchRetailPlayerDevices(abortController.signal)
+    resolveRetailPlayerDevices({ signal: abortController.signal })
       .then((result) => {
         const enabled = Boolean(result?.enabled)
         setIsApiEnabled(enabled)

--- a/ui/src/routes.jsx
+++ b/ui/src/routes.jsx
@@ -3,6 +3,7 @@ import { Redirect, Route } from 'react-router-dom'
 import Personal from './personal/Personal'
 import RetailPlayerDashboard from './retailPlayer/RetailPlayerDashboard'
 import RetailPlayerDevicesList from './retailPlayer/RetailPlayerDevicesList'
+import RetailPlayerFolderList from './retailPlayer/RetailPlayerFolderList'
 
 const routes = [
   <Route exact path="/personal" render={() => <Personal />} key={'personal'} />,
@@ -11,6 +12,12 @@ const routes = [
     path="/retailplayer"
     render={() => <Redirect to="/retailplayer/devices" />}
     key={'retailplayer-redirect'}
+  />,
+  <Route
+    exact
+    path="/retailplayer/folder"
+    render={() => <RetailPlayerFolderList />}
+    key={'retailplayer-folder'}
   />,
   <Route
     exact


### PR DESCRIPTION
## Summary
- add a gear shortcut beside the Retail Player menu label to open the device folder page
- add a retail player folder route and list component mirroring the playlist folder layout
- share retail player device fetching logic with the data provider to serve the new list view

## Testing
- npm --prefix ui run lint

------
https://chatgpt.com/codex/tasks/task_e_6909da1d5d5883308438194fb2064f3d