### PR TITLE
Fix playlist track number display

### DIFF
--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -289,7 +289,7 @@ const PlaylistSongs = ({
                 return ''
               }
               if (typeof value === 'string') {
-                return value.replace(/^_/, '')
+                return value.replace(/^_+/, '')
               }
               return value
             }}

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -277,7 +277,24 @@ const PlaylistSongs = ({
 
   const toggleableFields = useMemo(() => {
     return {
-      trackNumber: isDesktop && <TextField source="id" label={'#'} />,
+      trackNumber:
+        isDesktop && (
+          <FunctionField
+            source="id"
+            label={'#'}
+            sortBy={'id'}
+            render={(record) => {
+              const value = record?.id
+              if (value == null) {
+                return ''
+              }
+              if (typeof value === 'string') {
+                return value.replace(/^_/, '')
+              }
+              return value
+            }}
+          />
+        ),
       title: <SongTitleField source="title" showTrackNumbers={false} />,
       album: isDesktop && <AlbumLinkField source="album" />,
       artist: isDesktop && <ArtistLinkField source="artist" />,


### PR DESCRIPTION
## Summary
- hide the leading underscore when rendering playlist track numbers while keeping their ids unchanged

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f4f0b83908322b3f0613413495eb6)