### PR TITLE
Add dynamic device status indicator to retail player header

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { alpha, makeStyles } from '@material-ui/core/styles'
 import { ButtonBase, Slider, Typography } from '@material-ui/core'
+import Tooltip from '@material-ui/core/Tooltip'
 import { Title } from 'react-admin'
 import LinkIcon from '@material-ui/icons/Link'
 import SignalWifi4BarIcon from '@material-ui/icons/SignalWifi4Bar'
@@ -142,6 +143,33 @@ const useStyles = makeStyles((theme) => {
     },
     headerCenter: {
       flex: 1,
+    },
+    headerStatusGroup: {
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: theme.spacing(1.25),
+    },
+    headerStatusIndicator: {
+      width: 14,
+      height: 14,
+      borderRadius: '50%',
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      boxShadow: `0 0 0 2px ${alpha(theme.palette.common.white, 0.65)}`,
+      transition: theme.transitions.create(['background-color', 'box-shadow', 'transform'], {
+        duration: theme.transitions.duration.shorter,
+        easing: theme.transitions.easing.easeInOut,
+      }),
+      flexShrink: 0,
+    },
+    headerStatusIndicatorOnline: {
+      backgroundColor: successMain,
+      boxShadow: `0 0 0 2px ${alpha(successMain, 0.35)}`,
+    },
+    headerStatusIndicatorOffline: {
+      backgroundColor: dangerMain,
+      boxShadow: `0 0 0 2px ${alpha(dangerMain, 0.35)}`,
     },
     headerClock: {
       display: 'inline-flex',
@@ -1104,6 +1132,35 @@ const trackPool = useMemo(() => {
 
   const headerTimeLabel = useMemo(() => formatTime(currentTime), [currentTime])
 
+  const statusUpTime = device?.status?.upTime
+  const hasStatusValue = useMemo(() => {
+    if (statusUpTime === undefined || statusUpTime === null) {
+      return false
+    }
+    if (typeof statusUpTime === 'string') {
+      return statusUpTime.trim() !== ''
+    }
+    return true
+  }, [statusUpTime])
+  const isDeviceOnline = hasStatusValue
+  const formattedUpTime = useMemo(() => {
+    if (statusUpTime === undefined || statusUpTime === null) {
+      return ''
+    }
+    if (typeof statusUpTime === 'number' && Number.isFinite(statusUpTime)) {
+      return Math.round(statusUpTime)
+    }
+    const parsed = Number.parseFloat(statusUpTime)
+    if (Number.isFinite(parsed)) {
+      return Math.round(parsed)
+    }
+    return statusUpTime
+  }, [statusUpTime])
+  const statusTooltipTitle = isDeviceOnline
+    ? `Uptime: ${formattedUpTime} seconds`
+    : 'Device offline'
+  const statusAriaLabel = isDeviceOnline ? 'Device online' : 'Device offline'
+
   const statusItems = useMemo(() => {
     if (!device) {
       return []
@@ -1512,8 +1569,27 @@ const trackPool = useMemo(() => {
           <ArrowBackIcon className={classes.headerBackIcon} />
         </ButtonBase>
         <div className={classes.headerCenter} aria-hidden="true" />
-        <div className={classes.headerClock} aria-live="polite" aria-label={`Local time ${headerTimeLabel}`}>
-          {headerTimeLabel}
+        <div className={classes.headerStatusGroup}>
+          <Tooltip title={statusTooltipTitle} placement="bottom">
+            <span
+              tabIndex={0}
+              className={combineClasses(
+                classes.headerStatusIndicator,
+                isDeviceOnline
+                  ? classes.headerStatusIndicatorOnline
+                  : classes.headerStatusIndicatorOffline,
+              )}
+              role="status"
+              aria-label={statusAriaLabel}
+            />
+          </Tooltip>
+          <div
+            className={classes.headerClock}
+            aria-live="polite"
+            aria-label={`Local time ${headerTimeLabel}`}
+          >
+            {headerTimeLabel}
+          </div>
         </div>
       </header>
 

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -4,6 +4,7 @@ import { ButtonBase, Slider, Typography } from '@material-ui/core'
 import Tooltip from '@material-ui/core/Tooltip'
 import { Title } from 'react-admin'
 import LinkIcon from '@material-ui/icons/Link'
+import LinkOffIcon from '@material-ui/icons/LinkOff'
 import SignalWifi4BarIcon from '@material-ui/icons/SignalWifi4Bar'
 import VolumeOffIcon from '@material-ui/icons/VolumeOff'
 import VolumeUpIcon from '@material-ui/icons/VolumeUp'
@@ -147,29 +148,34 @@ const useStyles = makeStyles((theme) => {
     headerStatusGroup: {
       display: 'inline-flex',
       alignItems: 'center',
-      gap: theme.spacing(1.25),
+      gap: theme.spacing(1.5),
     },
-    headerStatusIndicator: {
-      width: 14,
-      height: 14,
-      borderRadius: '50%',
+    headerStatusIcon: {
       display: 'inline-flex',
       alignItems: 'center',
       justifyContent: 'center',
-      boxShadow: `0 0 0 2px ${alpha(theme.palette.common.white, 0.65)}`,
-      transition: theme.transitions.create(['background-color', 'box-shadow', 'transform'], {
+      padding: theme.spacing(0.5),
+      borderRadius: theme.shape.borderRadius,
+      color: alpha(theme.palette.common.white, 0.8),
+      transition: theme.transitions.create(['color', 'transform'], {
         duration: theme.transitions.duration.shorter,
         easing: theme.transitions.easing.easeInOut,
       }),
       flexShrink: 0,
+      '& > svg': {
+        fontSize: theme.typography.pxToRem(26),
+      },
+      '&:focus-visible': {
+        outline: `2px solid ${alpha(accentColor, 0.85)}`,
+        outlineOffset: 2,
+        transform: 'scale(1.02)',
+      },
     },
-    headerStatusIndicatorOnline: {
-      backgroundColor: successMain,
-      boxShadow: `0 0 0 2px ${alpha(successMain, 0.35)}`,
+    headerStatusIconOnline: {
+      color: successMain,
     },
-    headerStatusIndicatorOffline: {
-      backgroundColor: dangerMain,
-      boxShadow: `0 0 0 2px ${alpha(dangerMain, 0.35)}`,
+    headerStatusIconOffline: {
+      color: dangerMain,
     },
     headerClock: {
       display: 'inline-flex',
@@ -1142,22 +1148,46 @@ const trackPool = useMemo(() => {
     }
     return true
   }, [statusUpTime])
-  const isDeviceOnline = hasStatusValue
-  const formattedUpTime = useMemo(() => {
+  const statusUpTimeSeconds = useMemo(() => {
     if (statusUpTime === undefined || statusUpTime === null) {
-      return ''
+      return null
     }
     if (typeof statusUpTime === 'number' && Number.isFinite(statusUpTime)) {
-      return Math.round(statusUpTime)
+      return Math.max(0, Math.round(statusUpTime))
     }
-    const parsed = Number.parseFloat(statusUpTime)
-    if (Number.isFinite(parsed)) {
-      return Math.round(parsed)
+    if (typeof statusUpTime === 'string') {
+      const trimmed = statusUpTime.trim()
+      if (trimmed === '') {
+        return null
+      }
+      const parsed = Number.parseFloat(trimmed)
+      if (Number.isFinite(parsed)) {
+        return Math.max(0, Math.round(parsed))
+      }
     }
-    return statusUpTime
+    return null
   }, [statusUpTime])
+  const isDeviceOnline = hasStatusValue
+  const formattedUpTime = useMemo(() => {
+    if (statusUpTimeSeconds !== null) {
+      const totalSeconds = statusUpTimeSeconds
+      const days = Math.floor(totalSeconds / 86400)
+      const hours = Math.floor((totalSeconds % 86400) / 3600)
+      const minutes = Math.floor((totalSeconds % 3600) / 60)
+      const seconds = totalSeconds % 60
+      const pad = (value) => value.toString().padStart(2, '0')
+      return `${days}d ${pad(hours)}h ${pad(minutes)}m ${pad(seconds)}s`
+    }
+    if (typeof statusUpTime === 'string' && statusUpTime.trim() !== '') {
+      return statusUpTime.trim()
+    }
+    if (typeof statusUpTime === 'number' && Number.isFinite(statusUpTime)) {
+      return String(statusUpTime)
+    }
+    return ''
+  }, [statusUpTime, statusUpTimeSeconds])
   const statusTooltipTitle = isDeviceOnline
-    ? `Uptime: ${formattedUpTime} seconds`
+    ? `Uptime: ${formattedUpTime}`
     : 'Device offline'
   const statusAriaLabel = isDeviceOnline ? 'Device online' : 'Device offline'
 
@@ -1574,14 +1604,20 @@ const trackPool = useMemo(() => {
             <span
               tabIndex={0}
               className={combineClasses(
-                classes.headerStatusIndicator,
+                classes.headerStatusIcon,
                 isDeviceOnline
-                  ? classes.headerStatusIndicatorOnline
-                  : classes.headerStatusIndicatorOffline,
+                  ? classes.headerStatusIconOnline
+                  : classes.headerStatusIconOffline,
               )}
               role="status"
               aria-label={statusAriaLabel}
-            />
+            >
+              {isDeviceOnline ? (
+                <LinkIcon />
+              ) : (
+                <LinkOffIcon />
+              )}
+            </span>
           </Tooltip>
           <div
             className={classes.headerClock}


### PR DESCRIPTION
## Summary
- add a toolbar status indicator beside the device clock with smooth state transitions
- surface online/offline state from the status API uptime value and show contextual tooltip copy
- ensure the header layout stays aligned while exposing accessible status messaging

## Testing
- npx eslint src/retailPlayer/RetailPlayerDashboard.jsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f98c99e748322b3337f92f9a728e9)