### PR TITLE
Allow moving retail player devices to the root from the sidebar

### DIFF
--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -31,6 +31,7 @@ import useAssignRetailPlayerDeviceToFolder from '../retailPlayer/useAssignRetail
 import {
   useRetailPlayerDeviceDrag,
   useRetailPlayerFolderDrop,
+  useRetailPlayerRootDrop,
 } from '../retailPlayer/useRetailPlayerDnD'
 import buildRetailPlayerDnDStyles from '../retailPlayer/retailPlayerDnDStyles'
 
@@ -198,6 +199,9 @@ const useStyles = makeStyles((theme) => {
     dropTargetCanDrop: dndStyles.dropTargetCanDrop,
     dropTargetActive: dndStyles.dropTargetActive,
     dragging: dndStyles.dragItem,
+    retailPlayerRootDropZone: {
+      width: '100%',
+    },
     dndWrapper: {
       width: '100%',
       borderRadius: theme.shape.borderRadius,
@@ -306,6 +310,16 @@ const Menu = ({ dense = false }) => {
     [assignDeviceToFolder],
   )
 
+  const handleDeviceDropToRoot = useCallback(
+    (deviceId) => {
+      if (!deviceId) {
+        return
+      }
+      assignDeviceToFolder(deviceId, null)
+    },
+    [assignDeviceToFolder],
+  )
+
   const toggleFolder = useCallback((folderId) => {
     setOpenFolders((prev) => ({
       ...prev,
@@ -393,19 +407,39 @@ const Menu = ({ dense = false }) => {
     return renderRetailPlayerNodes(retailTree)
   }
 
+  const {
+    dropRef: retailPlayerRootDropRef,
+    isOver: isRetailPlayerRootOver,
+    canDrop: canDropOnRetailPlayerRoot,
+  } = useRetailPlayerRootDrop({
+    onDrop: (deviceId) => handleDeviceDropToRoot(deviceId),
+  })
+
   const renderRetailPlayerMenu = () => (
-    <SubMenu
-      handleToggle={() => handleToggle('menuRetailPlayer')}
-      isOpen={state.menuRetailPlayer}
-      sidebarIsOpen={open}
-      name="menu.retailPlayer.name"
-      icon={<SpeakerGroupIcon />}
-      dense={dense}
-      actionIcon={<BiCog />}
-      onAction={goToRetailPlayerSettings}
+    <div
+      ref={retailPlayerRootDropRef}
+      className={clsx(
+        classes.retailPlayerRootDropZone,
+        classes.dropTarget,
+        canDropOnRetailPlayerRoot && classes.dropTargetCanDrop,
+        canDropOnRetailPlayerRoot &&
+          isRetailPlayerRootOver &&
+          classes.dropTargetActive,
+      )}
     >
-      {renderRetailPlayerDevices()}
-    </SubMenu>
+      <SubMenu
+        handleToggle={() => handleToggle('menuRetailPlayer')}
+        isOpen={state.menuRetailPlayer}
+        sidebarIsOpen={open}
+        name="menu.retailPlayer.name"
+        icon={<SpeakerGroupIcon />}
+        dense={dense}
+        actionIcon={<BiCog />}
+        onAction={goToRetailPlayerSettings}
+      >
+        {renderRetailPlayerDevices()}
+      </SubMenu>
+    </div>
   )
 
   return (

--- a/ui/src/retailPlayer/useAssignRetailPlayerDeviceToFolder.js
+++ b/ui/src/retailPlayer/useAssignRetailPlayerDeviceToFolder.js
@@ -22,7 +22,7 @@ const useAssignRetailPlayerDeviceToFolder = () => {
 
   return useCallback(
     (deviceId, folderId) => {
-      if (!deviceId || !folderId) {
+      if (!deviceId) {
         return false
       }
 
@@ -32,7 +32,9 @@ const useAssignRetailPlayerDeviceToFolder = () => {
       }
 
       const currentFolderIds = normalizeFolderIds(targetDevice)
-      const nextFolderIds = [folderId]
+      const normalizedFolderId =
+        typeof folderId === 'string' && folderId.trim() !== '' ? folderId : null
+      const nextFolderIds = normalizedFolderId ? [normalizedFolderId] : []
       const unchanged =
         currentFolderIds.length === nextFolderIds.length &&
         currentFolderIds.every((id, index) => id === nextFolderIds[index])

--- a/ui/src/retailPlayer/useRetailPlayerDnD.js
+++ b/ui/src/retailPlayer/useRetailPlayerDnD.js
@@ -67,3 +67,38 @@ export const useRetailPlayerFolderDrop = ({ folderId, onDrop }) => {
 
   return { dropRef, isOver, canDrop }
 }
+
+export const useRetailPlayerRootDrop = ({ onDrop }) => {
+  const handleDrop = useCallback(
+    (item) => {
+      if (!item?.deviceId) {
+        return
+      }
+      if (onDrop) {
+        onDrop(item.deviceId, null, item)
+      }
+    },
+    [onDrop],
+  )
+
+  const [{ isOver, canDrop }, dropRef] = useDrop(
+    () => ({
+      accept: RETAIL_PLAYER_DND_TYPES.DEVICE,
+      canDrop: (item) => Boolean(item?.deviceId),
+      drop: (item, monitor) => {
+        if (monitor.didDrop()) {
+          return undefined
+        }
+        handleDrop(item)
+        return { folderId: null }
+      },
+      collect: (monitor) => ({
+        isOver: monitor.isOver({ shallow: true }),
+        canDrop: monitor.canDrop(),
+      }),
+    }),
+    [handleDrop],
+  )
+
+  return { dropRef, isOver, canDrop }
+}


### PR DESCRIPTION
## Summary
- allow retail player device assignments to clear folder associations when dropping on the root
- expose a drag-and-drop hook to support dropping devices onto the retail player heading
- wrap the retail player sidebar menu in a root drop zone so devices can be moved out of folders

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691128063dec8322a19c5f68916da042)