### PR TITLE
Add drag preview for Retail Player device drags

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -48,6 +48,7 @@ import PlaylistCreate from './playlist/PlaylistCreate'
 import PlaylistShow from './playlist/PlaylistShow'
 import PlaylistEdit from './playlist/PlaylistEdit'
 import RetailPlayerDeviceStoreProvider from './retailPlayer/RetailPlayerDeviceStoreContext'
+import RetailPlayerDragPreview from './retailPlayer/RetailPlayerDragPreview'
 
 const history = createHashHistory()
 if (!shareInfo && history.location.pathname === '/') history.replace('/song')
@@ -179,6 +180,7 @@ const AppWithHotkeys = () => {
   return (
     <HotKeys keyMap={keyMap}>
       <DndProvider backend={HTML5Backend}>
+        <RetailPlayerDragPreview />
         <App />
       </DndProvider>
     </HotKeys>

--- a/ui/src/retailPlayer/RetailPlayerDragPreview.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDragPreview.jsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import { makeStyles } from '@material-ui/core'
+import { fade } from '@material-ui/core/styles/colorManipulator'
+import { useDragLayer } from 'react-dnd'
+
+import { RETAIL_PLAYER_DND_TYPES } from './useRetailPlayerDnD'
+
+const useStyles = makeStyles((theme) => ({
+  layer: {
+    position: 'fixed',
+    pointerEvents: 'none',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    zIndex: theme.zIndex.modal + 2,
+  },
+  previewWrapper: {
+    transformOrigin: 'top left',
+  },
+  preview: {
+    backgroundColor: fade(theme.palette.common.black, 0.75),
+    color: theme.palette.common.white,
+    fontWeight: theme.typography.fontWeightBold,
+    borderRadius: theme.shape.borderRadius * 2,
+    boxShadow: '0 18px 40px rgba(0, 0, 0, 0.35)',
+    padding: theme.spacing(1, 2.5),
+    minWidth: 120,
+    maxWidth: 320,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontSize: theme.typography.pxToRem(14),
+    letterSpacing: 0.2,
+    textAlign: 'center',
+    backdropFilter: 'blur(6px)',
+  },
+}))
+
+const getItemStyles = (currentOffset) => {
+  if (!currentOffset) {
+    return {
+      display: 'none',
+    }
+  }
+
+  const { x, y } = currentOffset
+  const transform = `translate(${x + 12}px, ${y + 12}px)`
+
+  return {
+    transform,
+    WebkitTransform: transform,
+  }
+}
+
+const RetailPlayerDragPreview = () => {
+  const classes = useStyles()
+  const { itemType, item, isDragging, currentOffset } = useDragLayer((monitor) => ({
+    item: monitor.getItem(),
+    itemType: monitor.getItemType(),
+    currentOffset: monitor.getClientOffset(),
+    isDragging: monitor.isDragging(),
+  }))
+
+  if (!isDragging || itemType !== RETAIL_PLAYER_DND_TYPES.DEVICE) {
+    return null
+  }
+
+  if (!item?.deviceName) {
+    return null
+  }
+
+  return (
+    <div className={classes.layer}>
+      <div className={classes.previewWrapper} style={getItemStyles(currentOffset)}>
+        <div className={classes.preview}>{item.deviceName}</div>
+      </div>
+    </div>
+  )
+}
+
+export default RetailPlayerDragPreview


### PR DESCRIPTION
## Summary
- add a global drag preview layer for Retail Player device drag-and-drop
- render the device name with themed styling for the drag preview overlay
- wire the custom preview into the Retail Player DnD provider so it appears across the app

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb7f97b00832290ac5f227d2caa66)