### PR TITLE
Enable sorting for genre, comment, and date added columns

### DIFF
--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -84,6 +84,8 @@ func NewMediaFileRepository(ctx context.Context, db dbx.Builder) model.MediaFile
 		"created_at":     "media_file.created_at",
 		"recently_added": mediaFileRecentlyAddedSort(),
 		"starred_at":     "starred, starred_at",
+		"genre":          "genre",
+		"comment":        "comment",
 	})
 	return r
 }

--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -177,6 +177,7 @@ func (r *playlistRepository) Tracks(playlistId string, refreshSmartPlaylist bool
 			"order_album_artist_name": "order_album_artist_name",
 			"order_album_name":        "order_album_name",
 			"order_title":             "order_title",
+			"created_at":              "playlist_tracks.created_at",
 		},
 		"f") // TODO I don't like this solution, but I won't change it now as it's not the focus of BFR.
 

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -299,13 +299,17 @@ const PlaylistSongs = ({
         <DateField source="playDate" sortByOrder={'DESC'} showTime />
       ),
       createdAt: (
-        <DateField source="createdAt" showTime sortable={false} />
+        <DateField
+          source="createdAt"
+          sortBy="playlist_tracks.created_at"
+          showTime
+        />
       ),
       quality: isDesktop && <QualityInfo source="quality" sortable={false} />,
       channels: isDesktop && <NumberField source="channels" />,
       bpm: isDesktop && <NumberField source="bpm" />,
-      genre: <TextField source="genre" />,
-      comment: <TextField source="comment" />,
+      genre: <TextField source="genre" sortBy="genre" />,
+      comment: <TextField source="comment" sortBy="comment" />,
       path: <PathField source="path" />,
       rating: config.enableStarRating && (
         <RatingField

--- a/ui/src/song/ReorderableSongList.jsx
+++ b/ui/src/song/ReorderableSongList.jsx
@@ -270,7 +270,7 @@ const ReorderableSongList = (props) => {
           />
         ),
       bpm: isDesktop ? <NumberField source="bpm" /> : null,
-      genre: <TextField source="genre" />,
+      genre: <TextField source="genre" sortBy="genre" />,
       mood: isDesktop ? (
         <FunctionField
           source="mood"
@@ -278,7 +278,7 @@ const ReorderableSongList = (props) => {
           sortable={false}
         />
       ) : null,
-      comment: <TextField source="comment" />,
+      comment: <TextField source="comment" sortBy="comment" />,
       path: <PathField source="path" />,
       createdAt: <DateField source="createdAt" sortBy="recently_added" showTime />,
     }

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -203,7 +203,7 @@ const SongList = (props) => {
         />
       ),
       bpm: isDesktop && <NumberField source="bpm" />,
-      genre: <TextField source="genre" />,
+      genre: <TextField source="genre" sortBy="genre" />,
       mood: isDesktop && (
         <FunctionField
           source="mood"
@@ -211,7 +211,7 @@ const SongList = (props) => {
           sortable={false}
         />
       ),
-      comment: <TextField source="comment" />,
+      comment: <TextField source="comment" sortBy="comment" />,
       path: <PathField source="path" />,
       createdAt: (
         <DateField source="createdAt" sortBy="recently_added" showTime />


### PR DESCRIPTION
## Summary
- expose backend sort mappings for genre, comment, and playlist track creation date
- allow the Songs grid and playlist track grids to request sorting on genre, comment, and date added columns

## Testing
- go test ./persistence/... *(fails: interrupted after running too long)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e4f5d63148330aa79a2c9aa08d027)