### PR TITLE
Update retail player devices management UI

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   Button,
+  Checkbox,
   CircularProgress,
   Dialog,
   DialogActions,
@@ -10,10 +11,12 @@ import {
   FormHelperText,
   IconButton,
   InputLabel,
+  ListItemText,
   Menu,
   MenuItem,
   Paper,
   Select,
+  Switch,
   TextField,
   Tooltip,
   Typography,
@@ -74,7 +77,7 @@ const useStyles = makeStyles((theme) => ({
   listHeader: {
     display: 'grid',
     gridTemplateColumns:
-      'minmax(220px, 2fr) minmax(120px, 1fr) minmax(160px, 1fr) minmax(160px, 1fr) minmax(100px, 0.8fr)',
+      'minmax(48px, 0.4fr) minmax(220px, 2fr) minmax(160px, 1.2fr) minmax(180px, 1.2fr) minmax(140px, 0.8fr) minmax(140px, 0.8fr) minmax(100px, 0.6fr)',
     padding: theme.spacing(1.5, 2),
     backgroundColor: theme.palette.action.hover,
     color: theme.palette.text.secondary,
@@ -82,50 +85,21 @@ const useStyles = makeStyles((theme) => ({
     textTransform: 'uppercase',
     letterSpacing: 0.8,
     fontWeight: theme.typography.fontWeightMedium,
-    [theme.breakpoints.down('sm')]: {
-      gridTemplateColumns: 'minmax(200px, 2fr) minmax(120px, 1fr) minmax(140px, 1fr)',
-      gridTemplateAreas: "'name type actions' 'channel channelList actions'",
-      rowGap: theme.spacing(1),
-    },
   },
-  headerName: {
-    [theme.breakpoints.down('sm')]: {
-      gridArea: 'name',
-    },
-  },
-  headerType: {
-    [theme.breakpoints.down('sm')]: {
-      gridArea: 'type',
-    },
-  },
-  headerChannel: {
-    [theme.breakpoints.down('sm')]: {
-      gridArea: 'channel',
-    },
-  },
-  headerChannelList: {
-    [theme.breakpoints.down('sm')]: {
-      gridArea: 'channelList',
-    },
-  },
-  headerActions: {
-    [theme.breakpoints.down('sm')]: {
-      gridArea: 'actions',
-      justifySelf: 'flex-end',
-    },
-  },
+  headerSelect: { justifySelf: 'flex-start' },
+  headerName: {},
+  headerOwner: {},
+  headerUpdated: {},
+  headerDevices: {},
+  headerPublic: {},
+  headerActions: { justifySelf: 'flex-end' },
   row: {
     display: 'grid',
     gridTemplateColumns:
-      'minmax(220px, 2fr) minmax(120px, 1fr) minmax(160px, 1fr) minmax(160px, 1fr) minmax(100px, 0.8fr)',
+      'minmax(48px, 0.4fr) minmax(220px, 2fr) minmax(160px, 1.2fr) minmax(180px, 1.2fr) minmax(140px, 0.8fr) minmax(140px, 0.8fr) minmax(100px, 0.6fr)',
     alignItems: 'center',
     padding: theme.spacing(1.5, 2),
     borderTop: `1px solid ${theme.palette.divider}`,
-    [theme.breakpoints.down('sm')]: {
-      gridTemplateColumns: 'minmax(200px, 2fr) minmax(120px, 1fr) minmax(140px, 1fr)',
-      gridTemplateAreas: "'name type actions' 'channel channelList actions'",
-      rowGap: theme.spacing(1),
-    },
   },
   folderRow: {
     backgroundColor: theme.palette.action.selected,
@@ -150,7 +124,7 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   nameIcon: {
-    color: theme.palette.text.secondary,
+    color: theme.palette.secondary.main,
     fontSize: theme.typography.pxToRem(18),
   },
   nameLabel: {
@@ -158,27 +132,29 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
     gap: theme.spacing(0.5),
   },
-  typeCell: {
-    fontSize: theme.typography.pxToRem(14),
-    color: theme.palette.text.secondary,
-    [theme.breakpoints.down('sm')]: {
-      gridArea: 'type',
-    },
+  selectCell: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
   },
-  metaCell: {
+  ownerCell: {
     fontSize: theme.typography.pxToRem(14),
     color: theme.palette.text.secondary,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
-    [theme.breakpoints.down('sm')]: {
-      gridArea: 'channel',
-    },
   },
-  metaSecondary: {
-    [theme.breakpoints.down('sm')]: {
-      gridArea: 'channelList',
-    },
+  updatedCell: {
+    fontSize: theme.typography.pxToRem(14),
+    color: theme.palette.text.secondary,
+  },
+  devicesCell: {
+    fontSize: theme.typography.pxToRem(14),
+    color: theme.palette.text.secondary,
+  },
+  publicCell: {
+    display: 'flex',
+    alignItems: 'center',
   },
   actionsCell: {
     display: 'flex',
@@ -187,6 +163,9 @@ const useStyles = makeStyles((theme) => ({
     [theme.breakpoints.down('sm')]: {
       gridArea: 'actions',
     },
+  },
+  selectedRow: {
+    backgroundColor: theme.palette.action.selected,
   },
   breadcrumbBar: {
     display: 'flex',
@@ -248,17 +227,19 @@ const FolderDialog = ({
   const classes = useStyles()
   const [name, setName] = useState(initialValues?.name || '')
   const [parentId, setParentId] = useState(initialValues?.parentId || '')
+  const [ownerName, setOwnerName] = useState(initialValues?.ownerName || '')
 
   useEffect(() => {
     setName(initialValues?.name || '')
     setParentId(initialValues?.parentId || '')
+    setOwnerName(initialValues?.ownerName || '')
   }, [initialValues, open])
 
   const handleSubmit = () => {
     if (!name.trim()) {
       return
     }
-    onSubmit({ name: name.trim(), parentId: parentId || null })
+    onSubmit({ name: name.trim(), parentId: parentId || null, ownerName: ownerName.trim() })
   }
 
   return (
@@ -273,6 +254,13 @@ const FolderDialog = ({
             variant="outlined"
             value={name}
             onChange={(event) => setName(event.target.value)}
+          />
+          <TextField
+            label="Owner Name"
+            fullWidth
+            variant="outlined"
+            value={ownerName}
+            onChange={(event) => setOwnerName(event.target.value)}
           />
           <FormControl variant="outlined" fullWidth disabled={disableParent}>
             <InputLabel id="folder-parent-label">Parent Folder</InputLabel>
@@ -323,6 +311,7 @@ FolderDialog.propTypes = {
     id: PropTypes.string,
     name: PropTypes.string,
     parentId: PropTypes.string,
+    ownerName: PropTypes.string,
   }),
   disableParent: PropTypes.bool,
 }
@@ -344,7 +333,9 @@ const DeviceDialog = ({
     channel: initialValues?.channel || '',
     channelList: initialValues?.channelList || '',
     organization: initialValues?.organization || '',
-    folderId: initialValues?.folderId || '',
+    folderIds:
+      initialValues?.folderIds ||
+      (initialValues?.folderId ? [initialValues.folderId] : []),
   }))
 
   useEffect(() => {
@@ -353,7 +344,9 @@ const DeviceDialog = ({
       channel: initialValues?.channel || '',
       channelList: initialValues?.channelList || '',
       organization: initialValues?.organization || '',
-      folderId: initialValues?.folderId || '',
+      folderIds:
+        initialValues?.folderIds ||
+        (initialValues?.folderId ? [initialValues.folderId] : []),
     })
   }, [initialValues, open])
 
@@ -363,6 +356,13 @@ const DeviceDialog = ({
     setForm((prev) => ({ ...prev, [field]: event.target.value }))
   }
 
+  const handleFolderIdsChange = (event) => {
+    const { value } = event.target
+    const rawValues = Array.isArray(value) ? value : value.split(',')
+    const nextValue = rawValues.filter((item) => Boolean(item))
+    setForm((prev) => ({ ...prev, folderIds: nextValue }))
+  }
+
   const handleSubmit = () => {
     if (!form.name.trim()) {
       return
@@ -370,7 +370,7 @@ const DeviceDialog = ({
     onSubmit({
       ...form,
       name: form.name.trim(),
-      folderId: form.folderId || null,
+      folderIds: Array.isArray(form.folderIds) ? form.folderIds : [],
     })
   }
 
@@ -412,26 +412,42 @@ const DeviceDialog = ({
             onChange={handleChange('channelList')}
           />
           <TextField
-            label="Organization"
+            label="Owner Name"
             fullWidth
             variant="outlined"
             value={form.organization}
             onChange={handleChange('organization')}
           />
           <FormControl variant="outlined" fullWidth>
-            <InputLabel id="device-folder-label">Folder</InputLabel>
+            <InputLabel id="device-folder-label">Folders</InputLabel>
             <Select
               labelId="device-folder-label"
-              value={form.folderId}
-              onChange={handleChange('folderId')}
-              label="Folder"
+              multiple
+              value={form.folderIds}
+              onChange={handleFolderIdsChange}
+              label="Folders"
+              renderValue={(selected) => {
+                if (!selected || selected.length === 0) {
+                  return 'None'
+                }
+                const labels = selected
+                  .map((folderId) =>
+                    parentOptions.find((option) => option.id === folderId)?.name || folderId,
+                  )
+                  .filter(Boolean)
+                return labels.join(', ')
+              }}
             >
               <MenuItem value="">
                 <em>None</em>
               </MenuItem>
               {parentOptions.map((option) => (
                 <MenuItem key={option.id} value={option.id}>
-                  {option.name}
+                  <Checkbox
+                    color="primary"
+                    checked={form.folderIds?.includes(option.id)}
+                  />
+                  <ListItemText primary={option.name} />
                 </MenuItem>
               ))}
             </Select>
@@ -467,7 +483,7 @@ DeviceDialog.propTypes = {
     channel: PropTypes.string,
     channelList: PropTypes.string,
     organization: PropTypes.string,
-    folderId: PropTypes.string,
+    folderIds: PropTypes.arrayOf(PropTypes.string),
     source: PropTypes.string,
   }),
 }
@@ -482,12 +498,20 @@ const RetailPlayerDeviceManagement = () => {
   const history = useHistory()
   const {
     state: { tree, folders, devices, loading, error },
-    actions: { createFolder, updateFolder, createDevice, updateDevice },
+    actions: {
+      createFolder,
+      updateFolder,
+      createDevice,
+      updateDevice,
+      toggleFolderPublic,
+      toggleDevicePublic,
+    },
   } = useRetailPlayerDeviceStore()
   const [menuAnchor, setMenuAnchor] = useState(null)
   const [folderDialog, setFolderDialog] = useState({ open: false, target: null })
   const [deviceDialog, setDeviceDialog] = useState({ open: false, target: null })
   const [activeFolderId, setActiveFolderId] = useState(null)
+  const [selectedIds, setSelectedIds] = useState(() => new Set())
 
   const folderOptions = useMemo(
     () => folders.map((folder) => ({ id: folder.id, name: folder.name })),
@@ -517,7 +541,6 @@ const RetailPlayerDeviceManagement = () => {
     for (let index = 0; index < nodes.length; index += 1) {
       const node = nodes[index]
       if (node.type !== 'folder') {
-        // eslint-disable-next-line no-continue
         continue
       }
       if (node.id === targetId) {
@@ -564,7 +587,49 @@ const RetailPlayerDeviceManagement = () => {
     return path
   }, [activeFolderId, folderMap])
 
-  const visibleNodes = activeFolderNode ? activeFolderNode.children || [] : tree
+  const visibleNodes = useMemo(
+    () => (activeFolderNode ? activeFolderNode.children || [] : tree),
+    [activeFolderNode, tree],
+  )
+
+  const allNodeIds = useMemo(() => {
+    const ids = new Set()
+    const traverse = (nodes) => {
+      nodes.forEach((node) => {
+        if (node?.id) {
+          ids.add(node.id)
+        }
+        if (node.type === 'folder' && Array.isArray(node.children)) {
+          traverse(node.children)
+        }
+      })
+    }
+    traverse(tree)
+    return ids
+  }, [tree])
+
+  useEffect(() => {
+    setSelectedIds((prev) => {
+      const next = new Set()
+      prev.forEach((id) => {
+        if (allNodeIds.has(id)) {
+          next.add(id)
+        }
+      })
+      if (next.size === prev.size) {
+        let changed = false
+        prev.forEach((id) => {
+          if (!next.has(id)) {
+            changed = true
+          }
+        })
+        if (!changed) {
+          return prev
+        }
+      }
+      return next
+    })
+  }, [allNodeIds])
 
   const openMenu = (event) => {
     setMenuAnchor(event.currentTarget)
@@ -606,7 +671,11 @@ const RetailPlayerDeviceManagement = () => {
 
   const handleFolderSubmit = (values) => {
     if (folderDialog.target) {
-      updateFolder({ id: folderDialog.target.id, name: values.name })
+      updateFolder({
+        id: folderDialog.target.id,
+        name: values.name,
+        ownerName: values.ownerName,
+      })
     } else {
       createFolder(values)
     }
@@ -656,13 +725,127 @@ const RetailPlayerDeviceManagement = () => {
     if (!node || !Array.isArray(node.children)) {
       return 0
     }
-    return node.children.reduce((acc, child) => {
-      if (child.type === 'device') {
-        return acc + 1
-      }
-      return acc + countDevices(child)
-    }, 0)
+    const seen = new Set()
+    const traverse = (children) => {
+      children.forEach((child) => {
+        if (child.type === 'device') {
+          seen.add(child.id)
+        } else if (Array.isArray(child.children)) {
+          traverse(child.children)
+        }
+      })
+    }
+    traverse(node.children)
+    return seen.size
   }, [])
+
+  const flattenVisibleNodes = useCallback((nodes) => {
+    const result = []
+    nodes.forEach((node) => {
+      result.push(node)
+      if (node.type === 'folder' && Array.isArray(node.children)) {
+        result.push(...flattenVisibleNodes(node.children))
+      }
+    })
+    return result
+  }, [])
+
+  const allVisibleNodes = useMemo(
+    () => flattenVisibleNodes(visibleNodes),
+    [flattenVisibleNodes, visibleNodes],
+  )
+
+  const visibleIds = useMemo(() => {
+    const ids = new Set()
+    allVisibleNodes.forEach((node) => {
+      if (node?.id) {
+        ids.add(node.id)
+      }
+    })
+    return ids
+  }, [allVisibleNodes])
+
+  const allVisibleSelected = useMemo(() => {
+    if (!visibleIds.size) {
+      return false
+    }
+    for (const id of visibleIds) {
+      if (!selectedIds.has(id)) {
+        return false
+      }
+    }
+    return true
+  }, [selectedIds, visibleIds])
+
+  const someVisibleSelected = useMemo(() => {
+    if (!visibleIds.size) {
+      return false
+    }
+    for (const id of visibleIds) {
+      if (selectedIds.has(id)) {
+        return true
+      }
+    }
+    return false
+  }, [selectedIds, visibleIds])
+
+  const handleToggleSelectAll = () => {
+    if (!visibleIds.size) {
+      return
+    }
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (allVisibleSelected) {
+        visibleIds.forEach((id) => next.delete(id))
+      } else {
+        visibleIds.forEach((id) => next.add(id))
+      }
+      return next
+    })
+  }
+
+  const handleToggleSelection = (id) => (event) => {
+    event.stopPropagation()
+    if (!id) {
+      return
+    }
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }
+
+  const formatUpdatedAt = (value) => {
+    if (!value) {
+      return '—'
+    }
+    try {
+      return new Date(value).toLocaleString()
+    } catch (error) {
+      return '—'
+    }
+  }
+
+  const handleToggleFolderPublic = (folderId) => (event) => {
+    event.stopPropagation()
+    if (!folderId) {
+      return
+    }
+    toggleFolderPublic({ id: folderId })
+  }
+
+  const handleToggleDevicePublic = (deviceId) => (event) => {
+    event.stopPropagation()
+    if (!deviceId) {
+      return
+    }
+    toggleDevicePublic({ id: deviceId })
+  }
 
   const renderRows = (nodes, depth = 0) =>
     nodes.flatMap((node) => {
@@ -670,30 +853,51 @@ const RetailPlayerDeviceManagement = () => {
         const indentStyle = { paddingLeft: theme.spacing(depth * 2) }
         const folderChildren = renderRows(node.children || [], depth + 1)
         const deviceCount = countDevices(node)
+        const isSelected = selectedIds.has(node.id)
+        const rowKey = node.nodeKey || node.id
         return [
           <div
-            key={`folder-row-${node.id}`}
-            className={clsx(classes.row, classes.folderRow, classes.interactiveRow)}
+            key={`folder-row-${rowKey}`}
+            className={clsx(
+              classes.row,
+              classes.folderRow,
+              classes.interactiveRow,
+              { [classes.selectedRow]: isSelected },
+            )}
             role="button"
             tabIndex={0}
             onClick={() => handleEnterFolder(node.id)}
             onKeyDown={(event) => handleRowKeyDown(event, () => handleEnterFolder(node.id))}
             aria-label={`Open folder ${node.name}`}
           >
+            <div className={classes.selectCell}>
+              <Checkbox
+                color="primary"
+                checked={isSelected}
+                onClick={handleToggleSelection(node.id)}
+                onKeyDown={(event) => event.stopPropagation()}
+                inputProps={{ 'aria-label': `Select folder ${node.name}` }}
+              />
+            </div>
             <div className={classes.nameCell} style={indentStyle}>
               <FolderIcon className={classes.nameIcon} />
               <div className={classes.nameLabel}>
                 <Typography variant="body1" color="textPrimary">
                   {node.name}
                 </Typography>
-                <Typography variant="caption" color="textSecondary">
-                  {`${deviceCount} device${deviceCount === 1 ? '' : 's'}`}
-                </Typography>
               </div>
             </div>
-            <div className={classes.typeCell}>Folder</div>
-            <div className={classes.metaCell}>—</div>
-            <div className={clsx(classes.metaCell, classes.metaSecondary)}>—</div>
+            <div className={classes.ownerCell}>{node.ownerName || '—'}</div>
+            <div className={classes.updatedCell}>{formatUpdatedAt(node.updatedAt)}</div>
+            <div className={classes.devicesCell}>{deviceCount}</div>
+            <div className={classes.publicCell}>
+              <Switch
+                color="primary"
+                checked={Boolean(node.public)}
+                onChange={handleToggleFolderPublic(node.id)}
+                inputProps={{ 'aria-label': `Toggle public for folder ${node.name}` }}
+              />
+            </div>
             <div className={classes.actionsCell}>
               <Tooltip title="Edit folder">
                 <IconButton
@@ -713,33 +917,47 @@ const RetailPlayerDeviceManagement = () => {
         ]
       }
       const indentStyle = { paddingLeft: theme.spacing(depth * 2) }
+      const isSelected = selectedIds.has(node.id)
+      const rowKey = node.nodeKey || node.id
       return [
         <div
-          key={`device-row-${node.id}`}
-          className={clsx(classes.row, classes.interactiveRow)}
+          key={`device-row-${rowKey}`}
+          className={clsx(classes.row, classes.interactiveRow, {
+            [classes.selectedRow]: isSelected,
+          })}
           role="button"
           tabIndex={0}
           onClick={() => handleNavigateToDevice(node)}
           onKeyDown={(event) => handleRowKeyDown(event, () => handleNavigateToDevice(node))}
           aria-label={`Open device ${node.name}`}
         >
+          <div className={classes.selectCell}>
+            <Checkbox
+              color="primary"
+              checked={isSelected}
+              onClick={handleToggleSelection(node.id)}
+              onKeyDown={(event) => event.stopPropagation()}
+              inputProps={{ 'aria-label': `Select device ${node.name}` }}
+            />
+          </div>
           <div className={classes.nameCell} style={indentStyle}>
             <SpeakerGroupIcon className={classes.nameIcon} />
             <div className={classes.nameLabel}>
               <Typography variant="body1" color="textPrimary">
                 {node.name}
               </Typography>
-              {node.organization ? (
-                <Typography variant="caption" color="textSecondary">
-                  {node.organization}
-                </Typography>
-              ) : null}
             </div>
           </div>
-          <div className={classes.typeCell}>Device</div>
-          <div className={classes.metaCell}>{node.channel || '—'}</div>
-          <div className={clsx(classes.metaCell, classes.metaSecondary)}>
-            {node.channelList || '—'}
+          <div className={classes.ownerCell}>{node.organization || '—'}</div>
+          <div className={classes.updatedCell}>{formatUpdatedAt(node.updatedAt)}</div>
+          <div className={classes.devicesCell}>—</div>
+          <div className={classes.publicCell}>
+            <Switch
+              color="primary"
+              checked={Boolean(node.public)}
+              onChange={handleToggleDevicePublic(node.id)}
+              inputProps={{ 'aria-label': `Toggle public for device ${node.name}` }}
+            />
           </div>
           <div className={classes.actionsCell}>
             <Tooltip title="Edit device">
@@ -836,10 +1054,20 @@ const RetailPlayerDeviceManagement = () => {
           </div>
         ) : null}
         <div className={classes.listHeader}>
+          <span className={classes.headerSelect}>
+            <Checkbox
+              color="primary"
+              checked={allVisibleSelected}
+              indeterminate={!allVisibleSelected && someVisibleSelected}
+              onChange={handleToggleSelectAll}
+              inputProps={{ 'aria-label': 'Select all items' }}
+            />
+          </span>
           <span className={classes.headerName}>Name</span>
-          <span className={classes.headerType}>Type</span>
-          <span className={classes.headerChannel}>Channel</span>
-          <span className={classes.headerChannelList}>Channel List</span>
+          <span className={classes.headerOwner}>Owner Name</span>
+          <span className={classes.headerUpdated}>Updated At</span>
+          <span className={classes.headerDevices}>No. of Devices</span>
+          <span className={classes.headerPublic}>Public</span>
           <span className={classes.headerActions}>Actions</span>
         </div>
         {loading ? (

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -22,11 +22,20 @@ const initialState = {
   lastUpdated: null,
 }
 
-const ensureFolderId = (value) => {
-  if (typeof value === 'string' && value.trim() !== '') {
-    return value
+const normalizeFolderIds = (value) => {
+  if (Array.isArray(value)) {
+    const normalized = value
+      .map((item) => normalizeValue(item))
+      .filter((item) => typeof item === 'string' && item !== '')
+    return Array.from(new Set(normalized))
   }
-  return null
+
+  const normalizedValue = normalizeValue(value)
+  if (!normalizedValue) {
+    return []
+  }
+
+  return [normalizedValue]
 }
 
 const baseDeviceShape = (device, existing) => {
@@ -51,9 +60,19 @@ const baseDeviceShape = (device, existing) => {
     channelList: normalizedChannelList || '',
     organization: normalizedOrganization || '',
     timeZone: normalizedTimeZone || '',
-    folderId: ensureFolderId(existing?.folderId),
+    folderIds: normalizeFolderIds(
+      existing?.folderIds || existing?.folderId || device?.folderIds || device?.folderId,
+    ),
     source: existing?.source === 'local' ? 'local' : 'remote',
     attributes: existing?.attributes || {},
+    public:
+      typeof device?.public === 'boolean'
+        ? device.public
+        : typeof existing?.public === 'boolean'
+          ? existing.public
+          : false,
+    createdAt: existing?.createdAt || device?.createdAt || null,
+    updatedAt: existing?.updatedAt || device?.updatedAt || null,
   }
 }
 
@@ -80,7 +99,7 @@ const reducer = (state, action) => {
         const existing = key ? existingByKey.get(key) : null
         return {
           ...baseDeviceShape(device, existing || undefined),
-          folderId: ensureFolderId(existing?.folderId),
+          folderIds: normalizeFolderIds(existing?.folderIds || existing?.folderId),
         }
       })
 
@@ -93,14 +112,16 @@ const reducer = (state, action) => {
       }
     }
     case 'CREATE_FOLDER': {
-      const { name, parentId } = action.payload || {}
+      const { name, parentId, ownerName } = action.payload || {}
       const now = new Date().toISOString()
       const folder = {
         id: uuidv4(),
         name: normalizeValue(name) || 'New Folder',
-        parentId: ensureFolderId(parentId),
+        parentId: normalizeValue(parentId) || null,
+        ownerName: normalizeValue(ownerName) || '',
         createdAt: now,
         updatedAt: now,
+        public: false,
       }
       return {
         ...state,
@@ -109,7 +130,7 @@ const reducer = (state, action) => {
       }
     }
     case 'UPDATE_FOLDER': {
-      const { id, name } = action.payload || {}
+      const { id, name, ownerName } = action.payload || {}
       if (!id) {
         return state
       }
@@ -120,6 +141,10 @@ const reducer = (state, action) => {
         return {
           ...folder,
           name: normalizeValue(name) || folder.name,
+          ownerName:
+            ownerName !== undefined
+              ? normalizeValue(ownerName) || ''
+              : folder.ownerName || '',
           updatedAt: new Date().toISOString(),
         }
       })
@@ -132,10 +157,12 @@ const reducer = (state, action) => {
         channelList,
         organization,
         folderId,
+        folderIds,
         attributes,
       } = action.payload || {}
       const normalizedName = normalizeValue(name) || 'New Device'
       const slug = deviceSlugKey(normalizedName) || uuidv4()
+      const now = new Date().toISOString()
       const device = {
         id: uuidv4(),
         apiId: null,
@@ -146,9 +173,12 @@ const reducer = (state, action) => {
         channelList: normalizeValue(channelList) || '',
         organization: normalizeValue(organization) || '',
         timeZone: '',
-        folderId: ensureFolderId(folderId),
+        folderIds: normalizeFolderIds(folderIds || folderId),
         source: 'local',
         attributes: attributes && typeof attributes === 'object' ? { ...attributes } : {},
+        public: false,
+        createdAt: now,
+        updatedAt: now,
       }
       return {
         ...state,
@@ -157,7 +187,7 @@ const reducer = (state, action) => {
       }
     }
     case 'UPDATE_DEVICE': {
-      const { id, name, channel, channelList, organization, folderId } =
+      const { id, name, channel, channelList, organization, folderId, folderIds, public: nextPublic } =
         action.payload || {}
       if (!id) {
         return state
@@ -167,6 +197,12 @@ const reducer = (state, action) => {
           return device
         }
         const isLocal = device.source === 'local'
+        const nextFolderIds =
+          folderIds !== undefined
+            ? normalizeFolderIds(folderIds)
+            : folderId !== undefined
+              ? normalizeFolderIds(folderId)
+              : device.folderIds
         return {
           ...device,
           name: isLocal ? normalizeValue(name) || device.name : device.name,
@@ -174,16 +210,53 @@ const reducer = (state, action) => {
           channelList: normalizeValue(channelList) || device.channelList,
           organization:
             normalizeValue(organization) || device.organization,
-          folderId:
-            ensureFolderId(folderId) !== undefined
-              ? ensureFolderId(folderId)
-              : device.folderId,
+          folderIds: nextFolderIds,
+          public:
+            typeof nextPublic === 'boolean'
+              ? nextPublic
+              : device.public,
+          updatedAt: new Date().toISOString(),
         }
       })
       return { ...state, devices: nextDevices, lastUpdated: Date.now() }
     }
     case 'ASSIGN_DEVICE_FOLDER': {
-      const { id, folderId } = action.payload || {}
+      const { id, folderId, folderIds } = action.payload || {}
+      if (!id) {
+        return state
+      }
+      const nextFolderIds =
+        folderIds !== undefined
+          ? normalizeFolderIds(folderIds)
+          : normalizeFolderIds(folderId)
+      const nextDevices = state.devices.map((device) => {
+        if (device.id !== id) {
+          return device
+        }
+        return { ...device, folderIds: nextFolderIds }
+      })
+      return { ...state, devices: nextDevices, lastUpdated: Date.now() }
+    }
+    case 'TOGGLE_FOLDER_PUBLIC': {
+      const { id } = action.payload || {}
+      if (!id) {
+        return state
+      }
+      const nextFolders = state.folders.map((folder) => {
+        if (folder.id !== id) {
+          return folder
+        }
+        const isPublic = typeof folder.public === 'boolean' ? folder.public : false
+        return {
+          ...folder,
+          public: !isPublic,
+          updatedAt: new Date().toISOString(),
+        }
+      })
+      return { ...state, folders: nextFolders, lastUpdated: Date.now() }
+    }
+    case 'TOGGLE_DEVICE_PUBLIC': {
+      const { id } = action.payload || {}
       if (!id) {
         return state
       }
@@ -191,7 +264,12 @@ const reducer = (state, action) => {
         if (device.id !== id) {
           return device
         }
-        return { ...device, folderId: ensureFolderId(folderId) }
+        const isPublic = typeof device.public === 'boolean' ? device.public : false
+        return {
+          ...device,
+          public: !isPublic,
+          updatedAt: new Date().toISOString(),
+        }
       })
       return { ...state, devices: nextDevices, lastUpdated: Date.now() }
     }
@@ -226,11 +304,20 @@ const buildTree = (folders, devices) => {
       ...device,
       type: 'device',
     }
-    if (device.folderId && folderMap.has(device.folderId)) {
-      folderMap.get(device.folderId).children.push(node)
-    } else {
-      rootNodes.push(node)
+    const normalizedFolders = Array.isArray(device.folderIds)
+      ? device.folderIds.filter((folderId) => folderMap.has(folderId))
+      : []
+
+    if (!normalizedFolders.length) {
+      rootNodes.push({ ...node, nodeKey: `${node.id}::root` })
+      return
     }
+
+    normalizedFolders.forEach((folderId, index) => {
+      const parent = folderMap.get(folderId)
+      const instanceKey = `${node.id}::${folderId}::${index}`
+      parent.children.push({ ...node, nodeKey: instanceKey })
+    })
   }
 
   devices.forEach(attachDevice)
@@ -253,7 +340,7 @@ const buildTree = (folders, devices) => {
           children: normalizeTree(node.children || []),
         }
       }
-      return node
+      return { ...node }
     })
 
   return normalizeTree(rootNodes)
@@ -311,6 +398,14 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
     dispatch({ type: 'ASSIGN_DEVICE_FOLDER', payload })
   }, [])
 
+  const toggleFolderPublic = useCallback((payload) => {
+    dispatch({ type: 'TOGGLE_FOLDER_PUBLIC', payload })
+  }, [])
+
+  const toggleDevicePublic = useCallback((payload) => {
+    dispatch({ type: 'TOGGLE_DEVICE_PUBLIC', payload })
+  }, [])
+
   const value = useMemo(
     () => ({
       state: { ...state, tree },
@@ -320,9 +415,21 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
         createDevice,
         updateDevice,
         assignDeviceToFolder,
+        toggleFolderPublic,
+        toggleDevicePublic,
       },
     }),
-    [state, tree, createFolder, updateFolder, createDevice, updateDevice, assignDeviceToFolder],
+    [
+      state,
+      tree,
+      createFolder,
+      updateFolder,
+      createDevice,
+      updateDevice,
+      assignDeviceToFolder,
+      toggleFolderPublic,
+      toggleDevicePublic,
+    ],
   )
 
   return (
@@ -346,6 +453,7 @@ const useRetailPlayerDeviceStore = () => {
   return context
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export { RetailPlayerDeviceStoreProvider, useRetailPlayerDeviceStore }
 
 export default RetailPlayerDeviceStoreProvider


### PR DESCRIPTION
## Summary
- restyle the Retail Player Devices management table with selectable rows, owner/public columns, and updated icon styling
- support multi-folder assignments, public toggles, and owner metadata in the retail player device store
- extend folder/device dialogs to capture owner names and multiple folder selections

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690a57f9268483228494ca933928f460