### PR TITLE
Prevent retail player root drop highlight

### DIFF
--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -197,6 +197,15 @@ const useStyles = makeStyles((theme) => {
     dropTarget: dndStyles.dropTarget,
     dropTargetCanDrop: dndStyles.dropTargetCanDrop,
     dropTargetActive: dndStyles.dropTargetActive,
+    rootDropTarget: {
+      '&$dropTargetCanDrop': {
+        backgroundColor: 'transparent',
+      },
+      '&$dropTargetActive': {
+        backgroundColor: 'transparent',
+        boxShadow: 'none',
+      },
+    },
     dragging: dndStyles.dragItem,
     dndWrapper: {
       width: '100%',
@@ -404,6 +413,7 @@ const Menu = ({ dense = false }) => {
       ref={retailPlayerRootDrop.dropRef}
       className={clsx(
         classes.dropTarget,
+        classes.rootDropTarget,
         retailPlayerRootDrop.canDrop && classes.dropTargetCanDrop,
         retailPlayerRootDrop.canDrop &&
           retailPlayerRootDrop.isOver &&


### PR DESCRIPTION
## Summary
- avoid applying drop-target highlight styles to the retail player root drop zone so only hovered folders are emphasized

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691129d0e01c8322b826b1825b88934b)