### PR TITLE
Fix playlist shift selection regression

### DIFF
--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -59,11 +59,14 @@ export const selectPlaylistTrackIds = ({
 
   const newlyAddedIds = idsToSelect.filter((id) => !selectedIds.includes(id))
 
-  const isSelectingCurrentPage =
-    newlyAddedIds.length > 0 && newlyAddedIds.every((id) => pageIds.includes(id))
+  const isSelectingEntirePage =
+    pageIds.length > 0 && pageIds.every((id) => idsToSelect.includes(id))
 
   const shouldLoadAllIds =
-    isSelectingCurrentPage && typeof contextTotal === 'number' && contextTotal > idsToSelect.length
+    isSelectingEntirePage &&
+    newlyAddedIds.length > 0 &&
+    typeof contextTotal === 'number' &&
+    contextTotal > idsToSelect.length
 
   if (!shouldLoadAllIds) {
     onSelect(idsToSelect)


### PR DESCRIPTION
## Summary
- ensure the playlist bulk selection helper only loads all tracks when the full page is selected
- avoid treating shift-range selections as a select-all operation so playlist behavior matches the songs list

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f8f9755dc8322a03aaacd3cc14828)