### PR TITLE
Add unified drag-and-drop for retail player devices

### DIFF
--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import {
   Collapse,
@@ -20,6 +20,7 @@ import FolderIcon from '@material-ui/icons/Folder'
 import { useHistory } from 'react-router-dom'
 import { BiCog } from 'react-icons/bi'
 import { useDrag, useDrop } from 'react-dnd'
+import { getEmptyImage } from 'react-dnd-html5-backend'
 import { fade } from '@material-ui/core/styles/colorManipulator'
 import SubMenu from './SubMenu'
 import { humanize, pluralize } from 'inflection'
@@ -128,7 +129,7 @@ const RetailPlayerDeviceMenuItem = ({
   const encodedSlug = encodeURIComponent(slug)
   const padding = theme.spacing(4 + depth * 2)
 
-  const [{ isDragging }, dragRef] = useDrag(
+  const [{ isDragging }, dragRef, previewRef] = useDrag(
     () => ({
       type: RetailPlayerDndItemTypes.DEVICE,
       canDrag: () => Boolean(node?.id),
@@ -139,6 +140,10 @@ const RetailPlayerDeviceMenuItem = ({
     }),
     [node?.id],
   )
+
+  useEffect(() => {
+    previewRef(getEmptyImage(), { captureDraggingState: true })
+  }, [previewRef])
 
   return (
     <div

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -19,6 +19,8 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import FolderIcon from '@material-ui/icons/Folder'
 import { useHistory } from 'react-router-dom'
 import { BiCog } from 'react-icons/bi'
+import { useDrag, useDrop } from 'react-dnd'
+import { fade } from '@material-ui/core/styles/colorManipulator'
 import SubMenu from './SubMenu'
 import { humanize, pluralize } from 'inflection'
 import albumLists from '../album/albumLists'
@@ -27,6 +29,7 @@ import DiscoverySubMenu from './DiscoverySubMenu'
 import LibrarySelector from '../common/LibrarySelector'
 import config from '../config'
 import { useRetailPlayerDeviceStore } from '../retailPlayer/RetailPlayerDeviceStoreContext'
+import { RetailPlayerDndItemTypes } from '../retailPlayer/dndTypes'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -78,6 +81,16 @@ const useStyles = makeStyles((theme) => ({
       width: '100%',
     },
   },
+  dropTarget: {
+    transition: 'background-color 120ms ease, box-shadow 120ms ease',
+  },
+  dropAllowed: {
+    backgroundColor: fade(theme.palette.primary.main, 0.08),
+  },
+  dropActive: {
+    backgroundColor: fade(theme.palette.primary.main, 0.16),
+    boxShadow: `inset 0 0 0 2px ${fade(theme.palette.primary.main, 0.32)}`,
+  },
   deviceItem: {
     paddingTop: theme.spacing(0.5),
     paddingBottom: theme.spacing(0.5),
@@ -90,11 +103,134 @@ const useStyles = makeStyles((theme) => ({
       color: theme.palette.primary.main,
     },
   },
+  deviceDragWrapper: {
+    width: '100%',
+  },
   deviceIcon: {
     color: theme.palette.common.white,
     fontSize: theme.typography.pxToRem(16),
   },
+  dragging: {
+    opacity: 0.55,
+  },
 }))
+
+const RetailPlayerDeviceMenuItem = ({
+  node,
+  depth,
+  classes,
+  dense,
+  sidebarIsOpen,
+  activeClassName,
+  theme,
+}) => {
+  const slug = node.slug || node.name || node.id
+  const encodedSlug = encodeURIComponent(slug)
+  const padding = theme.spacing(4 + depth * 2)
+
+  const [{ isDragging }, dragRef] = useDrag(
+    () => ({
+      type: RetailPlayerDndItemTypes.DEVICE,
+      canDrag: () => Boolean(node?.id),
+      item: { deviceId: node?.id },
+      collect: (monitor) => ({
+        isDragging: monitor.isDragging(),
+      }),
+    }),
+    [node?.id],
+  )
+
+  return (
+    <div
+      ref={dragRef}
+      className={clsx(
+        classes.deviceDragWrapper,
+        isDragging && classes.dragging,
+      )}
+    >
+      <MenuItemLink
+        to={`/retailplayer/${encodedSlug}`}
+        activeClassName={activeClassName}
+        primaryText={node.name}
+        leftIcon={<SpeakerGroupIcon fontSize="small" className={classes.deviceIcon} />}
+        sidebarIsOpen={sidebarIsOpen}
+        dense={dense}
+        exact
+        className={classes.deviceItem}
+        style={{ paddingLeft: padding }}
+      />
+    </div>
+  )
+}
+
+const RetailPlayerFolderMenuItem = ({
+  node,
+  depth,
+  classes,
+  dense,
+  isOpen,
+  onToggle,
+  renderChildren,
+  onDropDevice,
+  theme,
+}) => {
+  const padding = theme.spacing(4 + depth * 2)
+  const childPadding = theme.spacing(2)
+
+  const [{ isOver, canDrop }, dropRef] = useDrop(
+    () => ({
+      accept: RetailPlayerDndItemTypes.DEVICE,
+      canDrop: (item) => Boolean(item?.deviceId) && Boolean(node?.id),
+      drop: (item, monitor) => {
+        if (!monitor.didDrop() && item?.deviceId && node?.id) {
+          onDropDevice(item.deviceId, node.id)
+        }
+      },
+      collect: (monitor) => ({
+        isOver: monitor.isOver({ shallow: true }),
+        canDrop: monitor.canDrop(),
+      }),
+    }),
+    [node?.id, onDropDevice],
+  )
+
+  return (
+    <React.Fragment>
+      <MenuItem
+        ref={dropRef}
+        dense={dense}
+        className={clsx(
+          classes.folderItem,
+          classes.dropTarget,
+          canDrop && classes.dropAllowed,
+          isOver && classes.dropActive,
+        )}
+        style={{ paddingLeft: padding }}
+        onClick={() => onToggle(node.id)}
+      >
+        <ListItemIcon>
+          {isOpen ? (
+            <ExpandMoreIcon fontSize="small" />
+          ) : (
+            <ChevronRightIcon fontSize="small" />
+          )}
+        </ListItemIcon>
+        <ListItemIcon>
+          <FolderIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText primary={node.name} />
+      </MenuItem>
+      <Collapse in={isOpen} timeout="auto" unmountOnExit>
+        <div
+          className={classes.folderChildren}
+          style={{ paddingLeft: childPadding }}
+        >
+          {renderChildren(node.children || [], depth + 1)}
+        </div>
+      </Collapse>
+    </React.Fragment>
+  )
+}
 
 const translatedResourceName = (resource, translate) =>
   translate(`resources.${resource.name}.name`, {
@@ -179,6 +315,7 @@ const Menu = ({ dense = false }) => {
       loading: retailDevicesLoading,
       error: retailDevicesError,
     },
+    actions: { assignDeviceToFolder },
   } = useRetailPlayerDeviceStore()
 
   const [openFolders, setOpenFolders] = useState({})
@@ -194,29 +331,14 @@ const Menu = ({ dense = false }) => {
     history.push('/retail-player/devices')
   }, [history])
 
-  const renderDeviceLink = useCallback(
-    (node, depth) => {
-      const slug = node.slug || node.name || node.id
-      const encodedSlug = encodeURIComponent(slug)
-      const padding = theme.spacing(4 + depth * 2)
-      return (
-        <MenuItemLink
-          key={`retailplayer-${node.apiId || node.id}`}
-          to={`/retailplayer/${encodedSlug}`}
-          activeClassName={classes.active}
-          primaryText={node.name}
-          leftIcon={
-            <SpeakerGroupIcon fontSize="small" className={classes.deviceIcon} />
-          }
-          sidebarIsOpen={open}
-          dense={dense}
-          exact
-          className={classes.deviceItem}
-          style={{ paddingLeft: padding }}
-        />
-      )
+  const handleDeviceDropOnFolder = useCallback(
+    (deviceId, folderId) => {
+      if (!deviceId || !folderId) {
+        return
+      }
+      assignDeviceToFolder({ id: deviceId, folderIds: [folderId] })
     },
-    [classes.active, classes.deviceIcon, classes.deviceItem, dense, open, theme],
+    [assignDeviceToFolder],
   )
 
   const renderRetailPlayerNodes = useCallback(
@@ -224,47 +346,40 @@ const Menu = ({ dense = false }) => {
       nodes.map((node) => {
         if (node.type === 'folder') {
           const isOpen = openFolders[node.id] ?? false
-          const padding = theme.spacing(4 + depth * 2)
-          const childPadding = theme.spacing(2)
           return (
-            <React.Fragment key={`retailfolder-${node.id}`}>
-              <MenuItem
-                dense={dense}
-                className={classes.folderItem}
-                style={{ paddingLeft: padding }}
-                onClick={() => toggleFolder(node.id)}
-              >
-                <ListItemIcon>
-                  {isOpen ? (
-                    <ExpandMoreIcon fontSize="small" />
-                  ) : (
-                    <ChevronRightIcon fontSize="small" />
-                  )}
-                </ListItemIcon>
-                <ListItemIcon>
-                  <FolderIcon fontSize="small" />
-                </ListItemIcon>
-                <ListItemText primary={node.name} />
-              </MenuItem>
-              <Collapse in={isOpen} timeout="auto" unmountOnExit>
-                <div
-                  className={classes.folderChildren}
-                  style={{ paddingLeft: childPadding }}
-                >
-                  {renderRetailPlayerNodes(node.children || [], depth + 1)}
-                </div>
-              </Collapse>
-            </React.Fragment>
+            <RetailPlayerFolderMenuItem
+              key={`retailfolder-${node.id}`}
+              node={node}
+              depth={depth}
+              classes={classes}
+              dense={dense}
+              isOpen={isOpen}
+              onToggle={toggleFolder}
+              renderChildren={renderRetailPlayerNodes}
+              onDropDevice={handleDeviceDropOnFolder}
+              theme={theme}
+            />
           )
         }
-        return renderDeviceLink(node, depth)
+        return (
+          <RetailPlayerDeviceMenuItem
+            key={`retailplayer-${node.apiId || node.id}`}
+            node={node}
+            depth={depth}
+            classes={classes}
+            dense={dense}
+            sidebarIsOpen={open}
+            activeClassName={classes.active}
+            theme={theme}
+          />
+        )
       }),
     [
-      classes.folderChildren,
-      classes.folderItem,
+      classes,
       dense,
+      handleDeviceDropOnFolder,
+      open,
       openFolders,
-      renderDeviceLink,
       theme,
       toggleFolder,
     ],

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -35,8 +35,10 @@ import Link from '@material-ui/core/Link'
 import clsx from 'clsx'
 import PropTypes from 'prop-types'
 import { useHistory } from 'react-router-dom'
+import { useDrag, useDrop } from 'react-dnd'
 import { useRetailPlayerDeviceStore } from './RetailPlayerDeviceStoreContext'
 import AddToFolderDialog from './AddToFolderDialog'
+import { RetailPlayerDndItemTypes } from './dndTypes'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -223,6 +225,19 @@ row: {
       outlineOffset: -2,
     },
   },
+  dropTarget: {
+    transition: 'background-color 120ms ease, box-shadow 120ms ease',
+  },
+  dropAllowed: {
+    backgroundColor: fade(theme.palette.primary.main, 0.08),
+  },
+  dropActive: {
+    backgroundColor: fade(theme.palette.primary.main, 0.16),
+    boxShadow: `inset 0 0 0 2px ${fade(theme.palette.primary.main, 0.32)}`,
+  },
+  dragging: {
+    opacity: 0.55,
+  },
   selectedRow: {
     backgroundColor: fade(theme.palette.primary.main, 0.12),
   },
@@ -318,6 +333,213 @@ row: {
     },
   },
 }))
+
+const FolderRow = ({
+  node,
+  deviceCount,
+  classes,
+  isSelected,
+  onEnterFolder,
+  onEditFolder,
+  onToggleSelection,
+  onDropDevice,
+}) => {
+  const [{ isOver, canDrop }, dropRef] = useDrop(
+    () => ({
+      accept: RetailPlayerDndItemTypes.DEVICE,
+      canDrop: (item) => Boolean(item?.deviceId) && Boolean(node?.id),
+      drop: (item, monitor) => {
+        if (!monitor.didDrop() && item?.deviceId && node?.id) {
+          onDropDevice(item.deviceId, node.id)
+        }
+      },
+      collect: (monitor) => ({
+        isOver: monitor.isOver({ shallow: true }),
+        canDrop: monitor.canDrop(),
+      }),
+    }),
+    [node?.id, onDropDevice],
+  )
+
+  const handleCheckboxClick = (event) => {
+    event.stopPropagation()
+    onToggleSelection(node?.id)
+  }
+
+  const rowClassName = clsx(
+    classes.row,
+    classes.folderRow,
+    classes.interactiveRow,
+    classes.dropTarget,
+    isSelected && classes.selectedRow,
+    canDrop && classes.dropAllowed,
+    isOver && classes.dropActive,
+  )
+
+  return (
+    <div
+      ref={dropRef}
+      className={rowClassName}
+      role="button"
+      tabIndex={0}
+      onClick={() => onEnterFolder(node?.id)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          onEnterFolder(node?.id)
+        }
+      }}
+      aria-label={`Open folder ${node?.name}`}
+    >
+      <div className={classes.selectCell}>
+        <Checkbox
+          color="primary"
+          checked={isSelected}
+          onChange={handleCheckboxClick}
+          onClick={handleCheckboxClick}
+          inputProps={{ 'aria-label': `Select folder ${node?.name}` }}
+          style={{ transform: 'scale(0.8)' }}
+        />
+      </div>
+      <div className={classes.nameCell}>
+        <FolderIcon className={classes.nameIcon} />
+        <div className={classes.nameLabel}>
+          <Typography variant="body1" className={classes.nameTitle}>
+            {node?.name}
+          </Typography>
+        </div>
+      </div>
+      <div className={classes.typeCell}>Folder</div>
+      <div className={classes.countCell}>{deviceCount}</div>
+      <div className={classes.actionsCell}>
+        <Tooltip title="Edit folder">
+          <IconButton
+            size="small"
+            onClick={(event) => {
+              event.stopPropagation()
+              onEditFolder(node?.id)
+            }}
+            aria-label={`Edit folder ${node?.name}`}
+          >
+            <EditIcon style={{ fontSize: 15 }} />
+          </IconButton>
+        </Tooltip>
+      </div>
+    </div>
+  )
+}
+
+FolderRow.propTypes = {
+  node: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+  }).isRequired,
+  deviceCount: PropTypes.number.isRequired,
+  classes: PropTypes.object.isRequired,
+  isSelected: PropTypes.bool.isRequired,
+  onEnterFolder: PropTypes.func.isRequired,
+  onEditFolder: PropTypes.func.isRequired,
+  onToggleSelection: PropTypes.func.isRequired,
+  onDropDevice: PropTypes.func.isRequired,
+}
+
+const DeviceRow = ({
+  node,
+  classes,
+  isSelected,
+  onNavigate,
+  onEditDevice,
+  onToggleSelection,
+}) => {
+  const [{ isDragging }, dragRef] = useDrag(
+    () => ({
+      type: RetailPlayerDndItemTypes.DEVICE,
+      canDrag: () => Boolean(node?.id),
+      item: { deviceId: node?.id },
+      collect: (monitor) => ({
+        isDragging: monitor.isDragging(),
+      }),
+    }),
+    [node?.id],
+  )
+
+  const handleCheckboxClick = (event) => {
+    event.stopPropagation()
+    onToggleSelection(node?.id)
+  }
+
+  const className = clsx(
+    classes.row,
+    classes.interactiveRow,
+    isSelected && classes.selectedRow,
+    isDragging && classes.dragging,
+  )
+
+  return (
+    <div
+      ref={dragRef}
+      className={className}
+      role="button"
+      tabIndex={0}
+      onClick={() => onNavigate(node)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          onNavigate(node)
+        }
+      }}
+      aria-label={`Open device ${node?.name}`}
+    >
+      <div className={classes.selectCell}>
+        <Checkbox
+          color="primary"
+          checked={isSelected}
+          onChange={handleCheckboxClick}
+          onClick={handleCheckboxClick}
+          inputProps={{ 'aria-label': `Select device ${node?.name}` }}
+          style={{ transform: 'scale(0.8)' }}
+        />
+      </div>
+      <div className={classes.nameCell}>
+        <SpeakerGroupIcon className={classes.nameIcon} />
+        <div className={classes.nameLabel}>
+          <Typography variant="body1" className={classes.nameTitle}>
+            {node?.name}
+          </Typography>
+        </div>
+      </div>
+      <div className={classes.typeCell}>Device</div>
+      <div className={classes.countCell}>—</div>
+      <div className={classes.actionsCell}>
+        <Tooltip title="Edit device">
+          <IconButton
+            size="small"
+            onClick={(event) => {
+              event.stopPropagation()
+              onEditDevice(node?.id)
+            }}
+            aria-label={`Edit device ${node?.name}`}
+          >
+            <EditIcon style={{ fontSize: 15 }} />
+          </IconButton>
+        </Tooltip>
+      </div>
+    </div>
+  )
+}
+
+DeviceRow.propTypes = {
+  node: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+    treeKey: PropTypes.string,
+  }).isRequired,
+  classes: PropTypes.object.isRequired,
+  isSelected: PropTypes.bool.isRequired,
+  onNavigate: PropTypes.func.isRequired,
+  onEditDevice: PropTypes.func.isRequired,
+  onToggleSelection: PropTypes.func.isRequired,
+}
 
 const FolderDialog = ({ open, onClose, onSubmit, initialValues }) => {
   const classes = useStyles()
@@ -530,7 +752,14 @@ const RetailPlayerDeviceManagement = () => {
   const history = useHistory()
   const {
     state: { tree, folders, devices, loading, error },
-    actions: { createFolder, updateFolder, createDevice, updateDevice, deleteNodes },
+    actions: {
+      createFolder,
+      updateFolder,
+      createDevice,
+      updateDevice,
+      deleteNodes,
+      assignDeviceToFolder,
+    },
   } = useRetailPlayerDeviceStore()
   const [folderDialog, setFolderDialog] = useState({
     open: false,
@@ -971,13 +1200,6 @@ const RetailPlayerDeviceManagement = () => {
     })
   }, [])
 
-  const handleRowKeyDown = (event, action) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault()
-      action()
-    }
-  }
-
   const countDevices = useCallback((node) => {
     if (!node || !Array.isArray(node.children)) {
       return 0
@@ -990,121 +1212,44 @@ const RetailPlayerDeviceManagement = () => {
     }, 0)
   }, [])
 
+  const handleDeviceDropOnFolder = useCallback(
+    (deviceId, folderId) => {
+      if (!deviceId || !folderId) {
+        return
+      }
+      assignDeviceToFolder({ id: deviceId, folderIds: [folderId] })
+    },
+    [assignDeviceToFolder],
+  )
+
   const renderRows = (nodes) =>
     nodes.map((node) => {
       if (node.type === 'folder') {
-        const deviceCount = countDevices(node)
-        const isSelected = selectedIds.has(node.id)
         return (
-          <div
+          <FolderRow
             key={`folder-row-${node.id}`}
-            className={clsx(
-              classes.row,
-              classes.folderRow,
-              classes.interactiveRow,
-              isSelected && classes.selectedRow,
-            )}
-            role="button"
-            tabIndex={0}
-            onClick={() => handleEnterFolder(node.id)}
-            onKeyDown={(event) => handleRowKeyDown(event, () => handleEnterFolder(node.id))}
-            aria-label={`Open folder ${node.name}`}
-          >
-            <div className={classes.selectCell}>
-              <Checkbox
-                color="primary"
-                checked={isSelected}
-                onChange={(event) => {
-                  event.stopPropagation()
-                  toggleNodeSelection(node.id)
-                }}
-                onClick={(event) => event.stopPropagation()}
-                inputProps={{ 'aria-label': `Select folder ${node.name}` }}
-                style={{ transform: 'scale(0.8)' }} 
-              />
-            </div>
-            <div className={classes.nameCell}>
-              <FolderIcon className={classes.nameIcon} />
-              <div className={classes.nameLabel}>
-                <Typography variant="body1" className={classes.nameTitle}>
-                  {node.name}
-                </Typography>
-              </div>
-            </div>
-            <div className={classes.typeCell}>Folder</div>
-            <div className={classes.countCell}>{deviceCount}</div>
-            <div className={classes.actionsCell}>
-              <Tooltip title="Edit folder">
-                <IconButton
-                  size="small"
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    handleEditFolder(node.id)
-                  }}
-                  aria-label={`Edit folder ${node.name}`}
-                >
-                  <EditIcon style={{ fontSize: 15 }} />
-                </IconButton>
-              </Tooltip>
-            </div>
-          </div>
+            node={node}
+            deviceCount={countDevices(node)}
+            classes={classes}
+            isSelected={selectedIds.has(node.id)}
+            onEnterFolder={handleEnterFolder}
+            onEditFolder={handleEditFolder}
+            onToggleSelection={toggleNodeSelection}
+            onDropDevice={handleDeviceDropOnFolder}
+          />
         )
       }
-      const isSelected = selectedIds.has(node.id)
-      const rowKey = node.treeKey || node.id
-      return (
-        <div
-          key={`device-row-${rowKey}`}
-          className={clsx(
-            classes.row,
-            classes.interactiveRow,
-            isSelected && classes.selectedRow,
-          )}
-          role="button"
-          tabIndex={0}
-          onClick={() => handleNavigateToDevice(node)}
-          onKeyDown={(event) => handleRowKeyDown(event, () => handleNavigateToDevice(node))}
-          aria-label={`Open device ${node.name}`}
-        >
-          <div className={classes.selectCell}>
-            <Checkbox
-              color="primary"
-              checked={isSelected}
-              onChange={(event) => {
-                event.stopPropagation()
-                toggleNodeSelection(node.id)
-              }}
-              onClick={(event) => event.stopPropagation()}
-              inputProps={{ 'aria-label': `Select device ${node.name}` }}
-              style={{ transform: 'scale(0.8)' }}
-            />
-          </div>
-          <div className={classes.nameCell}>
-            <SpeakerGroupIcon className={classes.nameIcon} />
-            <div className={classes.nameLabel}>
-              <Typography variant="body1" className={classes.nameTitle}>
-                {node.name}
-              </Typography>
-            </div>
-          </div>
-          <div className={classes.typeCell}>Device</div>
-          <div className={classes.countCell}>—</div>
-          <div className={classes.actionsCell}>
-            <Tooltip title="Edit device">
-              <IconButton
-                size="small"
-                onClick={(event) => {
-                  event.stopPropagation()
-                  handleEditDevice(node.id)
-                }}
-                aria-label={`Edit device ${node.name}`}
-              >
-                <EditIcon style={{ fontSize: 15 }} />
-              </IconButton>
-            </Tooltip>
-          </div>
-        </div>
-      )
+        return (
+          <DeviceRow
+            key={`device-row-${node.treeKey || node.id}`}
+            node={node}
+            classes={classes}
+            isSelected={selectedIds.has(node.id)}
+            onNavigate={handleNavigateToDevice}
+            onEditDevice={handleEditDevice}
+            onToggleSelection={toggleNodeSelection}
+          />
+        )
     })
 
   return (

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -36,6 +36,7 @@ import clsx from 'clsx'
 import PropTypes from 'prop-types'
 import { useHistory } from 'react-router-dom'
 import { useDrag, useDrop } from 'react-dnd'
+import { getEmptyImage } from 'react-dnd-html5-backend'
 import { useRetailPlayerDeviceStore } from './RetailPlayerDeviceStoreContext'
 import AddToFolderDialog from './AddToFolderDialog'
 import { RetailPlayerDndItemTypes } from './dndTypes'
@@ -451,7 +452,7 @@ const DeviceRow = ({
   onEditDevice,
   onToggleSelection,
 }) => {
-  const [{ isDragging }, dragRef] = useDrag(
+  const [{ isDragging }, dragRef, previewRef] = useDrag(
     () => ({
       type: RetailPlayerDndItemTypes.DEVICE,
       canDrag: () => Boolean(node?.id),
@@ -462,6 +463,10 @@ const DeviceRow = ({
     }),
     [node?.id],
   )
+
+  useEffect(() => {
+    previewRef(getEmptyImage(), { captureDraggingState: true })
+  }, [previewRef])
 
   const handleCheckboxClick = (event) => {
     event.stopPropagation()

--- a/ui/src/retailPlayer/dndTypes.js
+++ b/ui/src/retailPlayer/dndTypes.js
@@ -1,0 +1,5 @@
+export const RetailPlayerDndItemTypes = {
+  DEVICE: 'RETAIL_PLAYER_DEVICE',
+}
+
+export default RetailPlayerDndItemTypes


### PR DESCRIPTION
## Summary
- introduce shared drag-and-drop item types for retail player UI
- enable dragging devices onto folders within the sidebar retail player tree
- add drag handles and folder drop targets on the Retail Player Devices page with consistent visual feedback

## Testing
- `npm run lint`
- `npx eslint src/layout/Menu.jsx src/retailPlayer/RetailPlayerDeviceManagement.jsx`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f55ecf1a483229da41566858cf6f9)