### PR TITLE
feat: unify retail player device drag-and-drop

### DIFF
--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -27,17 +27,117 @@ import DiscoverySubMenu from './DiscoverySubMenu'
 import LibrarySelector from '../common/LibrarySelector'
 import config from '../config'
 import { useRetailPlayerDeviceStore } from '../retailPlayer/RetailPlayerDeviceStoreContext'
+import useAssignRetailPlayerDeviceToFolder from '../retailPlayer/useAssignRetailPlayerDeviceToFolder'
+import {
+  useRetailPlayerDeviceDrag,
+  useRetailPlayerFolderDrop,
+} from '../retailPlayer/useRetailPlayerDnD'
+import buildRetailPlayerDnDStyles from '../retailPlayer/retailPlayerDnDStyles'
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    marginTop: theme.spacing(1),
-    marginBottom: theme.spacing(1),
-    transition: theme.transitions.create('width', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-    paddingBottom: (props) => (props.addPadding ? '80px' : '20px'),
-  },
+const RetailPlayerMenuDeviceLink = ({
+  node,
+  paddingLeft,
+  classes,
+  open,
+  dense,
+}) => {
+  const slug = node.slug || node.name || node.id
+  const encodedSlug = encodeURIComponent(slug)
+  const { dragRef, isDragging } = useRetailPlayerDeviceDrag({
+    deviceId: node.id,
+    deviceName: node.name,
+    origin: 'sidebar-menu',
+  })
+
+  return (
+    <div
+      ref={dragRef}
+      className={clsx(classes.dndWrapper, isDragging && classes.dragging)}
+    >
+      <MenuItemLink
+        to={`/retailplayer/${encodedSlug}`}
+        activeClassName={classes.active}
+        primaryText={node.name}
+        leftIcon={
+          <SpeakerGroupIcon fontSize="small" className={classes.deviceIcon} />
+        }
+        sidebarIsOpen={open}
+        dense={dense}
+        exact
+        className={classes.deviceItem}
+        style={{ paddingLeft }}
+      />
+    </div>
+  )
+}
+
+const RetailPlayerMenuFolderItem = ({
+  node,
+  depth,
+  paddingLeft,
+  childPadding,
+  dense,
+  classes,
+  isOpen,
+  onToggle,
+  renderChildren,
+  onDeviceDrop,
+}) => {
+  const { dropRef, isOver, canDrop } = useRetailPlayerFolderDrop({
+    folderId: node.id,
+    onDrop: (deviceId, folderId) => onDeviceDrop(deviceId, folderId),
+  })
+
+  return (
+    <>
+      <MenuItem
+        ref={dropRef}
+        dense={dense}
+        className={clsx(
+          classes.folderItem,
+          classes.dropTarget,
+          canDrop && classes.dropTargetCanDrop,
+          canDrop && isOver && classes.dropTargetActive,
+        )}
+        style={{ paddingLeft }}
+        onClick={() => onToggle(node.id)}
+      >
+        <ListItemIcon>
+          {isOpen ? (
+            <ExpandMoreIcon fontSize="small" />
+          ) : (
+            <ChevronRightIcon fontSize="small" />
+          )}
+        </ListItemIcon>
+        <ListItemIcon>
+          <FolderIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText primary={node.name} />
+      </MenuItem>
+      <Collapse in={isOpen} timeout="auto" unmountOnExit>
+        <div
+          className={classes.folderChildren}
+          style={{ paddingLeft: childPadding }}
+        >
+          {renderChildren(node.children || [], depth + 1)}
+        </div>
+      </Collapse>
+    </>
+  )
+}
+
+const useStyles = makeStyles((theme) => {
+  const dndStyles = buildRetailPlayerDnDStyles(theme)
+  return {
+    root: {
+      marginTop: theme.spacing(1),
+      marginBottom: theme.spacing(1),
+      transition: theme.transitions.create('width', {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.leavingScreen,
+      }),
+      paddingBottom: (props) => (props.addPadding ? '80px' : '20px'),
+    },
   open: {
     width: 240,
   },
@@ -90,11 +190,20 @@ const useStyles = makeStyles((theme) => ({
       color: theme.palette.primary.main,
     },
   },
-  deviceIcon: {
-    color: theme.palette.common.white,
-    fontSize: theme.typography.pxToRem(16),
-  },
-}))
+    deviceIcon: {
+      color: theme.palette.common.white,
+      fontSize: theme.typography.pxToRem(16),
+    },
+    dropTarget: dndStyles.dropTarget,
+    dropTargetCanDrop: dndStyles.dropTargetCanDrop,
+    dropTargetActive: dndStyles.dropTargetActive,
+    dragging: dndStyles.dragItem,
+    dndWrapper: {
+      width: '100%',
+      borderRadius: theme.shape.borderRadius,
+    },
+  }
+})
 
 const translatedResourceName = (resource, translate) =>
   translate(`resources.${resource.name}.name`, {
@@ -182,6 +291,20 @@ const Menu = ({ dense = false }) => {
   } = useRetailPlayerDeviceStore()
 
   const [openFolders, setOpenFolders] = useState({})
+  const assignDeviceToFolder = useAssignRetailPlayerDeviceToFolder()
+
+  const handleDeviceDrop = useCallback(
+    (deviceId, folderId) => {
+      if (!deviceId || !folderId) {
+        return
+      }
+      const changed = assignDeviceToFolder(deviceId, folderId)
+      if (changed) {
+        setOpenFolders((prev) => ({ ...prev, [folderId]: true }))
+      }
+    },
+    [assignDeviceToFolder],
+  )
 
   const toggleFolder = useCallback((folderId) => {
     setOpenFolders((prev) => ({
@@ -194,31 +317,6 @@ const Menu = ({ dense = false }) => {
     history.push('/retail-player/devices')
   }, [history])
 
-  const renderDeviceLink = useCallback(
-    (node, depth) => {
-      const slug = node.slug || node.name || node.id
-      const encodedSlug = encodeURIComponent(slug)
-      const padding = theme.spacing(4 + depth * 2)
-      return (
-        <MenuItemLink
-          key={`retailplayer-${node.apiId || node.id}`}
-          to={`/retailplayer/${encodedSlug}`}
-          activeClassName={classes.active}
-          primaryText={node.name}
-          leftIcon={
-            <SpeakerGroupIcon fontSize="small" className={classes.deviceIcon} />
-          }
-          sidebarIsOpen={open}
-          dense={dense}
-          exact
-          className={classes.deviceItem}
-          style={{ paddingLeft: padding }}
-        />
-      )
-    },
-    [classes.active, classes.deviceIcon, classes.deviceItem, dense, open, theme],
-  )
-
   const renderRetailPlayerNodes = useCallback(
     (nodes, depth = 0) =>
       nodes.map((node) => {
@@ -227,44 +325,39 @@ const Menu = ({ dense = false }) => {
           const padding = theme.spacing(4 + depth * 2)
           const childPadding = theme.spacing(2)
           return (
-            <React.Fragment key={`retailfolder-${node.id}`}>
-              <MenuItem
-                dense={dense}
-                className={classes.folderItem}
-                style={{ paddingLeft: padding }}
-                onClick={() => toggleFolder(node.id)}
-              >
-                <ListItemIcon>
-                  {isOpen ? (
-                    <ExpandMoreIcon fontSize="small" />
-                  ) : (
-                    <ChevronRightIcon fontSize="small" />
-                  )}
-                </ListItemIcon>
-                <ListItemIcon>
-                  <FolderIcon fontSize="small" />
-                </ListItemIcon>
-                <ListItemText primary={node.name} />
-              </MenuItem>
-              <Collapse in={isOpen} timeout="auto" unmountOnExit>
-                <div
-                  className={classes.folderChildren}
-                  style={{ paddingLeft: childPadding }}
-                >
-                  {renderRetailPlayerNodes(node.children || [], depth + 1)}
-                </div>
-              </Collapse>
-            </React.Fragment>
+            <RetailPlayerMenuFolderItem
+              key={`retailfolder-${node.id}`}
+              node={node}
+              depth={depth}
+              paddingLeft={padding}
+              childPadding={childPadding}
+              dense={dense}
+              classes={classes}
+              isOpen={isOpen}
+              onToggle={toggleFolder}
+              renderChildren={renderRetailPlayerNodes}
+              onDeviceDrop={handleDeviceDrop}
+            />
           )
         }
-        return renderDeviceLink(node, depth)
+        const padding = theme.spacing(4 + depth * 2)
+        return (
+          <RetailPlayerMenuDeviceLink
+            key={`retailplayer-${node.apiId || node.id}`}
+            node={node}
+            paddingLeft={padding}
+            classes={classes}
+            open={open}
+            dense={dense}
+          />
+        )
       }),
     [
-      classes.folderChildren,
-      classes.folderItem,
+      classes,
       dense,
+      handleDeviceDrop,
       openFolders,
-      renderDeviceLink,
+      open,
       theme,
       toggleFolder,
     ],

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -66,6 +66,7 @@ const RetailPlayerMenuDeviceLink = ({
         exact
         className={classes.deviceItem}
         style={{ paddingLeft }}
+        draggable={false}
       />
     </div>
   )
@@ -201,6 +202,8 @@ const useStyles = makeStyles((theme) => {
     dndWrapper: {
       width: '100%',
       borderRadius: theme.shape.borderRadius,
+      WebkitUserDrag: 'none',
+      userDrag: 'none',
     },
   }
 })

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -37,6 +37,7 @@ import PlaylistSongBulkActions from './PlaylistSongBulkActions'
 import ExpandInfoDialog from '../dialogs/ExpandInfoDialog'
 import config from '../config'
 
+/* eslint-disable-next-line react-refresh/only-export-components */
 export const selectPlaylistTrackIds = ({
   idsToSelect,
   pageIds = [],

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState, memo } from 'react'
 import {
   Button,
   Checkbox,
@@ -37,25 +37,33 @@ import PropTypes from 'prop-types'
 import { useHistory } from 'react-router-dom'
 import { useRetailPlayerDeviceStore } from './RetailPlayerDeviceStoreContext'
 import AddToFolderDialog from './AddToFolderDialog'
+import useAssignRetailPlayerDeviceToFolder from './useAssignRetailPlayerDeviceToFolder'
+import {
+  useRetailPlayerDeviceDrag,
+  useRetailPlayerFolderDrop,
+} from './useRetailPlayerDnD'
+import buildRetailPlayerDnDStyles from './retailPlayerDnDStyles'
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    padding: theme.spacing(1, 5, 5, 5),
-    maxWidth: 1200,
-    margin: '0 auto',
-    width: '100%',
-    boxSizing: 'border-box',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: theme.spacing(2),
-    [theme.breakpoints.down('md')]: {
-      padding: theme.spacing(4),
-    },
-    [theme.breakpoints.down('sm')]: {
-      padding: theme.spacing(2.5),
+const useStyles = makeStyles((theme) => {
+  const dndStyles = buildRetailPlayerDnDStyles(theme)
+  return {
+    root: {
+      padding: theme.spacing(1, 5, 5, 5),
+      maxWidth: 1200,
+      margin: '0 auto',
+      width: '100%',
+      boxSizing: 'border-box',
+      display: 'flex',
+      flexDirection: 'column',
       gap: theme.spacing(2),
+      [theme.breakpoints.down('md')]: {
+        padding: theme.spacing(4),
+      },
+      [theme.breakpoints.down('sm')]: {
+        padding: theme.spacing(2.5),
+        gap: theme.spacing(2),
+      },
     },
-  },
   header: {
     display: 'flex',
     alignItems: 'center',
@@ -317,7 +325,12 @@ row: {
       minWidth: 'auto',
     },
   },
-}))
+  dropTarget: dndStyles.dropTarget,
+  dropTargetCanDrop: dndStyles.dropTargetCanDrop,
+  dropTargetActive: dndStyles.dropTargetActive,
+  dragging: dndStyles.dragItem,
+  }
+})
 
 const FolderDialog = ({ open, onClose, onSubmit, initialValues }) => {
   const classes = useStyles()
@@ -524,6 +537,188 @@ DeviceDialog.defaultProps = {
   initialValues: null,
 }
 
+const RetailPlayerFolderRow = memo(
+  ({
+    node,
+    deviceCount,
+    isSelected,
+    classes,
+    onEnterFolder,
+    onToggleSelection,
+    onKeyDown,
+    onEdit,
+    onDeviceDrop,
+  }) => {
+    const { dropRef, isOver, canDrop } = useRetailPlayerFolderDrop({
+      folderId: node.id,
+      onDrop: (deviceId, folderId) => onDeviceDrop(deviceId, folderId),
+    })
+
+    return (
+      <div
+        ref={dropRef}
+        className={clsx(
+          classes.row,
+          classes.folderRow,
+          classes.interactiveRow,
+          classes.dropTarget,
+          isSelected && classes.selectedRow,
+          canDrop && classes.dropTargetCanDrop,
+          canDrop && isOver && classes.dropTargetActive,
+        )}
+        role="button"
+        tabIndex={0}
+        onClick={() => onEnterFolder(node.id)}
+        onKeyDown={(event) => onKeyDown(event, () => onEnterFolder(node.id))}
+        aria-label={`Open folder ${node.name}`}
+      >
+        <div className={classes.selectCell}>
+          <Checkbox
+            color="primary"
+            checked={isSelected}
+            onChange={(event) => {
+              event.stopPropagation()
+              onToggleSelection(node.id)
+            }}
+            onClick={(event) => event.stopPropagation()}
+            inputProps={{ 'aria-label': `Select folder ${node.name}` }}
+            style={{ transform: 'scale(0.8)' }}
+          />
+        </div>
+        <div className={classes.nameCell}>
+          <FolderIcon className={classes.nameIcon} />
+          <div className={classes.nameLabel}>
+            <Typography variant="body1" className={classes.nameTitle}>
+              {node.name}
+            </Typography>
+          </div>
+        </div>
+        <div className={classes.typeCell}>Folder</div>
+        <div className={classes.countCell}>{deviceCount}</div>
+        <div className={classes.actionsCell}>
+          <Tooltip title="Edit folder">
+            <IconButton
+              size="small"
+              onClick={(event) => {
+                event.stopPropagation()
+                onEdit(node.id)
+              }}
+              aria-label={`Edit folder ${node.name}`}
+            >
+              <EditIcon style={{ fontSize: 15 }} />
+            </IconButton>
+          </Tooltip>
+        </div>
+      </div>
+    )
+  },
+)
+
+RetailPlayerFolderRow.propTypes = {
+  node: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+  }).isRequired,
+  deviceCount: PropTypes.number.isRequired,
+  isSelected: PropTypes.bool.isRequired,
+  classes: PropTypes.object.isRequired,
+  onEnterFolder: PropTypes.func.isRequired,
+  onToggleSelection: PropTypes.func.isRequired,
+  onKeyDown: PropTypes.func.isRequired,
+  onEdit: PropTypes.func.isRequired,
+  onDeviceDrop: PropTypes.func.isRequired,
+}
+
+RetailPlayerFolderRow.displayName = 'RetailPlayerFolderRow'
+
+const RetailPlayerDeviceRow = memo(
+  ({
+    node,
+    isSelected,
+    classes,
+    onNavigate,
+    onToggleSelection,
+    onKeyDown,
+    onEdit,
+  }) => {
+    const { dragRef, isDragging } = useRetailPlayerDeviceDrag({
+      deviceId: node.id,
+      deviceName: node.name,
+      origin: 'management-list',
+    })
+
+    return (
+      <div
+        ref={dragRef}
+        className={clsx(
+          classes.row,
+          classes.interactiveRow,
+          isSelected && classes.selectedRow,
+          isDragging && classes.dragging,
+        )}
+        role="button"
+        tabIndex={0}
+        onClick={() => onNavigate(node)}
+        onKeyDown={(event) => onKeyDown(event, () => onNavigate(node))}
+        aria-label={`Open device ${node.name}`}
+      >
+        <div className={classes.selectCell}>
+          <Checkbox
+            color="primary"
+            checked={isSelected}
+            onChange={(event) => {
+              event.stopPropagation()
+              onToggleSelection(node.id)
+            }}
+            onClick={(event) => event.stopPropagation()}
+            inputProps={{ 'aria-label': `Select device ${node.name}` }}
+            style={{ transform: 'scale(0.8)' }}
+          />
+        </div>
+        <div className={classes.nameCell}>
+          <SpeakerGroupIcon className={classes.nameIcon} />
+          <div className={classes.nameLabel}>
+            <Typography variant="body1" className={classes.nameTitle}>
+              {node.name}
+            </Typography>
+          </div>
+        </div>
+        <div className={classes.typeCell}>Device</div>
+        <div className={classes.countCell}>—</div>
+        <div className={classes.actionsCell}>
+          <Tooltip title="Edit device">
+            <IconButton
+              size="small"
+              onClick={(event) => {
+                event.stopPropagation()
+                onEdit(node.id)
+              }}
+              aria-label={`Edit device ${node.name}`}
+            >
+              <EditIcon style={{ fontSize: 15 }} />
+            </IconButton>
+          </Tooltip>
+        </div>
+      </div>
+    )
+  },
+)
+
+RetailPlayerDeviceRow.propTypes = {
+  node: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+  }).isRequired,
+  isSelected: PropTypes.bool.isRequired,
+  classes: PropTypes.object.isRequired,
+  onNavigate: PropTypes.func.isRequired,
+  onToggleSelection: PropTypes.func.isRequired,
+  onKeyDown: PropTypes.func.isRequired,
+  onEdit: PropTypes.func.isRequired,
+}
+
+RetailPlayerDeviceRow.displayName = 'RetailPlayerDeviceRow'
+
 const RetailPlayerDeviceManagement = () => {
   const classes = useStyles()
   const theme = useTheme()
@@ -543,6 +738,7 @@ const RetailPlayerDeviceManagement = () => {
   const [searchTerm, setSearchTerm] = useState('')
   const [addToFolderDialogOpen, setAddToFolderDialogOpen] = useState(false)
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const assignDeviceToFolder = useAssignRetailPlayerDeviceToFolder()
 
   const folderOptions = useMemo(
     () => folders.map((folder) => ({ id: folder.id, name: folder.name })),
@@ -615,6 +811,16 @@ const RetailPlayerDeviceManagement = () => {
   )
 
   const selectedCount = selectedFolderIds.length + selectedDeviceIds.length
+
+  const handleDeviceDropOnFolder = useCallback(
+    (deviceId, folderId) => {
+      if (!deviceId || !folderId) {
+        return
+      }
+      assignDeviceToFolder(deviceId, folderId)
+    },
+    [assignDeviceToFolder],
+  )
 
   const excludedFolderIds = useMemo(() => {
     const excluded = new Set(selectedFolderIds)
@@ -996,114 +1202,33 @@ const RetailPlayerDeviceManagement = () => {
         const deviceCount = countDevices(node)
         const isSelected = selectedIds.has(node.id)
         return (
-          <div
+          <RetailPlayerFolderRow
             key={`folder-row-${node.id}`}
-            className={clsx(
-              classes.row,
-              classes.folderRow,
-              classes.interactiveRow,
-              isSelected && classes.selectedRow,
-            )}
-            role="button"
-            tabIndex={0}
-            onClick={() => handleEnterFolder(node.id)}
-            onKeyDown={(event) => handleRowKeyDown(event, () => handleEnterFolder(node.id))}
-            aria-label={`Open folder ${node.name}`}
-          >
-            <div className={classes.selectCell}>
-              <Checkbox
-                color="primary"
-                checked={isSelected}
-                onChange={(event) => {
-                  event.stopPropagation()
-                  toggleNodeSelection(node.id)
-                }}
-                onClick={(event) => event.stopPropagation()}
-                inputProps={{ 'aria-label': `Select folder ${node.name}` }}
-                style={{ transform: 'scale(0.8)' }} 
-              />
-            </div>
-            <div className={classes.nameCell}>
-              <FolderIcon className={classes.nameIcon} />
-              <div className={classes.nameLabel}>
-                <Typography variant="body1" className={classes.nameTitle}>
-                  {node.name}
-                </Typography>
-              </div>
-            </div>
-            <div className={classes.typeCell}>Folder</div>
-            <div className={classes.countCell}>{deviceCount}</div>
-            <div className={classes.actionsCell}>
-              <Tooltip title="Edit folder">
-                <IconButton
-                  size="small"
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    handleEditFolder(node.id)
-                  }}
-                  aria-label={`Edit folder ${node.name}`}
-                >
-                  <EditIcon style={{ fontSize: 15 }} />
-                </IconButton>
-              </Tooltip>
-            </div>
-          </div>
+            node={node}
+            deviceCount={deviceCount}
+            isSelected={isSelected}
+            classes={classes}
+            onEnterFolder={handleEnterFolder}
+            onToggleSelection={toggleNodeSelection}
+            onKeyDown={handleRowKeyDown}
+            onEdit={handleEditFolder}
+            onDeviceDrop={handleDeviceDropOnFolder}
+          />
         )
       }
       const isSelected = selectedIds.has(node.id)
       const rowKey = node.treeKey || node.id
       return (
-        <div
+        <RetailPlayerDeviceRow
           key={`device-row-${rowKey}`}
-          className={clsx(
-            classes.row,
-            classes.interactiveRow,
-            isSelected && classes.selectedRow,
-          )}
-          role="button"
-          tabIndex={0}
-          onClick={() => handleNavigateToDevice(node)}
-          onKeyDown={(event) => handleRowKeyDown(event, () => handleNavigateToDevice(node))}
-          aria-label={`Open device ${node.name}`}
-        >
-          <div className={classes.selectCell}>
-            <Checkbox
-              color="primary"
-              checked={isSelected}
-              onChange={(event) => {
-                event.stopPropagation()
-                toggleNodeSelection(node.id)
-              }}
-              onClick={(event) => event.stopPropagation()}
-              inputProps={{ 'aria-label': `Select device ${node.name}` }}
-              style={{ transform: 'scale(0.8)' }}
-            />
-          </div>
-          <div className={classes.nameCell}>
-            <SpeakerGroupIcon className={classes.nameIcon} />
-            <div className={classes.nameLabel}>
-              <Typography variant="body1" className={classes.nameTitle}>
-                {node.name}
-              </Typography>
-            </div>
-          </div>
-          <div className={classes.typeCell}>Device</div>
-          <div className={classes.countCell}>—</div>
-          <div className={classes.actionsCell}>
-            <Tooltip title="Edit device">
-              <IconButton
-                size="small"
-                onClick={(event) => {
-                  event.stopPropagation()
-                  handleEditDevice(node.id)
-                }}
-                aria-label={`Edit device ${node.name}`}
-              >
-                <EditIcon style={{ fontSize: 15 }} />
-              </IconButton>
-            </Tooltip>
-          </div>
-        </div>
+          node={node}
+          isSelected={isSelected}
+          classes={classes}
+          onNavigate={handleNavigateToDevice}
+          onToggleSelection={toggleNodeSelection}
+          onKeyDown={handleRowKeyDown}
+          onEdit={handleEditDevice}
+        />
       )
     })
 

--- a/ui/src/retailPlayer/retailPlayerDnDStyles.js
+++ b/ui/src/retailPlayer/retailPlayerDnDStyles.js
@@ -1,0 +1,30 @@
+import { fade } from '@material-ui/core/styles/colorManipulator'
+
+const buildRetailPlayerDnDStyles = (theme) => {
+  const activeShadowColor = fade(theme.palette.primary.main, 0.45)
+  const activeBackground = fade(theme.palette.primary.main, 0.14)
+  const hoverBackground = fade(theme.palette.primary.main, 0.08)
+
+  return {
+    dropTarget: {
+      position: 'relative',
+      borderRadius: theme.shape.borderRadius,
+      transition: theme.transitions.create(['background-color', 'box-shadow'], {
+        duration: theme.transitions.duration.shortest,
+      }),
+    },
+    dropTargetCanDrop: {
+      backgroundColor: hoverBackground,
+    },
+    dropTargetActive: {
+      backgroundColor: activeBackground,
+      boxShadow: `0 0 0 2px ${activeShadowColor}`,
+    },
+    dragItem: {
+      opacity: 0.55,
+      cursor: 'grabbing',
+    },
+  }
+}
+
+export default buildRetailPlayerDnDStyles

--- a/ui/src/retailPlayer/useAssignRetailPlayerDeviceToFolder.js
+++ b/ui/src/retailPlayer/useAssignRetailPlayerDeviceToFolder.js
@@ -1,0 +1,51 @@
+import { useCallback } from 'react'
+import { useRetailPlayerDeviceStore } from './RetailPlayerDeviceStoreContext'
+
+const normalizeFolderIds = (device) => {
+  if (!device) {
+    return []
+  }
+  if (Array.isArray(device.folderIds)) {
+    return device.folderIds.filter(Boolean)
+  }
+  if (device.folderId) {
+    return [device.folderId].filter(Boolean)
+  }
+  return []
+}
+
+const useAssignRetailPlayerDeviceToFolder = () => {
+  const {
+    state: { devices },
+    actions: { assignDeviceToFolder },
+  } = useRetailPlayerDeviceStore()
+
+  return useCallback(
+    (deviceId, folderId) => {
+      if (!deviceId || !folderId) {
+        return false
+      }
+
+      const targetDevice = devices.find((device) => device.id === deviceId)
+      if (!targetDevice) {
+        return false
+      }
+
+      const currentFolderIds = normalizeFolderIds(targetDevice)
+      const nextFolderIds = [folderId]
+      const unchanged =
+        currentFolderIds.length === nextFolderIds.length &&
+        currentFolderIds.every((id, index) => id === nextFolderIds[index])
+
+      if (unchanged) {
+        return false
+      }
+
+      assignDeviceToFolder({ id: deviceId, folderIds: nextFolderIds })
+      return true
+    },
+    [assignDeviceToFolder, devices],
+  )
+}
+
+export default useAssignRetailPlayerDeviceToFolder

--- a/ui/src/retailPlayer/useRetailPlayerDnD.js
+++ b/ui/src/retailPlayer/useRetailPlayerDnD.js
@@ -1,5 +1,6 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 import { useDrag, useDrop } from 'react-dnd'
+import { getEmptyImage } from 'react-dnd-html5-backend'
 
 export const RETAIL_PLAYER_DND_TYPES = {
   DEVICE: 'RETAIL_PLAYER_DEVICE',
@@ -10,7 +11,7 @@ export const useRetailPlayerDeviceDrag = ({
   deviceName,
   origin,
 }) => {
-  const [{ isDragging }, dragRef] = useDrag(
+  const [{ isDragging }, dragRef, previewRef] = useDrag(
     () => ({
       type: RETAIL_PLAYER_DND_TYPES.DEVICE,
       item: {
@@ -24,6 +25,10 @@ export const useRetailPlayerDeviceDrag = ({
     }),
     [deviceId, deviceName, origin],
   )
+
+  useEffect(() => {
+    previewRef(getEmptyImage(), { captureDraggingState: true })
+  }, [previewRef])
 
   return { dragRef, isDragging }
 }

--- a/ui/src/retailPlayer/useRetailPlayerDnD.js
+++ b/ui/src/retailPlayer/useRetailPlayerDnD.js
@@ -1,0 +1,64 @@
+import { useCallback } from 'react'
+import { useDrag, useDrop } from 'react-dnd'
+
+export const RETAIL_PLAYER_DND_TYPES = {
+  DEVICE: 'RETAIL_PLAYER_DEVICE',
+}
+
+export const useRetailPlayerDeviceDrag = ({
+  deviceId,
+  deviceName,
+  origin,
+}) => {
+  const [{ isDragging }, dragRef] = useDrag(
+    () => ({
+      type: RETAIL_PLAYER_DND_TYPES.DEVICE,
+      item: {
+        deviceId,
+        deviceName,
+        origin,
+      },
+      canDrag: Boolean(deviceId),
+      collect: (monitor) => ({ isDragging: monitor.isDragging() }),
+      options: { dropEffect: 'move' },
+    }),
+    [deviceId, deviceName, origin],
+  )
+
+  return { dragRef, isDragging }
+}
+
+export const useRetailPlayerFolderDrop = ({ folderId, onDrop }) => {
+  const handleDrop = useCallback(
+    (item) => {
+      if (!folderId || !item?.deviceId) {
+        return
+      }
+      if (onDrop) {
+        onDrop(item.deviceId, folderId, item)
+      }
+    },
+    [folderId, onDrop],
+  )
+
+  const [{ isOver, canDrop }, dropRef] = useDrop(
+    () => ({
+      accept: RETAIL_PLAYER_DND_TYPES.DEVICE,
+      canDrop: (item) => Boolean(folderId) && Boolean(item?.deviceId),
+      drop: (item, monitor) => {
+        if (monitor.didDrop()) {
+          return undefined
+        }
+        handleDrop(item)
+        return { folderId }
+      },
+      collect: (monitor) => ({
+        isOver: monitor.isOver({ shallow: true }),
+        canDrop: monitor.canDrop(),
+      }),
+    }),
+    [folderId, handleDrop],
+  )
+
+  return { dropRef, isOver, canDrop }
+}


### PR DESCRIPTION
## Summary
- implement shared drag-and-drop hooks and styles so retail player devices can be dragged from the list or sidebar
- enable folders in both the management page and sidebar to accept device drops with consistent visual feedback and immediate reassignment
- update the playlist helper export lint directive to keep lint clean

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fade5a4f48322bbf34d5d79e11119)