### PR TITLE
Add retail player folder persistence and API integration

### DIFF
--- a/db/migrations/20250816074436_create_retail_player_folders.go
+++ b/db/migrations/20250816074436_create_retail_player_folders.go
@@ -1,0 +1,57 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upCreateRetailPlayerFolders, downCreateRetailPlayerFolders)
+}
+
+func upCreateRetailPlayerFolders(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+        CREATE TABLE IF NOT EXISTS retail_player_folder (
+            id         TEXT PRIMARY KEY NOT NULL,
+            name       TEXT NOT NULL,
+            parent_id  TEXT,
+            created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+            updated_at DATETIME NOT NULL DEFAULT (datetime('now')),
+            FOREIGN KEY(parent_id) REFERENCES retail_player_folder(id) ON DELETE SET NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_retail_player_folder_parent
+            ON retail_player_folder(parent_id);
+        CREATE INDEX IF NOT EXISTS idx_retail_player_folder_name
+            ON retail_player_folder(name COLLATE NOCASE);
+
+        CREATE TABLE IF NOT EXISTS retail_player_device_folder (
+            device_id  TEXT NOT NULL,
+            folder_id  TEXT NOT NULL,
+            created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+            updated_at DATETIME NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY(device_id, folder_id),
+            FOREIGN KEY(folder_id) REFERENCES retail_player_folder(id) ON DELETE CASCADE
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_retail_player_device_folder_device
+            ON retail_player_device_folder(device_id);
+        CREATE INDEX IF NOT EXISTS idx_retail_player_device_folder_folder
+            ON retail_player_device_folder(folder_id);
+    `)
+	return err
+}
+
+func downCreateRetailPlayerFolders(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+        DROP INDEX IF EXISTS idx_retail_player_device_folder_device;
+        DROP INDEX IF EXISTS idx_retail_player_device_folder_folder;
+        DROP TABLE IF EXISTS retail_player_device_folder;
+        DROP INDEX IF EXISTS idx_retail_player_folder_parent;
+        DROP INDEX IF EXISTS idx_retail_player_folder_name;
+        DROP TABLE IF EXISTS retail_player_folder;
+    `)
+	return err
+}

--- a/model/datastore.go
+++ b/model/datastore.go
@@ -36,6 +36,7 @@ type DataStore interface {
 	Player(ctx context.Context) PlayerRepository
 	Radio(ctx context.Context) RadioRepository
 	RetailPlayerDeviceMapping(ctx context.Context) RetailPlayerDeviceMappingRepository
+	RetailPlayerFolder(ctx context.Context) RetailPlayerFolderRepository
 	Share(ctx context.Context) ShareRepository
 	Property(ctx context.Context) PropertyRepository
 	User(ctx context.Context) UserRepository

--- a/model/retail_player_folder.go
+++ b/model/retail_player_folder.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"context"
+	"time"
+)
+
+type RetailPlayerFolder struct {
+	ID        string    `db:"id" json:"id"`
+	Name      string    `db:"name" json:"name"`
+	ParentID  *string   `db:"parent_id" json:"parentId,omitempty"`
+	CreatedAt time.Time `db:"created_at" json:"createdAt"`
+	UpdatedAt time.Time `db:"updated_at" json:"updatedAt"`
+}
+
+type RetailPlayerDeviceFolder struct {
+	DeviceID  string    `db:"device_id" json:"deviceId"`
+	FolderID  string    `db:"folder_id" json:"folderId"`
+	CreatedAt time.Time `db:"created_at" json:"createdAt"`
+	UpdatedAt time.Time `db:"updated_at" json:"updatedAt"`
+}
+
+type RetailPlayerFolderRepository interface {
+	List(ctx context.Context) ([]RetailPlayerFolder, error)
+	Upsert(ctx context.Context, folder RetailPlayerFolder) (RetailPlayerFolder, error)
+	DeleteMany(ctx context.Context, ids []string) error
+	Assignments(ctx context.Context) ([]RetailPlayerDeviceFolder, error)
+	ReplaceDeviceAssignments(ctx context.Context, deviceID string, folderIDs []string) error
+}

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -77,6 +77,10 @@ func (s *SQLStore) RetailPlayerDeviceMapping(ctx context.Context) model.RetailPl
 	return NewRetailPlayerDeviceMappingRepository(ctx, s.getDBXBuilder())
 }
 
+func (s *SQLStore) RetailPlayerFolder(ctx context.Context) model.RetailPlayerFolderRepository {
+	return NewRetailPlayerFolderRepository(ctx, s.getDBXBuilder())
+}
+
 func (s *SQLStore) UserProps(ctx context.Context) model.UserPropsRepository {
 	return NewUserPropsRepository(ctx, s.getDBXBuilder())
 }

--- a/persistence/retail_player_folder_repository.go
+++ b/persistence/retail_player_folder_repository.go
@@ -1,0 +1,153 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	. "github.com/Masterminds/squirrel"
+	"github.com/navidrome/navidrome/model"
+	"github.com/pocketbase/dbx"
+)
+
+type retailPlayerFolderRepository struct {
+	sqlRepository
+}
+
+func NewRetailPlayerFolderRepository(ctx context.Context, db dbx.Builder) model.RetailPlayerFolderRepository {
+	r := &retailPlayerFolderRepository{}
+	r.ctx = ctx
+	r.db = db
+	r.tableName = "retail_player_folder"
+	r.registerModel(&model.RetailPlayerFolder{}, nil)
+	return r
+}
+
+func (r retailPlayerFolderRepository) List(ctx context.Context) ([]model.RetailPlayerFolder, error) {
+	sel := Select("id", "name", "parent_id", "created_at", "updated_at").
+		From(r.tableName).
+		OrderBy("lower(name) asc", "created_at asc")
+
+	var folders []model.RetailPlayerFolder
+	err := r.queryAll(sel, &folders)
+	if errors.Is(err, model.ErrNotFound) {
+		return nil, nil
+	}
+	return folders, err
+}
+
+func (r retailPlayerFolderRepository) Upsert(ctx context.Context, folder model.RetailPlayerFolder) (model.RetailPlayerFolder, error) {
+	id := strings.TrimSpace(folder.ID)
+	if id == "" {
+		return model.RetailPlayerFolder{}, errors.New("retail player folder id is required")
+	}
+
+	name := strings.TrimSpace(folder.Name)
+	if name == "" {
+		return model.RetailPlayerFolder{}, errors.New("retail player folder name is required")
+	}
+
+	var parentID *string
+	if folder.ParentID != nil {
+		trimmedParent := strings.TrimSpace(*folder.ParentID)
+		if trimmedParent != "" && trimmedParent != id {
+			parentID = &trimmedParent
+		}
+	}
+
+	now := time.Now().UTC()
+
+	insert := Insert(r.tableName).
+		Columns("id", "name", "parent_id", "created_at", "updated_at").
+		Values(id, name, parentID, now, now).
+		Suffix(`ON CONFLICT(id) DO UPDATE SET
+            name = excluded.name,
+            parent_id = excluded.parent_id,
+            updated_at = excluded.updated_at`)
+
+	if _, err := r.executeSQL(insert); err != nil {
+		return model.RetailPlayerFolder{}, err
+	}
+
+	sel := Select("id", "name", "parent_id", "created_at", "updated_at").
+		From(r.tableName).
+		Where(Eq{"id": id}).
+		Limit(1)
+
+	var stored model.RetailPlayerFolder
+	if err := r.queryOne(sel, &stored); err != nil {
+		return model.RetailPlayerFolder{}, err
+	}
+
+	return stored, nil
+}
+
+func (r retailPlayerFolderRepository) DeleteMany(ctx context.Context, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	trimmed := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if value := strings.TrimSpace(id); value != "" {
+			trimmed = append(trimmed, value)
+		}
+	}
+
+	if len(trimmed) == 0 {
+		return nil
+	}
+
+	del := Delete(r.tableName).Where(Eq{"id": trimmed})
+	_, err := r.executeSQL(del)
+	return err
+}
+
+func (r retailPlayerFolderRepository) Assignments(ctx context.Context) ([]model.RetailPlayerDeviceFolder, error) {
+	sel := Select("device_id", "folder_id", "created_at", "updated_at").
+		From("retail_player_device_folder")
+
+	var assignments []model.RetailPlayerDeviceFolder
+	err := r.queryAll(sel, &assignments)
+	if errors.Is(err, model.ErrNotFound) {
+		return nil, nil
+	}
+	return assignments, err
+}
+
+func (r retailPlayerFolderRepository) ReplaceDeviceAssignments(ctx context.Context, deviceID string, folderIDs []string) error {
+	trimmedID := strings.TrimSpace(deviceID)
+	if trimmedID == "" {
+		return errors.New("retail player device id is required")
+	}
+
+	if _, err := r.executeSQL(Delete("retail_player_device_folder").Where(Eq{"device_id": trimmedID})); err != nil {
+		return err
+	}
+
+	normalized := make([]string, 0, len(folderIDs))
+	for _, id := range folderIDs {
+		if value := strings.TrimSpace(id); value != "" {
+			normalized = append(normalized, value)
+		}
+	}
+
+	if len(normalized) == 0 {
+		return nil
+	}
+
+	now := time.Now().UTC()
+	insert := Insert("retail_player_device_folder").
+		Columns("device_id", "folder_id", "created_at", "updated_at")
+
+	for _, folderID := range normalized {
+		insert = insert.Values(trimmedID, folderID, now, now)
+	}
+
+	insert = insert.Suffix(`ON CONFLICT(device_id, folder_id) DO UPDATE SET
+        updated_at = excluded.updated_at`)
+
+	_, err := r.executeSQL(insert)
+	return err
+}

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -195,18 +196,50 @@ type retailPlayerChannelListAPIResponse struct {
 }
 
 type retailPlayerDevice struct {
-	ID           string `json:"id"`
-	Name         string `json:"name"`
-	Channel      string `json:"channel"`
-	ChannelList  string `json:"channelList"`
-	Organization string `json:"organization"`
-	TimeZone     string `json:"timeZone,omitempty"`
+	ID           string   `json:"id"`
+	Name         string   `json:"name"`
+	Channel      string   `json:"channel"`
+	ChannelList  string   `json:"channelList"`
+	Organization string   `json:"organization"`
+	TimeZone     string   `json:"timeZone,omitempty"`
+	FolderIDs    []string `json:"folderIds,omitempty"`
 }
 
 type retailPlayerDevicesResponse struct {
-	Data  []retailPlayerDevice `json:"data"`
-	Page  *int                 `json:"page,omitempty"`
-	Total *int                 `json:"total,omitempty"`
+	Data         []retailPlayerDevice       `json:"data"`
+	Folders      []retailPlayerFolder       `json:"folders,omitempty"`
+	DeviceFolder []retailPlayerDeviceFolder `json:"deviceFolders,omitempty"`
+	Page         *int                       `json:"page,omitempty"`
+	Total        *int                       `json:"total,omitempty"`
+}
+
+type retailPlayerFolder struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	ParentID  *string   `json:"parentId,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+type retailPlayerDeviceFolder struct {
+	DeviceID  string    `json:"deviceId"`
+	FolderID  string    `json:"folderId"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+type retailPlayerFolderPayload struct {
+	ID       string  `json:"id"`
+	Name     string  `json:"name"`
+	ParentID *string `json:"parentId"`
+}
+
+type retailPlayerDeleteFoldersRequest struct {
+	FolderIDs []string `json:"folderIds"`
+}
+
+type retailPlayerAssignDeviceFoldersRequest struct {
+	FolderIDs []string `json:"folderIds"`
 }
 
 type retailPlayerAPIChannel struct {
@@ -251,7 +284,13 @@ func (n *Router) addRetailPlayerPublicRoutes(r chi.Router) {
 }
 
 func (n *Router) addRetailPlayerPrivateRoutes(r chi.Router) {
-	r.Get("/retailplayer/devices", n.handleRetailPlayerDevices())
+	r.Route("/retailplayer", func(r chi.Router) {
+		r.Get("/devices", n.handleRetailPlayerDevices())
+		r.Post("/folders", n.handleCreateRetailPlayerFolder())
+		r.Patch("/folders/{folderID}", n.handleUpdateRetailPlayerFolder())
+		r.Post("/folders/delete", n.handleDeleteRetailPlayerFolders())
+		r.Put("/devices/{deviceID}/folders", n.handleAssignRetailPlayerDeviceFolders())
+	})
 }
 
 var errRetailPlayerDeviceNotFound = errors.New("retail player device not found")
@@ -278,10 +317,287 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 		n.devices.RememberDevices(response.Data)
 		n.persistRetailPlayerDeviceMappings(ctx, response.Data)
 
+		folders, deviceFolders, err := n.loadRetailPlayerFolderData(ctx)
+		if err != nil {
+			log.Error(ctx, "Unable to load retail player folder data", "err", err)
+			http.Error(w, "Unable to load retail player folders", http.StatusInternalServerError)
+			return
+		}
+
+		if len(deviceFolders) > 0 {
+			folderSet := make(map[string]struct{}, len(folders))
+			for _, folder := range folders {
+				folderSet[folder.ID] = struct{}{}
+			}
+
+			assignments := make(map[string][]string)
+			for _, deviceFolder := range deviceFolders {
+				if _, ok := folderSet[deviceFolder.FolderID]; !ok {
+					continue
+				}
+
+				assignments[deviceFolder.DeviceID] = append(assignments[deviceFolder.DeviceID], deviceFolder.FolderID)
+			}
+
+			for index := range response.Data {
+				id := strings.TrimSpace(response.Data[index].ID)
+				if id == "" {
+					continue
+				}
+				if folderIDs, ok := assignments[id]; ok {
+					response.Data[index].FolderIDs = append([]string(nil), folderIDs...)
+				}
+			}
+		}
+
+		response.Folders = make([]retailPlayerFolder, 0, len(folders))
+		for _, folder := range folders {
+			response.Folders = append(response.Folders, mapModelRetailPlayerFolder(folder))
+		}
+
+		response.DeviceFolder = make([]retailPlayerDeviceFolder, 0, len(deviceFolders))
+		for _, deviceFolder := range deviceFolders {
+			response.DeviceFolder = append(response.DeviceFolder, mapModelRetailPlayerDeviceFolder(deviceFolder))
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(response); err != nil {
 			log.Error(ctx, "Unable to encode retail player devices response", "err", err)
 		}
+	}
+}
+
+func (n *Router) handleCreateRetailPlayerFolder() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		var payload retailPlayerFolderPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "Invalid retail player folder payload", http.StatusBadRequest)
+			return
+		}
+
+		folderID := strings.TrimSpace(payload.ID)
+		if folderID == "" {
+			folderID = uuid.NewString()
+		}
+
+		name := strings.TrimSpace(payload.Name)
+		if name == "" {
+			http.Error(w, "Retail player folder name is required", http.StatusBadRequest)
+			return
+		}
+
+		var parentID *string
+		if payload.ParentID != nil {
+			trimmed := strings.TrimSpace(*payload.ParentID)
+			if trimmed != "" && trimmed != folderID {
+				parentID = &trimmed
+			}
+		}
+
+		var folder model.RetailPlayerFolder
+		err := n.ds.WithTx(func(tx model.DataStore) error {
+			repo := tx.RetailPlayerFolder(ctx)
+			if repo == nil {
+				return errors.New("retail player folder repository not available")
+			}
+
+			stored, err := repo.Upsert(ctx, model.RetailPlayerFolder{ID: folderID, Name: name, ParentID: parentID})
+			if err != nil {
+				return err
+			}
+
+			folder = stored
+			return nil
+		})
+		if err != nil {
+			status := http.StatusInternalServerError
+			if isConstraintError(err) {
+				status = http.StatusBadRequest
+			}
+			log.Error(ctx, "Unable to create retail player folder", "err", err)
+			http.Error(w, "Unable to create retail player folder", status)
+			return
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusCreated, map[string]any{"data": mapModelRetailPlayerFolder(folder)})
+	}
+}
+
+func (n *Router) handleUpdateRetailPlayerFolder() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		folderID := strings.TrimSpace(chi.URLParam(r, "folderID"))
+		if folderID == "" {
+			http.Error(w, "Retail player folder id is required", http.StatusBadRequest)
+			return
+		}
+
+		var payload retailPlayerFolderPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "Invalid retail player folder payload", http.StatusBadRequest)
+			return
+		}
+
+		name := strings.TrimSpace(payload.Name)
+		if name == "" {
+			http.Error(w, "Retail player folder name is required", http.StatusBadRequest)
+			return
+		}
+
+		var parentID *string
+		if payload.ParentID != nil {
+			trimmed := strings.TrimSpace(*payload.ParentID)
+			if trimmed != "" && trimmed != folderID {
+				parentID = &trimmed
+			}
+		}
+
+		var folder model.RetailPlayerFolder
+		err := n.ds.WithTx(func(tx model.DataStore) error {
+			repo := tx.RetailPlayerFolder(ctx)
+			if repo == nil {
+				return errors.New("retail player folder repository not available")
+			}
+
+			stored, err := repo.Upsert(ctx, model.RetailPlayerFolder{ID: folderID, Name: name, ParentID: parentID})
+			if err != nil {
+				return err
+			}
+
+			folder = stored
+			return nil
+		})
+		if err != nil {
+			status := http.StatusInternalServerError
+			if isConstraintError(err) {
+				status = http.StatusBadRequest
+			}
+			log.Error(ctx, "Unable to update retail player folder", "folderID", folderID, "err", err)
+			http.Error(w, "Unable to update retail player folder", status)
+			return
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{"data": mapModelRetailPlayerFolder(folder)})
+	}
+}
+
+func (n *Router) handleDeleteRetailPlayerFolders() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		var payload retailPlayerDeleteFoldersRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "Invalid retail player folder payload", http.StatusBadRequest)
+			return
+		}
+
+		normalized := make([]string, 0, len(payload.FolderIDs))
+		seen := make(map[string]struct{}, len(payload.FolderIDs))
+		for _, id := range payload.FolderIDs {
+			trimmed := strings.TrimSpace(id)
+			if trimmed == "" {
+				continue
+			}
+			if _, ok := seen[trimmed]; ok {
+				continue
+			}
+			seen[trimmed] = struct{}{}
+			normalized = append(normalized, trimmed)
+		}
+
+		if len(normalized) == 0 {
+			writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{"data": map[string]any{"deletedFolderIds": []string{}}})
+			return
+		}
+
+		err := n.ds.WithTx(func(tx model.DataStore) error {
+			repo := tx.RetailPlayerFolder(ctx)
+			if repo == nil {
+				return errors.New("retail player folder repository not available")
+			}
+			return repo.DeleteMany(ctx, normalized)
+		})
+		if err != nil {
+			log.Error(ctx, "Unable to delete retail player folders", "err", err)
+			http.Error(w, "Unable to delete retail player folders", http.StatusInternalServerError)
+			return
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{"data": map[string]any{"deletedFolderIds": normalized}})
+	}
+}
+
+func (n *Router) handleAssignRetailPlayerDeviceFolders() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		deviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		if deviceID == "" {
+			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
+			return
+		}
+
+		var payload retailPlayerAssignDeviceFoldersRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "Invalid retail player folder payload", http.StatusBadRequest)
+			return
+		}
+
+		normalized := make([]string, 0, len(payload.FolderIDs))
+		seen := make(map[string]struct{}, len(payload.FolderIDs))
+		for _, id := range payload.FolderIDs {
+			trimmed := strings.TrimSpace(id)
+			if trimmed == "" {
+				continue
+			}
+			if _, ok := seen[trimmed]; ok {
+				continue
+			}
+			seen[trimmed] = struct{}{}
+			normalized = append(normalized, trimmed)
+		}
+
+		err := n.ds.WithTx(func(tx model.DataStore) error {
+			repo := tx.RetailPlayerFolder(ctx)
+			if repo == nil {
+				return errors.New("retail player folder repository not available")
+			}
+			return repo.ReplaceDeviceAssignments(ctx, deviceID, normalized)
+		})
+		if err != nil {
+			status := http.StatusInternalServerError
+			if isConstraintError(err) {
+				status = http.StatusBadRequest
+			}
+			log.Error(ctx, "Unable to assign retail player device folders", "deviceID", deviceID, "err", err)
+			http.Error(w, "Unable to assign retail player device folders", status)
+			return
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{"data": map[string]any{"deviceId": deviceID, "folderIds": normalized}})
 	}
 }
 
@@ -569,6 +885,65 @@ func (n *Router) persistRetailPlayerDeviceMappings(ctx context.Context, devices 
 	if err := repo.PutMany(ctx, mappings); err != nil {
 		log.Error(ctx, "Unable to persist retail player device mappings", "err", err)
 	}
+}
+
+func (n *Router) loadRetailPlayerFolderData(ctx context.Context) ([]model.RetailPlayerFolder, []model.RetailPlayerDeviceFolder, error) {
+	if n == nil || n.ds == nil {
+		return nil, nil, nil
+	}
+
+	repo := n.ds.RetailPlayerFolder(ctx)
+	if repo == nil {
+		return nil, nil, nil
+	}
+
+	folders, err := repo.List(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	assignments, err := repo.Assignments(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return folders, assignments, nil
+}
+
+func mapModelRetailPlayerFolder(folder model.RetailPlayerFolder) retailPlayerFolder {
+	var parentID *string
+	if folder.ParentID != nil {
+		trimmed := strings.TrimSpace(*folder.ParentID)
+		if trimmed != "" {
+			parentID = &trimmed
+		}
+	}
+
+	return retailPlayerFolder{
+		ID:        strings.TrimSpace(folder.ID),
+		Name:      strings.TrimSpace(folder.Name),
+		ParentID:  parentID,
+		CreatedAt: folder.CreatedAt,
+		UpdatedAt: folder.UpdatedAt,
+	}
+}
+
+func mapModelRetailPlayerDeviceFolder(deviceFolder model.RetailPlayerDeviceFolder) retailPlayerDeviceFolder {
+	return retailPlayerDeviceFolder{
+		DeviceID:  strings.TrimSpace(deviceFolder.DeviceID),
+		FolderID:  strings.TrimSpace(deviceFolder.FolderID),
+		CreatedAt: deviceFolder.CreatedAt,
+		UpdatedAt: deviceFolder.UpdatedAt,
+	}
+}
+
+func isConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	lower := strings.ToLower(err.Error())
+	return strings.Contains(lower, "constraint")
 }
 
 func mapRetailPlayerDeviceToMapping(device retailPlayerDevice) (model.RetailPlayerDeviceMapping, bool) {

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -284,13 +284,11 @@ func (n *Router) addRetailPlayerPublicRoutes(r chi.Router) {
 }
 
 func (n *Router) addRetailPlayerPrivateRoutes(r chi.Router) {
-	r.Route("/retailplayer", func(r chi.Router) {
-		r.Get("/devices", n.handleRetailPlayerDevices())
-		r.Post("/folders", n.handleCreateRetailPlayerFolder())
-		r.Patch("/folders/{folderID}", n.handleUpdateRetailPlayerFolder())
-		r.Post("/folders/delete", n.handleDeleteRetailPlayerFolders())
-		r.Put("/devices/{deviceID}/folders", n.handleAssignRetailPlayerDeviceFolders())
-	})
+	r.Get("/retailplayer/devices", n.handleRetailPlayerDevices())
+	r.Post("/retailplayer/folders", n.handleCreateRetailPlayerFolder())
+	r.Patch("/retailplayer/folders/{folderID}", n.handleUpdateRetailPlayerFolder())
+	r.Post("/retailplayer/folders/delete", n.handleDeleteRetailPlayerFolders())
+	r.Put("/retailplayer/devices/{deviceID}/folders", n.handleAssignRetailPlayerDeviceFolders())
 }
 
 var errRetailPlayerDeviceNotFound = errors.New("retail player device not found")

--- a/tests/mock_data_store.go
+++ b/tests/mock_data_store.go
@@ -29,6 +29,7 @@ type MockDataStore struct {
 	MockedScrobbleBuffer            model.ScrobbleBufferRepository
 	MockedRadio                     model.RadioRepository
 	MockedRetailPlayerDeviceMapping model.RetailPlayerDeviceMappingRepository
+	MockedRetailPlayerFolder        model.RetailPlayerFolderRepository
 	scrobbleBufferMu                sync.Mutex
 	repoMu                          sync.Mutex
 }
@@ -213,6 +214,19 @@ func (db *MockDataStore) RetailPlayerDeviceMapping(ctx context.Context) model.Re
 	return db.MockedRetailPlayerDeviceMapping
 }
 
+func (db *MockDataStore) RetailPlayerFolder(ctx context.Context) model.RetailPlayerFolderRepository {
+	if db.MockedRetailPlayerFolder == nil {
+		if db.RealDS != nil {
+			db.MockedRetailPlayerFolder = db.RealDS.RetailPlayerFolder(ctx)
+		} else {
+			db.MockedRetailPlayerFolder = struct {
+				model.RetailPlayerFolderRepository
+			}{}
+		}
+	}
+	return db.MockedRetailPlayerFolder
+}
+
 func (db *MockDataStore) Transcoding(ctx context.Context) model.TranscodingRepository {
 	if db.MockedTranscoding == nil {
 		if db.RealDS != nil {
@@ -291,6 +305,8 @@ func (db *MockDataStore) Resource(ctx context.Context, m any) model.ResourceRepo
 		return db.Transcoding(ctx).(model.ResourceRepository)
 	case model.Player, *model.Player:
 		return db.Player(ctx).(model.ResourceRepository)
+	case model.RetailPlayerFolder, *model.RetailPlayerFolder:
+		return db.RetailPlayerFolder(ctx).(model.ResourceRepository)
 	default:
 		return struct{ model.ResourceRepository }{}
 	}

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -294,13 +294,17 @@ const Menu = ({ dense = false }) => {
   const assignDeviceToFolder = useAssignRetailPlayerDeviceToFolder()
 
   const handleDeviceDrop = useCallback(
-    (deviceId, folderId) => {
+    async (deviceId, folderId) => {
       if (!deviceId || !folderId) {
         return
       }
-      const changed = assignDeviceToFolder(deviceId, folderId)
-      if (changed) {
-        setOpenFolders((prev) => ({ ...prev, [folderId]: true }))
+      try {
+        const changed = await assignDeviceToFolder(deviceId, folderId)
+        if (changed) {
+          setOpenFolders((prev) => ({ ...prev, [folderId]: true }))
+        }
+      } catch (err) {
+        console.error('Failed to assign retail player device to folder', err)
       }
     },
     [assignDeviceToFolder],

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -825,11 +825,15 @@ const RetailPlayerDeviceManagement = () => {
   const selectedCount = selectedFolderIds.length + selectedDeviceIds.length
 
   const handleDeviceDropOnFolder = useCallback(
-    (deviceId, folderId) => {
+    async (deviceId, folderId) => {
       if (!deviceId || !folderId) {
         return
       }
-      assignDeviceToFolder(deviceId, folderId)
+      try {
+        await assignDeviceToFolder(deviceId, folderId)
+      } catch (err) {
+        console.error('Failed to assign retail player device to folder', err)
+      }
     },
     [assignDeviceToFolder],
   )
@@ -871,7 +875,7 @@ const RetailPlayerDeviceManagement = () => {
   }, [])
 
   const handleAddToFolderConfirm = useCallback(
-    ({ folderIds: incomingFolderIds, newFolderName }) => {
+    async ({ folderIds: incomingFolderIds, newFolderName }) => {
       const folderIdSet = new Set(
         Array.isArray(incomingFolderIds)
           ? incomingFolderIds
@@ -888,12 +892,16 @@ const RetailPlayerDeviceManagement = () => {
           folderIdSet.size > 0
             ? Array.from(folderIdSet)[0]
             : activeFolderId || null
-        const newFolder = createFolder({
-          name: trimmedNewFolderName,
-          parentId: parentForNewFolder,
-        })
-        if (newFolder && newFolder.id) {
-          folderIdSet.add(newFolder.id)
+        try {
+          const newFolder = await createFolder({
+            name: trimmedNewFolderName,
+            parentId: parentForNewFolder,
+          })
+          if (newFolder && newFolder.id) {
+            folderIdSet.add(newFolder.id)
+          }
+        } catch (err) {
+          console.error('Failed to create retail player folder', err)
         }
       }
 
@@ -903,10 +911,10 @@ const RetailPlayerDeviceManagement = () => {
         return
       }
 
-      selectedDeviceIds.forEach((deviceId) => {
+      for (const deviceId of selectedDeviceIds) {
         const device = deviceMap.get(deviceId)
         if (!device) {
-          return
+          continue
         }
         const existingIds = Array.isArray(device.folderIds)
           ? device.folderIds
@@ -916,22 +924,30 @@ const RetailPlayerDeviceManagement = () => {
           mergedIds.length !== existingIds.length ||
           mergedIds.some((id, index) => id !== existingIds[index])
         if (changed) {
-          updateDevice({ id: deviceId, folderIds: mergedIds })
+          try {
+            await updateDevice({ id: deviceId, folderIds: mergedIds })
+          } catch (err) {
+            console.error('Failed to update retail player device folders', err)
+          }
         }
-      })
+      }
 
       const parentFolderId = targetFolderIds[0] || null
       if (parentFolderId) {
-        selectedFolderIds.forEach((folderId) => {
+        for (const folderId of selectedFolderIds) {
           if (folderId === parentFolderId) {
-            return
+            continue
           }
           const folder = folderMap.get(folderId)
           if (folder && folder.parentId === parentFolderId) {
-            return
+            continue
           }
-          updateFolder({ id: folderId, parentId: parentFolderId })
-        })
+          try {
+            await updateFolder({ id: folderId, parentId: parentFolderId })
+          } catch (err) {
+            console.error('Failed to move retail player folder', err)
+          }
+        }
       }
 
       setAddToFolderDialogOpen(false)
@@ -953,16 +969,21 @@ const RetailPlayerDeviceManagement = () => {
     setDeleteDialogOpen(false)
   }, [])
 
-  const handleDeleteConfirm = useCallback(() => {
+  const handleDeleteConfirm = useCallback(async () => {
     if (!selectedFolderIds.length && !selectedDeviceIds.length) {
       setDeleteDialogOpen(false)
       return
     }
 
-    deleteNodes({
-      folderIds: selectedFolderIds,
-      deviceIds: selectedDeviceIds,
-    })
+    try {
+      await deleteNodes({
+        folderIds: selectedFolderIds,
+        deviceIds: selectedDeviceIds,
+      })
+    } catch (err) {
+      console.error('Failed to delete retail player items', err)
+      return
+    }
 
     const deletedFolderSet = new Set(selectedFolderIds)
     selectedFolderIds.forEach((folderId) => {
@@ -1104,22 +1125,30 @@ const RetailPlayerDeviceManagement = () => {
     setDeviceDialog({ open: false, target: null })
   }
 
-  const handleFolderSubmit = (values) => {
-    if (folderDialog.target) {
-      updateFolder({ id: folderDialog.target.id, name: values.name })
-    } else {
-      createFolder({ ...values, parentId: folderDialog.parentId || null })
+  const handleFolderSubmit = async (values) => {
+    try {
+      if (folderDialog.target) {
+        await updateFolder({ id: folderDialog.target.id, name: values.name })
+      } else {
+        await createFolder({ ...values, parentId: folderDialog.parentId || null })
+      }
+      handleFolderDialogClose()
+    } catch (err) {
+      console.error('Failed to save retail player folder', err)
     }
-    handleFolderDialogClose()
   }
 
-  const handleDeviceSubmit = (values) => {
-    if (deviceDialog.target) {
-      updateDevice({ id: deviceDialog.target.id, ...values })
-    } else {
-      createDevice(values)
+  const handleDeviceSubmit = async (values) => {
+    try {
+      if (deviceDialog.target) {
+        await updateDevice({ id: deviceDialog.target.id, ...values })
+      } else {
+        createDevice(values)
+      }
+      handleDeviceDialogClose()
+    } catch (err) {
+      console.error('Failed to save retail player device', err)
     }
-    handleDeviceDialogClose()
   }
 
   const handleNavigateToDevice = useCallback(

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -9,6 +9,7 @@ import React, {
 import PropTypes from 'prop-types'
 import { v4 as uuidv4 } from 'uuid'
 import useRetailPlayerDevices from './useRetailPlayerDevices'
+import httpClient from '../dataProvider/httpClient'
 import { buildDeviceSlug, deviceSlugKey, normalizeValue } from './deviceUtils'
 
 const RetailPlayerDeviceStoreContext = createContext(null)
@@ -35,6 +36,58 @@ const normalizeFolderIds = (value) => {
   }
   const single = ensureFolderId(value)
   return single ? [single] : []
+}
+
+const normalizeTimestamp = (value, fallback) => {
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = new Date(value)
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString()
+    }
+  }
+  if (fallback instanceof Date) {
+    return fallback.toISOString()
+  }
+  if (typeof fallback === 'string' && fallback.trim() !== '') {
+    const parsed = new Date(fallback)
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString()
+    }
+  }
+  return new Date().toISOString()
+}
+
+const normalizeFolderRecord = (folder, existing) => {
+  if (!folder || typeof folder !== 'object') {
+    return existing || null
+  }
+
+  const existingFolder = existing || null
+  const id = ensureFolderId(folder.id) || existingFolder?.id || uuidv4()
+  const name = normalizeValue(folder.name) || existingFolder?.name || 'New Folder'
+
+  let parentId = existingFolder?.parentId || null
+  if (Object.prototype.hasOwnProperty.call(folder, 'parentId')) {
+    const normalizedParent = ensureFolderId(folder.parentId)
+    parentId = normalizedParent && normalizedParent !== id ? normalizedParent : null
+  }
+
+  const createdAt = normalizeTimestamp(
+    folder.createdAt,
+    existingFolder?.createdAt || new Date(),
+  )
+  const updatedAt = normalizeTimestamp(
+    folder.updatedAt,
+    folder.createdAt ? folder.createdAt : existingFolder?.updatedAt || createdAt,
+  )
+
+  return {
+    id,
+    name,
+    parentId,
+    createdAt,
+    updatedAt,
+  }
 }
 
 const baseDeviceShape = (device, existing) => {
@@ -83,8 +136,38 @@ const reducer = (state, action) => {
       return { ...state, error: action.payload || null }
     case 'SET_API_ENABLED':
       return { ...state, isApiEnabled: Boolean(action.payload) }
-    case 'SYNC_DEVICES': {
-      const incoming = Array.isArray(action.payload) ? action.payload : []
+    case 'SYNC_REMOTE': {
+      const incomingDevices = Array.isArray(action.payload?.devices)
+        ? action.payload.devices
+        : []
+      const incomingFolders = Array.isArray(action.payload?.folders)
+        ? action.payload.folders
+        : []
+      const incomingAssignments = Array.isArray(action.payload?.deviceFolders)
+        ? action.payload.deviceFolders
+        : []
+
+      const normalizedFolders = incomingFolders
+        .map((folder) => normalizeFolderRecord(folder))
+        .filter(Boolean)
+
+      const folderIdSet = new Set(normalizedFolders.map((folder) => folder.id))
+      const assignmentMap = new Map()
+      incomingAssignments.forEach((assignment) => {
+        if (!assignment || typeof assignment !== 'object') {
+          return
+        }
+        const deviceId = normalizeValue(assignment.deviceId || assignment.deviceID)
+        const folderId = ensureFolderId(assignment.folderId || assignment.folderID)
+        if (!deviceId || !folderId || !folderIdSet.has(folderId)) {
+          return
+        }
+        const existingFolders = assignmentMap.get(deviceId) || []
+        if (!existingFolders.includes(folderId)) {
+          assignmentMap.set(deviceId, [...existingFolders, folderId])
+        }
+      })
+
       const existingByKey = new Map()
       state.devices.forEach((device) => {
         const key = device.apiId || device.id
@@ -93,62 +176,46 @@ const reducer = (state, action) => {
         }
       })
 
-      const nextDevices = incoming.map((device) => {
+      const nextDevices = incomingDevices.map((device) => {
         const key = normalizeValue(device?.apiId || device?.id)
         const existing = key ? existingByKey.get(key) : null
-        return baseDeviceShape(device, existing || undefined)
+        const deviceId = normalizeValue(device?.id || device?.apiId)
+        const foldersForDevice = assignmentMap.get(deviceId)
+        const shapedDevice = foldersForDevice && foldersForDevice.length
+          ? { ...device, folderIds: foldersForDevice }
+          : device
+        return baseDeviceShape(shapedDevice, existing || undefined)
       })
 
       const localDevices = state.devices.filter((device) => device.source === 'local')
 
       return {
         ...state,
+        folders: normalizedFolders,
         devices: [...nextDevices, ...localDevices],
         lastUpdated: Date.now(),
       }
     }
-    case 'CREATE_FOLDER': {
-      const { id: providedId, name, parentId } = action.payload || {}
-      const now = new Date().toISOString()
-      const folder = {
-        id: ensureFolderId(providedId) || uuidv4(),
-        name: normalizeValue(name) || 'New Folder',
-        parentId: ensureFolderId(parentId),
-        createdAt: now,
-        updatedAt: now,
+    case 'UPSERT_FOLDER': {
+      const targetId = ensureFolderId(action.payload?.id)
+      const existingIndex = targetId
+        ? state.folders.findIndex((folder) => folder.id === targetId)
+        : -1
+      const existingFolder = existingIndex >= 0 ? state.folders[existingIndex] : undefined
+      const normalized = normalizeFolderRecord(action.payload, existingFolder)
+      if (!normalized) {
+        return state
+      }
+      if (existingIndex >= 0) {
+        const nextFolders = state.folders.slice()
+        nextFolders[existingIndex] = normalized
+        return { ...state, folders: nextFolders, lastUpdated: Date.now() }
       }
       return {
         ...state,
-        folders: [...state.folders, folder],
+        folders: [...state.folders, normalized],
         lastUpdated: Date.now(),
       }
-    }
-    case 'UPDATE_FOLDER': {
-      const { id, name, parentId } = action.payload || {}
-      if (!id) {
-        return state
-      }
-      const hasParentUpdate = Object.prototype.hasOwnProperty.call(
-        action.payload || {},
-        'parentId',
-      )
-      const nextFolders = state.folders.map((folder) => {
-        if (folder.id !== id) {
-          return folder
-        }
-        const normalizedParentId = hasParentUpdate
-          ? ensureFolderId(parentId) !== folder.id
-            ? ensureFolderId(parentId)
-            : null
-          : folder.parentId
-        return {
-          ...folder,
-          name: normalizeValue(name) || folder.name,
-          parentId: hasParentUpdate ? normalizedParentId : folder.parentId,
-          updatedAt: new Date().toISOString(),
-        }
-      })
-      return { ...state, folders: nextFolders, lastUpdated: Date.now() }
     }
     case 'CREATE_DEVICE': {
       const {
@@ -414,6 +481,8 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
   const [state, dispatch] = useReducer(reducer, initialState)
   const {
     devices: remoteDevices,
+    folders: remoteFolders,
+    deviceFolders: remoteDeviceFolders,
     error,
     isLoading,
     isApiEnabled,
@@ -432,45 +501,240 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
   }, [isApiEnabled])
 
   useEffect(() => {
-    if (Array.isArray(remoteDevices)) {
-      dispatch({ type: 'SYNC_DEVICES', payload: remoteDevices })
+    if (
+      !Array.isArray(remoteDevices) &&
+      !Array.isArray(remoteFolders) &&
+      !Array.isArray(remoteDeviceFolders)
+    ) {
+      return
     }
-  }, [remoteDevices])
+    dispatch({
+      type: 'SYNC_REMOTE',
+      payload: {
+        devices: Array.isArray(remoteDevices) ? remoteDevices : [],
+        folders: Array.isArray(remoteFolders) ? remoteFolders : [],
+        deviceFolders: Array.isArray(remoteDeviceFolders)
+          ? remoteDeviceFolders
+          : [],
+      },
+    })
+  }, [remoteDevices, remoteFolders, remoteDeviceFolders])
 
   const tree = useMemo(
     () => buildTree(state.folders, state.devices),
     [state.folders, state.devices],
   )
 
-  const createFolder = useCallback((payload) => {
-    const basePayload = payload && typeof payload === 'object' ? payload : {}
-    const folderPayload = {
-      ...basePayload,
-      id: ensureFolderId(basePayload.id) || uuidv4(),
-    }
-    dispatch({ type: 'CREATE_FOLDER', payload: folderPayload })
-    return folderPayload
-  }, [])
+  const apiEnabled = state.isApiEnabled
 
-  const updateFolder = useCallback((payload) => {
-    dispatch({ type: 'UPDATE_FOLDER', payload })
-  }, [])
+  const createFolder = useCallback(
+    async (payload) => {
+      const basePayload = payload && typeof payload === 'object' ? payload : {}
+      if (!apiEnabled) {
+        const folderPayload = normalizeFolderRecord({
+          ...basePayload,
+          id: ensureFolderId(basePayload.id) || uuidv4(),
+        })
+        if (folderPayload) {
+          dispatch({ type: 'UPSERT_FOLDER', payload: folderPayload })
+        }
+        return folderPayload
+      }
+
+      const requestBody = {
+        name: normalizeValue(basePayload.name) || 'New Folder',
+      }
+      const providedId = ensureFolderId(basePayload.id)
+      if (providedId) {
+        requestBody.id = providedId
+      }
+      if (Object.prototype.hasOwnProperty.call(basePayload, 'parentId')) {
+        const normalizedParent = ensureFolderId(basePayload.parentId)
+        requestBody.parentId = normalizedParent || null
+      }
+
+      const { json } = await httpClient('/api/retailplayer/folders', {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+        headers: new Headers({ 'Content-Type': 'application/json' }),
+      })
+
+      const folder = normalizeFolderRecord(json?.data)
+      if (folder) {
+        dispatch({ type: 'UPSERT_FOLDER', payload: folder })
+      }
+      return folder
+    },
+    [apiEnabled, dispatch],
+  )
+
+  const updateFolder = useCallback(
+    async (payload) => {
+      const basePayload = payload && typeof payload === 'object' ? payload : {}
+      const folderId = ensureFolderId(basePayload.id)
+      if (!folderId) {
+        return null
+      }
+
+      if (!apiEnabled) {
+        const normalized = normalizeFolderRecord(basePayload)
+        if (normalized) {
+          dispatch({ type: 'UPSERT_FOLDER', payload: normalized })
+        }
+        return normalized
+      }
+
+      const requestBody = {}
+      if (Object.prototype.hasOwnProperty.call(basePayload, 'name')) {
+        const normalizedName = normalizeValue(basePayload.name)
+        requestBody.name = normalizedName || 'New Folder'
+      }
+      if (Object.prototype.hasOwnProperty.call(basePayload, 'parentId')) {
+        const normalizedParent = ensureFolderId(basePayload.parentId)
+        requestBody.parentId = normalizedParent || null
+      }
+
+      const { json } = await httpClient(
+        `/api/retailplayer/folders/${encodeURIComponent(folderId)}`,
+        {
+          method: 'PATCH',
+          body: JSON.stringify(requestBody),
+          headers: new Headers({ 'Content-Type': 'application/json' }),
+        },
+      )
+
+      const folder = normalizeFolderRecord(json?.data)
+      if (folder) {
+        dispatch({ type: 'UPSERT_FOLDER', payload: folder })
+      }
+      return folder
+    },
+    [apiEnabled, dispatch],
+  )
 
   const createDevice = useCallback((payload) => {
     dispatch({ type: 'CREATE_DEVICE', payload })
   }, [])
 
-  const updateDevice = useCallback((payload) => {
-    dispatch({ type: 'UPDATE_DEVICE', payload })
-  }, [])
+  const updateDevice = useCallback(
+    async (payload) => {
+      const basePayload = payload && typeof payload === 'object' ? payload : {}
+      dispatch({ type: 'UPDATE_DEVICE', payload: basePayload })
 
-  const assignDeviceToFolder = useCallback((payload) => {
-    dispatch({ type: 'ASSIGN_DEVICE_FOLDER', payload })
-  }, [])
+      if (!apiEnabled) {
+        return basePayload
+      }
 
-  const deleteNodes = useCallback((payload) => {
-    dispatch({ type: 'DELETE_NODES', payload })
-  }, [])
+      const deviceId = typeof basePayload.id === 'string' ? basePayload.id : null
+      if (!deviceId) {
+        return basePayload
+      }
+
+      const hasFolderIds = Object.prototype.hasOwnProperty.call(
+        basePayload,
+        'folderIds',
+      )
+      const hasFolderId = Object.prototype.hasOwnProperty.call(
+        basePayload,
+        'folderId',
+      )
+
+      if (!hasFolderIds && !hasFolderId) {
+        return basePayload
+      }
+
+      const normalizedFolderIds = hasFolderIds
+        ? normalizeFolderIds(basePayload.folderIds)
+        : normalizeFolderIds(basePayload.folderId)
+
+      await httpClient(
+        `/api/retailplayer/devices/${encodeURIComponent(deviceId)}/folders`,
+        {
+          method: 'PUT',
+          body: JSON.stringify({ folderIds: normalizedFolderIds }),
+          headers: new Headers({ 'Content-Type': 'application/json' }),
+        },
+      )
+
+      dispatch({
+        type: 'ASSIGN_DEVICE_FOLDER',
+        payload: { id: deviceId, folderIds: normalizedFolderIds },
+      })
+
+      return basePayload
+    },
+    [apiEnabled, dispatch],
+  )
+
+  const assignDeviceToFolder = useCallback(
+    async (payload) => {
+      const basePayload = payload && typeof payload === 'object' ? payload : {}
+      const deviceId = typeof basePayload.id === 'string' ? basePayload.id : null
+      if (!deviceId) {
+        return []
+      }
+
+      const normalizedFolderIds = Object.prototype.hasOwnProperty.call(
+        basePayload,
+        'folderIds',
+      )
+        ? normalizeFolderIds(basePayload.folderIds)
+        : normalizeFolderIds(basePayload.folderId)
+
+      if (!apiEnabled) {
+        dispatch({
+          type: 'ASSIGN_DEVICE_FOLDER',
+          payload: { id: deviceId, folderIds: normalizedFolderIds },
+        })
+        return normalizedFolderIds
+      }
+
+      await httpClient(
+        `/api/retailplayer/devices/${encodeURIComponent(deviceId)}/folders`,
+        {
+          method: 'PUT',
+          body: JSON.stringify({ folderIds: normalizedFolderIds }),
+          headers: new Headers({ 'Content-Type': 'application/json' }),
+        },
+      )
+
+      dispatch({
+        type: 'ASSIGN_DEVICE_FOLDER',
+        payload: { id: deviceId, folderIds: normalizedFolderIds },
+      })
+
+      return normalizedFolderIds
+    },
+    [apiEnabled, dispatch],
+  )
+
+  const deleteNodes = useCallback(
+    async (payload) => {
+      const basePayload = payload && typeof payload === 'object' ? payload : {}
+      const folderIds = Array.isArray(basePayload.folderIds)
+        ? basePayload.folderIds.map(ensureFolderId).filter(Boolean)
+        : []
+      const deviceIds = Array.isArray(basePayload.deviceIds)
+        ? basePayload.deviceIds
+            .map((value) => (typeof value === 'string' ? value : null))
+            .filter(Boolean)
+        : []
+
+      if (apiEnabled && folderIds.length) {
+        await httpClient('/api/retailplayer/folders/delete', {
+          method: 'POST',
+          body: JSON.stringify({ folderIds }),
+          headers: new Headers({ 'Content-Type': 'application/json' }),
+        })
+      }
+
+      dispatch({
+        type: 'DELETE_NODES',
+        payload: { folderIds, deviceIds },
+      })
+    },
+    [apiEnabled, dispatch],
+  )
 
   const value = useMemo(
     () => ({

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -63,6 +63,11 @@ const mapRetailPlayerDevice = (device) => {
 
   const slug = buildDeviceSlug(device) || fallbackId
   const name = normalizeValue(device.name) || fallbackId
+  const folderIds = Array.isArray(device.folderIds)
+    ? device.folderIds
+        .map((value) => (typeof value === 'string' ? value.trim() : ''))
+        .filter(Boolean)
+    : []
 
   return {
     id: fallbackId,
@@ -77,6 +82,7 @@ const mapRetailPlayerDevice = (device) => {
       normalizeValue(device.orgUnit || device.org_unit) ||
       normalizeValue(device.location),
     timeZone: normalizeValue(device.timeZone || device.time_zone),
+    folderIds,
   }
 }
 

--- a/ui/src/retailPlayer/useAssignRetailPlayerDeviceToFolder.js
+++ b/ui/src/retailPlayer/useAssignRetailPlayerDeviceToFolder.js
@@ -21,7 +21,7 @@ const useAssignRetailPlayerDeviceToFolder = () => {
   } = useRetailPlayerDeviceStore()
 
   return useCallback(
-    (deviceId, folderId) => {
+    async (deviceId, folderId) => {
       if (!deviceId || !folderId) {
         return false
       }
@@ -41,7 +41,7 @@ const useAssignRetailPlayerDeviceToFolder = () => {
         return false
       }
 
-      assignDeviceToFolder({ id: deviceId, folderIds: nextFolderIds })
+      await assignDeviceToFolder({ id: deviceId, folderIds: nextFolderIds })
       return true
     },
     [assignDeviceToFolder, devices],

--- a/ui/src/retailPlayer/useRetailPlayerDevices.js
+++ b/ui/src/retailPlayer/useRetailPlayerDevices.js
@@ -10,7 +10,7 @@ const fetchRetailPlayerDevices = async (signal) => {
   const url = buildDevicesUrl()
 
   if (!url) {
-    return { devices: null, enabled: false }
+    return { devices: null, folders: null, deviceFolders: null, enabled: false }
   }
 
   let payload
@@ -34,8 +34,12 @@ const fetchRetailPlayerDevices = async (signal) => {
   const devices = Array.isArray(payload?.data)
     ? payload.data.map(mapRetailPlayerDevice).filter(Boolean)
     : []
+  const folders = Array.isArray(payload?.folders) ? payload.folders : []
+  const deviceFolders = Array.isArray(payload?.deviceFolders)
+    ? payload.deviceFolders
+    : []
 
-  return { devices, enabled: true }
+  return { devices, folders, deviceFolders, enabled: true }
 }
 
 const useRetailPlayerDevices = () => {
@@ -45,6 +49,8 @@ const useRetailPlayerDevices = () => {
     }
     return RetailPlayerMockService.listDevices()
   })
+  const [folders, setFolders] = useState([])
+  const [deviceFolders, setDeviceFolders] = useState([])
   const [error, setError] = useState(null)
   const [isLoading, setIsLoading] = useState(false)
   const [isApiEnabled, setIsApiEnabled] = useState(
@@ -71,6 +77,16 @@ const useRetailPlayerDevices = () => {
         } else if (!enabled) {
           setDevices(RetailPlayerMockService.listDevices())
         }
+        if (Array.isArray(result?.folders)) {
+          setFolders(result.folders)
+        } else if (!enabled) {
+          setFolders([])
+        }
+        if (Array.isArray(result?.deviceFolders)) {
+          setDeviceFolders(result.deviceFolders)
+        } else if (!enabled) {
+          setDeviceFolders([])
+        }
       })
       .catch((err) => {
         if (err?.name !== 'AbortError') {
@@ -88,6 +104,8 @@ const useRetailPlayerDevices = () => {
 
   return {
     devices,
+    folders,
+    deviceFolders,
     error,
     isApiEnabled,
     isLoading,


### PR DESCRIPTION
## Summary
- introduce persistent retail player folder storage with new model, repository, and migration
- expose REST endpoints for managing retail player folders and device-folder assignments while including folder data in device responses
- update retail player UI store and components to consume the new backend APIs and persist folder/device relationships

## Testing
- `go test ./...` *(fails: missing taglib pkg-config dependency)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69113ce5aee88322924dccd5199ea7bc)