### PR TITLE
Improve playlist drag preview

### DIFF
--- a/ui/src/common/useDragAndDrop.jsx
+++ b/ui/src/common/useDragAndDrop.jsx
@@ -1,7 +1,7 @@
 import { useDrag, useDrop } from 'react-dnd'
 
 const useDragAndDrop = (type, item, accepts, onDrop) => {
-    const [{ isDragging }, dragRef] = useDrag(() => ({
+    const [{ isDragging }, dragRef, previewRef] = useDrag(() => ({
         type,
         item,
         collect: (monitor) => ({ isDragging: !!monitor.isDragging() }),
@@ -15,6 +15,7 @@ const useDragAndDrop = (type, item, accepts, onDrop) => {
 
     return {
         dragDropRef: (node) => dragRef(dropRef(node)),
+        dragPreviewRef: previewRef,
         isDragging,
     }
 }

--- a/ui/src/layout/PlaylistDragPreview.jsx
+++ b/ui/src/layout/PlaylistDragPreview.jsx
@@ -1,0 +1,113 @@
+import React from 'react'
+import { makeStyles, Typography } from '@material-ui/core'
+import { useDragLayer } from 'react-dnd'
+import { RiPlayListFill } from 'react-icons/ri'
+
+import { DraggableTypes } from '../consts'
+
+const useStyles = makeStyles((theme) => ({
+  layer: {
+    position: 'fixed',
+    pointerEvents: 'none',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    zIndex: theme.zIndex.modal + 1,
+  },
+  previewWrapper: {
+    transformOrigin: 'top left',
+  },
+  preview: {
+    backgroundColor: theme.palette.background.paper,
+    color: theme.palette.text.primary,
+    borderRadius: theme.shape.borderRadius,
+    boxShadow: theme.shadows[8],
+    border: `1px solid ${theme.palette.divider}`,
+    padding: theme.spacing(1, 1.75),
+    minWidth: 160,
+    maxWidth: 320,
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+  },
+  iconWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: theme.spacing(4),
+    height: theme.spacing(4),
+    borderRadius: theme.shape.borderRadius,
+    backgroundColor: theme.palette.action.hover,
+    color: theme.palette.text.secondary,
+    flexShrink: 0,
+  },
+  textContainer: {
+    overflow: 'hidden',
+  },
+  title: {
+    fontWeight: theme.typography.fontWeightMedium,
+    fontSize: theme.typography.pxToRem(13),
+    lineHeight: 1.2,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+  subtitle: {
+    fontSize: theme.typography.pxToRem(11.5),
+    color: theme.palette.text.secondary,
+    marginTop: 2,
+  },
+}))
+
+const getItemStyles = (currentOffset) => {
+  if (!currentOffset) {
+    return { display: 'none' }
+  }
+
+  const { x, y } = currentOffset
+  const transform = `translate(${x + 12}px, ${y + 12}px)`
+
+  return {
+    transform,
+    WebkitTransform: transform,
+  }
+}
+
+const PlaylistDragPreview = () => {
+  const classes = useStyles()
+  const { itemType, item, isDragging, currentOffset } = useDragLayer((monitor) => ({
+    item: monitor.getItem(),
+    itemType: monitor.getItemType(),
+    currentOffset: monitor.getClientOffset(),
+    isDragging: monitor.isDragging(),
+  }))
+
+  if (!isDragging || itemType !== DraggableTypes.PLAYLIST) {
+    return null
+  }
+
+  const title = item?.name || 'Playlist'
+
+  return (
+    <div className={classes.layer}>
+      <div className={classes.previewWrapper} style={getItemStyles(currentOffset)}>
+        <div className={classes.preview}>
+          <div className={classes.iconWrapper}>
+            <RiPlayListFill size={18} />
+          </div>
+          <div className={classes.textContainer}>
+            <Typography component="div" className={classes.title}>
+              {title}
+            </Typography>
+            <Typography component="div" className={classes.subtitle}>
+              Drag to add or move
+            </Typography>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default PlaylistDragPreview

--- a/ui/src/layout/PlaylistsSubMenu.jsx
+++ b/ui/src/layout/PlaylistsSubMenu.jsx
@@ -7,6 +7,7 @@ import {
 } from '@material-ui/core'
 import { BiCog } from 'react-icons/bi'
 import { useDrop } from 'react-dnd'
+import { getEmptyImage } from 'react-dnd-html5-backend'
 import { RiFolder3Fill, RiPlayListFill } from 'react-icons/ri'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import ChevronRightIcon from '@material-ui/icons/ChevronRight'
@@ -17,6 +18,7 @@ import { DraggableTypes, REST_URL } from '../consts'
 import config from '../config'
 import useDragAndDrop from '../common/useDragAndDrop'
 import httpClient from '../dataProvider/httpClient'
+import PlaylistDragPreview from './PlaylistDragPreview'
 
 const fetchPlaylistTrackIds = async (playlistId) => {
   const res = await httpClient(`${REST_URL}/playlist/${playlistId}/tracks`)
@@ -316,12 +318,16 @@ const PlaylistMenuItemLink = memo(({ pls, depth = 0 }) => {
     [addTrackIdsToPlaylist, submitAddPayload],
   )
 
-  const { dragDropRef, isDragging } = useDragAndDrop(
+  const { dragDropRef, dragPreviewRef, isDragging } = useDragAndDrop(
     DraggableTypes.PLAYLIST,
-    { id: pls.id, type: 'playlist', parentId: parentIdForDnD },
+    { id: pls.id, type: 'playlist', parentId: parentIdForDnD, name: pls.name },
     canChangeTracks(pls) ? DraggableTypes.ALL : [],
     handleDrop
   )
+
+  useEffect(() => {
+    dragPreviewRef?.(getEmptyImage(), { captureDraggingState: true })
+  }, [dragPreviewRef])
 
   return (
     <ListItem
@@ -592,6 +598,7 @@ const PlaylistsSubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
       onAction={onPlaylistConfig}
       ref={dropRef}
     >
+      <PlaylistDragPreview />
       <List disablePadding>
         {!rootCached && rootDirty ? (
           <ListItem><CircularProgress size={16} className={classes.spinner} /></ListItem>


### PR DESCRIPTION
## Summary
- add a dedicated drag preview layer for sidebar playlists
- hide the native drag image so playlists use the polished custom ghost
- keep the playlist drag payload enriched with the playlist name for previews

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691079a6951c83229a9e331c00263732)