### PR TITLE
Improve playlist drag feedback

### DIFF
--- a/ui/src/common/useDragAndDrop.jsx
+++ b/ui/src/common/useDragAndDrop.jsx
@@ -8,15 +8,23 @@ const useDragAndDrop = (type, item, accepts, onDrop) => {
         options: { dropEffect: 'move' },
     }))
 
-    const [, dropRef] = useDrop(() => ({
+    const [{ isOver, canDrop, itemType }, dropRef] = useDrop(() => ({
         accept: accepts,
         drop: onDrop,
+        collect: (monitor) => ({
+            isOver: monitor.isOver({ shallow: true }),
+            canDrop: monitor.canDrop(),
+            itemType: monitor.getItemType(),
+        }),
     }))
 
     return {
         dragDropRef: (node) => dragRef(dropRef(node)),
         dragPreviewRef: previewRef,
         isDragging,
+        isOver,
+        canDrop,
+        itemType,
     }
 }
 

--- a/ui/src/layout/PlaylistDragPreview.jsx
+++ b/ui/src/layout/PlaylistDragPreview.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { createPortal } from 'react-dom'
 import { makeStyles } from '@material-ui/core'
 import { useDragLayer } from 'react-dnd'
 import { RiPlayListFill } from 'react-icons/ri'
@@ -12,7 +13,7 @@ const useStyles = makeStyles((theme) => ({
     left: 0,
     width: '100%',
     height: '100%',
-    zIndex: theme.zIndex.modal + 4,
+    zIndex: Math.max(theme.zIndex.modal ?? 1300, theme.zIndex.tooltip ?? 1500) + 10,
   },
   previewWrapper: {
     transformOrigin: 'top left',
@@ -68,7 +69,7 @@ const PlaylistDragPreview = () => {
     return null
   }
 
-  return (
+  const previewNode = (
     <div className={classes.layer}>
       <div className={classes.previewWrapper} style={getItemStyles(currentOffset)}>
         <div className={classes.preview}>
@@ -80,6 +81,12 @@ const PlaylistDragPreview = () => {
       </div>
     </div>
   )
+
+  if (typeof document === 'undefined') {
+    return previewNode
+  }
+
+  return createPortal(previewNode, document.body)
 }
 
 export default PlaylistDragPreview

--- a/ui/src/layout/PlaylistDragPreview.jsx
+++ b/ui/src/layout/PlaylistDragPreview.jsx
@@ -12,7 +12,7 @@ const useStyles = makeStyles((theme) => ({
     left: 0,
     width: '100%',
     height: '100%',
-    zIndex: theme.zIndex.modal + 2,
+    zIndex: theme.zIndex.modal + 4,
   },
   previewWrapper: {
     transformOrigin: 'top left',

--- a/ui/src/layout/PlaylistsSubMenu.jsx
+++ b/ui/src/layout/PlaylistsSubMenu.jsx
@@ -12,6 +12,7 @@ import { RiFolder3Fill, RiPlayListFill } from 'react-icons/ri'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import ChevronRightIcon from '@material-ui/icons/ChevronRight'
 import QueueMusicIcon from '@material-ui/icons/QueueMusic'
+import clsx from 'clsx'
 import SubMenu from './SubMenu'
 import { canChangeTracks } from '../common'
 import { DraggableTypes, REST_URL } from '../consts'
@@ -69,6 +70,10 @@ const useStyles = makeStyles((theme) => ({
   nested: { paddingLeft: theme.spacing(2) },
   depth: (props) => ({ paddingLeft: theme.spacing(2) + props.depth * theme.spacing(2) }),
   spinner: { marginLeft: 6 },
+  dropTargetHighlight: {
+    backgroundColor: 'rgba(255, 43, 138, 0.12)',
+    boxShadow: '0 0 0 1px rgba(255, 43, 138, 0.35), 0 6px 18px rgba(255, 43, 138, 0.2)',
+  },
 }))
 
 const parentKey = (id) => (id == null || id === '' ? '' : String(id))
@@ -318,7 +323,7 @@ const PlaylistMenuItemLink = memo(({ pls, depth = 0 }) => {
     [addTrackIdsToPlaylist, submitAddPayload],
   )
 
-  const { dragDropRef, dragPreviewRef, isDragging } = useDragAndDrop(
+  const { dragDropRef, dragPreviewRef, isDragging, isOver, canDrop } = useDragAndDrop(
     DraggableTypes.PLAYLIST,
     { id: pls.id, type: 'playlist', parentId: parentIdForDnD, name: pls.name },
     canChangeTracks(pls) ? DraggableTypes.ALL : [],
@@ -333,7 +338,9 @@ const PlaylistMenuItemLink = memo(({ pls, depth = 0 }) => {
     <ListItem
       button
       onClick={() => history.push(`/playlist/${pls.id}/show`)}
-      className={`${classes.listItem} ${classes.depth}`}
+      className={clsx(classes.listItem, classes.depth, {
+        [classes.dropTargetHighlight]: isOver && canDrop,
+      })}
       ref={dragDropRef}
       style={{ opacity: isDragging ? 0.5 : 1 }}
       onDragOver={handleNativeDragOver}
@@ -401,7 +408,7 @@ const FolderRow = memo(function FolderRow({
 
   const parentIdForDnD = node.parent_id ?? ''
 
-  const { dragDropRef, isDragging } = useDragAndDrop(
+  const { dragDropRef, isDragging, isOver, canDrop } = useDragAndDrop(
     DraggableTypes.FOLDER,
     { id: node.id, type: 'folder', parentId: parentIdForDnD },
     [DraggableTypes.FOLDER, DraggableTypes.PLAYLIST],
@@ -451,7 +458,9 @@ const FolderRow = memo(function FolderRow({
       <ListItem
         button
         onClick={() => history.push(`/folder/${node.id}/show`)}
-        className={`${classes.listItem} ${classes.depth}`}
+        className={clsx(classes.listItem, classes.depth, {
+          [classes.dropTargetHighlight]: isOver && canDrop,
+        })}
         ref={dragDropRef}
         style={{ opacity: isDragging ? 0.5 : 1 }}
       >


### PR DESCRIPTION
## Summary
- highlight playlist and folder drop targets during drag with a pink accent
- raise the playlist drag preview layer so it remains visible above the main content

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69107deb0b1c8322a5d7d608fbb9240f)