### PR TITLE
Fix retail player volume slider not reflecting API updates

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -925,19 +925,23 @@ const RetailPlayerDashboard = () => {
 
   const dropdownLabel = activeSchedule ? activeSchedule.label : 'No playlists available'
 
+  const deviceVolume = useMemo(() => {
+    if (typeof device?.volume === 'number' && !Number.isNaN(device.volume)) {
+      return device.volume
+    }
+
+    return 50
+  }, [device?.volume])
+
   useEffect(() => {
-    const initialVolume =
-      typeof device?.volume === 'number' && !Number.isNaN(device.volume)
-        ? device.volume
-        : 50
-    setIsMuted(Boolean(device?.isMuted) || initialVolume === 0)
-    setVolume(initialVolume)
-    setDisplayVolume(initialVolume)
-    if (initialVolume > 0) {
-      previousVolumeRef.current = initialVolume
+    setIsMuted(Boolean(device?.isMuted) || deviceVolume === 0)
+    setVolume(deviceVolume)
+    setDisplayVolume(deviceVolume)
+    if (deviceVolume > 0) {
+      previousVolumeRef.current = deviceVolume
     }
     volumeSyncReadyRef.current = false
-  }, [device])
+  }, [device?.apiId, device?.id, device?.isMuted, deviceVolume])
 
   useEffect(() => {
     volumeSyncReadyRef.current = false


### PR DESCRIPTION
## Summary
- memoize the current device volume value in the retail player dashboard
- update volume-related side effects to depend on primitives so the UI reflects manual changes until the backend responds

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f9f3fa87083228f278a303db21864)