### PR TITLE
Make playlist drag handle column toggleable

### DIFF
--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -240,6 +240,11 @@
         "setPositionConfirm": "Set position"
       }
     },
+    "playlistTrack": {
+      "fields": {
+        "dragHandle": "Drag Rows"
+      }
+    },
     "discovery": {
       "name": "Discovery |||| Discoveries",
       "fields": {

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -364,7 +364,7 @@ const PlaylistSongs = ({
             dragHandle: (
               <FunctionField
                 key="drag-handle"
-                label=""
+                label="Drag Rows"
                 sortable={false}
                 cellClassName={classes.dragHandleCell}
                 render={() => (

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -357,28 +357,25 @@ const PlaylistSongs = ({
     }
   }, [onAddToPlaylist, classes.contextMenu, readOnly, handleRequestPositionChange])
 
-  const dragHandleField = useMemo(() => {
-    if (readOnly) {
-      return null
-    }
-
-    return (
-      <FunctionField
-        key="drag-handle"
-        label=""
-        sortable={false}
-        cellClassName={classes.dragHandleCell}
-        render={() => (
-          <span className={clsx(classes.dragHandle, 'draggable')}>
-            <DragIndicatorIcon fontSize="small" />
-          </span>
-        )}
-      />
-    )
-  }, [classes.dragHandle, classes.dragHandleCell, readOnly])
-
   const toggleableFields = useMemo(() => {
     return {
+      ...(!readOnly
+        ? {
+            dragHandle: (
+              <FunctionField
+                key="drag-handle"
+                label=""
+                sortable={false}
+                cellClassName={classes.dragHandleCell}
+                render={() => (
+                  <span className={clsx(classes.dragHandle, 'draggable')}>
+                    <DragIndicatorIcon fontSize="small" />
+                  </span>
+                )}
+              />
+            ),
+          }
+        : {}),
       trackNumber:
         isDesktop && (
           <FunctionField
@@ -439,7 +436,14 @@ const PlaylistSongs = ({
         />
       ),
     }
-  }, [isDesktop, classes.draggable, classes.ratingField])
+  }, [
+    isDesktop,
+    classes.dragHandle,
+    classes.dragHandleCell,
+    classes.draggable,
+    classes.ratingField,
+    readOnly,
+  ])
 
   const columns = useSelectedFields({
     resource: 'playlistTrack',
@@ -524,7 +528,6 @@ const PlaylistSongs = ({
                   contextAlwaysVisible={!isDesktop}
                   classes={{ row: classes.row }}
                 >
-                  {dragHandleField}
                   {columns}
                   <SongContextMenu
                     {...contextMenuProps}


### PR DESCRIPTION
## Summary
- allow the playlist track drag handle to be toggled like other columns
- keep the drag handle column hidden when the playlist is read-only and update memo deps

## Testing
- npm test *(fails: existing suite expects a mocked `useNotify` export in `react-admin`)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915ec4f22508322a71e569554797dbc)