### PR TITLE
Fix retail player volume fallback

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1013,8 +1013,18 @@ const RetailPlayerDashboard = () => {
   const dropdownLabel = activeSchedule ? activeSchedule.label : 'No playlists available'
 
   const deviceVolume = useMemo(() => {
-    if (typeof device?.volume === 'number' && !Number.isNaN(device.volume)) {
-      return device.volume
+    const rawVolume = device?.volume
+
+    if (typeof rawVolume === 'number' && !Number.isNaN(rawVolume)) {
+      return rawVolume
+    }
+
+    if (typeof rawVolume === 'string' && rawVolume.trim() !== '') {
+      const parsedVolume = Number(rawVolume)
+
+      if (!Number.isNaN(parsedVolume)) {
+        return parsedVolume
+      }
     }
 
     return null

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1017,15 +1017,17 @@ const RetailPlayerDashboard = () => {
       return device.volume
     }
 
-    return 50
+    return null
   }, [device?.volume])
 
   useEffect(() => {
     setIsMuted(Boolean(device?.isMuted) || deviceVolume === 0)
-    setVolume(deviceVolume)
-    setDisplayVolume(deviceVolume)
-    if (deviceVolume > 0) {
-      previousVolumeRef.current = deviceVolume
+    if (typeof deviceVolume === 'number' && !Number.isNaN(deviceVolume)) {
+      setVolume(deviceVolume)
+      setDisplayVolume(deviceVolume)
+      if (deviceVolume > 0) {
+        previousVolumeRef.current = deviceVolume
+      }
     }
     volumeSyncReadyRef.current = false
   }, [device?.apiId, device?.id, device?.isMuted, deviceVolume])

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -549,7 +549,8 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
     nowPlayingArtist = ''
   }
 
-  const volume = combinedMetadata.volume ?? parseVolume(status.volume)
+  const metadataVolume = parseVolume(combinedMetadata.volume)
+  const volume = metadataVolume ?? parseVolume(status.volume)
 
   const scheduleStatus = normalizeValue(status.scheduleStatus).toLowerCase()
   const isConnected =


### PR DESCRIPTION
## Summary
- stop defaulting the retail player dashboard volume to 50 when device volume is unavailable
- keep the existing volume display until a valid device volume is received

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915ea034df48322878e9dfc96486398)