### PR TITLE
Validate retail player artwork availability

### DIFF
--- a/cmd/wire_gen.go
+++ b/cmd/wire_gen.go
@@ -73,7 +73,7 @@ func CreateNativeAPIRouter(ctx context.Context) *nativeapi.Router {
 	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, discoveries, metricsMetrics)
 	watcher := scanner.GetWatcher(dataStore, scannerScanner)
 	library := core.NewLibrary(dataStore, scannerScanner, watcher, broker)
-	router := nativeapi.New(dataStore, share, playlists, insights, library)
+	router := nativeapi.New(dataStore, artworkArtwork, share, playlists, insights, library)
 	return router
 }
 

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/core"
+	"github.com/navidrome/navidrome/core/artwork"
 	"github.com/navidrome/navidrome/core/metrics"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -25,6 +26,7 @@ import (
 type Router struct {
 	http.Handler
 	ds        model.DataStore
+	artwork   artwork.Artwork
 	share     core.Share
 	playlists core.Playlists
 	insights  metrics.Insights
@@ -32,9 +34,10 @@ type Router struct {
 	devices   *retailPlayerDeviceResolver
 }
 
-func New(ds model.DataStore, share core.Share, playlists core.Playlists, insights metrics.Insights, libraryService core.Library) *Router {
+func New(ds model.DataStore, artworkService artwork.Artwork, share core.Share, playlists core.Playlists, insights metrics.Insights, libraryService core.Library) *Router {
 	r := &Router{
 		ds:        ds,
+		artwork:   artworkService,
 		share:     share,
 		playlists: playlists,
 		insights:  insights,

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/core/artwork"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/server/public"
@@ -454,6 +455,20 @@ func (n *Router) handleRetailPlayerCoverArt() http.HandlerFunc {
 			return
 		}
 
+		if err := n.ensureRetailPlayerArtworkAvailable(ctx, artworkID, size, square); err != nil {
+			switch {
+			case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+				return
+			case errors.Is(err, artwork.ErrUnavailable), errors.Is(err, model.ErrNotFound):
+				http.Error(w, "Artwork not found", http.StatusNotFound)
+				return
+			default:
+				log.Error(ctx, "Unable to load retail player cover art", "artworkID", artworkID, "err", err)
+				http.Error(w, "Error retrieving cover art", http.StatusInternalServerError)
+				return
+			}
+		}
+
 		imageURL := public.ImageURLWithOptions(r, artworkID, size, square)
 		if imageURL == "" {
 			http.Error(w, "Artwork not found", http.StatusNotFound)
@@ -473,6 +488,25 @@ func (n *Router) handleRetailPlayerCoverArt() http.HandlerFunc {
 			log.Error(ctx, "Unable to encode retail player cover art response", "err", err)
 		}
 	}
+}
+
+func (n *Router) ensureRetailPlayerArtworkAvailable(ctx context.Context, artID model.ArtworkID, size int, square bool) error {
+	if n == nil || n.artwork == nil || artID.String() == "" {
+		return nil
+	}
+
+	reader, _, err := n.artwork.Get(ctx, artID, size, square)
+	if err != nil {
+		return err
+	}
+
+	if reader != nil {
+		if closeErr := reader.Close(); closeErr != nil {
+			log.Debug(ctx, "Error closing artwork reader", "artworkID", artID, "err", closeErr)
+		}
+	}
+
+	return nil
 }
 
 func (n *Router) resolveRetailPlayerDevice(ctx context.Context, identifier string) (retailPlayerDevice, error) {

--- a/server/nativeapi/retail_player_cover_art_test.go
+++ b/server/nativeapi/retail_player_cover_art_test.go
@@ -1,7 +1,10 @@
 package nativeapi
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -10,6 +13,7 @@ import (
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
 	"github.com/navidrome/navidrome/core"
+	"github.com/navidrome/navidrome/core/artwork"
 	"github.com/navidrome/navidrome/core/auth"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/tests"
@@ -17,10 +21,35 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+type stubArtwork struct {
+	err        error
+	lastArtID  model.ArtworkID
+	lastSize   int
+	lastSquare bool
+}
+
+func (s *stubArtwork) Get(ctx context.Context, artID model.ArtworkID, size int, square bool) (io.ReadCloser, time.Time, error) {
+	s.lastArtID = artID
+	s.lastSize = size
+	s.lastSquare = square
+	if s.err != nil {
+		return nil, time.Time{}, s.err
+	}
+	return io.NopCloser(bytes.NewReader(nil)), time.Now(), nil
+}
+
+func (s *stubArtwork) GetOrPlaceholder(ctx context.Context, id string, size int, square bool) (io.ReadCloser, time.Time, error) {
+	if s.err != nil {
+		return nil, time.Time{}, s.err
+	}
+	return io.NopCloser(bytes.NewReader(nil)), time.Now(), nil
+}
+
 var _ = Describe("Retail Player Cover Art Endpoint", func() {
 	var (
 		router http.Handler
 		ds     *tests.MockDataStore
+		art    *stubArtwork
 	)
 
 	BeforeEach(func() {
@@ -35,7 +64,8 @@ var _ = Describe("Retail Player Cover Art Endpoint", func() {
 
 		auth.Init(ds)
 
-		nativeRouter := New(ds, nil, nil, nil, core.NewMockLibraryService())
+		art = &stubArtwork{}
+		nativeRouter := New(ds, art, nil, nil, core.NewMockLibraryService())
 		router = nativeRouter
 	})
 
@@ -60,6 +90,9 @@ var _ = Describe("Retail Player Cover Art Endpoint", func() {
 		Expect(resp.URL).To(ContainSubstring("/public/img/"))
 		Expect(resp.URL).To(ContainSubstring("size=300"))
 		Expect(resp.URL).To(ContainSubstring("square=true"))
+		Expect(art.lastArtID).To(Equal(artID))
+		Expect(art.lastSize).To(Equal(300))
+		Expect(art.lastSquare).To(BeTrue())
 	})
 
 	It("searches for cover art using metadata", func() {
@@ -93,11 +126,29 @@ var _ = Describe("Retail Player Cover Art Endpoint", func() {
 		Expect(resp.ArtworkID).To(Equal(mediaFile.CoverArtID().String()))
 		Expect(resp.MediaFileID).To(Equal(mediaFile.ID))
 		Expect(resp.URL).To(ContainSubstring("/public/img/"))
+		Expect(art.lastArtID).To(Equal(mediaFile.CoverArtID()))
+		Expect(art.lastSize).To(Equal(200))
+		Expect(art.lastSquare).To(BeFalse())
 	})
 
 	It("returns 404 when no artwork can be found", func() {
 		recorder := httptest.NewRecorder()
 		request := httptest.NewRequest(http.MethodGet, "/retailplayer/cover-art?title=Unknown", nil)
+
+		router.ServeHTTP(recorder, request)
+
+		Expect(recorder.Code).To(Equal(http.StatusNotFound))
+	})
+
+	It("returns 404 when the artwork cannot be retrieved", func() {
+		art.err = artwork.ErrUnavailable
+
+		recorder := httptest.NewRecorder()
+		artID := model.NewArtworkID(model.KindMediaFileArtwork, "song-2", nil)
+		query := url.Values{
+			"artworkId": []string{artID.String()},
+		}
+		request := httptest.NewRequest(http.MethodGet, "/retailplayer/cover-art?"+query.Encode(), nil)
 
 		router.ServeHTTP(recorder, request)
 


### PR DESCRIPTION
## Summary
- ensure the retail player cover art endpoint validates artwork availability before responding
- wire the artwork service into the native API router so the validation can run
- cover the new behaviour with tests using a stub artwork service

## Testing
- go test ./... *(fails: pkg-config cannot find taglib)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911253d59548322ba8c1a3a95ffe604)