### PR TITLE
Add public retail player cover art endpoint

### DIFF
--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -22,6 +22,7 @@ import (
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/server/public"
 	"github.com/navidrome/navidrome/utils"
 )
 
@@ -239,6 +240,7 @@ type retailPlayerConfig struct {
 
 func (n *Router) addRetailPlayerPublicRoutes(r chi.Router) {
 	r.Route("/retailplayer", func(r chi.Router) {
+		r.Get("/cover-art", n.handleRetailPlayerCoverArt())
 		r.Get("/devices/{deviceID}/status", n.handleRetailPlayerDeviceStatus())
 		r.Get("/channel-lists/{channelListID}/channels", n.handleRetailPlayerChannelListChannels())
 		r.Post("/devices/{deviceID}/volume", n.handleRetailPlayerDeviceVolume())
@@ -350,6 +352,125 @@ func (n *Router) handleRetailPlayerDeviceStatus() http.HandlerFunc {
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(response); err != nil {
 			log.Error(ctx, "Unable to encode retail player device status response", "identifier", deviceIdentifier, "resolvedID", resolvedID, "err", err)
+		}
+	}
+}
+
+func (n *Router) handleRetailPlayerCoverArt() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		query := r.URL.Query()
+
+		size := 0
+		if rawSize := strings.TrimSpace(query.Get("size")); rawSize != "" {
+			parsed, err := strconv.Atoi(rawSize)
+			if err != nil || parsed < 0 {
+				http.Error(w, "Invalid size parameter", http.StatusBadRequest)
+				return
+			}
+			size = parsed
+		}
+
+		square := false
+		if rawSquare := strings.TrimSpace(query.Get("square")); rawSquare != "" {
+			parsed, err := strconv.ParseBool(rawSquare)
+			if err != nil {
+				http.Error(w, "Invalid square parameter", http.StatusBadRequest)
+				return
+			}
+			square = parsed
+		}
+
+		var (
+			artworkID   model.ArtworkID
+			mediaFileID string
+		)
+
+		if rawArtworkID := strings.TrimSpace(query.Get("artworkId")); rawArtworkID != "" {
+			parsed, err := model.ParseArtworkID(rawArtworkID)
+			if err != nil {
+				http.Error(w, "Invalid artworkId", http.StatusBadRequest)
+				return
+			}
+			artworkID = parsed
+		} else {
+			title := strings.TrimSpace(query.Get("title"))
+			if title == "" {
+				http.Error(w, "artworkId or title is required", http.StatusBadRequest)
+				return
+			}
+			artist := strings.TrimSpace(query.Get("artist"))
+
+			repo := n.ds.MediaFile(ctx)
+			if repo == nil {
+				http.Error(w, "Artwork not found", http.StatusNotFound)
+				return
+			}
+
+			queries := buildRetailPlayerCoverArtQueries(title, artist)
+			for _, q := range queries {
+				if q == "" {
+					continue
+				}
+
+				files, err := repo.Search(q, 0, 10)
+				if err != nil {
+					log.Debug(ctx, "Retail player cover art search failed", "query", q, "err", err)
+					continue
+				}
+				if len(files) == 0 {
+					continue
+				}
+
+				matched := matchMediaFileByMetadata(title, artist, files)
+				if matched == nil {
+					continue
+				}
+
+				candidate := matched.CoverArtID()
+				if candidate.String() == "" {
+					continue
+				}
+
+				artworkID = candidate
+				mediaFileID = matched.ID
+				break
+			}
+
+			if artworkID.String() == "" {
+				http.Error(w, "Artwork not found", http.StatusNotFound)
+				return
+			}
+		}
+
+		if artworkID.String() == "" {
+			http.Error(w, "Artwork not found", http.StatusNotFound)
+			return
+		}
+
+		imageURL := public.ImageURLWithOptions(r, artworkID, size, square)
+		if imageURL == "" {
+			http.Error(w, "Artwork not found", http.StatusNotFound)
+			return
+		}
+
+		response := retailPlayerCoverArtResponse{
+			URL:       imageURL,
+			ArtworkID: artworkID.String(),
+		}
+		if mediaFileID != "" {
+			response.MediaFileID = mediaFileID
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			log.Error(ctx, "Unable to encode retail player cover art response", "err", err)
 		}
 	}
 }
@@ -1159,6 +1280,12 @@ type retailPlayerStatusArtwork struct {
 	ArtworkID   string `json:"artworkId,omitempty"`
 }
 
+type retailPlayerCoverArtResponse struct {
+	URL         string `json:"url"`
+	ArtworkID   string `json:"artworkId,omitempty"`
+	MediaFileID string `json:"mediaFileId,omitempty"`
+}
+
 func (n *Router) sendRetailPlayerDeviceCommand(ctx context.Context, deviceID string, command retailPlayerCommandRequest) (string, error) {
 	cfg := conf.Server.RetailPlayer
 	if cfg.BaseURL == "" || cfg.OrgID == "" {
@@ -1478,6 +1605,85 @@ func buildRetailPlayerRequest(ctx context.Context, cfg retailPlayerConfig, pathP
 	applyRetailPlayerHeaders(req, cfg)
 
 	return req, nil
+}
+
+func buildRetailPlayerCoverArtQueries(title, artist string) []string {
+	trimmedTitle := strings.TrimSpace(title)
+	trimmedArtist := strings.TrimSpace(artist)
+	queries := make([]string, 0, 4)
+	if trimmedArtist != "" && trimmedTitle != "" {
+		queries = append(queries, fmt.Sprintf("%s %s", trimmedArtist, trimmedTitle))
+		queries = append(queries, fmt.Sprintf("%s - %s", trimmedArtist, trimmedTitle))
+	}
+	if trimmedTitle != "" {
+		queries = append(queries, trimmedTitle)
+	}
+	if trimmedArtist != "" {
+		queries = append(queries, trimmedArtist)
+	}
+	return uniqueStringsInsensitive(queries)
+}
+
+func matchMediaFileByMetadata(title, artist string, files model.MediaFiles) *model.MediaFile {
+	if len(files) == 0 {
+		return nil
+	}
+
+	trimmedTitle := strings.TrimSpace(title)
+	trimmedArtist := strings.TrimSpace(artist)
+	lowerTitle := strings.ToLower(trimmedTitle)
+	lowerArtist := strings.ToLower(trimmedArtist)
+
+	if trimmedTitle != "" {
+		for _, file := range files {
+			if !strings.EqualFold(strings.TrimSpace(file.Title), trimmedTitle) {
+				continue
+			}
+			if trimmedArtist != "" {
+				if !strings.EqualFold(strings.TrimSpace(file.Artist), trimmedArtist) &&
+					!strings.EqualFold(strings.TrimSpace(file.AlbumArtist), trimmedArtist) {
+					continue
+				}
+			}
+			return &file
+		}
+	}
+
+	if trimmedTitle != "" {
+		for _, file := range files {
+			fileTitle := strings.TrimSpace(file.Title)
+			if fileTitle == "" {
+				continue
+			}
+			if !strings.Contains(strings.ToLower(fileTitle), lowerTitle) {
+				continue
+			}
+			if trimmedArtist == "" {
+				return &file
+			}
+			if strings.EqualFold(strings.TrimSpace(file.Artist), trimmedArtist) ||
+				strings.EqualFold(strings.TrimSpace(file.AlbumArtist), trimmedArtist) ||
+				strings.Contains(strings.ToLower(strings.TrimSpace(file.Artist)), lowerArtist) ||
+				strings.Contains(strings.ToLower(strings.TrimSpace(file.AlbumArtist)), lowerArtist) {
+				return &file
+			}
+		}
+	}
+
+	if trimmedArtist != "" {
+		for _, file := range files {
+			if strings.Contains(strings.ToLower(strings.TrimSpace(file.Artist)), lowerArtist) ||
+				strings.Contains(strings.ToLower(strings.TrimSpace(file.AlbumArtist)), lowerArtist) {
+				return &file
+			}
+		}
+	}
+
+	if trimmedTitle != "" {
+		return selectBestMediaFileMatch(trimmedTitle, files)
+	}
+
+	return &files[0]
 }
 
 func buildRetailPlayerChannelListRequest(ctx context.Context, cfg retailPlayerConfig, channelListID string, pathParts ...string) (*http.Request, error) {

--- a/server/nativeapi/retail_player_cover_art_test.go
+++ b/server/nativeapi/retail_player_cover_art_test.go
@@ -1,0 +1,106 @@
+package nativeapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"time"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/conf/configtest"
+	"github.com/navidrome/navidrome/core"
+	"github.com/navidrome/navidrome/core/auth"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/tests"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Retail Player Cover Art Endpoint", func() {
+	var (
+		router http.Handler
+		ds     *tests.MockDataStore
+	)
+
+	BeforeEach(func() {
+		DeferCleanup(configtest.SetupConfig())
+		conf.Server.RetailPlayer.Enabled = true
+		conf.Server.EnableMediaFileCoverArt = true
+
+		ds = &tests.MockDataStore{
+			MockedMediaFile: tests.CreateMockMediaFileRepo(),
+			MockedProperty:  &tests.MockedPropertyRepo{},
+		}
+
+		auth.Init(ds)
+
+		nativeRouter := New(ds, nil, nil, nil, core.NewMockLibraryService())
+		router = nativeRouter
+	})
+
+	It("returns a cover art URL when artworkId is provided", func() {
+		recorder := httptest.NewRecorder()
+		artID := model.NewArtworkID(model.KindMediaFileArtwork, "song-1", nil)
+		query := url.Values{
+			"artworkId": []string{artID.String()},
+			"size":      []string{"300"},
+			"square":    []string{"true"},
+		}
+		request := httptest.NewRequest(http.MethodGet, "/retailplayer/cover-art?"+query.Encode(), nil)
+
+		router.ServeHTTP(recorder, request)
+
+		Expect(recorder.Code).To(Equal(http.StatusOK))
+
+		var resp retailPlayerCoverArtResponse
+		err := json.Unmarshal(recorder.Body.Bytes(), &resp)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.ArtworkID).To(Equal(artID.String()))
+		Expect(resp.URL).To(ContainSubstring("/public/img/"))
+		Expect(resp.URL).To(ContainSubstring("size=300"))
+		Expect(resp.URL).To(ContainSubstring("square=true"))
+	})
+
+	It("searches for cover art using metadata", func() {
+		recorder := httptest.NewRecorder()
+
+		mediaFile := model.MediaFile{
+			ID:          "song-42",
+			Title:       "Pigeon",
+			Artist:      "Faye Webster",
+			Album:       "Atlanta Millionaires Club",
+			AlbumID:     "album-1",
+			HasCoverArt: true,
+			UpdatedAt:   time.Now(),
+		}
+		ds.MockedMediaFile.(*tests.MockMediaFileRepo).SetData(model.MediaFiles{mediaFile})
+
+		query := url.Values{
+			"title":  []string{"Pigeon"},
+			"artist": []string{"Faye Webster"},
+			"size":   []string{"200"},
+		}
+		request := httptest.NewRequest(http.MethodGet, "/retailplayer/cover-art?"+query.Encode(), nil)
+
+		router.ServeHTTP(recorder, request)
+
+		Expect(recorder.Code).To(Equal(http.StatusOK))
+
+		var resp retailPlayerCoverArtResponse
+		err := json.Unmarshal(recorder.Body.Bytes(), &resp)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.ArtworkID).To(Equal(mediaFile.CoverArtID().String()))
+		Expect(resp.MediaFileID).To(Equal(mediaFile.ID))
+		Expect(resp.URL).To(ContainSubstring("/public/img/"))
+	})
+
+	It("returns 404 when no artwork can be found", func() {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodGet, "/retailplayer/cover-art?title=Unknown", nil)
+
+		router.ServeHTTP(recorder, request)
+
+		Expect(recorder.Code).To(Equal(http.StatusNotFound))
+	})
+})

--- a/server/public/encode_id.go
+++ b/server/public/encode_id.go
@@ -16,11 +16,18 @@ import (
 )
 
 func ImageURL(r *http.Request, artID model.ArtworkID, size int) string {
+	return ImageURLWithOptions(r, artID, size, false)
+}
+
+func ImageURLWithOptions(r *http.Request, artID model.ArtworkID, size int, square bool) string {
 	token := encodeArtworkID(artID)
 	uri := path.Join(consts.URLPathPublicImages, token)
 	params := url.Values{}
 	if size > 0 {
 		params.Add("size", strconv.Itoa(size))
+	}
+	if square {
+		params.Add("square", "true")
 	}
 	return publicURL(r, uri, params)
 }

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -1,9 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { useDataProvider } from 'react-admin'
 import config from '../config'
-import subsonic from '../subsonic'
 import httpClient from '../dataProvider/httpClient'
-import { baseUrl } from '../utils'
 import {
   buildDeviceSlug,
   deviceSlugKey,
@@ -50,6 +47,35 @@ const extractErrorMessage = (error) => {
   }
 
   return normalizeValue(error.message)
+}
+
+const buildRetailPlayerCoverArtPath = ({
+  artworkId,
+  title,
+  artist,
+  size,
+  square,
+}) => {
+  const params = new URLSearchParams()
+  if (artworkId) {
+    params.set('artworkId', artworkId)
+  }
+  if (!artworkId) {
+    if (title) {
+      params.set('title', title)
+    }
+    if (artist) {
+      params.set('artist', artist)
+    }
+  }
+  if (typeof size === 'number' && Number.isFinite(size) && size > 0) {
+    params.set('size', String(Math.round(size)))
+  }
+  if (square) {
+    params.set('square', 'true')
+  }
+  const query = params.toString()
+  return query ? `/api/retailplayer/cover-art?${query}` : '/api/retailplayer/cover-art'
 }
 
 const isIntegrationDisabledError = (error) => {
@@ -812,7 +838,6 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
     [baseDevice, channelState.data, statusState.data],
   )
 
-  const dataProvider = useDataProvider()
   const [artworkUrl, setArtworkUrl] = useState(null)
 
   const artworkSignature = useMemo(() => {
@@ -848,51 +873,47 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
       return undefined
     }
 
+    const coverArtParams = {
+      size: 300,
+      square: true,
+    }
+
     if (backendArtworkId) {
-      const coverArtPath = subsonic.url('getCoverArt', backendArtworkId, {
-        size: 300,
-        square: true,
-      })
-      setArtworkUrl(baseUrl(coverArtPath))
-      return undefined
+      coverArtParams.artworkId = backendArtworkId
+    } else {
+      if (!statusState.data) {
+        setArtworkUrl(null)
+        return undefined
+      }
+
+      if (!metadataTitle) {
+        setArtworkUrl(null)
+        return undefined
+      }
+
+      coverArtParams.title = metadataTitle
+      if (metadataArtist) {
+        coverArtParams.artist = metadataArtist
+      }
     }
 
-    if (!statusState.data) {
-      setArtworkUrl(null)
-      return undefined
-    }
-
-    if (!metadataTitle) {
-      setArtworkUrl(null)
-      return undefined
-    }
-
+    const abortController = new AbortController()
     let isCancelled = false
-    const filter = { title: metadataTitle }
-    if (metadataArtist) {
-      filter.artist = metadataArtist
-    }
 
     const fetchArtwork = async () => {
       try {
-        const response = await dataProvider.getList('song', {
-          pagination: { page: 1, perPage: 1 },
-          sort: { field: 'id', order: 'ASC' },
-          filter,
-        })
-        if (isCancelled) {
+        const url = buildRetailPlayerCoverArtPath(coverArtParams)
+        const response = await httpClient(url, { signal: abortController.signal })
+        if (isCancelled || abortController.signal.aborted) {
           return
         }
-        const songs = Array.isArray(response?.data) ? response.data : []
-        if (songs.length > 0) {
-          setArtworkUrl(subsonic.getCoverArtUrl(songs[0], 300, true))
+        const imageUrl = normalizeValue(response?.json?.url)
+        setArtworkUrl(imageUrl || null)
+      } catch (err) {
+        if (isCancelled || abortController.signal.aborted) {
           return
         }
         setArtworkUrl(null)
-      } catch (err) {
-        if (!isCancelled) {
-          setArtworkUrl(null)
-        }
       }
     }
 
@@ -900,11 +921,11 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
 
     return () => {
       isCancelled = true
+      abortController.abort()
     }
   }, [
     artworkSignature,
     backendArtworkId,
-    dataProvider,
     existingArtwork,
     metadataArtist,
     metadataTitle,


### PR DESCRIPTION
## Summary
- add an unauthenticated `/api/retailplayer/cover-art` endpoint and cover art matching helpers for retail players
- extend public image URLs to support square thumbnails for the new endpoint
- update the retail player dashboard to request artwork through the public API and cover art tests

## Testing
- go test ./server/nativeapi ./server/public *(hangs in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ff0607aa08322a398a8f1d7a02fc6)