### PR TITLE
Ensure retail player folders persist via API

### DIFF
--- a/server/nativeapi/retail_player_folder_test.go
+++ b/server/nativeapi/retail_player_folder_test.go
@@ -1,0 +1,87 @@
+package nativeapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/db"
+	"github.com/navidrome/navidrome/persistence"
+)
+
+type retailPlayerDevicesPayload struct {
+	Data    []map[string]any `json:"data"`
+	Folders []map[string]any `json:"folders"`
+}
+
+func setupRetailPlayerTest(t *testing.T) func() {
+	t.Helper()
+	conf.Server.DbPath = path.Join(t.TempDir(), "test.db")
+	conf.Server.RetailPlayer.Enabled = true
+	conf.Server.RetailPlayer.OrgID = "test-org"
+	conf.Server.RetailPlayer.BaseURL = "http://example.com"
+	conf.Server.RetailPlayer.APIKeyHeader = "X-Test-Key"
+	conf.Server.RetailPlayer.APIKey = "secret"
+
+	cleanup := db.Init(context.Background())
+	return cleanup
+}
+
+func TestRetailPlayerCreateFolderPersists(t *testing.T) {
+	cleanup := setupRetailPlayerTest(t)
+	defer cleanup()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/orgs/test-org/devices" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer ts.Close()
+
+	prevClient := retailPlayerHTTPClient
+	retailPlayerHTTPClient = ts.Client()
+	defer func() { retailPlayerHTTPClient = prevClient }()
+
+	conf.Server.RetailPlayer.BaseURL = ts.URL
+
+	ds := persistence.New(db.Db())
+	router := &Router{ds: ds, devices: newRetailPlayerDeviceResolver()}
+
+	createHandler := router.handleCreateRetailPlayerFolder()
+	req := httptest.NewRequest(http.MethodPost, "/retailplayer/folders", strings.NewReader(`{"name":"Test Folder"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	createHandler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("unexpected status: %d", rr.Code)
+	}
+
+	getHandler := router.handleRetailPlayerDevices()
+	getReq := httptest.NewRequest(http.MethodGet, "/retailplayer/devices", nil)
+	getRec := httptest.NewRecorder()
+	getHandler.ServeHTTP(getRec, getReq)
+
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("unexpected status from devices: %d", getRec.Code)
+	}
+
+	var payload retailPlayerDevicesPayload
+	if err := json.Unmarshal(getRec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode payload: %v", err)
+	}
+
+	if len(payload.Folders) != 1 {
+		t.Fatalf("expected 1 folder, got %d", len(payload.Folders))
+	}
+	if name, _ := payload.Folders[0]["name"].(string); name != "Test Folder" {
+		t.Fatalf("unexpected folder name: %s", name)
+	}
+}

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -429,16 +429,22 @@ const DeviceDialog = ({
 
   const handleFolderChange = (event) => {
     const value = event.target.value
-    const valuesArray = Array.isArray(value)
+    let valuesArray = Array.isArray(value)
       ? value
       : value
       ? [value]
       : []
-    if (valuesArray.includes(ROOT_FOLDER_VALUE)) {
-      setForm((prev) => ({ ...prev, folderIds: [] }))
-      return
+
+    const includesRoot = valuesArray.includes(ROOT_FOLDER_VALUE)
+    if (includesRoot) {
+      if (form.folderIds.length > 0) {
+        setForm((prev) => ({ ...prev, folderIds: [] }))
+        return
+      }
+      valuesArray = valuesArray.filter((id) => id !== ROOT_FOLDER_VALUE)
     }
-    const nextValue = valuesArray.filter(Boolean)
+
+    const nextValue = Array.from(new Set(valuesArray.filter(Boolean)))
     setForm((prev) => ({ ...prev, folderIds: nextValue }))
   }
 
@@ -483,11 +489,20 @@ const DeviceDialog = ({
             <Select
               labelId="device-folder-label"
               multiple
-              value={form.folderIds}
+              displayEmpty
+              value={
+                form.folderIds.length
+                  ? form.folderIds
+                  : [ROOT_FOLDER_VALUE]
+              }
               onChange={handleFolderChange}
               label="Folder"
               renderValue={(selected) => {
-                if (!Array.isArray(selected) || !selected.length) {
+                if (
+                  !Array.isArray(selected) ||
+                  !selected.length ||
+                  selected.includes(ROOT_FOLDER_VALUE)
+                ) {
                   return 'Root'
                 }
                 const labels = parentOptions
@@ -495,7 +510,7 @@ const DeviceDialog = ({
                   .map((option) => option.name)
                 return labels.join(', ')
               }}
-            >
+              >
               <MenuItem value={ROOT_FOLDER_VALUE}>
                 <Checkbox
                   color="primary"

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -387,6 +387,8 @@ FolderDialog.defaultProps = {
   initialValues: null,
 }
 
+const ROOT_FOLDER_VALUE = '__root__'
+
 const DeviceDialog = ({
   open,
   onClose,
@@ -427,11 +429,16 @@ const DeviceDialog = ({
 
   const handleFolderChange = (event) => {
     const value = event.target.value
-    const nextValue = Array.isArray(value)
-      ? value.filter(Boolean)
+    const valuesArray = Array.isArray(value)
+      ? value
       : value
       ? [value]
       : []
+    if (valuesArray.includes(ROOT_FOLDER_VALUE)) {
+      setForm((prev) => ({ ...prev, folderIds: [] }))
+      return
+    }
+    const nextValue = valuesArray.filter(Boolean)
     setForm((prev) => ({ ...prev, folderIds: nextValue }))
   }
 
@@ -481,7 +488,7 @@ const DeviceDialog = ({
               label="Folder"
               renderValue={(selected) => {
                 if (!Array.isArray(selected) || !selected.length) {
-                  return 'None'
+                  return 'Root'
                 }
                 const labels = parentOptions
                   .filter((option) => selected.includes(option.id))
@@ -489,6 +496,13 @@ const DeviceDialog = ({
                 return labels.join(', ')
               }}
             >
+              <MenuItem value={ROOT_FOLDER_VALUE}>
+                <Checkbox
+                  color="primary"
+                  checked={form.folderIds.length === 0}
+                />
+                <ListItemText primary="Root" secondary="No folder" />
+              </MenuItem>
               {parentOptions.map((option) => (
                 <MenuItem key={option.id} value={option.id}>
                   <Checkbox

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -530,7 +530,8 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
   const createFolder = useCallback(
     async (payload) => {
       const basePayload = payload && typeof payload === 'object' ? payload : {}
-      if (!apiEnabled) {
+
+      const createLocalFolder = () => {
         const folderPayload = normalizeFolderRecord({
           ...basePayload,
           id: ensureFolderId(basePayload.id) || uuidv4(),
@@ -553,17 +554,37 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
         requestBody.parentId = normalizedParent || null
       }
 
-      const { json } = await httpClient('/api/retailplayer/folders', {
-        method: 'POST',
-        body: JSON.stringify(requestBody),
-        headers: new Headers({ 'Content-Type': 'application/json' }),
-      })
+      const persistRemote = async () => {
+        const { json } = await httpClient('/api/retailplayer/folders', {
+          method: 'POST',
+          body: JSON.stringify(requestBody),
+          headers: new Headers({ 'Content-Type': 'application/json' }),
+        })
 
-      const folder = normalizeFolderRecord(json?.data)
-      if (folder) {
-        dispatch({ type: 'UPSERT_FOLDER', payload: folder })
+        const folder = normalizeFolderRecord(json?.data)
+        if (folder) {
+          dispatch({ type: 'UPSERT_FOLDER', payload: folder })
+          return folder
+        }
+        return createLocalFolder()
       }
-      return folder
+
+      if (!apiEnabled) {
+        try {
+          return await persistRemote()
+        } catch (error) {
+          return createLocalFolder()
+        }
+      }
+
+      try {
+        return await persistRemote()
+      } catch (error) {
+        if (error?.status === 404) {
+          return createLocalFolder()
+        }
+        throw error
+      }
     },
     [apiEnabled, dispatch],
   )
@@ -576,7 +597,7 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
         return null
       }
 
-      if (!apiEnabled) {
+      const applyLocalUpdate = () => {
         const normalized = normalizeFolderRecord(basePayload)
         if (normalized) {
           dispatch({ type: 'UPSERT_FOLDER', payload: normalized })
@@ -594,20 +615,40 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
         requestBody.parentId = normalizedParent || null
       }
 
-      const { json } = await httpClient(
-        `/api/retailplayer/folders/${encodeURIComponent(folderId)}`,
-        {
-          method: 'PATCH',
-          body: JSON.stringify(requestBody),
-          headers: new Headers({ 'Content-Type': 'application/json' }),
-        },
-      )
+      const persistRemote = async () => {
+        const { json } = await httpClient(
+          `/api/retailplayer/folders/${encodeURIComponent(folderId)}`,
+          {
+            method: 'PATCH',
+            body: JSON.stringify(requestBody),
+            headers: new Headers({ 'Content-Type': 'application/json' }),
+          },
+        )
 
-      const folder = normalizeFolderRecord(json?.data)
-      if (folder) {
-        dispatch({ type: 'UPSERT_FOLDER', payload: folder })
+        const folder = normalizeFolderRecord(json?.data)
+        if (folder) {
+          dispatch({ type: 'UPSERT_FOLDER', payload: folder })
+          return folder
+        }
+        return applyLocalUpdate()
       }
-      return folder
+
+      if (!apiEnabled) {
+        try {
+          return await persistRemote()
+        } catch (error) {
+          return applyLocalUpdate()
+        }
+      }
+
+      try {
+        return await persistRemote()
+      } catch (error) {
+        if (error?.status === 404) {
+          return applyLocalUpdate()
+        }
+        throw error
+      }
     },
     [apiEnabled, dispatch],
   )


### PR DESCRIPTION
## Summary
- ensure retail player folder creation and updates attempt to persist on the backend even when the API flag reports disabled, falling back to local state only when necessary
- add a native API regression test that creates a retail player folder and confirms it is returned by the devices endpoint

## Testing
- `go test ./server/nativeapi -run TestRetailPlayerCreateFolderPersists -count=1 -v`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915b28561848322a204df990686df2b)