### PR TITLE
Enable public retail player device lookup and slug resolution

### DIFF
--- a/db/migrations/20250816074435_create_retail_player_device_mapping.go
+++ b/db/migrations/20250816074435_create_retail_player_device_mapping.go
@@ -1,0 +1,42 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upCreateRetailPlayerDeviceMapping, downCreateRetailPlayerDeviceMapping)
+}
+
+func upCreateRetailPlayerDeviceMapping(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+                CREATE TABLE IF NOT EXISTS retail_player_device_mapping (
+                        device_id    TEXT NOT NULL PRIMARY KEY,
+                        device_name  TEXT NOT NULL,
+                        device_slug  TEXT NOT NULL,
+                        channel      TEXT,
+                        channel_list TEXT,
+                        organization TEXT,
+                        time_zone    TEXT,
+                        updated_at   DATETIME NOT NULL DEFAULT (datetime('now'))
+                );
+
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_retail_player_device_mapping_slug
+                        ON retail_player_device_mapping(device_slug);
+                CREATE INDEX IF NOT EXISTS idx_retail_player_device_mapping_name
+                        ON retail_player_device_mapping(device_name COLLATE NOCASE);
+        `)
+	return err
+}
+
+func downCreateRetailPlayerDeviceMapping(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+                DROP INDEX IF EXISTS idx_retail_player_device_mapping_slug;
+                DROP INDEX IF EXISTS idx_retail_player_device_mapping_name;
+                DROP TABLE IF EXISTS retail_player_device_mapping;
+        `)
+	return err
+}

--- a/model/datastore.go
+++ b/model/datastore.go
@@ -35,6 +35,7 @@ type DataStore interface {
 	Transcoding(ctx context.Context) TranscodingRepository
 	Player(ctx context.Context) PlayerRepository
 	Radio(ctx context.Context) RadioRepository
+	RetailPlayerDeviceMapping(ctx context.Context) RetailPlayerDeviceMappingRepository
 	Share(ctx context.Context) ShareRepository
 	Property(ctx context.Context) PropertyRepository
 	User(ctx context.Context) UserRepository

--- a/model/retail_player_device_mapping.go
+++ b/model/retail_player_device_mapping.go
@@ -1,0 +1,55 @@
+package model
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+type RetailPlayerDeviceMapping struct {
+	DeviceID     string    `db:"device_id" json:"deviceId"`
+	DeviceName   string    `db:"device_name" json:"deviceName"`
+	DeviceSlug   string    `db:"device_slug" json:"deviceSlug"`
+	Channel      string    `db:"channel" json:"channel"`
+	ChannelList  string    `db:"channel_list" json:"channelList"`
+	Organization string    `db:"organization" json:"organization"`
+	TimeZone     string    `db:"time_zone" json:"timeZone"`
+	UpdatedAt    time.Time `db:"updated_at" json:"updatedAt"`
+}
+
+type RetailPlayerDeviceMappingRepository interface {
+	Put(ctx context.Context, mapping RetailPlayerDeviceMapping) error
+	PutMany(ctx context.Context, mappings []RetailPlayerDeviceMapping) error
+	FindByIdentifier(ctx context.Context, identifier string) (*RetailPlayerDeviceMapping, error)
+	All(ctx context.Context) ([]RetailPlayerDeviceMapping, error)
+}
+
+func RetailPlayerNormalizeValue(value string) string {
+	return strings.TrimSpace(value)
+}
+
+func RetailPlayerDeviceSlug(value string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(value))
+	if trimmed == "" {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.Grow(len(trimmed))
+
+	lastWasHyphen := false
+	for _, r := range trimmed {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			builder.WriteRune(r)
+			lastWasHyphen = false
+			continue
+		}
+
+		if !lastWasHyphen && builder.Len() > 0 {
+			builder.WriteRune('-')
+			lastWasHyphen = true
+		}
+	}
+
+	return strings.Trim(builder.String(), "-")
+}

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -73,6 +73,10 @@ func (s *SQLStore) Radio(ctx context.Context) model.RadioRepository {
 	return NewRadioRepository(ctx, s.getDBXBuilder())
 }
 
+func (s *SQLStore) RetailPlayerDeviceMapping(ctx context.Context) model.RetailPlayerDeviceMappingRepository {
+	return NewRetailPlayerDeviceMappingRepository(ctx, s.getDBXBuilder())
+}
+
 func (s *SQLStore) UserProps(ctx context.Context) model.UserPropsRepository {
 	return NewUserPropsRepository(ctx, s.getDBXBuilder())
 }

--- a/persistence/retail_player_device_mapping_repository.go
+++ b/persistence/retail_player_device_mapping_repository.go
@@ -1,0 +1,131 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	. "github.com/Masterminds/squirrel"
+	"github.com/navidrome/navidrome/model"
+	"github.com/pocketbase/dbx"
+)
+
+type retailPlayerDeviceMappingRepository struct {
+	sqlRepository
+}
+
+func NewRetailPlayerDeviceMappingRepository(ctx context.Context, db dbx.Builder) model.RetailPlayerDeviceMappingRepository {
+	r := &retailPlayerDeviceMappingRepository{}
+	r.ctx = ctx
+	r.db = db
+	r.tableName = "retail_player_device_mapping"
+	r.registerModel(&model.RetailPlayerDeviceMapping{}, nil)
+	return r
+}
+
+func (r retailPlayerDeviceMappingRepository) Put(ctx context.Context, mapping model.RetailPlayerDeviceMapping) error {
+	if mapping.DeviceID == "" {
+		return errors.New("retail player device id is required")
+	}
+	return r.PutMany(ctx, []model.RetailPlayerDeviceMapping{mapping})
+}
+
+func (r retailPlayerDeviceMappingRepository) PutMany(ctx context.Context, mappings []model.RetailPlayerDeviceMapping) error {
+	if len(mappings) == 0 {
+		return nil
+	}
+
+	now := time.Now().UTC()
+
+	insert := Insert(r.tableName).
+		Columns("device_id", "device_name", "device_slug", "channel", "channel_list", "organization", "time_zone", "updated_at")
+	valuesAdded := 0
+
+	for _, mapping := range mappings {
+		id := strings.TrimSpace(mapping.DeviceID)
+		if id == "" {
+			continue
+		}
+
+		name := strings.TrimSpace(mapping.DeviceName)
+		slug := strings.TrimSpace(mapping.DeviceSlug)
+		if slug == "" {
+			slug = model.RetailPlayerDeviceSlug(name)
+			if slug == "" {
+				slug = model.RetailPlayerDeviceSlug(id)
+			}
+		}
+
+		insert = insert.Values(
+			id,
+			name,
+			slug,
+			strings.TrimSpace(mapping.Channel),
+			strings.TrimSpace(mapping.ChannelList),
+			strings.TrimSpace(mapping.Organization),
+			strings.TrimSpace(mapping.TimeZone),
+			now,
+		)
+		valuesAdded++
+	}
+
+	if valuesAdded == 0 {
+		return nil
+	}
+
+	insert = insert.Suffix(`ON CONFLICT(device_id) DO UPDATE SET
+                device_name = excluded.device_name,
+                device_slug = excluded.device_slug,
+                channel = excluded.channel,
+                channel_list = excluded.channel_list,
+                organization = excluded.organization,
+                time_zone = excluded.time_zone,
+                updated_at = excluded.updated_at`)
+
+	_, err := r.executeSQL(insert)
+	return err
+}
+
+func (r retailPlayerDeviceMappingRepository) FindByIdentifier(ctx context.Context, identifier string) (*model.RetailPlayerDeviceMapping, error) {
+	trimmed := model.RetailPlayerNormalizeValue(identifier)
+	if trimmed == "" {
+		return nil, model.ErrNotFound
+	}
+
+	slug := model.RetailPlayerDeviceSlug(trimmed)
+
+	conditions := []Sqlizer{Eq{"device_id": trimmed}}
+	conditions = append(conditions, Expr("lower(device_name) = lower(?)", trimmed))
+	if slug != "" {
+		conditions = append(conditions, Eq{"device_slug": slug})
+	}
+
+	sel := Select("device_id", "device_name", "device_slug", "channel", "channel_list", "organization", "time_zone", "updated_at").
+		From(r.tableName).
+		Where(Or(conditions...)).
+		OrderBy("updated_at DESC").
+		Limit(1)
+
+	var mapping model.RetailPlayerDeviceMapping
+	if err := r.queryOne(sel, &mapping); err != nil {
+		return nil, err
+	}
+	return &mapping, nil
+}
+
+func (r retailPlayerDeviceMappingRepository) All(ctx context.Context) ([]model.RetailPlayerDeviceMapping, error) {
+	sel := Select("device_id", "device_name", "device_slug", "channel", "channel_list", "organization", "time_zone", "updated_at").
+		From(r.tableName).
+		OrderBy("updated_at DESC")
+
+	var mappings []model.RetailPlayerDeviceMapping
+	err := r.queryAll(sel, &mappings)
+	if err != nil {
+		if errors.Is(err, model.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return mappings, nil
+}

--- a/persistence/retail_player_device_mapping_repository.go
+++ b/persistence/retail_player_device_mapping_repository.go
@@ -101,9 +101,12 @@ func (r retailPlayerDeviceMappingRepository) FindByIdentifier(ctx context.Contex
 		conditions = append(conditions, Eq{"device_slug": slug})
 	}
 
+	orClause := Or{}
+	orClause = append(orClause, conditions...)
+
 	sel := Select("device_id", "device_name", "device_slug", "channel", "channel_list", "organization", "time_zone", "updated_at").
 		From(r.tableName).
-		Where(Or(conditions...)).
+		Where(orClause).
 		OrderBy("updated_at DESC").
 		Limit(1)
 

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -40,6 +40,7 @@ func (n *Router) routes() http.Handler {
 	r := chi.NewRouter()
 
 	// Public
+	n.addRetailPlayerPublicRoutes(r)
 	n.RX(r, "/translation", newTranslationRepository, false)
 
 	// Protected
@@ -71,7 +72,7 @@ func (n *Router) routes() http.Handler {
 		n.addNotificationsRoute(r)
 		n.addKeepAliveRoute(r)
 		n.addInsightsRoute(r)
-		n.addRetailPlayerRoute(r)
+		n.addRetailPlayerPrivateRoutes(r)
 
 		r.With(adminOnlyMiddleware).Group(func(r chi.Router) {
 			n.addInspectRoute(r)

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/deluan/rest"
@@ -40,8 +41,50 @@ func New(ds model.DataStore, share core.Share, playlists core.Playlists, insight
 		libs:      libraryService,
 		devices:   newRetailPlayerDeviceResolver(),
 	}
+	r.preloadRetailPlayerDeviceMappings()
 	r.Handler = r.routes()
 	return r
+}
+
+func (n *Router) preloadRetailPlayerDeviceMappings() {
+	if n.ds == nil || n.devices == nil {
+		return
+	}
+
+	ctx := context.Background()
+	repo := n.ds.RetailPlayerDeviceMapping(ctx)
+	if repo == nil {
+		return
+	}
+
+	mappings, err := repo.All(ctx)
+	if err != nil {
+		log.Error(ctx, "Unable to preload retail player device mappings", "err", err)
+		return
+	}
+
+	if len(mappings) == 0 {
+		return
+	}
+
+	devices := make([]retailPlayerDevice, 0, len(mappings))
+	for _, mapping := range mappings {
+		id := strings.TrimSpace(mapping.DeviceID)
+		if id == "" {
+			continue
+		}
+
+		devices = append(devices, retailPlayerDevice{
+			ID:           id,
+			Name:         strings.TrimSpace(mapping.DeviceName),
+			Channel:      strings.TrimSpace(mapping.Channel),
+			ChannelList:  strings.TrimSpace(mapping.ChannelList),
+			Organization: strings.TrimSpace(mapping.Organization),
+			TimeZone:     strings.TrimSpace(mapping.TimeZone),
+		})
+	}
+
+	n.devices.RememberDevices(devices)
 }
 
 func (n *Router) routes() http.Handler {

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -28,10 +28,18 @@ type Router struct {
 	playlists core.Playlists
 	insights  metrics.Insights
 	libs      core.Library
+	devices   *retailPlayerDeviceResolver
 }
 
 func New(ds model.DataStore, share core.Share, playlists core.Playlists, insights metrics.Insights, libraryService core.Library) *Router {
-	r := &Router{ds: ds, share: share, playlists: playlists, insights: insights, libs: libraryService}
+	r := &Router{
+		ds:        ds,
+		share:     share,
+		playlists: playlists,
+		insights:  insights,
+		libs:      libraryService,
+		devices:   newRetailPlayerDeviceResolver(),
+	}
 	r.Handler = r.routes()
 	return r
 }

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -98,15 +98,20 @@ type retailPlayerConfig struct {
 	AdditionalHeaders map[string]string
 }
 
-func (n *Router) addRetailPlayerRoute(r chi.Router) {
+func (n *Router) addRetailPlayerPublicRoutes(r chi.Router) {
 	r.Route("/retailplayer", func(r chi.Router) {
-		r.Get("/devices", n.handleRetailPlayerDevices())
 		r.Get("/devices/{deviceID}/status", n.handleRetailPlayerDeviceStatus())
 		r.Get("/channel-lists/{channelListID}/channels", n.handleRetailPlayerChannelListChannels())
 		r.Post("/devices/{deviceID}/volume", n.handleRetailPlayerDeviceVolume())
 		r.Post("/devices/{deviceID}/channel", n.handleRetailPlayerDeviceChannel())
 		r.Post("/devices/{deviceID}/channel/toggle", n.handleRetailPlayerDeviceToggleChannel())
 		r.Post("/devices/{deviceID}/dislike", n.handleRetailPlayerDeviceDislike())
+	})
+}
+
+func (n *Router) addRetailPlayerPrivateRoutes(r chi.Router) {
+	r.Route("/retailplayer", func(r chi.Router) {
+		r.Get("/devices", n.handleRetailPlayerDevices())
 	})
 }
 
@@ -147,31 +152,75 @@ func (n *Router) handleRetailPlayerDeviceStatus() http.HandlerFunc {
 			return
 		}
 
-		deviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
-		if deviceID == "" {
+		deviceIdentifier := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		if deviceIdentifier == "" {
 			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
 			return
 		}
 
-		log.Info(ctx, "Fetching retail player device status from remote API", "deviceID", deviceID)
-		response, err := n.fetchRetailPlayerDeviceStatus(ctx, deviceID)
+		log.Info(ctx, "Fetching retail player device status from remote API", "identifier", deviceIdentifier)
+
+		resolvedID := deviceIdentifier
+		device, err := fetchRetailPlayerDevice(ctx, resolvedID)
 		if err != nil {
 			if errors.Is(err, errRetailPlayerDeviceNotFound) {
-				log.Info(ctx, "Retail player device not found", "deviceID", deviceID)
+				log.Info(ctx, "Retail player device not found by id, attempting lookup", "identifier", deviceIdentifier)
+				device, err = lookupRetailPlayerDevice(ctx, deviceIdentifier)
+				if err != nil {
+					if errors.Is(err, errRetailPlayerDeviceNotFound) {
+						log.Info(ctx, "Retail player device not found", "identifier", deviceIdentifier)
+						http.Error(w, "Retail player device not found", http.StatusNotFound)
+						return
+					}
+
+					log.Error(ctx, "Unable to lookup retail player device", "identifier", deviceIdentifier, "err", err)
+					http.Error(w, "Unable to fetch retail player device status", http.StatusBadGateway)
+					return
+				}
+				resolvedID = strings.TrimSpace(device.ID)
+			} else {
+				log.Error(ctx, "Unable to fetch retail player device metadata", "identifier", deviceIdentifier, "err", err)
+				http.Error(w, "Unable to fetch retail player device status", http.StatusBadGateway)
+				return
+			}
+		}
+
+		if resolvedID == "" {
+			log.Info(ctx, "Retail player device missing resolved id", "identifier", deviceIdentifier)
+			http.Error(w, "Retail player device not found", http.StatusNotFound)
+			return
+		}
+
+		response, err := n.fetchRetailPlayerDeviceStatus(ctx, resolvedID)
+		if err != nil {
+			if errors.Is(err, errRetailPlayerDeviceNotFound) {
+				log.Info(ctx, "Retail player device not found while fetching status", "identifier", deviceIdentifier, "resolvedID", resolvedID)
 				http.Error(w, "Retail player device not found", http.StatusNotFound)
 				return
 			}
 
-			log.Error(ctx, "Unable to fetch retail player device status", "deviceID", deviceID, "err", err)
+			log.Error(ctx, "Unable to fetch retail player device status", "identifier", deviceIdentifier, "resolvedID", resolvedID, "err", err)
 			http.Error(w, "Unable to fetch retail player device status", http.StatusBadGateway)
 			return
 		}
 
-		log.Info(ctx, "Retail player device status fetched", "deviceID", deviceID)
+		if device.ID == "" {
+			if metadata, metadataErr := fetchRetailPlayerDevice(ctx, resolvedID); metadataErr == nil {
+				device = metadata
+			} else {
+				log.Debug(ctx, "Unable to fetch device metadata after status", "identifier", deviceIdentifier, "resolvedID", resolvedID, "err", metadataErr)
+			}
+		}
+
+		if device.ID != "" {
+			response.Device = &device
+		}
+
+		log.Info(ctx, "Retail player device status fetched", "identifier", deviceIdentifier, "resolvedID", resolvedID)
 
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(response); err != nil {
-			log.Error(ctx, "Unable to encode retail player device status response", "deviceID", deviceID, "err", err)
+			log.Error(ctx, "Unable to encode retail player device status response", "identifier", deviceIdentifier, "resolvedID", resolvedID, "err", err)
 		}
 	}
 }
@@ -625,6 +674,83 @@ func fetchRetailPlayerDevices(ctx context.Context) (retailPlayerDevicesResponse,
 	}, nil
 }
 
+func lookupRetailPlayerDevice(ctx context.Context, identifier string) (retailPlayerDevice, error) {
+	normalizedIdentifier := strings.TrimSpace(identifier)
+	if normalizedIdentifier == "" {
+		return retailPlayerDevice{}, errRetailPlayerDeviceNotFound
+	}
+
+	slugKey := retailPlayerDeviceSlugKey(normalizedIdentifier)
+	lowerIdentifier := strings.ToLower(normalizedIdentifier)
+
+	response, err := fetchRetailPlayerDevices(ctx)
+	if err != nil {
+		return retailPlayerDevice{}, err
+	}
+
+	for _, device := range response.Data {
+		if strings.EqualFold(strings.TrimSpace(device.ID), normalizedIdentifier) {
+			return device, nil
+		}
+		if strings.EqualFold(strings.TrimSpace(device.Name), normalizedIdentifier) {
+			return device, nil
+		}
+
+		if slugKey == "" {
+			continue
+		}
+
+		if retailPlayerDeviceSlugKey(device.Name) == slugKey {
+			return device, nil
+		}
+
+		if retailPlayerDeviceSlugKey(device.ID) == slugKey {
+			return device, nil
+		}
+
+		if lowerIdentifier != "" {
+			if retailPlayerDeviceSlugKey(device.Channel) == slugKey {
+				return device, nil
+			}
+			if retailPlayerDeviceSlugKey(device.ChannelList) == slugKey {
+				return device, nil
+			}
+			if retailPlayerDeviceSlugKey(device.Organization) == slugKey {
+				return device, nil
+			}
+		}
+	}
+
+	return retailPlayerDevice{}, errRetailPlayerDeviceNotFound
+}
+
+func retailPlayerDeviceSlugKey(value string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(value))
+	if trimmed == "" {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.Grow(len(trimmed))
+
+	lastWasHyphen := false
+	for _, r := range trimmed {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			builder.WriteRune(r)
+			lastWasHyphen = false
+			continue
+		}
+
+		if !lastWasHyphen && builder.Len() > 0 {
+			builder.WriteRune('-')
+			lastWasHyphen = true
+		}
+	}
+
+	result := strings.Trim(builder.String(), "-")
+	return result
+}
+
 func fetchRetailPlayerDevice(ctx context.Context, deviceID string) (retailPlayerDevice, error) {
 	cfg := conf.Server.RetailPlayer
 	if cfg.BaseURL == "" || cfg.OrgID == "" {
@@ -748,6 +874,7 @@ type retailPlayerDeviceStatusResponse struct {
 	Status         map[string]any             `json:"status"`
 	StreamMetadata []map[string]any           `json:"streamMetadata"`
 	Artwork        *retailPlayerStatusArtwork `json:"artwork,omitempty"`
+	Device         *retailPlayerDevice        `json:"device,omitempty"`
 }
 
 type retailPlayerCommandRequest struct {

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -253,6 +253,7 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 		log.Info(ctx, "Retail player devices fetched", "count", len(response.Data))
 
 		n.devices.RememberDevices(response.Data)
+		n.persistRetailPlayerDeviceMappings(ctx, response.Data)
 
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(response); err != nil {
@@ -318,6 +319,10 @@ func (n *Router) handleRetailPlayerDeviceStatus() http.HandlerFunc {
 			response.Device = &deviceCopy
 		}
 
+		if response.Device != nil {
+			n.persistRetailPlayerDeviceMappings(ctx, []retailPlayerDevice{*response.Device})
+		}
+
 		log.Info(ctx, "Retail player device status fetched", "identifier", deviceIdentifier, "resolvedID", resolvedID)
 
 		w.Header().Set("Content-Type", "application/json")
@@ -337,9 +342,17 @@ func (n *Router) resolveRetailPlayerDevice(ctx context.Context, identifier strin
 		return device, nil
 	}
 
+	if mappedDevice, err := n.findRetailPlayerDeviceMapping(ctx, trimmed); err == nil {
+		n.devices.Remember(mappedDevice)
+		return mappedDevice, nil
+	} else if err != nil && !errors.Is(err, errRetailPlayerDeviceNotFound) {
+		return retailPlayerDevice{}, err
+	}
+
 	device, err := fetchRetailPlayerDevice(ctx, trimmed)
 	if err == nil {
 		n.devices.Remember(device)
+		n.persistRetailPlayerDeviceMappings(ctx, []retailPlayerDevice{device})
 		return device, nil
 	}
 	if err != nil && !errors.Is(err, errRetailPlayerDeviceNotFound) {
@@ -350,12 +363,103 @@ func (n *Router) resolveRetailPlayerDevice(ctx context.Context, identifier strin
 	device, devices, lookupErr := lookupRetailPlayerDevice(ctx, trimmed)
 	if len(devices) > 0 {
 		n.devices.RememberDevices(devices)
+		n.persistRetailPlayerDeviceMappings(ctx, devices)
 	}
 	if lookupErr != nil {
 		return retailPlayerDevice{}, lookupErr
 	}
 
+	if strings.TrimSpace(device.ID) != "" {
+		n.persistRetailPlayerDeviceMappings(ctx, []retailPlayerDevice{device})
+	}
+
 	return device, nil
+}
+
+func (n *Router) findRetailPlayerDeviceMapping(ctx context.Context, identifier string) (retailPlayerDevice, error) {
+	if n.ds == nil {
+		return retailPlayerDevice{}, errRetailPlayerDeviceNotFound
+	}
+
+	repo := n.ds.RetailPlayerDeviceMapping(ctx)
+	if repo == nil {
+		return retailPlayerDevice{}, errRetailPlayerDeviceNotFound
+	}
+
+	mapping, err := repo.FindByIdentifier(ctx, identifier)
+	if err != nil {
+		if errors.Is(err, model.ErrNotFound) {
+			return retailPlayerDevice{}, errRetailPlayerDeviceNotFound
+		}
+		return retailPlayerDevice{}, err
+	}
+
+	device := mapRetailPlayerMappingToDevice(*mapping)
+	if strings.TrimSpace(device.ID) == "" {
+		return retailPlayerDevice{}, errRetailPlayerDeviceNotFound
+	}
+
+	return device, nil
+}
+
+func (n *Router) persistRetailPlayerDeviceMappings(ctx context.Context, devices []retailPlayerDevice) {
+	if len(devices) == 0 || n.ds == nil {
+		return
+	}
+
+	repo := n.ds.RetailPlayerDeviceMapping(ctx)
+	if repo == nil {
+		return
+	}
+
+	mappings := make([]model.RetailPlayerDeviceMapping, 0, len(devices))
+	for _, device := range devices {
+		if mapping, ok := mapRetailPlayerDeviceToMapping(device); ok {
+			mappings = append(mappings, mapping)
+		}
+	}
+
+	if len(mappings) == 0 {
+		return
+	}
+
+	if err := repo.PutMany(ctx, mappings); err != nil {
+		log.Error(ctx, "Unable to persist retail player device mappings", "err", err)
+	}
+}
+
+func mapRetailPlayerDeviceToMapping(device retailPlayerDevice) (model.RetailPlayerDeviceMapping, bool) {
+	id := strings.TrimSpace(device.ID)
+	if id == "" {
+		return model.RetailPlayerDeviceMapping{}, false
+	}
+
+	name := strings.TrimSpace(device.Name)
+	slug := model.RetailPlayerDeviceSlug(name)
+	if slug == "" {
+		slug = model.RetailPlayerDeviceSlug(id)
+	}
+
+	return model.RetailPlayerDeviceMapping{
+		DeviceID:     id,
+		DeviceName:   name,
+		DeviceSlug:   slug,
+		Channel:      strings.TrimSpace(device.Channel),
+		ChannelList:  strings.TrimSpace(device.ChannelList),
+		Organization: strings.TrimSpace(device.Organization),
+		TimeZone:     strings.TrimSpace(device.TimeZone),
+	}, true
+}
+
+func mapRetailPlayerMappingToDevice(mapping model.RetailPlayerDeviceMapping) retailPlayerDevice {
+	return retailPlayerDevice{
+		ID:           strings.TrimSpace(mapping.DeviceID),
+		Name:         strings.TrimSpace(mapping.DeviceName),
+		Channel:      strings.TrimSpace(mapping.Channel),
+		ChannelList:  strings.TrimSpace(mapping.ChannelList),
+		Organization: strings.TrimSpace(mapping.Organization),
+		TimeZone:     strings.TrimSpace(mapping.TimeZone),
+	}
 }
 
 func (n *Router) handleRetailPlayerChannelListChannels() http.HandlerFunc {
@@ -584,6 +688,9 @@ func (n *Router) handleRetailPlayerDeviceToggleChannel() http.HandlerFunc {
 			}
 
 			log.Info(ctx, "Retail player device metadata fetched for toggle", "deviceID", deviceID, "channel", device.Channel, "channelList", device.ChannelList)
+
+			n.devices.Remember(device)
+			n.persistRetailPlayerDeviceMappings(ctx, []retailPlayerDevice{device})
 
 			if currentChannelID == "" {
 				currentChannelID = strings.TrimSpace(device.Channel)
@@ -858,30 +965,7 @@ func lookupRetailPlayerDevice(ctx context.Context, identifier string) (retailPla
 }
 
 func retailPlayerDeviceSlugKey(value string) string {
-	trimmed := strings.ToLower(strings.TrimSpace(value))
-	if trimmed == "" {
-		return ""
-	}
-
-	var builder strings.Builder
-	builder.Grow(len(trimmed))
-
-	lastWasHyphen := false
-	for _, r := range trimmed {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
-			builder.WriteRune(r)
-			lastWasHyphen = false
-			continue
-		}
-
-		if !lastWasHyphen && builder.Len() > 0 {
-			builder.WriteRune('-')
-			lastWasHyphen = true
-		}
-	}
-
-	result := strings.Trim(builder.String(), "-")
-	return result
+	return model.RetailPlayerDeviceSlug(value)
 }
 
 func fetchRetailPlayerDevice(ctx context.Context, deviceID string) (retailPlayerDevice, error) {
@@ -1003,9 +1087,42 @@ func fetchRetailPlayerChannelListChannels(ctx context.Context, channelListID str
 	return retailPlayerChannelsResponse{Channels: channels}, nil
 }
 
+type retailPlayerStreamMetadata []map[string]any
+
+func (m *retailPlayerStreamMetadata) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		*m = nil
+		return nil
+	}
+
+	switch trimmed[0] {
+	case '[':
+		var slice []map[string]any
+		if err := json.Unmarshal(trimmed, &slice); err != nil {
+			return err
+		}
+		*m = slice
+	case '{':
+		var obj map[string]any
+		if err := json.Unmarshal(trimmed, &obj); err != nil {
+			return err
+		}
+		if len(obj) == 0 {
+			*m = nil
+		} else {
+			*m = []map[string]any{obj}
+		}
+	default:
+		*m = nil
+	}
+
+	return nil
+}
+
 type retailPlayerDeviceStatusResponse struct {
 	Status         map[string]any             `json:"status"`
-	StreamMetadata []map[string]any           `json:"streamMetadata"`
+	StreamMetadata retailPlayerStreamMetadata `json:"streamMetadata"`
 	Artwork        *retailPlayerStatusArtwork `json:"artwork,omitempty"`
 	Device         *retailPlayerDevice        `json:"device,omitempty"`
 }

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -15,6 +15,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -30,6 +31,123 @@ const (
 )
 
 var retailPlayerHTTPClient = &http.Client{Timeout: 15 * time.Second}
+
+type retailPlayerDeviceResolver struct {
+	mu      sync.RWMutex
+	devices map[string]retailPlayerDevice
+}
+
+func newRetailPlayerDeviceResolver() *retailPlayerDeviceResolver {
+	return &retailPlayerDeviceResolver{devices: make(map[string]retailPlayerDevice)}
+}
+
+func (r *retailPlayerDeviceResolver) Remember(device retailPlayerDevice) {
+	if r == nil {
+		return
+	}
+	r.RememberDevices([]retailPlayerDevice{device})
+}
+
+func (r *retailPlayerDeviceResolver) RememberDevices(devices []retailPlayerDevice) {
+	if r == nil || len(devices) == 0 {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.devices == nil {
+		r.devices = make(map[string]retailPlayerDevice, len(devices)*4)
+	}
+
+	for _, device := range devices {
+		trimmedID := strings.TrimSpace(device.ID)
+		if trimmedID == "" {
+			continue
+		}
+
+		keys := make(map[string]struct{})
+		addKey := func(key string) {
+			if key != "" {
+				keys[key] = struct{}{}
+			}
+		}
+
+		addKey(makeRetailPlayerExactKey(trimmedID))
+		addKey(makeRetailPlayerNormalizedKey(trimmedID))
+		addKey(makeRetailPlayerSlugKey(trimmedID))
+
+		candidates := []string{device.Name, device.Channel, device.ChannelList, device.Organization}
+		for _, candidate := range candidates {
+			trimmed := strings.TrimSpace(candidate)
+			if trimmed == "" {
+				continue
+			}
+			addKey(makeRetailPlayerExactKey(trimmed))
+			addKey(makeRetailPlayerNormalizedKey(trimmed))
+			addKey(makeRetailPlayerSlugKey(trimmed))
+		}
+
+		for key := range keys {
+			r.devices[key] = device
+		}
+	}
+}
+
+func (r *retailPlayerDeviceResolver) Find(identifier string) (retailPlayerDevice, bool) {
+	if r == nil {
+		return retailPlayerDevice{}, false
+	}
+
+	trimmed := strings.TrimSpace(identifier)
+	if trimmed == "" {
+		return retailPlayerDevice{}, false
+	}
+
+	keys := []string{
+		makeRetailPlayerExactKey(trimmed),
+		makeRetailPlayerNormalizedKey(trimmed),
+		makeRetailPlayerSlugKey(trimmed),
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, key := range keys {
+		if key == "" {
+			continue
+		}
+		if device, ok := r.devices[key]; ok {
+			return device, true
+		}
+	}
+
+	return retailPlayerDevice{}, false
+}
+
+func makeRetailPlayerExactKey(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	return "exact:" + trimmed
+}
+
+func makeRetailPlayerNormalizedKey(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	if normalized == "" {
+		return ""
+	}
+	return "norm:" + normalized
+}
+
+func makeRetailPlayerSlugKey(value string) string {
+	slug := retailPlayerDeviceSlugKey(value)
+	if slug == "" {
+		return ""
+	}
+	return "slug:" + slug
+}
 
 type retailPlayerAPIDevice struct {
 	Ordinal      *int   `json:"ordinal"`
@@ -110,9 +228,7 @@ func (n *Router) addRetailPlayerPublicRoutes(r chi.Router) {
 }
 
 func (n *Router) addRetailPlayerPrivateRoutes(r chi.Router) {
-	r.Route("/retailplayer", func(r chi.Router) {
-		r.Get("/devices", n.handleRetailPlayerDevices())
-	})
+	r.Get("/retailplayer/devices", n.handleRetailPlayerDevices())
 }
 
 var errRetailPlayerDeviceNotFound = errors.New("retail player device not found")
@@ -135,6 +251,8 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 		}
 
 		log.Info(ctx, "Retail player devices fetched", "count", len(response.Data))
+
+		n.devices.RememberDevices(response.Data)
 
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(response); err != nil {
@@ -160,31 +278,20 @@ func (n *Router) handleRetailPlayerDeviceStatus() http.HandlerFunc {
 
 		log.Info(ctx, "Fetching retail player device status from remote API", "identifier", deviceIdentifier)
 
-		resolvedID := deviceIdentifier
-		device, err := fetchRetailPlayerDevice(ctx, resolvedID)
+		device, err := n.resolveRetailPlayerDevice(ctx, deviceIdentifier)
 		if err != nil {
 			if errors.Is(err, errRetailPlayerDeviceNotFound) {
-				log.Info(ctx, "Retail player device not found by id, attempting lookup", "identifier", deviceIdentifier)
-				device, err = lookupRetailPlayerDevice(ctx, deviceIdentifier)
-				if err != nil {
-					if errors.Is(err, errRetailPlayerDeviceNotFound) {
-						log.Info(ctx, "Retail player device not found", "identifier", deviceIdentifier)
-						http.Error(w, "Retail player device not found", http.StatusNotFound)
-						return
-					}
-
-					log.Error(ctx, "Unable to lookup retail player device", "identifier", deviceIdentifier, "err", err)
-					http.Error(w, "Unable to fetch retail player device status", http.StatusBadGateway)
-					return
-				}
-				resolvedID = strings.TrimSpace(device.ID)
-			} else {
-				log.Error(ctx, "Unable to fetch retail player device metadata", "identifier", deviceIdentifier, "err", err)
-				http.Error(w, "Unable to fetch retail player device status", http.StatusBadGateway)
+				log.Info(ctx, "Retail player device not found", "identifier", deviceIdentifier)
+				http.Error(w, "Retail player device not found", http.StatusNotFound)
 				return
 			}
+
+			log.Error(ctx, "Unable to resolve retail player device", "identifier", deviceIdentifier, "err", err)
+			http.Error(w, "Unable to fetch retail player device status", http.StatusBadGateway)
+			return
 		}
 
+		resolvedID := strings.TrimSpace(device.ID)
 		if resolvedID == "" {
 			log.Info(ctx, "Retail player device missing resolved id", "identifier", deviceIdentifier)
 			http.Error(w, "Retail player device not found", http.StatusNotFound)
@@ -204,16 +311,11 @@ func (n *Router) handleRetailPlayerDeviceStatus() http.HandlerFunc {
 			return
 		}
 
-		if device.ID == "" {
-			if metadata, metadataErr := fetchRetailPlayerDevice(ctx, resolvedID); metadataErr == nil {
-				device = metadata
-			} else {
-				log.Debug(ctx, "Unable to fetch device metadata after status", "identifier", deviceIdentifier, "resolvedID", resolvedID, "err", metadataErr)
-			}
-		}
-
-		if device.ID != "" {
-			response.Device = &device
+		if response.Device != nil {
+			n.devices.Remember(*response.Device)
+		} else {
+			deviceCopy := device
+			response.Device = &deviceCopy
 		}
 
 		log.Info(ctx, "Retail player device status fetched", "identifier", deviceIdentifier, "resolvedID", resolvedID)
@@ -223,6 +325,37 @@ func (n *Router) handleRetailPlayerDeviceStatus() http.HandlerFunc {
 			log.Error(ctx, "Unable to encode retail player device status response", "identifier", deviceIdentifier, "resolvedID", resolvedID, "err", err)
 		}
 	}
+}
+
+func (n *Router) resolveRetailPlayerDevice(ctx context.Context, identifier string) (retailPlayerDevice, error) {
+	trimmed := strings.TrimSpace(identifier)
+	if trimmed == "" {
+		return retailPlayerDevice{}, errRetailPlayerDeviceNotFound
+	}
+
+	if device, ok := n.devices.Find(trimmed); ok {
+		return device, nil
+	}
+
+	device, err := fetchRetailPlayerDevice(ctx, trimmed)
+	if err == nil {
+		n.devices.Remember(device)
+		return device, nil
+	}
+	if err != nil && !errors.Is(err, errRetailPlayerDeviceNotFound) {
+		return retailPlayerDevice{}, err
+	}
+
+	log.Info(ctx, "Retail player device not found by id, attempting lookup", "identifier", identifier)
+	device, devices, lookupErr := lookupRetailPlayerDevice(ctx, trimmed)
+	if len(devices) > 0 {
+		n.devices.RememberDevices(devices)
+	}
+	if lookupErr != nil {
+		return retailPlayerDevice{}, lookupErr
+	}
+
+	return device, nil
 }
 
 func (n *Router) handleRetailPlayerChannelListChannels() http.HandlerFunc {
@@ -674,10 +807,10 @@ func fetchRetailPlayerDevices(ctx context.Context) (retailPlayerDevicesResponse,
 	}, nil
 }
 
-func lookupRetailPlayerDevice(ctx context.Context, identifier string) (retailPlayerDevice, error) {
+func lookupRetailPlayerDevice(ctx context.Context, identifier string) (retailPlayerDevice, []retailPlayerDevice, error) {
 	normalizedIdentifier := strings.TrimSpace(identifier)
 	if normalizedIdentifier == "" {
-		return retailPlayerDevice{}, errRetailPlayerDeviceNotFound
+		return retailPlayerDevice{}, nil, errRetailPlayerDeviceNotFound
 	}
 
 	slugKey := retailPlayerDeviceSlugKey(normalizedIdentifier)
@@ -685,15 +818,15 @@ func lookupRetailPlayerDevice(ctx context.Context, identifier string) (retailPla
 
 	response, err := fetchRetailPlayerDevices(ctx)
 	if err != nil {
-		return retailPlayerDevice{}, err
+		return retailPlayerDevice{}, nil, err
 	}
 
 	for _, device := range response.Data {
 		if strings.EqualFold(strings.TrimSpace(device.ID), normalizedIdentifier) {
-			return device, nil
+			return device, response.Data, nil
 		}
 		if strings.EqualFold(strings.TrimSpace(device.Name), normalizedIdentifier) {
-			return device, nil
+			return device, response.Data, nil
 		}
 
 		if slugKey == "" {
@@ -701,27 +834,27 @@ func lookupRetailPlayerDevice(ctx context.Context, identifier string) (retailPla
 		}
 
 		if retailPlayerDeviceSlugKey(device.Name) == slugKey {
-			return device, nil
+			return device, response.Data, nil
 		}
 
 		if retailPlayerDeviceSlugKey(device.ID) == slugKey {
-			return device, nil
+			return device, response.Data, nil
 		}
 
 		if lowerIdentifier != "" {
 			if retailPlayerDeviceSlugKey(device.Channel) == slugKey {
-				return device, nil
+				return device, response.Data, nil
 			}
 			if retailPlayerDeviceSlugKey(device.ChannelList) == slugKey {
-				return device, nil
+				return device, response.Data, nil
 			}
 			if retailPlayerDeviceSlugKey(device.Organization) == slugKey {
-				return device, nil
+				return device, response.Data, nil
 			}
 		}
 	}
 
-	return retailPlayerDevice{}, errRetailPlayerDeviceNotFound
+	return retailPlayerDevice{}, response.Data, errRetailPlayerDeviceNotFound
 }
 
 func retailPlayerDeviceSlugKey(value string) string {
@@ -781,7 +914,7 @@ func fetchRetailPlayerDevice(ctx context.Context, deviceID string) (retailPlayer
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusNotFound {
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusBadRequest {
 		return retailPlayerDevice{}, errRetailPlayerDeviceNotFound
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -149,6 +149,27 @@ func makeRetailPlayerSlugKey(value string) string {
 	return "slug:" + slug
 }
 
+func normalizeRetailPlayerIdentifier(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+
+	decoded := trimmed
+	for i := 0; i < 5; i++ {
+		unescaped, err := url.PathUnescape(decoded)
+		if err != nil {
+			break
+		}
+		if unescaped == decoded {
+			break
+		}
+		decoded = unescaped
+	}
+
+	return strings.TrimSpace(decoded)
+}
+
 type retailPlayerAPIDevice struct {
 	Ordinal      *int   `json:"ordinal"`
 	ID           string `json:"id"`
@@ -271,23 +292,24 @@ func (n *Router) handleRetailPlayerDeviceStatus() http.HandlerFunc {
 			return
 		}
 
-		deviceIdentifier := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		rawIdentifier := chi.URLParam(r, "deviceID")
+		deviceIdentifier := normalizeRetailPlayerIdentifier(rawIdentifier)
 		if deviceIdentifier == "" {
-			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
+			http.Error(w, "Retail player device identifier is required", http.StatusBadRequest)
 			return
 		}
 
-		log.Info(ctx, "Fetching retail player device status from remote API", "identifier", deviceIdentifier)
+		log.Info(ctx, "Fetching retail player device status from remote API", "identifier", deviceIdentifier, "rawIdentifier", rawIdentifier)
 
 		device, err := n.resolveRetailPlayerDevice(ctx, deviceIdentifier)
 		if err != nil {
 			if errors.Is(err, errRetailPlayerDeviceNotFound) {
-				log.Info(ctx, "Retail player device not found", "identifier", deviceIdentifier)
+				log.Info(ctx, "Retail player device not found", "identifier", deviceIdentifier, "rawIdentifier", rawIdentifier)
 				http.Error(w, "Retail player device not found", http.StatusNotFound)
 				return
 			}
 
-			log.Error(ctx, "Unable to resolve retail player device", "identifier", deviceIdentifier, "err", err)
+			log.Error(ctx, "Unable to resolve retail player device", "identifier", deviceIdentifier, "rawIdentifier", rawIdentifier, "err", err)
 			http.Error(w, "Unable to fetch retail player device status", http.StatusBadGateway)
 			return
 		}
@@ -302,12 +324,12 @@ func (n *Router) handleRetailPlayerDeviceStatus() http.HandlerFunc {
 		response, err := n.fetchRetailPlayerDeviceStatus(ctx, resolvedID)
 		if err != nil {
 			if errors.Is(err, errRetailPlayerDeviceNotFound) {
-				log.Info(ctx, "Retail player device not found while fetching status", "identifier", deviceIdentifier, "resolvedID", resolvedID)
+				log.Info(ctx, "Retail player device not found while fetching status", "identifier", deviceIdentifier, "rawIdentifier", rawIdentifier, "resolvedID", resolvedID)
 				http.Error(w, "Retail player device not found", http.StatusNotFound)
 				return
 			}
 
-			log.Error(ctx, "Unable to fetch retail player device status", "identifier", deviceIdentifier, "resolvedID", resolvedID, "err", err)
+			log.Error(ctx, "Unable to fetch retail player device status", "identifier", deviceIdentifier, "rawIdentifier", rawIdentifier, "resolvedID", resolvedID, "err", err)
 			http.Error(w, "Unable to fetch retail player device status", http.StatusBadGateway)
 			return
 		}
@@ -323,7 +345,7 @@ func (n *Router) handleRetailPlayerDeviceStatus() http.HandlerFunc {
 			n.persistRetailPlayerDeviceMappings(ctx, []retailPlayerDevice{*response.Device})
 		}
 
-		log.Info(ctx, "Retail player device status fetched", "identifier", deviceIdentifier, "resolvedID", resolvedID)
+		log.Info(ctx, "Retail player device status fetched", "identifier", deviceIdentifier, "rawIdentifier", rawIdentifier, "resolvedID", resolvedID)
 
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(response); err != nil {
@@ -333,23 +355,23 @@ func (n *Router) handleRetailPlayerDeviceStatus() http.HandlerFunc {
 }
 
 func (n *Router) resolveRetailPlayerDevice(ctx context.Context, identifier string) (retailPlayerDevice, error) {
-	trimmed := strings.TrimSpace(identifier)
-	if trimmed == "" {
+	normalized := normalizeRetailPlayerIdentifier(identifier)
+	if normalized == "" {
 		return retailPlayerDevice{}, errRetailPlayerDeviceNotFound
 	}
 
-	if device, ok := n.devices.Find(trimmed); ok {
+	if device, ok := n.devices.Find(normalized); ok {
 		return device, nil
 	}
 
-	if mappedDevice, err := n.findRetailPlayerDeviceMapping(ctx, trimmed); err == nil {
+	if mappedDevice, err := n.findRetailPlayerDeviceMapping(ctx, normalized); err == nil {
 		n.devices.Remember(mappedDevice)
 		return mappedDevice, nil
 	} else if err != nil && !errors.Is(err, errRetailPlayerDeviceNotFound) {
 		return retailPlayerDevice{}, err
 	}
 
-	device, err := fetchRetailPlayerDevice(ctx, trimmed)
+	device, err := fetchRetailPlayerDevice(ctx, normalized)
 	if err == nil {
 		n.devices.Remember(device)
 		n.persistRetailPlayerDeviceMappings(ctx, []retailPlayerDevice{device})
@@ -359,8 +381,8 @@ func (n *Router) resolveRetailPlayerDevice(ctx context.Context, identifier strin
 		return retailPlayerDevice{}, err
 	}
 
-	log.Info(ctx, "Retail player device not found by id, attempting lookup", "identifier", identifier)
-	device, devices, lookupErr := lookupRetailPlayerDevice(ctx, trimmed)
+	log.Info(ctx, "Retail player device not found by id, attempting lookup", "identifier", normalized)
+	device, devices, lookupErr := lookupRetailPlayerDevice(ctx, normalized)
 	if len(devices) > 0 {
 		n.devices.RememberDevices(devices)
 		n.persistRetailPlayerDeviceMappings(ctx, devices)

--- a/tests/mock_data_store.go
+++ b/tests/mock_data_store.go
@@ -8,28 +8,29 @@ import (
 )
 
 type MockDataStore struct {
-	RealDS               model.DataStore
-	MockedLibrary        model.LibraryRepository
-	MockedFolder         model.FolderRepository
-	MockedGenre          model.GenreRepository
-	MockedAlbum          model.AlbumRepository
-	MockedArtist         model.ArtistRepository
-	MockedMediaFile      model.MediaFileRepository
-	MockedTag            model.TagRepository
-	MockedUser           model.UserRepository
-	MockedProperty       model.PropertyRepository
-	MockedPlayer         model.PlayerRepository
-	MockedPlaylist       model.PlaylistRepository
-	MockedDiscovery      model.DiscoveryRepository
-	MockedPlaylistFolder model.PlaylistFolderRepository
-	MockedPlayQueue      model.PlayQueueRepository
-	MockedShare          model.ShareRepository
-	MockedTranscoding    model.TranscodingRepository
-	MockedUserProps      model.UserPropsRepository
-	MockedScrobbleBuffer model.ScrobbleBufferRepository
-	MockedRadio          model.RadioRepository
-	scrobbleBufferMu     sync.Mutex
-	repoMu               sync.Mutex
+	RealDS                          model.DataStore
+	MockedLibrary                   model.LibraryRepository
+	MockedFolder                    model.FolderRepository
+	MockedGenre                     model.GenreRepository
+	MockedAlbum                     model.AlbumRepository
+	MockedArtist                    model.ArtistRepository
+	MockedMediaFile                 model.MediaFileRepository
+	MockedTag                       model.TagRepository
+	MockedUser                      model.UserRepository
+	MockedProperty                  model.PropertyRepository
+	MockedPlayer                    model.PlayerRepository
+	MockedPlaylist                  model.PlaylistRepository
+	MockedDiscovery                 model.DiscoveryRepository
+	MockedPlaylistFolder            model.PlaylistFolderRepository
+	MockedPlayQueue                 model.PlayQueueRepository
+	MockedShare                     model.ShareRepository
+	MockedTranscoding               model.TranscodingRepository
+	MockedUserProps                 model.UserPropsRepository
+	MockedScrobbleBuffer            model.ScrobbleBufferRepository
+	MockedRadio                     model.RadioRepository
+	MockedRetailPlayerDeviceMapping model.RetailPlayerDeviceMappingRepository
+	scrobbleBufferMu                sync.Mutex
+	repoMu                          sync.Mutex
 }
 
 func (db *MockDataStore) Library(ctx context.Context) model.LibraryRepository {
@@ -197,6 +198,19 @@ func (db *MockDataStore) User(ctx context.Context) model.UserRepository {
 		}
 	}
 	return db.MockedUser
+}
+
+func (db *MockDataStore) RetailPlayerDeviceMapping(ctx context.Context) model.RetailPlayerDeviceMappingRepository {
+	if db.MockedRetailPlayerDeviceMapping == nil {
+		if db.RealDS != nil {
+			db.MockedRetailPlayerDeviceMapping = db.RealDS.RetailPlayerDeviceMapping(ctx)
+		} else {
+			db.MockedRetailPlayerDeviceMapping = struct {
+				model.RetailPlayerDeviceMappingRepository
+			}{}
+		}
+	}
+	return db.MockedRetailPlayerDeviceMapping
 }
 
 func (db *MockDataStore) Transcoding(ctx context.Context) model.TranscodingRepository {

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -46,4 +46,38 @@ const deviceSlugKey = (value) => {
   return normalized.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
 }
 
-export { buildDeviceSlug, deviceSlugKey, normalizeValue }
+const mapRetailPlayerDevice = (device) => {
+  if (!device || typeof device !== 'object') {
+    return null
+  }
+
+  const rawId = normalizeValue(device.id)
+  const fallbackId =
+    rawId ||
+    normalizeValue(device.macAddress || device.mac_address) ||
+    normalizeValue(device.ordinal)
+
+  if (!fallbackId) {
+    return null
+  }
+
+  const slug = buildDeviceSlug(device) || fallbackId
+  const name = normalizeValue(device.name) || fallbackId
+
+  return {
+    id: fallbackId,
+    apiId: rawId || null,
+    name,
+    slug,
+    slugKey: deviceSlugKey(slug),
+    channel: normalizeValue(device.channel),
+    channelList: normalizeValue(device.channelList),
+    organization:
+      normalizeValue(device.organization) ||
+      normalizeValue(device.orgUnit || device.org_unit) ||
+      normalizeValue(device.location),
+    timeZone: normalizeValue(device.timeZone || device.time_zone),
+  }
+}
+
+export { buildDeviceSlug, deviceSlugKey, mapRetailPlayerDevice, normalizeValue }

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -1,10 +1,15 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useDataProvider } from 'react-admin'
+import config from '../config'
 import subsonic from '../subsonic'
 import httpClient from '../dataProvider/httpClient'
 import { baseUrl } from '../utils'
-import useRetailPlayerDevices from './useRetailPlayerDevices'
-import { buildDeviceSlug, deviceSlugKey, normalizeValue } from './deviceUtils'
+import {
+  buildDeviceSlug,
+  deviceSlugKey,
+  mapRetailPlayerDevice,
+  normalizeValue,
+} from './deviceUtils'
 
 const buildStatusUrl = (deviceId) =>
   deviceId ? `/api/retailplayer/devices/${encodeURIComponent(deviceId)}/status` : null
@@ -25,6 +30,44 @@ const parseVolume = (value) => {
 }
 
 const ensureArray = (value) => (Array.isArray(value) ? value : [])
+
+const extractErrorMessage = (error) => {
+  if (!error) {
+    return ''
+  }
+
+  const body = error.body
+  if (typeof body === 'string') {
+    return normalizeValue(body)
+  }
+
+  if (body && typeof body === 'object') {
+    const candidates = [body.message, body.error, body.detail, body.title]
+    const found = candidates.find((candidate) => normalizeValue(candidate))
+    if (found) {
+      return normalizeValue(found)
+    }
+  }
+
+  return normalizeValue(error.message)
+}
+
+const isIntegrationDisabledError = (error) => {
+  if (!error || typeof error.status !== 'number') {
+    return false
+  }
+
+  if (error.status !== 404) {
+    return false
+  }
+
+  const message = extractErrorMessage(error)
+  if (!message) {
+    return false
+  }
+
+  return /integration disabled/i.test(message)
+}
 
 const parseActiveStreamInfo = (value) => {
   const normalized = normalizeValue(value)
@@ -569,6 +612,13 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
   }
 }
 
+const initialDeviceState = {
+  data: null,
+  error: null,
+  isLoading: false,
+  fetchedAt: null,
+}
+
 const initialStatusState = {
   data: null,
   error: null,
@@ -584,13 +634,6 @@ const initialChannelState = {
 }
 
 const useRetailPlayerDeviceStatus = (slugParam) => {
-  const {
-    devices,
-    error: devicesError,
-    isLoading: devicesLoading,
-    isApiEnabled,
-  } = useRetailPlayerDevices()
-
   const normalizedSlugKey = useMemo(() => {
     if (!slugParam) {
       return ''
@@ -602,57 +645,67 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
     }
   }, [slugParam])
 
-  const baseDevice = useMemo(() => {
-    if (!devices.length) {
-      return null
-    }
-    if (!normalizedSlugKey) {
-      return devices[0]
-    }
-
-    return (
-      devices.find((device) => {
-        const deviceKey = device.slugKey || deviceSlugKey(device.slug || device.name || device.id)
-        return deviceKey === normalizedSlugKey
-      }) ||
-      devices.find((device) => deviceSlugKey(device.name) === normalizedSlugKey) ||
-      devices.find((device) => deviceSlugKey(device.apiId) === normalizedSlugKey) ||
-      devices.find((device) => deviceSlugKey(device.id) === normalizedSlugKey) ||
-      null
-    )
-  }, [devices, normalizedSlugKey])
-
+  const [deviceState, setDeviceState] = useState(initialDeviceState)
   const [statusState, setStatusState] = useState(initialStatusState)
   const [refreshIndex, setRefreshIndex] = useState(0)
   const [channelState, setChannelState] = useState(initialChannelState)
+  const [isApiEnabled, setIsApiEnabled] = useState(
+    Boolean(config.retailPlayerDevicesEnabled),
+  )
+
+  const baseDevice = useMemo(() => {
+    const ensureMatchingDevice = (device) => {
+      if (!device) {
+        return null
+      }
+
+      if (!normalizedSlugKey) {
+        return device
+      }
+
+      const candidateKey =
+        device.slugKey ||
+        deviceSlugKey(device.slug || device.name || device.id)
+      if (!candidateKey) {
+        return null
+      }
+
+      return candidateKey === normalizedSlugKey ? device : null
+    }
+
+    const mappedDevice = ensureMatchingDevice(deviceState.data)
+    if (mappedDevice) {
+      return mappedDevice
+    }
+
+    const payloadDevice = statusState.data?.device
+    if (payloadDevice) {
+      return ensureMatchingDevice(mapRetailPlayerDevice(payloadDevice))
+    }
+
+    return null
+  }, [deviceState.data, normalizedSlugKey, statusState.data])
 
   const refresh = useCallback(() => {
     setRefreshIndex((previous) => previous + 1)
   }, [])
 
   useEffect(() => {
-    if (!isApiEnabled) {
+    if (!slugParam) {
+      setDeviceState(initialDeviceState)
       setStatusState(initialStatusState)
       return undefined
     }
 
-    if (devicesLoading) {
-      return undefined
-    }
-
-    const deviceId = normalizeValue(baseDevice?.apiId)
-    if (!deviceId) {
-      setStatusState(initialStatusState)
-      return undefined
-    }
-
-    const url = buildStatusUrl(deviceId)
+    const url = buildStatusUrl(slugParam)
     if (!url) {
+      setDeviceState(initialDeviceState)
       setStatusState(initialStatusState)
       return undefined
     }
 
     const abortController = new AbortController()
+    setDeviceState((previous) => ({ ...previous, isLoading: true, error: null }))
     setStatusState((previous) => ({ ...previous, isLoading: true, error: null }))
 
     httpClient(url, { signal: abortController.signal })
@@ -660,19 +713,50 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
         if (abortController.signal.aborted) {
           return
         }
-        setStatusState({ data: json, error: null, isLoading: false, fetchedAt: new Date() })
+
+        const mappedDevice = mapRetailPlayerDevice(json?.device) || null
+
+        setIsApiEnabled(true)
+        setDeviceState({
+          data: mappedDevice,
+          error: null,
+          isLoading: false,
+          fetchedAt: new Date(),
+        })
+        setStatusState({
+          data: json,
+          error: null,
+          isLoading: false,
+          fetchedAt: new Date(),
+        })
       })
       .catch((err) => {
         if (abortController.signal.aborted) {
           return
         }
-        setStatusState({ data: null, error: err, isLoading: false, fetchedAt: new Date() })
+
+        if (isIntegrationDisabledError(err)) {
+          setIsApiEnabled(false)
+          setDeviceState(initialDeviceState)
+          setStatusState(initialStatusState)
+          return
+        }
+
+        setIsApiEnabled(true)
+        const nextState = {
+          data: null,
+          error: err,
+          isLoading: false,
+          fetchedAt: new Date(),
+        }
+        setDeviceState(nextState)
+        setStatusState(nextState)
       })
 
     return () => {
       abortController.abort()
     }
-  }, [baseDevice?.apiId, devicesLoading, isApiEnabled, refreshIndex])
+  }, [slugParam, refreshIndex])
 
   useEffect(() => {
     if (!isApiEnabled) {
@@ -680,7 +764,7 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
       return undefined
     }
 
-    if (devicesLoading) {
+    if (deviceState.isLoading) {
       return undefined
     }
 
@@ -721,7 +805,7 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
     return () => {
       abortController.abort()
     }
-  }, [baseDevice?.channelList, devicesLoading, isApiEnabled])
+  }, [baseDevice?.channelList, deviceState.isLoading, isApiEnabled])
 
   const normalizedDevice = useMemo(
     () => mapStatusPayloadToDevice(baseDevice, statusState.data, channelState.data),
@@ -846,20 +930,30 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
     }
   }, [artworkUrl, existingArtwork, normalizedDevice])
 
+  const rawDevicesError = deviceState.error
+  const devicesError =
+    rawDevicesError && rawDevicesError.status === 404 ? null : rawDevicesError
+
   const notFound =
     Boolean(normalizedSlugKey) &&
-    !devicesLoading &&
+    isApiEnabled &&
+    !deviceState.isLoading &&
     (!baseDevice || (statusState.error && statusState.error.status === 404))
 
-  const statusError = statusState.error && statusState.error.status !== 404 ? statusState.error : null
+  const statusError =
+    statusState.error && statusState.error.status !== 404
+      ? statusState.error
+      : null
   const error = statusError || devicesError || channelState.error || null
 
   return {
     device: deviceWithArtwork,
     baseDevice,
     refresh,
-    isLoading: Boolean(devicesLoading || statusState.isLoading || channelState.isLoading),
-    isDeviceListLoading: devicesLoading,
+    isLoading: Boolean(
+      deviceState.isLoading || statusState.isLoading || channelState.isLoading,
+    ),
+    isDeviceListLoading: deviceState.isLoading,
     isStatusLoading: statusState.isLoading,
     isChannelListLoading: channelState.isLoading,
     error,

--- a/ui/src/retailPlayer/useRetailPlayerDevices.js
+++ b/ui/src/retailPlayer/useRetailPlayerDevices.js
@@ -2,40 +2,9 @@ import { useEffect, useState } from 'react'
 import config from '../config'
 import httpClient from '../dataProvider/httpClient'
 import RetailPlayerMockService from './RetailPlayerMockService'
-import { buildDeviceSlug, deviceSlugKey, normalizeValue } from './deviceUtils'
+import { mapRetailPlayerDevice } from './deviceUtils'
 
 const buildDevicesUrl = () => '/api/retailplayer/devices'
-
-const mapDevice = (device) => {
-  if (!device || typeof device !== 'object') {
-    return null
-  }
-
-  const rawId = normalizeValue(device.id)
-  const fallbackId = rawId || normalizeValue(device.macAddress) || normalizeValue(device.ordinal)
-
-  if (!fallbackId) {
-    return null
-  }
-
-  const slug = buildDeviceSlug(device) || fallbackId
-  const name = normalizeValue(device.name) || fallbackId
-
-  return {
-    id: fallbackId,
-    apiId: rawId || null,
-    name,
-    slug,
-    slugKey: deviceSlugKey(slug),
-    channel: normalizeValue(device.channel),
-    channelList: normalizeValue(device.channelList),
-    organization:
-      normalizeValue(device.organization) ||
-      normalizeValue(device.orgUnit) ||
-      normalizeValue(device.location),
-    timeZone: normalizeValue(device.timeZone),
-  }
-}
 
 const fetchRetailPlayerDevices = async (signal) => {
   const url = buildDevicesUrl()
@@ -63,7 +32,7 @@ const fetchRetailPlayerDevices = async (signal) => {
     throw err
   }
   const devices = Array.isArray(payload?.data)
-    ? payload.data.map(mapDevice).filter(Boolean)
+    ? payload.data.map(mapRetailPlayerDevice).filter(Boolean)
     : []
 
   return { devices, enabled: true }


### PR DESCRIPTION
## Summary
- expose retail player status and control endpoints without requiring Navidrome auth while keeping the device listing protected
- resolve device identifiers by slug/name on the backend and include device metadata in status responses
- update the retail player dashboard to rely on backend resolution instead of loading the full device list and share the device mapping helper

## Testing
- `go test ./...` *(fails: pkg-config could not find taglib)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fd063fb988322a4e3b29d1857ee8d)