### PR TITLE
Fix missing track duplication and remove retail device creation

### DIFF
--- a/ui/src/layout/MissingTracksPanel.jsx
+++ b/ui/src/layout/MissingTracksPanel.jsx
@@ -232,13 +232,27 @@ const MissingTracksPanel = () => {
               if (!entry) {
                 return `unknown-${fallbackIndex}`
               }
-              return (
-                entry.id ||
-                entry.path ||
-                entry.trackPath ||
-                `${entry.title || ''}-${entry.artist || ''}` ||
-                `unknown-${fallbackIndex}`
-              )
+
+              const stringValue = (value) => {
+                if (value === undefined || value === null) {
+                  return ''
+                }
+                return `${value}`.trim()
+              }
+
+              const lowerStringValue = (value) => stringValue(value).toLocaleLowerCase()
+
+              const candidates = [
+                lowerStringValue(entry.path),
+                lowerStringValue(entry.trackPath),
+                lowerStringValue(entry.trackId),
+                stringValue(entry.id),
+                stringValue(`${entry.title || ''}-${entry.artist || ''}`),
+              ]
+
+              const key = candidates.find((candidate) => candidate.length > 0)
+
+              return key || `unknown-${fallbackIndex}`
             }
 
             const addEntry = (entry, indexOffset = 0) => {
@@ -332,16 +346,6 @@ const MissingTracksPanel = () => {
     [translate],
   )
 
-  const getEntrySecondaryLabel = useCallback((entry) => {
-    if (!entry) {
-      return ''
-    }
-    const details = [entry.libraryName, entry.album || entry.albumName]
-      .map((value) => (typeof value === 'string' ? value.trim() : ''))
-      .filter(Boolean)
-    return details.join(' • ')
-  }, [])
-
   useEffect(() => {
     fetchEntries(0, false)
   }, [fetchEntries])
@@ -410,8 +414,6 @@ const MissingTracksPanel = () => {
                     <ListItem key={key} className={classes.listItem}>
                       <ListItemText
                         primary={getEntryLabel(entry)}
-                        secondary={getEntrySecondaryLabel(entry)}
-                        secondaryTypographyProps={{ variant: 'body2', color: 'textSecondary' }}
                       />
                     </ListItem>
                   )

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -878,11 +878,6 @@ const RetailPlayerDeviceManagement = () => {
     setFolderDialog({ open: true, target: null, parentId: activeFolderId })
   }
 
-  const handleCreateDevice = () => {
-    closeMenu()
-    setDeviceDialog({ open: true, target: null })
-  }
-
   const handleEditFolder = (folderId) => {
     const folder = folderMap.get(folderId)
     if (!folder) return
@@ -1173,12 +1168,6 @@ const RetailPlayerDeviceManagement = () => {
                   <FolderIcon fontSize="small" className={classes.nameIcon} />
                 </ListItemIcon>
                 <ListItemText primary="Create Folder" />
-              </MenuItem>
-              <MenuItem onClick={handleCreateDevice}>
-                <ListItemIcon>
-                  <SpeakerGroupIcon fontSize="small" className={classes.nameIcon} />
-                </ListItemIcon>
-                <ListItemText primary="Create Device" />
               </MenuItem>
             </Menu>
           </div>


### PR DESCRIPTION
## Summary
- ensure missing track notifications merge by shared paths to avoid duplicate entries and remove secondary text
- remove the obsolete "Create Device" option from the retail player actions menu

## Testing
- npm run lint *(fails: existing react-refresh warning in ui/src/playlist/PlaylistSongs.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_690ce227edc483228720af1cb86857ab