### PR TITLE
Fix pointer reuse when tracking missing files

### DIFF
--- a/scanner/phase_1_folders.go
+++ b/scanner/phase_1_folders.go
@@ -216,7 +216,8 @@ func (p *phaseFolders) processFolder(entry *folderEntry) (*folderEntry, error) {
 			log.Error(p.ctx, "Scanner: Error loading mediafiles from DB", "folder", entry.path, err)
 			return entry, err
 		}
-		dbTracks[mf.Path] = &mf
+		mfCopy := mf
+		dbTracks[mf.Path] = &mfCopy
 	}
 
 	// Get list of files to import, based on modtime (or all if fullScan),

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -83,8 +83,8 @@ var _ = Describe("Scanner", Ordered, func() {
 		}
 		Expect(ds.User(ctx).Put(&adminUser)).To(Succeed())
 
-                s = scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
-                        core.NewPlaylists(ds), core.NewDiscoveries(ds), metrics.NewNoopInstance())
+		s = scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
+			core.NewPlaylists(ds), core.NewDiscoveries(ds), metrics.NewNoopInstance())
 
 		lib = model.Library{ID: 1, Name: "Fake Library", Path: "fake:///music"}
 		Expect(ds.Library(ctx).Put(&lib)).To(Succeed())
@@ -330,6 +330,27 @@ var _ = Describe("Scanner", Ordered, func() {
 			mf, err := findByPath("The Beatles/Revolver/02 - Eleanor Rigby.mp3")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mf.Missing).To(BeTrue())
+		})
+
+		It("keeps existing files available when another file is removed", func() {
+			By("Running an initial full scan")
+			Expect(runScanner(ctx, true)).To(Succeed())
+
+			By("Removing a different file")
+			fsys.Remove("The Beatles/Revolver/02 - Eleanor Rigby.mp3")
+
+			By("Running an incremental scan")
+			Expect(runScanner(ctx, false)).To(Succeed())
+
+			By("Verifying the removed file is marked as missing")
+			removed, err := findByPath("The Beatles/Revolver/02 - Eleanor Rigby.mp3")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(removed.Missing).To(BeTrue())
+
+			By("Ensuring another file in the folder remains available")
+			kept, err := findByPath("The Beatles/Revolver/01 - Taxman.mp3")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kept.Missing).To(BeFalse())
 		})
 
 		It("detects a file was moved to a different folder", func() {


### PR DESCRIPTION
## Summary
- avoid reusing the iterator variable when caching database media files during folder scans
- add a regression test to ensure removing a file does not incorrectly mark other tracks as missing

## Testing
- go test ./scanner -run Scanner -count=1 *(fails: build error in phase_4_playlists_test.go due to undefined playlistRepoMock)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e336d2f708330bd443ce06976da01)