### PR TITLE
Fix song selection when drag and drop enabled

### DIFF
--- a/ui/src/common/SongDatagrid.jsx
+++ b/ui/src/common/SongDatagrid.jsx
@@ -281,7 +281,7 @@ export const SongDatagridRow = ({
     const preventTextSelection = (event) => {
       if (
         event?.target?.closest(
-          'button,input,textarea,select,a,[data-no-drag]',
+          'button,input,textarea,select,a,[data-no-drag],[role="button"],[role="checkbox"]',
         )
       ) {
         return
@@ -291,7 +291,7 @@ export const SongDatagridRow = ({
     node.addEventListener('selectstart', preventTextSelection)
 
     const interactiveSelector =
-      'button,input,textarea,select,a,[data-no-drag]'
+      'button,input,textarea,select,a,[data-no-drag],[role="button"],[role="checkbox"]'
     const interactiveElements = Array.from(
       node.querySelectorAll(interactiveSelector),
     )
@@ -312,7 +312,11 @@ export const SongDatagridRow = ({
 
   const handleDragStart = useCallback(
     (event) => {
-      if (event?.target?.closest('button,input,textarea,select,a,[data-no-drag]')) {
+      if (
+        event?.target?.closest(
+          'button,input,textarea,select,a,[data-no-drag],[role="button"],[role="checkbox"]',
+        )
+      ) {
         return
       }
       if (!event?.dataTransfer) {


### PR DESCRIPTION
## Summary
- ensure draggable song rows treat button and checkbox roles as interactive elements so selection controls remain clickable

## Testing
- npm run lint *(fails: existing warning in ui/src/playlist/PlaylistSongs.jsx)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f95e05dd4832287380f7cc33d9ea2)