### PR TITLE
Improve playlist folder drag feedback

### DIFF
--- a/ui/src/common/useDragAndDrop.jsx
+++ b/ui/src/common/useDragAndDrop.jsx
@@ -8,15 +8,21 @@ const useDragAndDrop = (type, item, accepts, onDrop) => {
         options: { dropEffect: 'move' },
     }))
 
-    const [, dropRef] = useDrop(() => ({
+    const [{ isOver, canDrop }, dropRef] = useDrop(() => ({
         accept: accepts,
         drop: onDrop,
+        collect: (monitor) => ({
+            isOver: monitor.isOver({ shallow: true }),
+            canDrop: monitor.canDrop(),
+        }),
     }))
 
     return {
         dragDropRef: (node) => dragRef(dropRef(node)),
         dragPreviewRef: previewRef,
         isDragging,
+        isOver,
+        canDrop,
     }
 }
 

--- a/ui/src/layout/PlaylistDragPreview.jsx
+++ b/ui/src/layout/PlaylistDragPreview.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import ReactDOM from 'react-dom'
 import { makeStyles } from '@material-ui/core'
 import { useDragLayer } from 'react-dnd'
 import { RiPlayListFill } from 'react-icons/ri'
@@ -68,7 +69,12 @@ const PlaylistDragPreview = () => {
     return null
   }
 
-  return (
+  const portalTarget = typeof document !== 'undefined' ? document.body : null
+  if (!portalTarget) {
+    return null
+  }
+
+  return ReactDOM.createPortal(
     <div className={classes.layer}>
       <div className={classes.previewWrapper} style={getItemStyles(currentOffset)}>
         <div className={classes.preview}>
@@ -78,7 +84,8 @@ const PlaylistDragPreview = () => {
           {item.name}
         </div>
       </div>
-    </div>
+    </div>,
+    portalTarget
   )
 }
 

--- a/ui/src/layout/PlaylistsSubMenu.jsx
+++ b/ui/src/layout/PlaylistsSubMenu.jsx
@@ -19,6 +19,8 @@ import config from '../config'
 import useDragAndDrop from '../common/useDragAndDrop'
 import httpClient from '../dataProvider/httpClient'
 import PlaylistDragPreview from './PlaylistDragPreview'
+import clsx from 'clsx'
+import { alpha } from '@material-ui/core/styles/colorManipulator'
 
 const fetchPlaylistTrackIds = async (playlistId) => {
   const res = await httpClient(`${REST_URL}/playlist/${playlistId}/tracks`)
@@ -64,11 +66,21 @@ const useStyles = makeStyles((theme) => ({
   active: { backgroundColor: theme.palette.action.selected, fontWeight: theme.typography.fontWeightMedium },
   text: { transition: 'color 0.2s ease' },
   toggleButton: { padding: 4, marginRight: 4 },
-  listItemIcon: { minWidth: 28 },
+  listItemIcon: { minWidth: 28, transition: 'color 0.2s ease' },
   spacer: { width: 24 },
   nested: { paddingLeft: theme.spacing(2) },
   depth: (props) => ({ paddingLeft: theme.spacing(2) + props.depth * theme.spacing(2) }),
   spinner: { marginLeft: 6 },
+  dropTarget: {
+    backgroundColor: alpha(theme.palette.primary.main, 0.08),
+    boxShadow: `inset 0 0 0 2px ${alpha(theme.palette.primary.main, 0.24)}`,
+    color: theme.palette.primary.main,
+    '& $text': {
+      color: theme.palette.primary.main,
+      fontWeight: theme.typography.fontWeightMedium,
+    },
+    '& $listItemIcon': { color: theme.palette.primary.main },
+  },
 }))
 
 const parentKey = (id) => (id == null || id === '' ? '' : String(id))
@@ -318,7 +330,7 @@ const PlaylistMenuItemLink = memo(({ pls, depth = 0 }) => {
     [addTrackIdsToPlaylist, submitAddPayload],
   )
 
-  const { dragDropRef, dragPreviewRef, isDragging } = useDragAndDrop(
+  const { dragDropRef, dragPreviewRef, isDragging, isOver, canDrop } = useDragAndDrop(
     DraggableTypes.PLAYLIST,
     { id: pls.id, type: 'playlist', parentId: parentIdForDnD, name: pls.name },
     canChangeTracks(pls) ? DraggableTypes.ALL : [],
@@ -329,11 +341,13 @@ const PlaylistMenuItemLink = memo(({ pls, depth = 0 }) => {
     dragPreviewRef?.(getEmptyImage(), { captureDraggingState: true })
   }, [dragPreviewRef])
 
+  const showDropHighlight = isOver && canDrop
+
   return (
     <ListItem
       button
       onClick={() => history.push(`/playlist/${pls.id}/show`)}
-      className={`${classes.listItem} ${classes.depth}`}
+      className={clsx(classes.listItem, classes.depth, showDropHighlight && classes.dropTarget)}
       ref={dragDropRef}
       style={{ opacity: isDragging ? 0.5 : 1 }}
       onDragOver={handleNativeDragOver}
@@ -401,7 +415,7 @@ const FolderRow = memo(function FolderRow({
 
   const parentIdForDnD = node.parent_id ?? ''
 
-  const { dragDropRef, isDragging } = useDragAndDrop(
+  const { dragDropRef, isDragging, isOver, canDrop } = useDragAndDrop(
     DraggableTypes.FOLDER,
     { id: node.id, type: 'folder', parentId: parentIdForDnD },
     [DraggableTypes.FOLDER, DraggableTypes.PLAYLIST],
@@ -446,12 +460,14 @@ const FolderRow = memo(function FolderRow({
     playlists: (items || []).filter((i) => i.type === 'playlist'),
   }), [items])
 
+  const showDropHighlight = isOver && canDrop
+
   return (
     <>
       <ListItem
         button
         onClick={() => history.push(`/folder/${node.id}/show`)}
-        className={`${classes.listItem} ${classes.depth}`}
+        className={clsx(classes.listItem, classes.depth, showDropHighlight && classes.dropTarget)}
         ref={dragDropRef}
         style={{ opacity: isDragging ? 0.5 : 1 }}
       >

--- a/ui/src/playlist_folder/PlaylistFolderDataGrid.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderDataGrid.jsx
@@ -11,11 +11,12 @@ import PropTypes from 'prop-types'
 import clsx from 'clsx'
 import { DraggableTypes } from '../consts'
 import { makeStyles } from '@material-ui/core/styles'
+import { alpha } from '@material-ui/core/styles/colorManipulator'
 import { useHistory, useLocation } from 'react-router-dom'
 import useDragAndDrop from '../common/useDragAndDrop'
 import { matchPath } from 'react-router'
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme) => ({
   row: {
     cursor: 'pointer',
     '&:hover': { backgroundColor: '#f5f5f5' },
@@ -29,7 +30,12 @@ const useStyles = makeStyles({
     '& thead': { boxShadow: '0px 3px 3px rgba(0,0,0,.15)' },
     '& th': { fontWeight: 'bold', padding: '15px' },
   },
-})
+  dropTarget: {
+    backgroundColor: alpha(theme.palette.primary.main, 0.08),
+    boxShadow: `inset 0 0 0 2px ${alpha(theme.palette.primary.main, 0.24)}`,
+    transition: 'background-color 120ms ease, box-shadow 120ms ease',
+  },
+}))
 
 const PlaylistFolderRow = ({ record, children, className, rowClick, ...rest }) => {
   const classes = useStyles()
@@ -94,17 +100,20 @@ const PlaylistFolderRow = ({ record, children, className, rowClick, ...rest }) =
     [dataProvider, notify, refresh, record.id, record.type]
   )
 
-  const { dragDropRef, isDragging } = useDragAndDrop(
+  const { dragDropRef, isDragging, isOver, canDrop } = useDragAndDrop(
     record.type === 'playlist' ? DraggableTypes.PLAYLIST : DraggableTypes.FOLDER,
     { id: record.id, type: record.type },
     record.type === 'playlist' ? DraggableTypes.ALL : [DraggableTypes.PLAYLIST, DraggableTypes.FOLDER],
     handleDrop
   )
 
+  const showDropHighlight = record.type === 'folder' && isOver && canDrop
+
   const computedClasses = clsx(
     className,
     classes.row,
-    record.missing && classes.missingRow
+    record.missing && classes.missingRow,
+    showDropHighlight && classes.dropTarget
   )
 
   const handleRowClick = (event) => {


### PR DESCRIPTION
## Summary
- highlight playlist folders when a draggable item is hovered in both the sidebar and folder grid
- expose drop state from the drag-and-drop hook so consumers can react to hover state
- render the playlist drag preview in a portal to keep it above the main content

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910c31d02048322a3aa4f0fc5e2121c)