### PR TITLE
Prevent drag start when selecting retail device

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -496,6 +496,8 @@ const DeviceRow = ({
           checked={isSelected}
           onChange={handleCheckboxClick}
           onClick={handleCheckboxClick}
+          onMouseDown={(event) => event.stopPropagation()}
+          onTouchStart={(event) => event.stopPropagation()}
           inputProps={{ 'aria-label': `Select device ${node?.name}` }}
           style={{ transform: 'scale(0.8)' }}
         />


### PR DESCRIPTION
## Summary
- stop drag events from starting when clicking the retail device selection checkbox
- keep checkbox interaction limited to selection only so navigation and drag continue to work elsewhere

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f9745b4848322a6a82b1336e8335b)