### PR TITLE
Add drag-and-drop device organization to Retail Player UI

### DIFF
--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 import {
   Collapse,
@@ -18,6 +18,7 @@ import ChevronRightIcon from '@material-ui/icons/ChevronRight'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import FolderIcon from '@material-ui/icons/Folder'
 import { useHistory } from 'react-router-dom'
+import { fade } from '@material-ui/core/styles/colorManipulator'
 import { BiCog } from 'react-icons/bi'
 import SubMenu from './SubMenu'
 import { humanize, pluralize } from 'inflection'
@@ -63,15 +64,23 @@ const useStyles = makeStyles((theme) => ({
     '& .MuiListItemIcon-root': {
       minWidth: theme.spacing(4),
     },
-
-  '& .MuiListItemIcon-root svg': {
-    fontSize: theme.typography.pxToRem(16), 
-   },
-
+    '& .MuiListItemIcon-root svg': {
+      fontSize: theme.typography.pxToRem(16),
+    },
     '& .MuiTypography-body1': {
       fontSize: theme.typography.pxToRem(14),
       color: theme.palette.common.white,
     },
+  },
+  folderDropTarget: {
+    borderRadius: theme.shape.borderRadius / 2,
+    transition: theme.transitions.create(['background-color', 'box-shadow'], {
+      duration: theme.transitions.duration.shorter,
+    }),
+  },
+  folderDropTargetActive: {
+    backgroundColor: fade(theme.palette.primary.main, 0.18),
+    boxShadow: `inset 0 0 0 2px ${fade(theme.palette.primary.main, 0.35)}`,
   },
   folderChildren: {
     '& > *': {
@@ -178,8 +187,193 @@ const Menu = ({ dense = false }) => {
       tree: retailTree,
       loading: retailDevicesLoading,
       error: retailDevicesError,
+      folders: retailFolders,
+      devices: retailDevices,
+    },
+    actions: { updateDevice },
+    dragState: {
+      draggedDevice,
+      dropTargetFolderId,
+      setDropTargetFolderId,
+      setLastDeviceDrop,
     },
   } = useRetailPlayerDeviceStore()
+
+  const folderMap = useMemo(() => {
+    const map = new Map()
+    if (Array.isArray(retailFolders)) {
+      retailFolders.forEach((folder) => {
+        if (folder?.id) {
+          map.set(folder.id, folder)
+        }
+      })
+    }
+    return map
+  }, [retailFolders])
+
+  const deviceMap = useMemo(() => {
+    const map = new Map()
+    if (Array.isArray(retailDevices)) {
+      retailDevices.forEach((device) => {
+        if (device?.id) {
+          map.set(device.id, device)
+        }
+      })
+    }
+    return map
+  }, [retailDevices])
+
+  const draggedDeviceId = draggedDevice?.id || null
+
+  const canDropDeviceOnFolder = useCallback(
+    (deviceId, folderId) => {
+      if (!deviceId || !folderId) {
+        return false
+      }
+      if (!folderMap.has(folderId)) {
+        return false
+      }
+      const device = deviceMap.get(deviceId)
+      if (!device) {
+        return false
+      }
+      if (draggedDevice?.sourceFolderId === folderId) {
+        return false
+      }
+      const currentFolders = Array.isArray(device.folderIds)
+        ? device.folderIds.filter(Boolean)
+        : device.folderId
+        ? [device.folderId].filter(Boolean)
+        : []
+      if (currentFolders.length === 1 && currentFolders[0] === folderId) {
+        return false
+      }
+      return true
+    },
+    [deviceMap, folderMap, draggedDevice],
+  )
+
+  const extractDeviceIdFromEvent = useCallback(
+    (event) => {
+      if (draggedDeviceId) {
+        return draggedDeviceId
+      }
+      const transfer = event?.dataTransfer
+      if (!transfer) {
+        return null
+      }
+      try {
+        const raw = transfer.getData('application/json')
+        if (raw) {
+          const parsed = JSON.parse(raw)
+          if (parsed?.deviceId) {
+            return parsed.deviceId
+          }
+        }
+      } catch (error) {
+        // Ignore malformed data
+      }
+      try {
+        const fallback = transfer.getData('text/plain')
+        if (fallback) {
+          return fallback
+        }
+      } catch (error) {
+        // Ignore malformed data
+      }
+      return null
+    },
+    [draggedDeviceId],
+  )
+
+  const handleFolderDragOver = useCallback(
+    (event, folderId) => {
+      if (!draggedDeviceId) {
+        return
+      }
+      if (!canDropDeviceOnFolder(draggedDeviceId, folderId)) {
+        return
+      }
+      event.preventDefault()
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = 'move'
+      }
+    },
+    [draggedDeviceId, canDropDeviceOnFolder],
+  )
+
+  const handleFolderDragEnter = useCallback(
+    (event, folderId) => {
+      if (!draggedDeviceId) {
+        return
+      }
+      if (!canDropDeviceOnFolder(draggedDeviceId, folderId)) {
+        return
+      }
+      event.preventDefault()
+      setDropTargetFolderId(folderId)
+    },
+    [draggedDeviceId, canDropDeviceOnFolder, setDropTargetFolderId],
+  )
+
+  const handleFolderDragLeave = useCallback(
+    (event, folderId) => {
+      if (!draggedDeviceId) {
+        return
+      }
+      const nextTarget = event.relatedTarget
+      if (nextTarget && event.currentTarget.contains(nextTarget)) {
+        return
+      }
+      setDropTargetFolderId((previous) => (previous === folderId ? null : previous))
+    },
+    [draggedDeviceId, setDropTargetFolderId],
+  )
+
+  const handleDeviceDropOnFolder = useCallback(
+    (deviceId, folderId) => {
+      if (!deviceId || !folderId) {
+        return
+      }
+      const device = deviceMap.get(deviceId)
+      if (!device) {
+        return
+      }
+      const existingFolderIds = Array.isArray(device.folderIds)
+        ? device.folderIds.filter(Boolean)
+        : device.folderId
+        ? [device.folderId].filter(Boolean)
+        : []
+      if (existingFolderIds.length === 1 && existingFolderIds[0] === folderId) {
+        return
+      }
+      updateDevice({ id: deviceId, folderIds: [folderId] })
+      setLastDeviceDrop({ deviceId, folderId, timestamp: Date.now() })
+    },
+    [deviceMap, updateDevice, setLastDeviceDrop],
+  )
+
+  const handleFolderDrop = useCallback(
+    (event, folderId) => {
+      const deviceId = extractDeviceIdFromEvent(event)
+      if (!deviceId) {
+        return
+      }
+      if (!canDropDeviceOnFolder(deviceId, folderId)) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      handleDeviceDropOnFolder(deviceId, folderId)
+      setDropTargetFolderId(null)
+    },
+    [
+      extractDeviceIdFromEvent,
+      canDropDeviceOnFolder,
+      handleDeviceDropOnFolder,
+      setDropTargetFolderId,
+    ],
+  )
 
   const [openFolders, setOpenFolders] = useState({})
 
@@ -226,13 +420,23 @@ const Menu = ({ dense = false }) => {
           const isOpen = openFolders[node.id] ?? false
           const padding = theme.spacing(4 + depth * 2)
           const childPadding = theme.spacing(2)
+          const isActiveDropTarget =
+            dropTargetFolderId === node.id &&
+            !!draggedDeviceId &&
+            canDropDeviceOnFolder(draggedDeviceId, node.id)
           return (
             <React.Fragment key={`retailfolder-${node.id}`}>
               <MenuItem
                 dense={dense}
-                className={classes.folderItem}
+                className={clsx(classes.folderItem, classes.folderDropTarget, {
+                  [classes.folderDropTargetActive]: isActiveDropTarget,
+                })}
                 style={{ paddingLeft: padding }}
                 onClick={() => toggleFolder(node.id)}
+                onDragOver={(event) => handleFolderDragOver(event, node.id)}
+                onDragEnter={(event) => handleFolderDragEnter(event, node.id)}
+                onDragLeave={(event) => handleFolderDragLeave(event, node.id)}
+                onDrop={(event) => handleFolderDrop(event, node.id)}
               >
                 <ListItemIcon>
                   {isOpen ? (
@@ -262,7 +466,16 @@ const Menu = ({ dense = false }) => {
     [
       classes.folderChildren,
       classes.folderItem,
+      classes.folderDropTarget,
+      classes.folderDropTargetActive,
       dense,
+      dropTargetFolderId,
+      draggedDeviceId,
+      canDropDeviceOnFolder,
+      handleFolderDragEnter,
+      handleFolderDragLeave,
+      handleFolderDragOver,
+      handleFolderDrop,
       openFolders,
       renderDeviceLink,
       theme,

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -550,6 +550,14 @@ const RetailPlayerDeviceManagement = () => {
       updateDevice,
       deleteNodes,
     },
+    dragState: {
+      draggedDevice,
+      setDraggedDevice,
+      dropTargetFolderId,
+      setDropTargetFolderId,
+      lastDeviceDrop,
+      setLastDeviceDrop,
+    },
   } = useRetailPlayerDeviceStore()
   const [folderDialog, setFolderDialog] = useState({
     open: false,
@@ -562,8 +570,6 @@ const RetailPlayerDeviceManagement = () => {
   const [searchTerm, setSearchTerm] = useState('')
   const [addToFolderDialogOpen, setAddToFolderDialogOpen] = useState(false)
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-  const [draggedDevice, setDraggedDevice] = useState(null)
-  const [dropTargetFolderId, setDropTargetFolderId] = useState(null)
 
   const folderOptions = useMemo(
     () => folders.map((folder) => ({ id: folder.id, name: folder.name })),
@@ -670,6 +676,20 @@ const RetailPlayerDeviceManagement = () => {
       return changed ? next : prev
     })
   }, [folders, devices])
+
+  useEffect(() => {
+    if (!lastDeviceDrop?.deviceId) {
+      return
+    }
+    setSelectedIds((previous) => {
+      if (!previous || !previous.has(lastDeviceDrop.deviceId)) {
+        return previous
+      }
+      const next = new Set(previous)
+      next.delete(lastDeviceDrop.deviceId)
+      return next
+    })
+  }, [lastDeviceDrop])
 
   const handleAddToFolderDialogClose = useCallback(() => {
     setAddToFolderDialogOpen(false)
@@ -1099,7 +1119,7 @@ const RetailPlayerDeviceManagement = () => {
       event.preventDefault()
       setDropTargetFolderId(folderId)
     },
-    [draggedDeviceId, canDropDeviceOnFolder],
+    [draggedDeviceId, canDropDeviceOnFolder, setDropTargetFolderId],
   )
 
   const handleFolderDragLeave = useCallback((event, folderId) => {
@@ -1131,8 +1151,9 @@ const RetailPlayerDeviceManagement = () => {
         return
       }
       updateDevice({ id: deviceId, folderIds: [folderId] })
+      setLastDeviceDrop({ deviceId, folderId, timestamp: Date.now() })
     },
-    [deviceMap, updateDevice],
+    [deviceMap, updateDevice, setLastDeviceDrop],
   )
 
   const handleFolderDrop = useCallback(

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -213,6 +213,16 @@ row: {
   folderRow: {
     backgroundColor: fade(theme.palette.primary.main, 0.04),
   },
+  folderDropTarget: {
+    position: 'relative',
+    transition: theme.transitions.create(['background-color', 'box-shadow'], {
+      duration: theme.transitions.duration.shorter,
+    }),
+  },
+  folderDropTargetActive: {
+    backgroundColor: fade(theme.palette.primary.main, 0.16),
+    boxShadow: `inset 0 0 0 2px ${fade(theme.palette.primary.main, 0.35)}`,
+  },
   interactiveRow: {
     cursor: 'pointer',
     '&:hover': {
@@ -225,6 +235,9 @@ row: {
   },
   selectedRow: {
     backgroundColor: fade(theme.palette.primary.main, 0.12),
+  },
+  draggingRow: {
+    opacity: 0.6,
   },
   selectCell: {
     display: 'flex',
@@ -530,7 +543,13 @@ const RetailPlayerDeviceManagement = () => {
   const history = useHistory()
   const {
     state: { tree, folders, devices, loading, error },
-    actions: { createFolder, updateFolder, createDevice, updateDevice, deleteNodes },
+    actions: {
+      createFolder,
+      updateFolder,
+      createDevice,
+      updateDevice,
+      deleteNodes,
+    },
   } = useRetailPlayerDeviceStore()
   const [folderDialog, setFolderDialog] = useState({
     open: false,
@@ -543,6 +562,8 @@ const RetailPlayerDeviceManagement = () => {
   const [searchTerm, setSearchTerm] = useState('')
   const [addToFolderDialogOpen, setAddToFolderDialogOpen] = useState(false)
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [draggedDevice, setDraggedDevice] = useState(null)
+  const [dropTargetFolderId, setDropTargetFolderId] = useState(null)
 
   const folderOptions = useMemo(
     () => folders.map((folder) => ({ id: folder.id, name: folder.name })),
@@ -564,6 +585,8 @@ const RetailPlayerDeviceManagement = () => {
     })
     return map
   }, [devices])
+
+  const draggedDeviceId = draggedDevice?.id || null
 
   const folderChildrenMap = useMemo(() => {
     const map = new Map()
@@ -990,6 +1013,157 @@ const RetailPlayerDeviceManagement = () => {
     }, 0)
   }, [])
 
+  const handleDeviceDragStart = useCallback(
+    (event, node) => {
+      if (!node || node.type !== 'device') {
+        return
+      }
+      if (event?.dataTransfer) {
+        event.dataTransfer.effectAllowed = 'move'
+        try {
+          event.dataTransfer.setData(
+            'application/json',
+            JSON.stringify({ deviceId: node.id }),
+          )
+        } catch {
+          // Ignore browsers that do not support custom data types
+        }
+        event.dataTransfer.setData('text/plain', node.id)
+      }
+      setDraggedDevice({
+        id: node.id,
+        sourceFolderId: node.parentFolderId || null,
+      })
+      setDropTargetFolderId(null)
+    },
+    [setDraggedDevice, setDropTargetFolderId],
+  )
+
+  const handleDeviceDragEnd = useCallback(() => {
+    setDraggedDevice(null)
+    setDropTargetFolderId(null)
+  }, [setDraggedDevice, setDropTargetFolderId])
+
+  const canDropDeviceOnFolder = useCallback(
+    (deviceId, folderId) => {
+      if (!deviceId || !folderId) {
+        return false
+      }
+      if (!folderMap.has(folderId)) {
+        return false
+      }
+      const device = deviceMap.get(deviceId)
+      if (!device) {
+        return false
+      }
+      if (draggedDevice?.sourceFolderId === folderId) {
+        return false
+      }
+      const currentFolders = Array.isArray(device.folderIds)
+        ? device.folderIds.filter(Boolean)
+        : device.folderId
+        ? [device.folderId].filter(Boolean)
+        : []
+      if (currentFolders.length === 1 && currentFolders[0] === folderId) {
+        return false
+      }
+      return true
+    },
+    [deviceMap, folderMap, draggedDevice],
+  )
+
+  const handleFolderDragOver = useCallback(
+    (event, folderId) => {
+      if (!draggedDeviceId) {
+        return
+      }
+      if (!canDropDeviceOnFolder(draggedDeviceId, folderId)) {
+        return
+      }
+      event.preventDefault()
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = 'move'
+      }
+    },
+    [draggedDeviceId, canDropDeviceOnFolder],
+  )
+
+  const handleFolderDragEnter = useCallback(
+    (event, folderId) => {
+      if (!draggedDeviceId) {
+        return
+      }
+      if (!canDropDeviceOnFolder(draggedDeviceId, folderId)) {
+        return
+      }
+      event.preventDefault()
+      setDropTargetFolderId(folderId)
+    },
+    [draggedDeviceId, canDropDeviceOnFolder],
+  )
+
+  const handleFolderDragLeave = useCallback((event, folderId) => {
+    if (!draggedDeviceId) {
+      return
+    }
+    const nextTarget = event.relatedTarget
+    if (event.currentTarget.contains(nextTarget)) {
+      return
+    }
+    setDropTargetFolderId((previous) => (previous === folderId ? null : previous))
+  }, [draggedDeviceId, setDropTargetFolderId])
+
+  const handleDeviceDropOnFolder = useCallback(
+    (deviceId, folderId) => {
+      if (!deviceId || !folderId) {
+        return
+      }
+      const device = deviceMap.get(deviceId)
+      if (!device) {
+        return
+      }
+      const existingFolderIds = Array.isArray(device.folderIds)
+        ? device.folderIds.filter(Boolean)
+        : device.folderId
+        ? [device.folderId].filter(Boolean)
+        : []
+      if (existingFolderIds.length === 1 && existingFolderIds[0] === folderId) {
+        return
+      }
+      updateDevice({ id: deviceId, folderIds: [folderId] })
+    },
+    [deviceMap, updateDevice],
+  )
+
+  const handleFolderDrop = useCallback(
+    (event, folderId) => {
+      if (!draggedDeviceId) {
+        return
+      }
+      if (!canDropDeviceOnFolder(draggedDeviceId, folderId)) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      handleDeviceDropOnFolder(draggedDeviceId, folderId)
+      setSelectedIds((previous) => {
+        if (!previous || !previous.has(draggedDeviceId)) {
+          return previous
+        }
+        const next = new Set(previous)
+        next.delete(draggedDeviceId)
+        return next
+      })
+      handleDeviceDragEnd()
+    },
+    [
+      draggedDeviceId,
+      canDropDeviceOnFolder,
+      handleDeviceDropOnFolder,
+      handleDeviceDragEnd,
+    ],
+  )
+
   const renderRows = (nodes) =>
     nodes.map((node) => {
       if (node.type === 'folder') {
@@ -1001,14 +1175,22 @@ const RetailPlayerDeviceManagement = () => {
             className={clsx(
               classes.row,
               classes.folderRow,
+              classes.folderDropTarget,
               classes.interactiveRow,
               isSelected && classes.selectedRow,
+              dropTargetFolderId === node.id &&
+                draggedDeviceId &&
+                classes.folderDropTargetActive,
             )}
             role="button"
             tabIndex={0}
             onClick={() => handleEnterFolder(node.id)}
             onKeyDown={(event) => handleRowKeyDown(event, () => handleEnterFolder(node.id))}
             aria-label={`Open folder ${node.name}`}
+            onDragOver={(event) => handleFolderDragOver(event, node.id)}
+            onDragEnter={(event) => handleFolderDragEnter(event, node.id)}
+            onDragLeave={(event) => handleFolderDragLeave(event, node.id)}
+            onDrop={(event) => handleFolderDrop(event, node.id)}
           >
             <div className={classes.selectCell}>
               <Checkbox
@@ -1059,12 +1241,16 @@ const RetailPlayerDeviceManagement = () => {
             classes.row,
             classes.interactiveRow,
             isSelected && classes.selectedRow,
+            draggedDeviceId === node.id && classes.draggingRow,
           )}
           role="button"
           tabIndex={0}
           onClick={() => handleNavigateToDevice(node)}
           onKeyDown={(event) => handleRowKeyDown(event, () => handleNavigateToDevice(node))}
           aria-label={`Open device ${node.name}`}
+          draggable
+          onDragStart={(event) => handleDeviceDragStart(event, node)}
+          onDragEnd={handleDeviceDragEnd}
         >
           <div className={classes.selectCell}>
             <Checkbox

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   useMemo,
   useReducer,
+  useState,
 } from 'react'
 import PropTypes from 'prop-types'
 import { v4 as uuidv4 } from 'uuid'
@@ -444,6 +445,10 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
     [state.folders, state.devices],
   )
 
+  const [draggedDevice, setDraggedDevice] = useState(null)
+  const [dropTargetFolderId, setDropTargetFolderId] = useState(null)
+  const [lastDeviceDrop, setLastDeviceDrop] = useState(null)
+
   const createFolder = useCallback((payload) => {
     const basePayload = payload && typeof payload === 'object' ? payload : {}
     const folderPayload = {
@@ -485,6 +490,14 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
         assignDeviceToFolder,
         deleteNodes,
       },
+      dragState: {
+        draggedDevice,
+        setDraggedDevice,
+        dropTargetFolderId,
+        setDropTargetFolderId,
+        lastDeviceDrop,
+        setLastDeviceDrop,
+      },
     }),
     [
       state,
@@ -495,6 +508,9 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
       updateDevice,
       assignDeviceToFolder,
       deleteNodes,
+      draggedDevice,
+      dropTargetFolderId,
+      lastDeviceDrop,
     ],
   )
 

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -366,6 +366,7 @@ const buildTree = (folders, devices) => {
         ...device,
         type: 'device',
         treeKey: `${device.id}-root`,
+        parentFolderId: null,
       })
       return
     }
@@ -375,6 +376,7 @@ const buildTree = (folders, devices) => {
         ...device,
         type: 'device',
         treeKey: `${device.id}-${folderId}`,
+        parentFolderId: folderId,
       }
       if (folderMap.has(folderId)) {
         folderMap.get(folderId).children.push(node)


### PR DESCRIPTION
## Summary
- allow devices to be dragged onto folders in the Retail Player management page
- highlight valid drop targets and update device folder assignments immediately
- include parent folder metadata on tree nodes to keep the UI tree in sync after moves

## Testing
- not run (UI change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f4328ef8c8322bd125fd9b0b7f6d0)