### PR TITLE
Enable public retail player device lookup and status

### DIFF
--- a/db/migrations/20250816074435_create_retail_player_device_mapping.go
+++ b/db/migrations/20250816074435_create_retail_player_device_mapping.go
@@ -1,0 +1,33 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upCreateRetailPlayerDeviceMapping, downCreateRetailPlayerDeviceMapping)
+}
+
+func upCreateRetailPlayerDeviceMapping(_ context.Context, tx *sql.Tx) error {
+	_, err := tx.Exec(`
+create table if not exists retail_player_device_mapping
+(
+    id          varchar(255) primary key,
+    slug_key    varchar       not null unique,
+    identifier  varchar       not null,
+    device_id   varchar       not null,
+    created_at  datetime,
+    updated_at  datetime
+);
+create unique index if not exists idx_retail_player_device_mapping_device_id
+    on retail_player_device_mapping (device_id);
+`)
+	return err
+}
+
+func downCreateRetailPlayerDeviceMapping(_ context.Context, tx *sql.Tx) error {
+	return nil
+}

--- a/model/datastore.go
+++ b/model/datastore.go
@@ -40,6 +40,7 @@ type DataStore interface {
 	User(ctx context.Context) UserRepository
 	UserProps(ctx context.Context) UserPropsRepository
 	ScrobbleBuffer(ctx context.Context) ScrobbleBufferRepository
+	RetailPlayerDeviceMapping(ctx context.Context) RetailPlayerDeviceMappingRepository
 
 	Resource(ctx context.Context, model interface{}) ResourceRepository
 

--- a/model/retail_player_device_mapping.go
+++ b/model/retail_player_device_mapping.go
@@ -1,0 +1,16 @@
+package model
+
+import "time"
+
+type RetailPlayerDeviceMapping struct {
+	ID         string    `structs:"id"         json:"id"`
+	SlugKey    string    `structs:"slug_key"    json:"slugKey"`
+	Identifier string    `structs:"identifier" json:"identifier"`
+	DeviceID   string    `structs:"device_id"   json:"deviceId"`
+	CreatedAt  time.Time `structs:"created_at"  json:"createdAt"`
+	UpdatedAt  time.Time `structs:"updated_at"  json:"updatedAt"`
+}
+
+type RetailPlayerDeviceMappingRepository interface {
+	FindBySlugKey(slugKey string) (*RetailPlayerDeviceMapping, error)
+}

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -97,6 +97,10 @@ func (s *SQLStore) ScrobbleBuffer(ctx context.Context) model.ScrobbleBufferRepos
 	return NewScrobbleBufferRepository(ctx, s.getDBXBuilder())
 }
 
+func (s *SQLStore) RetailPlayerDeviceMapping(ctx context.Context) model.RetailPlayerDeviceMappingRepository {
+	return NewRetailPlayerDeviceMappingRepository(ctx, s.getDBXBuilder())
+}
+
 func (s *SQLStore) Resource(ctx context.Context, m interface{}) model.ResourceRepository {
 	switch m.(type) {
 	case model.User:

--- a/persistence/retail_player_device_mapping_repository.go
+++ b/persistence/retail_player_device_mapping_repository.go
@@ -1,0 +1,38 @@
+package persistence
+
+import (
+	"context"
+	"strings"
+
+	. "github.com/Masterminds/squirrel"
+	"github.com/navidrome/navidrome/model"
+	"github.com/pocketbase/dbx"
+)
+
+type retailPlayerDeviceMappingRepository struct {
+	sqlRepository
+}
+
+func NewRetailPlayerDeviceMappingRepository(ctx context.Context, db dbx.Builder) model.RetailPlayerDeviceMappingRepository {
+	r := &retailPlayerDeviceMappingRepository{}
+	r.ctx = ctx
+	r.db = db
+	r.registerModel(&model.RetailPlayerDeviceMapping{}, nil)
+	return r
+}
+
+func (r *retailPlayerDeviceMappingRepository) FindBySlugKey(slugKey string) (*model.RetailPlayerDeviceMapping, error) {
+	normalized := strings.TrimSpace(strings.ToLower(slugKey))
+	if normalized == "" {
+		return nil, model.ErrNotFound
+	}
+
+	sel := r.newSelect().Columns("*").Where(Eq{"slug_key": normalized}).Limit(1)
+	mapping := model.RetailPlayerDeviceMapping{}
+	if err := r.queryOne(sel, &mapping); err != nil {
+		return nil, err
+	}
+	return &mapping, nil
+}
+
+var _ model.RetailPlayerDeviceMappingRepository = (*retailPlayerDeviceMappingRepository)(nil)

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -41,6 +41,7 @@ func (n *Router) routes() http.Handler {
 
 	// Public
 	n.RX(r, "/translation", newTranslationRepository, false)
+	n.addPublicRetailPlayerRoute(r)
 
 	// Protected
 	r.Group(func(r chi.Router) {

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -41,7 +41,7 @@ func (n *Router) routes() http.Handler {
 
 	// Public
 	n.RX(r, "/translation", newTranslationRepository, false)
-	n.addPublicRetailPlayerRoute(r)
+	n.addRetailPlayerRoutes(r)
 
 	// Protected
 	r.Group(func(r chi.Router) {
@@ -72,7 +72,6 @@ func (n *Router) routes() http.Handler {
 		n.addNotificationsRoute(r)
 		n.addKeepAliveRoute(r)
 		n.addInsightsRoute(r)
-		n.addRetailPlayerRoute(r)
 
 		r.With(adminOnlyMiddleware).Group(func(r chi.Router) {
 			n.addInspectRoute(r)

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -101,12 +101,18 @@ type retailPlayerConfig struct {
 func (n *Router) addRetailPlayerRoute(r chi.Router) {
 	r.Route("/retailplayer", func(r chi.Router) {
 		r.Get("/devices", n.handleRetailPlayerDevices())
+		r.Post("/devices/{deviceID}/channel", n.handleRetailPlayerDeviceChannel())
+		r.Post("/devices/{deviceID}/dislike", n.handleRetailPlayerDeviceDislike())
+	})
+}
+
+func (n *Router) addPublicRetailPlayerRoute(r chi.Router) {
+	r.Route("/retailplayer", func(r chi.Router) {
 		r.Get("/devices/{deviceID}/status", n.handleRetailPlayerDeviceStatus())
+		r.Get("/devices/{deviceID}/channel", n.handleRetailPlayerDeviceCurrentChannel())
 		r.Get("/channel-lists/{channelListID}/channels", n.handleRetailPlayerChannelListChannels())
 		r.Post("/devices/{deviceID}/volume", n.handleRetailPlayerDeviceVolume())
-		r.Post("/devices/{deviceID}/channel", n.handleRetailPlayerDeviceChannel())
 		r.Post("/devices/{deviceID}/channel/toggle", n.handleRetailPlayerDeviceToggleChannel())
-		r.Post("/devices/{deviceID}/dislike", n.handleRetailPlayerDeviceDislike())
 	})
 }
 
@@ -147,32 +153,95 @@ func (n *Router) handleRetailPlayerDeviceStatus() http.HandlerFunc {
 			return
 		}
 
-		deviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
-		if deviceID == "" {
+		rawDeviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		if rawDeviceID == "" {
 			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
 			return
 		}
 
-		log.Info(ctx, "Fetching retail player device status from remote API", "deviceID", deviceID)
-		response, err := n.fetchRetailPlayerDeviceStatus(ctx, deviceID)
+		deviceIdentifier, err := url.PathUnescape(rawDeviceID)
+		if err != nil || strings.TrimSpace(deviceIdentifier) == "" {
+			deviceIdentifier = rawDeviceID
+		}
+
+		device, err := resolveRetailPlayerDevice(ctx, deviceIdentifier)
 		if err != nil {
 			if errors.Is(err, errRetailPlayerDeviceNotFound) {
-				log.Info(ctx, "Retail player device not found", "deviceID", deviceID)
+				log.Info(ctx, "Retail player device not found", "identifier", deviceIdentifier)
 				http.Error(w, "Retail player device not found", http.StatusNotFound)
 				return
 			}
 
-			log.Error(ctx, "Unable to fetch retail player device status", "deviceID", deviceID, "err", err)
+			log.Error(ctx, "Unable to resolve retail player device", "identifier", deviceIdentifier, "err", err)
+			http.Error(w, "Unable to resolve retail player device", http.StatusBadGateway)
+			return
+		}
+
+		log.Info(ctx, "Fetching retail player device status from remote API", "deviceID", device.ID, "identifier", deviceIdentifier)
+		response, err := n.fetchRetailPlayerDeviceStatus(ctx, device.ID)
+		if err != nil {
+			if errors.Is(err, errRetailPlayerDeviceNotFound) {
+				log.Info(ctx, "Retail player device not found", "deviceID", device.ID)
+				http.Error(w, "Retail player device not found", http.StatusNotFound)
+				return
+			}
+
+			log.Error(ctx, "Unable to fetch retail player device status", "deviceID", device.ID, "err", err)
 			http.Error(w, "Unable to fetch retail player device status", http.StatusBadGateway)
 			return
 		}
 
-		log.Info(ctx, "Retail player device status fetched", "deviceID", deviceID)
+		response.Device = &device
+
+		log.Info(ctx, "Retail player device status fetched", "deviceID", device.ID)
 
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(response); err != nil {
-			log.Error(ctx, "Unable to encode retail player device status response", "deviceID", deviceID, "err", err)
+			log.Error(ctx, "Unable to encode retail player device status response", "deviceID", device.ID, "err", err)
 		}
+	}
+}
+
+func (n *Router) handleRetailPlayerDeviceCurrentChannel() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		rawDeviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		if rawDeviceID == "" {
+			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
+			return
+		}
+
+		deviceIdentifier, err := url.PathUnescape(rawDeviceID)
+		if err != nil || strings.TrimSpace(deviceIdentifier) == "" {
+			deviceIdentifier = rawDeviceID
+		}
+
+		device, err := resolveRetailPlayerDevice(ctx, deviceIdentifier)
+		if err != nil {
+			if errors.Is(err, errRetailPlayerDeviceNotFound) {
+				log.Info(ctx, "Retail player device not found", "identifier", deviceIdentifier)
+				http.Error(w, "Retail player device not found", http.StatusNotFound)
+				return
+			}
+
+			log.Error(ctx, "Unable to resolve retail player device", "identifier", deviceIdentifier, "err", err)
+			http.Error(w, "Unable to resolve retail player device", http.StatusBadGateway)
+			return
+		}
+
+		payload := map[string]any{
+			"device":      device,
+			"channel":     device.Channel,
+			"channelList": device.ChannelList,
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusOK, payload)
 	}
 }
 
@@ -570,6 +639,148 @@ func (n *Router) handleRetailPlayerDeviceDislike() http.HandlerFunc {
 	}
 }
 
+func resolveRetailPlayerDevice(ctx context.Context, identifier string) (retailPlayerDevice, error) {
+	trimmed := strings.TrimSpace(identifier)
+	if trimmed == "" {
+		return retailPlayerDevice{}, errors.New("retail player device identifier is empty")
+	}
+
+	device, err := fetchRetailPlayerDevice(ctx, trimmed)
+	if err == nil {
+		return device, nil
+	}
+	if err != nil && !errors.Is(err, errRetailPlayerDeviceNotFound) {
+		return retailPlayerDevice{}, err
+	}
+
+	response, err := fetchRetailPlayerDevices(ctx)
+	if err != nil {
+		return retailPlayerDevice{}, err
+	}
+
+	slugKey := deviceSlugKey(trimmed)
+	identifierVariants := buildDeviceIdentifierVariants(trimmed)
+
+	for _, candidate := range response.Data {
+		if matchRetailPlayerDeviceIdentifier(candidate, identifierVariants, slugKey) {
+			return candidate, nil
+		}
+	}
+
+	return retailPlayerDevice{}, errRetailPlayerDeviceNotFound
+}
+
+func buildDeviceIdentifierVariants(identifier string) []string {
+	trimmed := strings.TrimSpace(identifier)
+	if trimmed == "" {
+		return nil
+	}
+
+	variants := []string{trimmed}
+
+	hyphenToUnderscore := strings.ReplaceAll(trimmed, "-", "_")
+	if hyphenToUnderscore != trimmed {
+		variants = append(variants, hyphenToUnderscore)
+	}
+
+	underscoreToHyphen := strings.ReplaceAll(trimmed, "_", "-")
+	if underscoreToHyphen != trimmed {
+		variants = append(variants, underscoreToHyphen)
+	}
+
+	withoutSpaces := strings.ReplaceAll(trimmed, " ", "")
+	if withoutSpaces != trimmed {
+		variants = append(variants, withoutSpaces)
+	}
+
+	return uniqueStringsCaseInsensitive(variants)
+}
+
+func matchRetailPlayerDeviceIdentifier(device retailPlayerDevice, identifiers []string, slugKey string) bool {
+	if len(identifiers) == 0 {
+		return false
+	}
+
+	candidates := []string{
+		device.ID,
+		device.Name,
+	}
+
+	for _, candidate := range candidates {
+		trimmedCandidate := strings.TrimSpace(candidate)
+		if trimmedCandidate == "" {
+			continue
+		}
+
+		for _, identifier := range identifiers {
+			if strings.EqualFold(trimmedCandidate, identifier) {
+				return true
+			}
+		}
+
+		if slugKey != "" && deviceSlugKey(trimmedCandidate) == slugKey {
+			return true
+		}
+	}
+
+	return false
+}
+
+func uniqueStringsCaseInsensitive(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+
+		lower := strings.ToLower(trimmed)
+		if _, exists := seen[lower]; exists {
+			continue
+		}
+
+		seen[lower] = struct{}{}
+		result = append(result, trimmed)
+	}
+
+	return result
+}
+
+func deviceSlugKey(value string) string {
+	trimmed := strings.TrimSpace(strings.ToLower(value))
+	if trimmed == "" {
+		return ""
+	}
+
+	var builder strings.Builder
+	lastHyphen := false
+
+	for _, r := range trimmed {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			builder.WriteRune(r)
+			lastHyphen = false
+			continue
+		}
+
+		if builder.Len() == 0 || lastHyphen {
+			lastHyphen = true
+			continue
+		}
+
+		builder.WriteRune('-')
+		lastHyphen = true
+	}
+
+	slug := builder.String()
+	return strings.Trim(slug, "-")
+}
+
 func fetchRetailPlayerDevices(ctx context.Context) (retailPlayerDevicesResponse, error) {
 	cfg := conf.Server.RetailPlayer
 	if cfg.BaseURL == "" || cfg.OrgID == "" {
@@ -748,6 +959,7 @@ type retailPlayerDeviceStatusResponse struct {
 	Status         map[string]any             `json:"status"`
 	StreamMetadata []map[string]any           `json:"streamMetadata"`
 	Artwork        *retailPlayerStatusArtwork `json:"artwork,omitempty"`
+	Device         *retailPlayerDevice        `json:"device,omitempty"`
 }
 
 type retailPlayerCommandRequest struct {

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -21,6 +21,7 @@ import (
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/server"
 	"github.com/navidrome/navidrome/utils"
 )
 
@@ -98,25 +99,56 @@ type retailPlayerConfig struct {
 	AdditionalHeaders map[string]string
 }
 
-func (n *Router) addRetailPlayerRoute(r chi.Router) {
+func (n *Router) addRetailPlayerRoutes(r chi.Router) {
 	r.Route("/retailplayer", func(r chi.Router) {
-		r.Get("/devices", n.handleRetailPlayerDevices())
-		r.Post("/devices/{deviceID}/channel", n.handleRetailPlayerDeviceChannel())
-		r.Post("/devices/{deviceID}/dislike", n.handleRetailPlayerDeviceDislike())
-	})
-}
 
-func (n *Router) addPublicRetailPlayerRoute(r chi.Router) {
-	r.Route("/retailplayer", func(r chi.Router) {
-		r.Get("/devices/{deviceID}/status", n.handleRetailPlayerDeviceStatus())
-		r.Get("/devices/{deviceID}/channel", n.handleRetailPlayerDeviceCurrentChannel())
-		r.Get("/channel-lists/{channelListID}/channels", n.handleRetailPlayerChannelListChannels())
-		r.Post("/devices/{deviceID}/volume", n.handleRetailPlayerDeviceVolume())
-		r.Post("/devices/{deviceID}/channel/toggle", n.handleRetailPlayerDeviceToggleChannel())
+		// ===== Public routes (NO authentication) =====
+		// These must NOT require server.Authenticator.
+		// They are used by guests to view/control a single device page.
+		r.Get("/devices/{deviceId}/status", n.handleRetailPlayerDeviceStatus())
+		r.Post("/devices/{deviceId}/channel/toggle", n.handleRetailPlayerDeviceChannelToggle())
+		r.Get("/channel-lists/{listId}/channels", n.handleRetailPlayerChannelList())
+		r.Get("/devices/{deviceId}/channel", n.handleRetailPlayerDeviceChannelInfo())
+		r.Post("/devices/{deviceId}/volume", n.handleRetailPlayerDeviceVolume())
+
+		// ===== Private / authenticated routes =====
+		// Keep the existing protected/legacy/internal Retail Player endpoints here.
+		r.Group(func(r chi.Router) {
+			// Require normal Navidrome auth for anything that should remain protected.
+			r.Use(server.Authenticator(n.ds))
+			r.Use(server.JWTRefresher)
+			r.Use(server.UpdateLastAccessMiddleware(n.ds))
+
+			// ADD the existing private/protected Retail Player routes here.
+			// For example, anything that used to be registered in addRetailPlayerPrivateRoutes(...)
+			// should move into this group.
+			//
+			// NOTE: Do not duplicate the public handlers above. Only include the
+			// routes that are supposed to stay restricted.
+			r.Get("/devices", n.handleRetailPlayerDevices())
+			r.Post("/devices/{deviceId}/channel", n.handleRetailPlayerDeviceChannel())
+			r.Post("/devices/{deviceId}/dislike", n.handleRetailPlayerDeviceDislike())
+		})
 	})
 }
 
 var errRetailPlayerDeviceNotFound = errors.New("retail player device not found")
+
+func retailPlayerDeviceIDParam(r *http.Request) string {
+	if deviceID := strings.TrimSpace(chi.URLParam(r, "deviceId")); deviceID != "" {
+		return deviceID
+	}
+
+	return strings.TrimSpace(chi.URLParam(r, "deviceID"))
+}
+
+func retailPlayerChannelListIDParam(r *http.Request) string {
+	if listID := strings.TrimSpace(chi.URLParam(r, "listId")); listID != "" {
+		return listID
+	}
+
+	return strings.TrimSpace(chi.URLParam(r, "channelListID"))
+}
 
 func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -153,7 +185,7 @@ func (n *Router) handleRetailPlayerDeviceStatus() http.HandlerFunc {
 			return
 		}
 
-		rawDeviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		rawDeviceID := retailPlayerDeviceIDParam(r)
 		if rawDeviceID == "" {
 			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
 			return
@@ -202,7 +234,7 @@ func (n *Router) handleRetailPlayerDeviceStatus() http.HandlerFunc {
 	}
 }
 
-func (n *Router) handleRetailPlayerDeviceCurrentChannel() http.HandlerFunc {
+func (n *Router) handleRetailPlayerDeviceChannelInfo() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -211,7 +243,7 @@ func (n *Router) handleRetailPlayerDeviceCurrentChannel() http.HandlerFunc {
 			return
 		}
 
-		rawDeviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		rawDeviceID := retailPlayerDeviceIDParam(r)
 		if rawDeviceID == "" {
 			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
 			return
@@ -245,7 +277,7 @@ func (n *Router) handleRetailPlayerDeviceCurrentChannel() http.HandlerFunc {
 	}
 }
 
-func (n *Router) handleRetailPlayerChannelListChannels() http.HandlerFunc {
+func (n *Router) handleRetailPlayerChannelList() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -254,7 +286,7 @@ func (n *Router) handleRetailPlayerChannelListChannels() http.HandlerFunc {
 			return
 		}
 
-		channelListID := strings.TrimSpace(chi.URLParam(r, "channelListID"))
+		channelListID := retailPlayerChannelListIDParam(r)
 		if channelListID == "" {
 			http.Error(w, "Retail player channel list id is required", http.StatusBadRequest)
 			return
@@ -303,7 +335,7 @@ func (n *Router) handleRetailPlayerDeviceVolume() http.HandlerFunc {
 			return
 		}
 
-		deviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		deviceID := retailPlayerDeviceIDParam(r)
 		if deviceID == "" {
 			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
 			return
@@ -368,7 +400,7 @@ func (n *Router) handleRetailPlayerDeviceChannel() http.HandlerFunc {
 			return
 		}
 
-		deviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		deviceID := retailPlayerDeviceIDParam(r)
 		if deviceID == "" {
 			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
 			return
@@ -413,7 +445,7 @@ func (n *Router) handleRetailPlayerDeviceChannel() http.HandlerFunc {
 	}
 }
 
-func (n *Router) handleRetailPlayerDeviceToggleChannel() http.HandlerFunc {
+func (n *Router) handleRetailPlayerDeviceChannelToggle() http.HandlerFunc {
 	type toggleRequest struct {
 		Channel          string `json:"channel,omitempty"`
 		ChannelList      string `json:"channelList,omitempty"`
@@ -428,7 +460,7 @@ func (n *Router) handleRetailPlayerDeviceToggleChannel() http.HandlerFunc {
 			return
 		}
 
-		deviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		deviceID := retailPlayerDeviceIDParam(r)
 		if deviceID == "" {
 			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
 			return
@@ -597,7 +629,7 @@ func (n *Router) handleRetailPlayerDeviceDislike() http.HandlerFunc {
 			return
 		}
 
-		deviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		deviceID := retailPlayerDeviceIDParam(r)
 		if deviceID == "" {
 			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
 			return

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -196,7 +196,7 @@ func (n *Router) handleRetailPlayerDeviceStatus() http.HandlerFunc {
 			deviceIdentifier = rawDeviceID
 		}
 
-		device, err := resolveRetailPlayerDevice(ctx, deviceIdentifier)
+		device, err := n.resolveRetailPlayerDevice(ctx, deviceIdentifier)
 		if err != nil {
 			if errors.Is(err, errRetailPlayerDeviceNotFound) {
 				log.Info(ctx, "Retail player device not found", "identifier", deviceIdentifier)
@@ -254,7 +254,7 @@ func (n *Router) handleRetailPlayerDeviceChannelInfo() http.HandlerFunc {
 			deviceIdentifier = rawDeviceID
 		}
 
-		device, err := resolveRetailPlayerDevice(ctx, deviceIdentifier)
+		device, err := n.resolveRetailPlayerDevice(ctx, deviceIdentifier)
 		if err != nil {
 			if errors.Is(err, errRetailPlayerDeviceNotFound) {
 				log.Info(ctx, "Retail player device not found", "identifier", deviceIdentifier)
@@ -671,7 +671,7 @@ func (n *Router) handleRetailPlayerDeviceDislike() http.HandlerFunc {
 	}
 }
 
-func resolveRetailPlayerDevice(ctx context.Context, identifier string) (retailPlayerDevice, error) {
+func (n *Router) resolveRetailPlayerDevice(ctx context.Context, identifier string) (retailPlayerDevice, error) {
 	trimmed := strings.TrimSpace(identifier)
 	if trimmed == "" {
 		return retailPlayerDevice{}, errors.New("retail player device identifier is empty")
@@ -685,12 +685,35 @@ func resolveRetailPlayerDevice(ctx context.Context, identifier string) (retailPl
 		return retailPlayerDevice{}, err
 	}
 
+	slugKey := deviceSlugKey(trimmed)
+
+	if slugKey != "" && n.ds != nil {
+		repo := n.ds.RetailPlayerDeviceMapping(ctx)
+		if repo != nil {
+			mapping, mapErr := repo.FindBySlugKey(slugKey)
+			if mapErr == nil && mapping != nil {
+				mappedID := strings.TrimSpace(mapping.DeviceID)
+				if mappedID != "" {
+					log.Info(ctx, "Retail player device resolved via mapping", "identifier", trimmed, "slugKey", slugKey, "mappedDeviceID", mappedID)
+					device, fetchErr := fetchRetailPlayerDevice(ctx, mappedID)
+					if fetchErr == nil {
+						return device, nil
+					}
+					if fetchErr != nil && !errors.Is(fetchErr, errRetailPlayerDeviceNotFound) {
+						return retailPlayerDevice{}, fetchErr
+					}
+				}
+			} else if mapErr != nil && !errors.Is(mapErr, model.ErrNotFound) {
+				return retailPlayerDevice{}, mapErr
+			}
+		}
+	}
+
 	response, err := fetchRetailPlayerDevices(ctx)
 	if err != nil {
 		return retailPlayerDevice{}, err
 	}
 
-	slugKey := deviceSlugKey(trimmed)
 	identifierVariants := buildDeviceIdentifierVariants(trimmed)
 
 	for _, candidate := range response.Data {
@@ -898,7 +921,7 @@ func fetchRetailPlayerDevice(ctx context.Context, deviceID string) (retailPlayer
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusNotFound {
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusBadRequest {
 		return retailPlayerDevice{}, errRetailPlayerDeviceNotFound
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {

--- a/tests/mock_data_store.go
+++ b/tests/mock_data_store.go
@@ -8,28 +8,29 @@ import (
 )
 
 type MockDataStore struct {
-	RealDS               model.DataStore
-	MockedLibrary        model.LibraryRepository
-	MockedFolder         model.FolderRepository
-	MockedGenre          model.GenreRepository
-	MockedAlbum          model.AlbumRepository
-	MockedArtist         model.ArtistRepository
-	MockedMediaFile      model.MediaFileRepository
-	MockedTag            model.TagRepository
-	MockedUser           model.UserRepository
-	MockedProperty       model.PropertyRepository
-	MockedPlayer         model.PlayerRepository
-	MockedPlaylist       model.PlaylistRepository
-	MockedDiscovery      model.DiscoveryRepository
-	MockedPlaylistFolder model.PlaylistFolderRepository
-	MockedPlayQueue      model.PlayQueueRepository
-	MockedShare          model.ShareRepository
-	MockedTranscoding    model.TranscodingRepository
-	MockedUserProps      model.UserPropsRepository
-	MockedScrobbleBuffer model.ScrobbleBufferRepository
-	MockedRadio          model.RadioRepository
-	scrobbleBufferMu     sync.Mutex
-	repoMu               sync.Mutex
+	RealDS                          model.DataStore
+	MockedLibrary                   model.LibraryRepository
+	MockedFolder                    model.FolderRepository
+	MockedGenre                     model.GenreRepository
+	MockedAlbum                     model.AlbumRepository
+	MockedArtist                    model.ArtistRepository
+	MockedMediaFile                 model.MediaFileRepository
+	MockedTag                       model.TagRepository
+	MockedUser                      model.UserRepository
+	MockedProperty                  model.PropertyRepository
+	MockedPlayer                    model.PlayerRepository
+	MockedPlaylist                  model.PlaylistRepository
+	MockedDiscovery                 model.DiscoveryRepository
+	MockedPlaylistFolder            model.PlaylistFolderRepository
+	MockedPlayQueue                 model.PlayQueueRepository
+	MockedShare                     model.ShareRepository
+	MockedTranscoding               model.TranscodingRepository
+	MockedUserProps                 model.UserPropsRepository
+	MockedScrobbleBuffer            model.ScrobbleBufferRepository
+	MockedRadio                     model.RadioRepository
+	MockedRetailPlayerDeviceMapping model.RetailPlayerDeviceMappingRepository
+	scrobbleBufferMu                sync.Mutex
+	repoMu                          sync.Mutex
 }
 
 func (db *MockDataStore) Library(ctx context.Context) model.LibraryRepository {
@@ -243,6 +244,19 @@ func (db *MockDataStore) Radio(ctx context.Context) model.RadioRepository {
 		}
 	}
 	return db.MockedRadio
+}
+
+func (db *MockDataStore) RetailPlayerDeviceMapping(ctx context.Context) model.RetailPlayerDeviceMappingRepository {
+	if db.MockedRetailPlayerDeviceMapping == nil {
+		if db.RealDS != nil {
+			db.MockedRetailPlayerDeviceMapping = db.RealDS.RetailPlayerDeviceMapping(ctx)
+		} else {
+			db.MockedRetailPlayerDeviceMapping = struct {
+				model.RetailPlayerDeviceMappingRepository
+			}{}
+		}
+	}
+	return db.MockedRetailPlayerDeviceMapping
 }
 
 func (db *MockDataStore) WithTx(block func(tx model.DataStore) error, label ...string) error {

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -3,7 +3,8 @@ import { useDataProvider } from 'react-admin'
 import subsonic from '../subsonic'
 import httpClient from '../dataProvider/httpClient'
 import { baseUrl } from '../utils'
-import useRetailPlayerDevices from './useRetailPlayerDevices'
+import config from '../config'
+import RetailPlayerMockService from './RetailPlayerMockService'
 import { buildDeviceSlug, deviceSlugKey, normalizeValue } from './deviceUtils'
 
 const buildStatusUrl = (deviceId) =>
@@ -111,6 +112,55 @@ const mapChannelListResponse = (payload) =>
       }
     })
     .filter(Boolean)
+
+const mapResponseDevice = (device) => {
+  if (!device || typeof device !== 'object') {
+    return null
+  }
+
+  const rawId = normalizeValue(device.id)
+  const fallbackId =
+    rawId || normalizeValue(device.macAddress) || normalizeValue(device.ordinal)
+
+  const resolvedId = fallbackId || normalizeValue(device.name)
+
+  if (!resolvedId) {
+    return null
+  }
+
+  const slugSource = buildDeviceSlug({ ...device, id: resolvedId }) || resolvedId
+  const name = normalizeValue(device.name) || resolvedId
+
+  return {
+    id: resolvedId,
+    apiId: rawId || resolvedId,
+    name,
+    slug: slugSource,
+    slugKey: deviceSlugKey(slugSource),
+    channel: normalizeValue(device.channel),
+    channelList: normalizeValue(device.channelList),
+    organization: normalizeValue(device.organization),
+    timeZone: normalizeValue(device.timeZone),
+  }
+}
+
+const selectDeviceBySlug = (devices, slugKey) => {
+  if (!Array.isArray(devices) || !devices.length) {
+    return null
+  }
+
+  if (!slugKey) {
+    return devices[0]
+  }
+
+  return (
+    devices.find((device) => device.slugKey === slugKey) ||
+    devices.find((device) => deviceSlugKey(device.slug || device.name) === slugKey) ||
+    devices.find((device) => deviceSlugKey(device.apiId) === slugKey) ||
+    devices.find((device) => deviceSlugKey(device.id) === slugKey) ||
+    null
+  )
+}
 
 const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
   if (!baseDevice) {
@@ -584,43 +634,30 @@ const initialChannelState = {
 }
 
 const useRetailPlayerDeviceStatus = (slugParam) => {
-  const {
-    devices,
-    error: devicesError,
-    isLoading: devicesLoading,
-    isApiEnabled,
-  } = useRetailPlayerDevices()
+  const isApiEnabled = Boolean(config.retailPlayerDevicesEnabled)
 
-  const normalizedSlugKey = useMemo(() => {
+  const deviceIdentifier = useMemo(() => {
     if (!slugParam) {
       return ''
     }
     try {
-      return deviceSlugKey(decodeURIComponent(slugParam))
+      return decodeURIComponent(slugParam)
     } catch (err) {
-      return deviceSlugKey(slugParam)
+      return slugParam
     }
   }, [slugParam])
 
-  const baseDevice = useMemo(() => {
-    if (!devices.length) {
-      return null
-    }
-    if (!normalizedSlugKey) {
-      return devices[0]
-    }
+  const normalizedSlugKey = useMemo(() => deviceSlugKey(deviceIdentifier), [deviceIdentifier])
 
-    return (
-      devices.find((device) => {
-        const deviceKey = device.slugKey || deviceSlugKey(device.slug || device.name || device.id)
-        return deviceKey === normalizedSlugKey
-      }) ||
-      devices.find((device) => deviceSlugKey(device.name) === normalizedSlugKey) ||
-      devices.find((device) => deviceSlugKey(device.apiId) === normalizedSlugKey) ||
-      devices.find((device) => deviceSlugKey(device.id) === normalizedSlugKey) ||
-      null
-    )
-  }, [devices, normalizedSlugKey])
+  const [baseDevice, setBaseDevice] = useState(() => {
+    if (!isApiEnabled) {
+      const devices = RetailPlayerMockService.listDevices()
+      return selectDeviceBySlug(devices, normalizedSlugKey)
+    }
+    return null
+  })
+  const [devicesError, setDevicesError] = useState(null)
+  const [devicesLoading, setDevicesLoading] = useState(false)
 
   const [statusState, setStatusState] = useState(initialStatusState)
   const [refreshIndex, setRefreshIndex] = useState(0)
@@ -632,27 +669,97 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
 
   useEffect(() => {
     if (!isApiEnabled) {
+      setDevicesLoading(false)
+      setDevicesError(null)
+
+      const devices = RetailPlayerMockService.listDevices()
+      const selectedDevice = selectDeviceBySlug(devices, normalizedSlugKey)
+      setBaseDevice(selectedDevice || null)
+
+      if (!selectedDevice) {
+        setStatusState(initialStatusState)
+        setChannelState(initialChannelState)
+        return undefined
+      }
+
+      const mockDevice = RetailPlayerMockService.getDevice(selectedDevice.apiId)
+      if (!mockDevice) {
+        setStatusState(initialStatusState)
+        setChannelState(initialChannelState)
+        return undefined
+      }
+
+      const resolvedChannel =
+        normalizeValue(mockDevice.channel) || normalizeValue(selectedDevice.channel)
+
+      const statusPayload = {
+        status: {
+          channel: resolvedChannel,
+          activeStreamName: resolvedChannel,
+          volume: mockDevice.volume,
+          isMuted: mockDevice.isMuted,
+          isConnected: mockDevice.isConnected,
+          hasSignal: mockDevice.hasSignal,
+        },
+        streamMetadata: [],
+      }
+
+      const channelPayload = Array.isArray(mockDevice.schedules)
+        ? mockDevice.schedules
+            .map((schedule) => {
+              if (!schedule || typeof schedule !== 'object') {
+                return null
+              }
+              const id = normalizeValue(schedule.key) || normalizeValue(schedule.label)
+              const name = normalizeValue(schedule.label) || normalizeValue(schedule.key)
+              if (!id && !name) {
+                return null
+              }
+              return { id: id || name, name: name || id }
+            })
+            .filter(Boolean)
+        : []
+
+      setStatusState({
+        data: statusPayload,
+        error: null,
+        isLoading: false,
+        fetchedAt: new Date(),
+      })
+      setChannelState({
+        data: channelPayload,
+        error: null,
+        isLoading: false,
+        fetchedAt: new Date(),
+      })
+
+      return undefined
+    }
+
+    const identifier = normalizeValue(deviceIdentifier)
+    if (!identifier) {
+      setBaseDevice(null)
       setStatusState(initialStatusState)
+      setChannelState(initialChannelState)
+      setDevicesLoading(false)
+      setDevicesError(null)
       return undefined
     }
 
-    if (devicesLoading) {
-      return undefined
-    }
-
-    const deviceId = normalizeValue(baseDevice?.apiId)
-    if (!deviceId) {
-      setStatusState(initialStatusState)
-      return undefined
-    }
-
-    const url = buildStatusUrl(deviceId)
+    const url = buildStatusUrl(identifier)
     if (!url) {
+      setBaseDevice(null)
       setStatusState(initialStatusState)
+      setChannelState(initialChannelState)
+      setDevicesLoading(false)
+      setDevicesError(null)
       return undefined
     }
 
     const abortController = new AbortController()
+    setDevicesLoading(true)
+    setDevicesError(null)
+    setChannelState({ data: [], error: null, isLoading: true, fetchedAt: null })
     setStatusState((previous) => ({ ...previous, isLoading: true, error: null }))
 
     httpClient(url, { signal: abortController.signal })
@@ -660,23 +767,58 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
         if (abortController.signal.aborted) {
           return
         }
-        setStatusState({ data: json, error: null, isLoading: false, fetchedAt: new Date() })
+
+        const mappedDevice = mapResponseDevice(json?.device)
+        const fallbackDevice =
+          mappedDevice ||
+          mapResponseDevice({
+            id: identifier,
+            name: identifier,
+            channel: '',
+            channelList: '',
+            organization: '',
+            timeZone: '',
+          })
+
+        setBaseDevice(fallbackDevice)
+        setStatusState({
+          data: json,
+          error: null,
+          isLoading: false,
+          fetchedAt: new Date(),
+        })
+        setDevicesLoading(false)
+        setDevicesError(null)
       })
       .catch((err) => {
         if (abortController.signal.aborted) {
           return
         }
-        setStatusState({ data: null, error: err, isLoading: false, fetchedAt: new Date() })
+
+        setBaseDevice(null)
+        setChannelState(initialChannelState)
+        setStatusState({
+          data: null,
+          error: err,
+          isLoading: false,
+          fetchedAt: new Date(),
+        })
+        setDevicesLoading(false)
+        if (err?.status && err.status !== 404) {
+          setDevicesError(err)
+        } else {
+          setDevicesError(null)
+        }
       })
 
     return () => {
       abortController.abort()
+      setDevicesLoading(false)
     }
-  }, [baseDevice?.apiId, devicesLoading, isApiEnabled, refreshIndex])
+  }, [deviceIdentifier, isApiEnabled, normalizedSlugKey, refreshIndex])
 
   useEffect(() => {
     if (!isApiEnabled) {
-      setChannelState(initialChannelState)
       return undefined
     }
 

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -634,8 +634,6 @@ const initialChannelState = {
 }
 
 const useRetailPlayerDeviceStatus = (slugParam) => {
-  const isApiEnabled = Boolean(config.retailPlayerDevicesEnabled)
-
   const deviceIdentifier = useMemo(() => {
     if (!slugParam) {
       return ''
@@ -649,8 +647,15 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
 
   const normalizedSlugKey = useMemo(() => deviceSlugKey(deviceIdentifier), [deviceIdentifier])
 
+  const [apiCapability, setApiCapability] = useState(() => ({
+    isEnabled: Boolean(config.retailPlayerDevicesEnabled),
+    hasChecked: Boolean(config.retailPlayerDevicesEnabled),
+  }))
+
+  const shouldAttemptApi = apiCapability.isEnabled || !apiCapability.hasChecked
+
   const [baseDevice, setBaseDevice] = useState(() => {
-    if (!isApiEnabled) {
+    if (!shouldAttemptApi) {
       const devices = RetailPlayerMockService.listDevices()
       return selectDeviceBySlug(devices, normalizedSlugKey)
     }
@@ -667,72 +672,76 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
     setRefreshIndex((previous) => previous + 1)
   }, [])
 
+  const applyMockDeviceState = useCallback(() => {
+    const devices = RetailPlayerMockService.listDevices()
+    const selectedDevice = selectDeviceBySlug(devices, normalizedSlugKey)
+    setBaseDevice(selectedDevice || null)
+
+    if (!selectedDevice) {
+      setStatusState(initialStatusState)
+      setChannelState(initialChannelState)
+      return false
+    }
+
+    const mockDevice = RetailPlayerMockService.getDevice(selectedDevice.apiId)
+    if (!mockDevice) {
+      setStatusState(initialStatusState)
+      setChannelState(initialChannelState)
+      return false
+    }
+
+    const resolvedChannel =
+      normalizeValue(mockDevice.channel) || normalizeValue(selectedDevice.channel)
+
+    const statusPayload = {
+      status: {
+        channel: resolvedChannel,
+        activeStreamName: resolvedChannel,
+        volume: mockDevice.volume,
+        isMuted: mockDevice.isMuted,
+        isConnected: mockDevice.isConnected,
+        hasSignal: mockDevice.hasSignal,
+      },
+      streamMetadata: [],
+    }
+
+    const channelPayload = Array.isArray(mockDevice.schedules)
+      ? mockDevice.schedules
+          .map((schedule) => {
+            if (!schedule || typeof schedule !== 'object') {
+              return null
+            }
+            const id = normalizeValue(schedule.key) || normalizeValue(schedule.label)
+            const name = normalizeValue(schedule.label) || normalizeValue(schedule.key)
+            if (!id && !name) {
+              return null
+            }
+            return { id: id || name, name: name || id }
+          })
+          .filter(Boolean)
+      : []
+
+    setStatusState({
+      data: statusPayload,
+      error: null,
+      isLoading: false,
+      fetchedAt: new Date(),
+    })
+    setChannelState({
+      data: channelPayload,
+      error: null,
+      isLoading: false,
+      fetchedAt: new Date(),
+    })
+
+    return true
+  }, [normalizedSlugKey])
+
   useEffect(() => {
-    if (!isApiEnabled) {
+    if (!shouldAttemptApi) {
       setDevicesLoading(false)
       setDevicesError(null)
-
-      const devices = RetailPlayerMockService.listDevices()
-      const selectedDevice = selectDeviceBySlug(devices, normalizedSlugKey)
-      setBaseDevice(selectedDevice || null)
-
-      if (!selectedDevice) {
-        setStatusState(initialStatusState)
-        setChannelState(initialChannelState)
-        return undefined
-      }
-
-      const mockDevice = RetailPlayerMockService.getDevice(selectedDevice.apiId)
-      if (!mockDevice) {
-        setStatusState(initialStatusState)
-        setChannelState(initialChannelState)
-        return undefined
-      }
-
-      const resolvedChannel =
-        normalizeValue(mockDevice.channel) || normalizeValue(selectedDevice.channel)
-
-      const statusPayload = {
-        status: {
-          channel: resolvedChannel,
-          activeStreamName: resolvedChannel,
-          volume: mockDevice.volume,
-          isMuted: mockDevice.isMuted,
-          isConnected: mockDevice.isConnected,
-          hasSignal: mockDevice.hasSignal,
-        },
-        streamMetadata: [],
-      }
-
-      const channelPayload = Array.isArray(mockDevice.schedules)
-        ? mockDevice.schedules
-            .map((schedule) => {
-              if (!schedule || typeof schedule !== 'object') {
-                return null
-              }
-              const id = normalizeValue(schedule.key) || normalizeValue(schedule.label)
-              const name = normalizeValue(schedule.label) || normalizeValue(schedule.key)
-              if (!id && !name) {
-                return null
-              }
-              return { id: id || name, name: name || id }
-            })
-            .filter(Boolean)
-        : []
-
-      setStatusState({
-        data: statusPayload,
-        error: null,
-        isLoading: false,
-        fetchedAt: new Date(),
-      })
-      setChannelState({
-        data: channelPayload,
-        error: null,
-        isLoading: false,
-        fetchedAt: new Date(),
-      })
-
+      applyMockDeviceState()
       return undefined
     }
 
@@ -768,6 +777,8 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
           return
         }
 
+        setApiCapability({ isEnabled: true, hasChecked: true })
+
         const mappedDevice = mapResponseDevice(json?.device)
         const fallbackDevice =
           mappedDevice ||
@@ -795,6 +806,21 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
           return
         }
 
+        const status = typeof err?.status === 'number' ? err.status : null
+        const message = normalizeValue(err?.body?.message || err?.body).toLowerCase()
+        const integrationDisabled =
+          status === 404 && message.includes('retail player integration disabled')
+
+        if (integrationDisabled) {
+          setApiCapability({ isEnabled: false, hasChecked: true })
+          applyMockDeviceState()
+          setDevicesLoading(false)
+          setDevicesError(null)
+          return
+        }
+
+        setApiCapability({ isEnabled: true, hasChecked: true })
+
         setBaseDevice(null)
         setChannelState(initialChannelState)
         setStatusState({
@@ -804,7 +830,7 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
           fetchedAt: new Date(),
         })
         setDevicesLoading(false)
-        if (err?.status && err.status !== 404) {
+        if (status && status !== 404) {
           setDevicesError(err)
         } else {
           setDevicesError(null)
@@ -815,10 +841,16 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
       abortController.abort()
       setDevicesLoading(false)
     }
-  }, [deviceIdentifier, isApiEnabled, normalizedSlugKey, refreshIndex])
+  }, [
+    applyMockDeviceState,
+    deviceIdentifier,
+    normalizedSlugKey,
+    refreshIndex,
+    shouldAttemptApi,
+  ])
 
   useEffect(() => {
-    if (!isApiEnabled) {
+    if (!apiCapability.isEnabled) {
       return undefined
     }
 
@@ -863,7 +895,7 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
     return () => {
       abortController.abort()
     }
-  }, [baseDevice?.channelList, devicesLoading, isApiEnabled])
+  }, [apiCapability.isEnabled, baseDevice?.channelList, devicesLoading])
 
   const normalizedDevice = useMemo(
     () => mapStatusPayloadToDevice(baseDevice, statusState.data, channelState.data),
@@ -1009,7 +1041,7 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
     devicesError,
     channelListError: channelState.error,
     notFound,
-    isApiEnabled,
+    isApiEnabled: apiCapability.isEnabled,
     lastUpdated: statusState.fetchedAt,
   }
 }


### PR DESCRIPTION
## Summary
- expose the retail player status, volume, toggle, and channel-list endpoints on the public router and resolve device identifiers by name or slug server-side
- add a device channel lookup handler and include the resolved device metadata alongside status responses
- update the retail player dashboard hook to request status by slug without loading the full device list while keeping the mock-device fallback

## Testing
- go test ./... *(aborted: command produced no output and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_690b679afdb08322962089ed5c8f8304