### PR TITLE
Fix song queue to include entire list when starting from middle

### DIFF
--- a/ui/src/actions/player.js
+++ b/ui/src/actions/player.js
@@ -27,11 +27,20 @@ export const filterSongs = (data, ids) => {
       }, {})
 }
 
+const getOrderedIds = (songs, ids) => {
+  if (ids && ids.length) {
+    return ids.filter((id) => songs[id])
+  }
+
+  return Object.keys(songs)
+}
+
 export const addTracks = (data, ids) => {
   const songs = filterSongs(data, ids)
   return {
     type: PLAYER_ADD_TRACKS,
     data: songs,
+    orderedIds: getOrderedIds(songs, ids),
   }
 }
 
@@ -40,6 +49,7 @@ export const playNext = (data, ids) => {
   return {
     type: PLAYER_PLAY_NEXT,
     data: songs,
+    orderedIds: getOrderedIds(songs, ids),
   }
 }
 
@@ -69,10 +79,16 @@ export const shuffleTracks = (data, ids) => {
 
 export const playTracks = (data, ids, selectedId) => {
   const songs = filterSongs(data, ids)
+  const orderedIds = getOrderedIds(songs, ids)
+  const defaultId = orderedIds[0]
+  const idToPlay =
+    (selectedId && songs[selectedId] && selectedId) || defaultId
+
   return {
     type: PLAYER_PLAY_TRACKS,
-    id: selectedId || Object.keys(songs)[0],
+    id: idToPlay,
     data: songs,
+    orderedIds,
   }
 }
 

--- a/ui/src/reducers/playerReducer.js
+++ b/ui/src/reducers/playerReducer.js
@@ -90,10 +90,22 @@ const mapToAudioLists = (item) => {
 
 const reduceClearQueue = () => ({ ...initialState, clear: true })
 
-const reducePlayTracks = (state, { data, id }) => {
+const normalizeKey = (value) =>
+  value === undefined || value === null ? undefined : value.toString()
+
+const reducePlayTracks = (state, { data, id, orderedIds }) => {
+  const keys = (orderedIds && orderedIds.length
+    ? orderedIds
+    : Object.keys(data)
+  )
+    .map(normalizeKey)
+    .filter((key) => key && data[key])
+
+  const normalizedId = normalizeKey(id) ?? keys[0]
+
   let playIndex = 0
-  const queue = Object.keys(data).map((key, idx) => {
-    if (key === id) {
+  const queue = keys.map((key, idx) => {
+    if (key === normalizedId) {
       playIndex = idx
     }
     return mapToAudioLists(data[key])
@@ -115,30 +127,43 @@ const reduceSetTrack = (state, { data }) => {
   }
 }
 
-const reduceAddTracks = (state, { data }) => {
-  const queue = state.queue
-  Object.keys(data).forEach((id) => {
-    queue.push(mapToAudioLists(data[id]))
+const reduceAddTracks = (state, { data, orderedIds }) => {
+  const queue = state.queue.slice()
+  const keys = (orderedIds && orderedIds.length
+    ? orderedIds
+    : Object.keys(data)
+  )
+    .map(normalizeKey)
+    .filter((key) => key && data[key])
+
+  keys.forEach((key) => {
+    queue.push(mapToAudioLists(data[key]))
   })
   return { ...state, queue, clear: false }
 }
 
-const reducePlayNext = (state, { data }) => {
+const reducePlayNext = (state, { data, orderedIds }) => {
   const newQueue = []
   const current = state.current || {}
+  const keys = (orderedIds && orderedIds.length
+    ? orderedIds
+    : Object.keys(data)
+  )
+    .map(normalizeKey)
+    .filter((key) => key && data[key])
   let foundPos = false
   state.queue.forEach((item) => {
     newQueue.push(item)
     if (item.uuid === current.uuid) {
       foundPos = true
-      Object.keys(data).forEach((id) => {
-        newQueue.push(mapToAudioLists(data[id]))
+      keys.forEach((key) => {
+        newQueue.push(mapToAudioLists(data[key]))
       })
     }
   })
   if (!foundPos) {
-    Object.keys(data).forEach((id) => {
-      newQueue.push(mapToAudioLists(data[id]))
+    keys.forEach((key) => {
+      newQueue.push(mapToAudioLists(data[key]))
     })
   }
 

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -139,38 +139,44 @@ const SongList = (props) => {
 
   const songs = useSelector((state) => state.admin.resources.song)
 
-  const handleRowClick = useCallback((id, basePath, record) => {
-      // Convert songs.data to an array if it's an object
-      const songsArray = Array.isArray(songs.data) ? songs.data : Object.values(songs.data);
+  const songsById = useMemo(() => {
+    if (!songs?.data) {
+      return {}
+    }
 
-      if (songsArray.length > 0 && Array.isArray(songs.list?.ids)) {
-        // Filter songs to include only those whose IDs exist in songs.list.ids
-        const filteredSongs = songsArray.filter(song => songs.list.ids.includes(song.id));
-
-        // Find the index of the selected song
-        const index = filteredSongs.findIndex(song => song.id === record.id);
-
-        if (index !== -1) {
-          // Rearrange array to start from the selected song
-          const orderedSongs = [
-            ...filteredSongs.slice(index),
-            ...filteredSongs.slice(0, index)
-          ];
-
-          // Convert the array into an object where key = song.id, value = song
-          // const updatedSongs = Object.fromEntries(orderedSongs.map(song => [song.id, song]));
-
-          // Convert array to an object with index-based keys, updating the song id as well
-          const updatedSongs = Object.fromEntries(
-            orderedSongs.map((song, idx) => 
-               [idx, song] // Setting both the key and `id` inside each song
-            )
-          );
-
-          dispatch(playTracks(updatedSongs,0));
+    if (Array.isArray(songs.data)) {
+      return songs.data.reduce((acc, song) => {
+        if (song?.id !== undefined) {
+          acc[song.id] = song
         }
+        return acc
+      }, {})
+    }
+
+    return songs.data
+  }, [songs?.data])
+
+  const handleRowClick = useCallback(
+    (id, basePath, record) => {
+      const listIds = songs?.list?.ids
+      if (!Array.isArray(listIds) || listIds.length === 0) {
+        return
       }
-    }, [dispatch, songs.data, songs.list?.ids]);
+
+      const availableIds = listIds.filter((songId) => songsById[songId])
+      if (availableIds.length === 0) {
+        return
+      }
+
+      const selectedId = record?.id ?? id
+      if (!selectedId || !songsById[selectedId]) {
+        return
+      }
+
+      dispatch(playTracks(songsById, availableIds, selectedId))
+    },
+    [dispatch, songs?.list?.ids, songsById],
+  )
 
   const toggleableFields = useMemo(() => {
     return {


### PR DESCRIPTION
## Summary
- ensure the song list click handler keeps the queue ordered from the list while selecting the clicked song to start playback
- normalize the songs resource into an id-keyed map before dispatching playTracks

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910ccac5b6c8322949078fe8be234fd)