### PR TITLE
Add playlist track position dialog for manual reordering

### DIFF
--- a/ui/src/common/SongContextMenu.jsx
+++ b/ui/src/common/SongContextMenu.jsx
@@ -57,6 +57,7 @@ export const SongContextMenu = ({
   showLove,
   onAddToPlaylist,
   className,
+  onRequestPositionChange,
 }) => {
   const classes = useStyles()
   const dispatch = useDispatch()
@@ -96,6 +97,13 @@ export const SongContextMenu = ({
             onSuccess: (id) => onAddToPlaylist(id),
           }),
         ),
+    },
+    setPlaylistPosition: {
+      enabled: Boolean(onRequestPositionChange),
+      label: translate('resources.playlist.actions.setPosition', {
+        _: 'Set song position',
+      }),
+      action: (record) => onRequestPositionChange?.(record),
     },
     showInPlaylist: {
       enabled: true,
@@ -285,6 +293,7 @@ SongContextMenu.propTypes = {
   record: PropTypes.object.isRequired,
   onAddToPlaylist: PropTypes.func,
   showLove: PropTypes.bool,
+  onRequestPositionChange: PropTypes.func,
 }
 
 SongContextMenu.defaultProps = {
@@ -293,4 +302,5 @@ SongContextMenu.defaultProps = {
   resource: 'song',
   showLove: true,
   addLabel: true,
+  onRequestPositionChange: null,
 }

--- a/ui/src/common/SongContextMenu.test.jsx
+++ b/ui/src/common/SongContextMenu.test.jsx
@@ -104,4 +104,28 @@ describe('SongContextMenu', () => {
     )
     expect(mockOnClick).not.toHaveBeenCalled()
   })
+
+  it('invokes position change handler when requested', async () => {
+    const handleRequestPositionChange = vi.fn()
+    render(
+      <TestContext>
+        <SongContextMenu
+          record={{ id: '4', size: 1 }}
+          resource="playlistTrack"
+          onRequestPositionChange={handleRequestPositionChange}
+        />
+      </TestContext>,
+    )
+
+    fireEvent.click(screen.getAllByRole('button')[1])
+    await waitFor(() =>
+      screen.getByText(/resources\.playlist\.actions\.setPosition/),
+    )
+
+    fireEvent.click(
+      screen.getByText(/resources\.playlist\.actions\.setPosition/),
+    )
+
+    expect(handleRequestPositionChange).toHaveBeenCalled()
+  })
 })

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -220,7 +220,8 @@
         "duplicates": "Duplicates",
         "searchOrCreate": "Search playlists or type to create new...",
         "pressEnterToCreate": "Press Enter to create new playlist",
-        "removeFromSelection": "Remove from selection"
+        "removeFromSelection": "Remove from selection",
+        "setPosition": "Set song position"
       },
       "notifications": {
         "published": "%{smart_count} song from %{name} published to Sync folder |||| %{smart_count} songs from %{name} published to Sync folder"
@@ -230,6 +231,13 @@
         "song_exist": "There are duplicates being added to the playlist. Would you like to add the duplicates or skip them?",
         "noPlaylistsFound": "No playlists found",
         "noPlaylists": "No playlists available"
+      },
+      "dialog": {
+        "setPositionTitle": "Set song position",
+        "setPositionLabel": "New position",
+        "setPositionHint": "Enter a value between 1 and %{max}.",
+        "setPositionError": "Please enter a value between 1 and %{max}.",
+        "setPositionConfirm": "Set position"
       }
     },
     "discovery": {

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   BulkActionsToolbar,
   ListToolbar,
@@ -35,6 +35,7 @@ import { AlbumLinkField } from '../song/AlbumLinkField'
 import { playTracks } from '../actions'
 import PlaylistSongBulkActions from './PlaylistSongBulkActions'
 import ExpandInfoDialog from '../dialogs/ExpandInfoDialog'
+import PlaylistTrackPositionDialog from './PlaylistTrackPositionDialog'
 import config from '../config'
 
 /* eslint-disable-next-line react-refresh/only-export-components */
@@ -189,6 +190,8 @@ const PlaylistSongs = ({
   useResourceRefresh('song', 'playlist')
 
   const prevShowDuplicates = React.useRef(showDuplicatesOnly)
+  const [positionDialogOpen, setPositionDialogOpen] = useState(false)
+  const [positionDialogTrack, setPositionDialogTrack] = useState(null)
 
   useEffect(() => {
     if (prevShowDuplicates.current !== showDuplicatesOnly) {
@@ -256,17 +259,23 @@ const PlaylistSongs = ({
 
   const reorder = useCallback(
     (playlistId, id, newPos) => {
-      dataProvider
+      if (newPos == null) {
+        return Promise.resolve(false)
+      }
+
+      return dataProvider
         .update('playlistTrack', {
           id,
-          data: { insert_before: newPos },
+          data: { insert_before: `${newPos}` },
           filter: { playlist_id: playlistId },
         })
         .then(() => {
           refetch()
+          return true
         })
         .catch(() => {
           notify('ra.page.error', 'warning')
+          return false
         })
     },
     [dataProvider, notify, refetch],
@@ -280,6 +289,48 @@ const PlaylistSongs = ({
     },
     [playlistId, reorder, ids],
   )
+
+  const handleRequestPositionChange = useCallback((track) => {
+    setPositionDialogTrack(track)
+    setPositionDialogOpen(true)
+  }, [])
+
+  const handleClosePositionDialog = useCallback(() => {
+    setPositionDialogOpen(false)
+    setPositionDialogTrack(null)
+  }, [])
+
+  const handlePositionSubmit = useCallback(
+    (track, newPosition) => {
+      if (!track) {
+        return
+      }
+
+      reorder(playlistId, track.id, newPosition).then((success) => {
+        if (success) {
+          handleClosePositionDialog()
+        }
+      })
+    },
+    [playlistId, reorder, handleClosePositionDialog],
+  )
+
+  const contextMenuProps = useMemo(() => {
+    const baseProps = {
+      onAddToPlaylist,
+      showLove: true,
+      className: classes.contextMenu,
+    }
+
+    if (readOnly) {
+      return baseProps
+    }
+
+    return {
+      ...baseProps,
+      onRequestPositionChange: handleRequestPositionChange,
+    }
+  }, [onAddToPlaylist, classes.contextMenu, readOnly, handleRequestPositionChange])
 
   const toggleableFields = useMemo(() => {
     return {
@@ -412,11 +463,7 @@ const PlaylistSongs = ({
                 {...filteredListContext}
                 hasBulkActions={!readOnly}
                 selectedIds={selectedIds}
-                contextMenuProps={{
-                  onAddToPlaylist,
-                  showLove: true,
-                  className: classes.contextMenu,
-                }}
+                contextMenuProps={contextMenuProps}
               />
             ) : (
               <ReorderableList
@@ -434,9 +481,7 @@ const PlaylistSongs = ({
                 >
                   {columns}
                   <SongContextMenu
-                    onAddToPlaylist={onAddToPlaylist}
-                    showLove={true}
-                    className={classes.contextMenu}
+                    {...contextMenuProps}
                   />
                 </SongDatagrid>
               </ReorderableList>
@@ -445,6 +490,13 @@ const PlaylistSongs = ({
         </div>
       </ListContextProvider>
       <ExpandInfoDialog content={<SongInfo />} />
+      <PlaylistTrackPositionDialog
+        open={positionDialogOpen && !readOnly}
+        track={positionDialogTrack}
+        maxPosition={Math.max(ids.length, 1)}
+        onCancel={handleClosePositionDialog}
+        onSubmit={handlePositionSubmit}
+      />
       {React.cloneElement(props.pagination, listContext)}
     </>
   )

--- a/ui/src/playlist/PlaylistTrackPositionDialog.jsx
+++ b/ui/src/playlist/PlaylistTrackPositionDialog.jsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useState, useMemo } from 'react'
+import PropTypes from 'prop-types'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+} from '@material-ui/core'
+import { useTranslate } from 'react-admin'
+
+const clampValue = (value, maxPosition) => {
+  const numericValue = Number.parseInt(value, 10)
+  if (Number.isNaN(numericValue)) {
+    return null
+  }
+  if (numericValue < 1 || numericValue > maxPosition) {
+    return null
+  }
+  return numericValue
+}
+
+const normalizeInitialValue = (value) => {
+  if (value == null) {
+    return ''
+  }
+  if (typeof value === 'string') {
+    return value.replace(/^_+/, '')
+  }
+  return String(value)
+}
+
+const PlaylistTrackPositionDialog = ({
+  open,
+  track,
+  maxPosition,
+  onCancel,
+  onSubmit,
+}) => {
+  const translate = useTranslate()
+  const [value, setValue] = useState('')
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (open) {
+      setValue(normalizeInitialValue(track?.id))
+      setError('')
+    }
+  }, [open, track])
+
+  const hint = useMemo(
+    () =>
+      translate('resources.playlist.dialog.setPositionHint', {
+        max: maxPosition,
+        _: `Enter a value between 1 and ${maxPosition}.`,
+      }),
+    [translate, maxPosition],
+  )
+
+  const errorMessage = useMemo(
+    () =>
+      translate('resources.playlist.dialog.setPositionError', {
+        max: maxPosition,
+        _: `Please enter a value between 1 and ${maxPosition}.`,
+      }),
+    [translate, maxPosition],
+  )
+
+  const handleChange = (event) => {
+    const newValue = event.target.value
+    setValue(newValue)
+    if (!newValue) {
+      setError('')
+      return
+    }
+
+    const numericValue = clampValue(newValue, maxPosition)
+    setError(numericValue == null ? errorMessage : '')
+  }
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    const numericValue = clampValue(value, maxPosition)
+    if (numericValue == null || !track) {
+      setError(errorMessage)
+      return
+    }
+
+    onSubmit(track, numericValue)
+  }
+
+  return (
+    <Dialog open={open} onClose={onCancel} maxWidth="xs" fullWidth>
+      <form onSubmit={handleSubmit}>
+        <DialogTitle>
+          {translate('resources.playlist.dialog.setPositionTitle', {
+            _: 'Set song position',
+          })}
+        </DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            fullWidth
+            margin="dense"
+            type="number"
+            label={translate('resources.playlist.dialog.setPositionLabel', {
+              _: 'New position',
+            })}
+            value={value}
+            onChange={handleChange}
+            inputProps={{ min: 1, max: maxPosition }}
+            helperText={error || hint}
+            error={Boolean(error)}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onCancel} color="primary">
+            {translate('ra.action.cancel', { _: 'Cancel' })}
+          </Button>
+          <Button
+            type="submit"
+            color="primary"
+            variant="contained"
+            disabled={!value || Boolean(error)}
+          >
+            {translate('resources.playlist.dialog.setPositionConfirm', {
+              _: 'Set position',
+            })}
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  )
+}
+
+PlaylistTrackPositionDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  track: PropTypes.object,
+  maxPosition: PropTypes.number,
+  onCancel: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+}
+
+PlaylistTrackPositionDialog.defaultProps = {
+  track: null,
+  maxPosition: 1,
+}
+
+export default PlaylistTrackPositionDialog


### PR DESCRIPTION
## Summary
- add a dedicated dialog to input playlist track positions and trigger reordering
- expose a "Set song position" action in the playlist song context menu with new translations
- update the playlist songs view to open the dialog and reuse the action on desktop and mobile

## Testing
- npm test -- SongContextMenu.test.jsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915b881c5ec83229363fef518c80096)