### PR TITLE
Align playlist drag preview with cursor

### DIFF
--- a/ui/src/common/useDragAndDrop.jsx
+++ b/ui/src/common/useDragAndDrop.jsx
@@ -6,6 +6,7 @@ const useDragAndDrop = (type, item, accepts, onDrop) => {
         item,
         collect: (monitor) => ({ isDragging: !!monitor.isDragging() }),
         options: { dropEffect: 'move' },
+        previewOptions: { offsetX: 0, offsetY: 0 },
     }))
 
     const [, dropRef] = useDrop(() => ({


### PR DESCRIPTION
## Summary
- adjust the shared drag-and-drop hook to request a drag preview offset aligned with the cursor

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f96f470788322bcb304372f29d7fa)