### PR TITLE
Add backend retail player lookup endpoint

### DIFF
--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os/exec"
 	"path"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -101,6 +102,7 @@ type retailPlayerConfig struct {
 func (n *Router) addRetailPlayerRoute(r chi.Router) {
 	r.Route("/retailplayer", func(r chi.Router) {
 		r.Get("/devices", n.handleRetailPlayerDevices())
+		r.Get("/devices/lookup/{deviceSlug}", n.handleRetailPlayerDeviceLookup())
 		r.Get("/devices/{deviceID}/status", n.handleRetailPlayerDeviceStatus())
 		r.Get("/channel-lists/{channelListID}/channels", n.handleRetailPlayerChannelListChannels())
 		r.Post("/devices/{deviceID}/volume", n.handleRetailPlayerDeviceVolume())
@@ -135,6 +137,48 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 		if err := json.NewEncoder(w).Encode(response); err != nil {
 			log.Error(ctx, "Unable to encode retail player devices response", "err", err)
 		}
+	}
+}
+
+func (n *Router) handleRetailPlayerDeviceLookup() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		rawSlug := strings.TrimSpace(chi.URLParam(r, "deviceSlug"))
+		if rawSlug == "" {
+			http.Error(w, "Retail player device slug is required", http.StatusBadRequest)
+			return
+		}
+
+		slugKey := retailPlayerDeviceSlugKey(rawSlug)
+		if slugKey == "" {
+			http.Error(w, "Retail player device slug is invalid", http.StatusBadRequest)
+			return
+		}
+
+		log.Info(ctx, "Looking up retail player device", "slug", rawSlug, "slugKey", slugKey)
+
+		device, err := lookupRetailPlayerDevice(ctx, slugKey)
+		if err != nil {
+			if errors.Is(err, errRetailPlayerDeviceNotFound) {
+				log.Info(ctx, "Retail player device not found during lookup", "slug", rawSlug, "slugKey", slugKey)
+				http.Error(w, "Retail player device not found", http.StatusNotFound)
+				return
+			}
+
+			log.Error(ctx, "Unable to lookup retail player device", "slug", rawSlug, "err", err)
+			http.Error(w, "Unable to lookup retail player device", http.StatusBadGateway)
+			return
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{
+			"data": device,
+		})
 	}
 }
 
@@ -684,6 +728,61 @@ func fetchRetailPlayerDevice(ctx context.Context, deviceID string) (retailPlayer
 	}
 
 	return device, nil
+}
+
+func lookupRetailPlayerDevice(ctx context.Context, slugKey string) (retailPlayerDevice, error) {
+	response, err := fetchRetailPlayerDevices(ctx)
+	if err != nil {
+		return retailPlayerDevice{}, err
+	}
+
+	for _, device := range response.Data {
+		if retailPlayerDeviceMatchesSlug(device, slugKey) {
+			return device, nil
+		}
+	}
+
+	return retailPlayerDevice{}, errRetailPlayerDeviceNotFound
+}
+
+var retailPlayerSlugPattern = regexp.MustCompile(`[^a-z0-9]+`)
+
+func retailPlayerDeviceMatchesSlug(device retailPlayerDevice, slugKey string) bool {
+	if slugKey == "" {
+		return false
+	}
+
+	candidates := []string{
+		retailPlayerDevicePrimarySlug(device),
+		device.Name,
+		device.ID,
+	}
+
+	for _, candidate := range candidates {
+		if retailPlayerDeviceSlugKey(candidate) == slugKey {
+			return true
+		}
+	}
+
+	return false
+}
+
+func retailPlayerDevicePrimarySlug(device retailPlayerDevice) string {
+	if strings.TrimSpace(device.Name) != "" {
+		return device.Name
+	}
+	return device.ID
+}
+
+func retailPlayerDeviceSlugKey(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	if normalized == "" {
+		return ""
+	}
+
+	slug := retailPlayerSlugPattern.ReplaceAllString(normalized, "-")
+	slug = strings.Trim(slug, "-")
+	return slug
 }
 
 func fetchRetailPlayerChannelListChannels(ctx context.Context, channelListID string) (retailPlayerChannelsResponse, error) {

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -149,29 +149,44 @@ func (n *Router) handleRetailPlayerDeviceLookup() http.HandlerFunc {
 			return
 		}
 
-		rawSlug := strings.TrimSpace(chi.URLParam(r, "deviceSlug"))
-		if rawSlug == "" {
+		rawSlugParam := strings.TrimSpace(chi.URLParam(r, "deviceSlug"))
+		if rawSlugParam == "" {
 			http.Error(w, "Retail player device slug is required", http.StatusBadRequest)
 			return
 		}
 
-		slugKey := retailPlayerDeviceSlugKey(rawSlug)
+		decodedSlug, err := url.PathUnescape(rawSlugParam)
+		if err != nil {
+			log.Warn(ctx, "Unable to decode retail player device slug", "slug", rawSlugParam, "err", err)
+			decodedSlug = rawSlugParam
+		}
+
+		normalizedSlug := strings.TrimSpace(decodedSlug)
+		if normalizedSlug == "" {
+			http.Error(w, "Retail player device slug is invalid", http.StatusBadRequest)
+			return
+		}
+
+		slugKey := retailPlayerDeviceSlugKey(normalizedSlug)
+		if slugKey == "" && rawSlugParam != normalizedSlug {
+			slugKey = retailPlayerDeviceSlugKey(rawSlugParam)
+		}
 		if slugKey == "" {
 			http.Error(w, "Retail player device slug is invalid", http.StatusBadRequest)
 			return
 		}
 
-		log.Info(ctx, "Looking up retail player device", "slug", rawSlug, "slugKey", slugKey)
+		log.Info(ctx, "Looking up retail player device", "slug", normalizedSlug, "slugKey", slugKey)
 
 		device, err := lookupRetailPlayerDevice(ctx, slugKey)
 		if err != nil {
 			if errors.Is(err, errRetailPlayerDeviceNotFound) {
-				log.Info(ctx, "Retail player device not found during lookup", "slug", rawSlug, "slugKey", slugKey)
+				log.Info(ctx, "Retail player device not found during lookup", "slug", normalizedSlug, "slugKey", slugKey)
 				http.Error(w, "Retail player device not found", http.StatusNotFound)
 				return
 			}
 
-			log.Error(ctx, "Unable to lookup retail player device", "slug", rawSlug, "err", err)
+			log.Error(ctx, "Unable to lookup retail player device", "slug", normalizedSlug, "rawSlug", rawSlugParam, "err", err)
 			http.Error(w, "Unable to lookup retail player device", http.StatusBadGateway)
 			return
 		}

--- a/ui/src/retailPlayer/useRetailPlayerDeviceLookup.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceLookup.js
@@ -1,0 +1,115 @@
+import { useEffect, useMemo, useState } from 'react'
+import config from '../config'
+import httpClient from '../dataProvider/httpClient'
+import RetailPlayerMockService from './RetailPlayerMockService'
+import { deviceSlugKey } from './deviceUtils'
+import { mapDevice } from './useRetailPlayerDevices'
+
+const buildLookupUrl = (slug) =>
+  slug ? `/api/retailplayer/devices/lookup/${encodeURIComponent(slug)}` : null
+
+const findMockDeviceBySlugKey = (slugKey) => {
+  if (!slugKey) {
+    return null
+  }
+
+  const devices = RetailPlayerMockService.listDevices()
+  return (
+    devices.find((device) => device.slugKey === slugKey) ||
+    devices.find((device) => deviceSlugKey(device.name) === slugKey) ||
+    devices.find((device) => deviceSlugKey(device.id) === slugKey) ||
+    null
+  )
+}
+
+const normalizeSlugParam = (slugParam) => {
+  if (!slugParam) {
+    return ''
+  }
+  try {
+    return decodeURIComponent(slugParam)
+  } catch (err) {
+    return slugParam
+  }
+}
+
+const useRetailPlayerDeviceLookup = (slugParam) => {
+  const [device, setDevice] = useState(null)
+  const [error, setError] = useState(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isApiEnabled, setIsApiEnabled] = useState(
+    Boolean(config.retailPlayerDevicesEnabled),
+  )
+
+  const normalizedSlug = useMemo(
+    () => normalizeSlugParam(slugParam),
+    [slugParam],
+  )
+  const normalizedSlugKey = useMemo(
+    () => deviceSlugKey(normalizedSlug),
+    [normalizedSlug],
+  )
+
+  useEffect(() => {
+    if (!normalizedSlugKey) {
+      setDevice(null)
+      setError(null)
+      setIsLoading(false)
+      setIsApiEnabled(Boolean(config.retailPlayerDevicesEnabled))
+      return undefined
+    }
+
+    if (!config.retailPlayerDevicesEnabled) {
+      const mockDevice = findMockDeviceBySlugKey(normalizedSlugKey)
+      setDevice(mockDevice)
+      setError(null)
+      setIsApiEnabled(false)
+      setIsLoading(false)
+      return undefined
+    }
+
+    const url = buildLookupUrl(slugParam)
+    if (!url) {
+      setDevice(null)
+      setError(null)
+      setIsLoading(false)
+      setIsApiEnabled(true)
+      return undefined
+    }
+
+    const abortController = new AbortController()
+    setIsLoading(true)
+    setError(null)
+    setIsApiEnabled(true)
+
+    httpClient(url, { signal: abortController.signal })
+      .then(({ json }) => {
+        if (abortController.signal.aborted) {
+          return
+        }
+        const mappedDevice = mapDevice(json?.data)
+        setDevice(mappedDevice)
+        setError(null)
+      })
+      .catch((err) => {
+        if (abortController.signal.aborted) {
+          return
+        }
+        setDevice(null)
+        setError(err)
+      })
+      .finally(() => {
+        if (!abortController.signal.aborted) {
+          setIsLoading(false)
+        }
+      })
+
+    return () => {
+      abortController.abort()
+    }
+  }, [normalizedSlugKey, slugParam])
+
+  return { device, error, isApiEnabled, isLoading }
+}
+
+export default useRetailPlayerDeviceLookup

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -4,6 +4,7 @@ import subsonic from '../subsonic'
 import httpClient from '../dataProvider/httpClient'
 import { baseUrl } from '../utils'
 import useRetailPlayerDevices from './useRetailPlayerDevices'
+import useRetailPlayerDeviceLookup from './useRetailPlayerDeviceLookup'
 import { buildDeviceSlug, deviceSlugKey, normalizeValue } from './deviceUtils'
 
 const buildStatusUrl = (deviceId) =>
@@ -584,13 +585,6 @@ const initialChannelState = {
 }
 
 const useRetailPlayerDeviceStatus = (slugParam) => {
-  const {
-    devices,
-    error: devicesError,
-    isLoading: devicesLoading,
-    isApiEnabled,
-  } = useRetailPlayerDevices()
-
   const normalizedSlugKey = useMemo(() => {
     if (!slugParam) {
       return ''
@@ -602,7 +596,27 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
     }
   }, [slugParam])
 
+  const shouldUseDeviceList = !normalizedSlugKey
+
+  const {
+    devices,
+    error: deviceListError,
+    isLoading: deviceListLoading,
+    isApiEnabled: isDeviceListApiEnabled,
+  } = useRetailPlayerDevices({ enabled: shouldUseDeviceList })
+
+  const {
+    device: lookupDevice,
+    error: lookupError,
+    isLoading: lookupLoading,
+    isApiEnabled: isLookupApiEnabled,
+  } = useRetailPlayerDeviceLookup(shouldUseDeviceList ? null : slugParam)
+
   const baseDevice = useMemo(() => {
+    if (!shouldUseDeviceList) {
+      return lookupDevice || null
+    }
+
     if (!devices.length) {
       return null
     }
@@ -620,7 +634,11 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
       devices.find((device) => deviceSlugKey(device.id) === normalizedSlugKey) ||
       null
     )
-  }, [devices, normalizedSlugKey])
+  }, [devices, lookupDevice, normalizedSlugKey, shouldUseDeviceList])
+
+  const devicesLoading = shouldUseDeviceList ? deviceListLoading : lookupLoading
+  const devicesError = shouldUseDeviceList ? deviceListError : lookupError
+  const isApiEnabled = shouldUseDeviceList ? isDeviceListApiEnabled : isLookupApiEnabled
 
   const [statusState, setStatusState] = useState(initialStatusState)
   const [refreshIndex, setRefreshIndex] = useState(0)

--- a/ui/src/retailPlayer/useRetailPlayerDevices.js
+++ b/ui/src/retailPlayer/useRetailPlayerDevices.js
@@ -69,7 +69,8 @@ const fetchRetailPlayerDevices = async (signal) => {
   return { devices, enabled: true }
 }
 
-const useRetailPlayerDevices = () => {
+const useRetailPlayerDevices = (options = {}) => {
+  const { enabled = true } = options
   const [devices, setDevices] = useState(() => {
     if (config.retailPlayerDevicesEnabled) {
       return []
@@ -79,10 +80,22 @@ const useRetailPlayerDevices = () => {
   const [error, setError] = useState(null)
   const [isLoading, setIsLoading] = useState(false)
   const [isApiEnabled, setIsApiEnabled] = useState(
-    Boolean(config.retailPlayerDevicesEnabled),
+    Boolean(config.retailPlayerDevicesEnabled && enabled),
   )
 
   useEffect(() => {
+    if (!enabled) {
+      setIsApiEnabled(Boolean(config.retailPlayerDevicesEnabled && enabled))
+      if (config.retailPlayerDevicesEnabled) {
+        setDevices([])
+      } else {
+        setDevices(RetailPlayerMockService.listDevices())
+      }
+      setIsLoading(false)
+      setError(null)
+      return undefined
+    }
+
     const url = buildDevicesUrl()
     if (!url) {
       setIsApiEnabled(false)
@@ -115,7 +128,7 @@ const useRetailPlayerDevices = () => {
     return () => {
       abortController.abort()
     }
-  }, [])
+  }, [enabled])
 
   return {
     devices,
@@ -125,4 +138,5 @@ const useRetailPlayerDevices = () => {
   }
 }
 
+export { mapDevice }
 export default useRetailPlayerDevices


### PR DESCRIPTION
## Summary
- add a backend endpoint to resolve retail player devices by slug without exposing the full device list
- add a client hook that calls the lookup endpoint (with mock fallbacks) and reuse it when loading a device by slug
- update the retail player device status hook to rely on the lookup hook and skip the list fetch for direct device views

## Testing
- go test ./... *(fails: taglib package missing in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fbf0d56608322829a10f0a3407e3e)