### PR TITLE
Allow dropping retail player devices to root

### DIFF
--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -190,27 +190,41 @@ const useStyles = makeStyles((theme) => {
       color: theme.palette.primary.main,
     },
   },
-    deviceIcon: {
-      color: theme.palette.common.white,
-      fontSize: theme.typography.pxToRem(16),
-    },
-    dropTarget: dndStyles.dropTarget,
-    dropTargetCanDrop: dndStyles.dropTargetCanDrop,
-    dropTargetActive: dndStyles.dropTargetActive,
-    rootDropWrapper: {
-      '&$dropTargetCanDrop': {
+  deviceIcon: {
+    color: theme.palette.common.white,
+    fontSize: theme.typography.pxToRem(16),
+  },
+  dropTarget: dndStyles.dropTarget,
+  dropTargetCanDrop: dndStyles.dropTargetCanDrop,
+  dropTargetActive: dndStyles.dropTargetActive,
+  rootDropWrapper: {
+    borderRadius: theme.shape.borderRadius,
+    transition: theme.transitions.create(['background-color', 'box-shadow'], {
+      duration: theme.transitions.duration.shortest,
+    }),
+  },
+  rootDropWrapperCanDrop: {
+    '& .MuiMenuItem-root': {
+      backgroundColor: 'transparent',
+      '&:hover': {
         backgroundColor: 'transparent',
       },
-      '&$dropTargetActive': {
+    },
+  },
+  rootDropWrapperActive: {
+    '& .MuiMenuItem-root': {
+      backgroundColor: 'transparent',
+      boxShadow: 'none',
+      '&:hover': {
         backgroundColor: 'transparent',
-        boxShadow: 'none',
       },
     },
-    dragging: dndStyles.dragItem,
-    dndWrapper: {
-      width: '100%',
-      borderRadius: theme.shape.borderRadius,
-    },
+  },
+  dragging: dndStyles.dragItem,
+  dndWrapper: {
+    width: '100%',
+    borderRadius: theme.shape.borderRadius,
+  },
   }
 })
 
@@ -315,11 +329,22 @@ const Menu = ({ dense = false }) => {
     [assignDeviceToFolder],
   )
 
-  const retailPlayerRootDrop = useRetailPlayerFolderDrop({
+  const {
+    dropRef: retailPlayerRootDropRef,
+    isOver: retailPlayerRootIsOver,
+    canDrop: retailPlayerRootCanDrop,
+  } = useRetailPlayerFolderDrop({
     folderId: null,
     allowRootDrop: true,
     onDrop: (deviceId, targetFolderId) => handleDeviceDrop(deviceId, targetFolderId),
   })
+
+  const rootDropRef = useCallback(
+    (node) => {
+      retailPlayerRootDropRef(node)
+    },
+    [retailPlayerRootDropRef],
+  )
 
   const toggleFolder = useCallback((folderId) => {
     setOpenFolders((prev) => ({
@@ -410,17 +435,17 @@ const Menu = ({ dense = false }) => {
 
   const renderRetailPlayerMenu = () => (
     <div
-      ref={retailPlayerRootDrop.dropRef}
       className={clsx(
         classes.dropTarget,
         classes.rootDropWrapper,
-        retailPlayerRootDrop.canDrop && classes.dropTargetCanDrop,
-        retailPlayerRootDrop.canDrop &&
-          retailPlayerRootDrop.isOver &&
-          classes.dropTargetActive,
+        retailPlayerRootCanDrop && classes.rootDropWrapperCanDrop,
+        retailPlayerRootCanDrop &&
+          retailPlayerRootIsOver &&
+          classes.rootDropWrapperActive,
       )}
     >
       <SubMenu
+        ref={rootDropRef}
         handleToggle={() => handleToggle('menuRetailPlayer')}
         isOpen={state.menuRetailPlayer}
         sidebarIsOpen={open}

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -197,6 +197,15 @@ const useStyles = makeStyles((theme) => {
     dropTarget: dndStyles.dropTarget,
     dropTargetCanDrop: dndStyles.dropTargetCanDrop,
     dropTargetActive: dndStyles.dropTargetActive,
+    rootDropWrapper: {
+      '&$dropTargetCanDrop': {
+        backgroundColor: 'transparent',
+      },
+      '&$dropTargetActive': {
+        backgroundColor: 'transparent',
+        boxShadow: 'none',
+      },
+    },
     dragging: dndStyles.dragItem,
     dndWrapper: {
       width: '100%',
@@ -404,6 +413,7 @@ const Menu = ({ dense = false }) => {
       ref={retailPlayerRootDrop.dropRef}
       className={clsx(
         classes.dropTarget,
+        classes.rootDropWrapper,
         retailPlayerRootDrop.canDrop && classes.dropTargetCanDrop,
         retailPlayerRootDrop.canDrop &&
           retailPlayerRootDrop.isOver &&

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -295,16 +295,22 @@ const Menu = ({ dense = false }) => {
 
   const handleDeviceDrop = useCallback(
     (deviceId, folderId) => {
-      if (!deviceId || !folderId) {
+      if (!deviceId) {
         return
       }
       const changed = assignDeviceToFolder(deviceId, folderId)
-      if (changed) {
+      if (changed && folderId) {
         setOpenFolders((prev) => ({ ...prev, [folderId]: true }))
       }
     },
     [assignDeviceToFolder],
   )
+
+  const retailPlayerRootDrop = useRetailPlayerFolderDrop({
+    folderId: null,
+    allowRootDrop: true,
+    onDrop: (deviceId, targetFolderId) => handleDeviceDrop(deviceId, targetFolderId),
+  })
 
   const toggleFolder = useCallback((folderId) => {
     setOpenFolders((prev) => ({
@@ -394,18 +400,29 @@ const Menu = ({ dense = false }) => {
   }
 
   const renderRetailPlayerMenu = () => (
-    <SubMenu
-      handleToggle={() => handleToggle('menuRetailPlayer')}
-      isOpen={state.menuRetailPlayer}
-      sidebarIsOpen={open}
-      name="menu.retailPlayer.name"
-      icon={<SpeakerGroupIcon />}
-      dense={dense}
-      actionIcon={<BiCog />}
-      onAction={goToRetailPlayerSettings}
+    <div
+      ref={retailPlayerRootDrop.dropRef}
+      className={clsx(
+        classes.dropTarget,
+        retailPlayerRootDrop.canDrop && classes.dropTargetCanDrop,
+        retailPlayerRootDrop.canDrop &&
+          retailPlayerRootDrop.isOver &&
+          classes.dropTargetActive,
+      )}
     >
-      {renderRetailPlayerDevices()}
-    </SubMenu>
+      <SubMenu
+        handleToggle={() => handleToggle('menuRetailPlayer')}
+        isOpen={state.menuRetailPlayer}
+        sidebarIsOpen={open}
+        name="menu.retailPlayer.name"
+        icon={<SpeakerGroupIcon />}
+        dense={dense}
+        actionIcon={<BiCog />}
+        onAction={goToRetailPlayerSettings}
+      >
+        {renderRetailPlayerDevices()}
+      </SubMenu>
+    </div>
   )
 
   return (

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -339,13 +339,6 @@ const Menu = ({ dense = false }) => {
     onDrop: (deviceId, targetFolderId) => handleDeviceDrop(deviceId, targetFolderId),
   })
 
-  const rootDropRef = useCallback(
-    (node) => {
-      retailPlayerRootDropRef(node)
-    },
-    [retailPlayerRootDropRef],
-  )
-
   const toggleFolder = useCallback((folderId) => {
     setOpenFolders((prev) => ({
       ...prev,
@@ -435,6 +428,7 @@ const Menu = ({ dense = false }) => {
 
   const renderRetailPlayerMenu = () => (
     <div
+      ref={retailPlayerRootDropRef}
       className={clsx(
         classes.dropTarget,
         classes.rootDropWrapper,
@@ -445,7 +439,6 @@ const Menu = ({ dense = false }) => {
       )}
     >
       <SubMenu
-        ref={rootDropRef}
         handleToggle={() => handleToggle('menuRetailPlayer')}
         isOpen={state.menuRetailPlayer}
         sidebarIsOpen={open}

--- a/ui/src/retailPlayer/useAssignRetailPlayerDeviceToFolder.js
+++ b/ui/src/retailPlayer/useAssignRetailPlayerDeviceToFolder.js
@@ -1,15 +1,21 @@
 import { useCallback } from 'react'
 import { useRetailPlayerDeviceStore } from './RetailPlayerDeviceStoreContext'
 
-const normalizeFolderIds = (device) => {
-  if (!device) {
+const normalizeFolderIds = (value) => {
+  if (!value) {
     return []
   }
-  if (Array.isArray(device.folderIds)) {
-    return device.folderIds.filter(Boolean)
+  if (Array.isArray(value)) {
+    return value.filter(Boolean)
   }
-  if (device.folderId) {
-    return [device.folderId].filter(Boolean)
+  if (typeof value === 'string') {
+    return [value].filter(Boolean)
+  }
+  if (Array.isArray(value.folderIds)) {
+    return value.folderIds.filter(Boolean)
+  }
+  if (value.folderId) {
+    return [value.folderId].filter(Boolean)
   }
   return []
 }
@@ -22,7 +28,7 @@ const useAssignRetailPlayerDeviceToFolder = () => {
 
   return useCallback(
     (deviceId, folderId) => {
-      if (!deviceId || !folderId) {
+      if (!deviceId) {
         return false
       }
 
@@ -32,7 +38,7 @@ const useAssignRetailPlayerDeviceToFolder = () => {
       }
 
       const currentFolderIds = normalizeFolderIds(targetDevice)
-      const nextFolderIds = [folderId]
+      const nextFolderIds = normalizeFolderIds(folderId)
       const unchanged =
         currentFolderIds.length === nextFolderIds.length &&
         currentFolderIds.every((id, index) => id === nextFolderIds[index])

--- a/ui/src/retailPlayer/useRetailPlayerDnD.js
+++ b/ui/src/retailPlayer/useRetailPlayerDnD.js
@@ -33,36 +33,45 @@ export const useRetailPlayerDeviceDrag = ({
   return { dragRef, isDragging }
 }
 
-export const useRetailPlayerFolderDrop = ({ folderId, onDrop }) => {
+export const useRetailPlayerFolderDrop = ({
+  folderId,
+  onDrop,
+  allowRootDrop = false,
+}) => {
+  const normalizedFolderId = folderId ?? null
   const handleDrop = useCallback(
     (item) => {
-      if (!folderId || !item?.deviceId) {
+      if (!item?.deviceId) {
+        return
+      }
+      if (!allowRootDrop && !normalizedFolderId) {
         return
       }
       if (onDrop) {
-        onDrop(item.deviceId, folderId, item)
+        onDrop(item.deviceId, normalizedFolderId, item)
       }
     },
-    [folderId, onDrop],
+    [normalizedFolderId, onDrop, allowRootDrop],
   )
 
   const [{ isOver, canDrop }, dropRef] = useDrop(
     () => ({
       accept: RETAIL_PLAYER_DND_TYPES.DEVICE,
-      canDrop: (item) => Boolean(folderId) && Boolean(item?.deviceId),
+      canDrop: (item) =>
+        Boolean(item?.deviceId) && (allowRootDrop || Boolean(normalizedFolderId)),
       drop: (item, monitor) => {
         if (monitor.didDrop()) {
           return undefined
         }
         handleDrop(item)
-        return { folderId }
+        return { folderId: normalizedFolderId }
       },
       collect: (monitor) => ({
         isOver: monitor.isOver({ shallow: true }),
         canDrop: monitor.canDrop(),
       }),
     }),
-    [folderId, handleDrop],
+    [normalizedFolderId, handleDrop, allowRootDrop],
   )
 
   return { dropRef, isOver, canDrop }


### PR DESCRIPTION
## Summary
- allow the Retail Player menu header to accept dropped devices so they can be moved out of folders
- update the assignment helper to clear folder memberships when dropping onto the root
- relax the folder drop hook to support root-level drop targets

## Testing
- npm --prefix ui test *(fails: existing suite error "No `useNotify` export is defined on the `react-admin` mock")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691121259f6c8322a9363d944fc63f3e)