### PR TITLE
Fix retail player volume synchronization

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -759,7 +759,7 @@ const RetailPlayerDashboard = () => {
   const [displayVolume, setDisplayVolume] = useState(() => initialDeviceVolume ?? 0)
   const volumeTimeoutRef = useRef(null)
   const previousVolumeRef = useRef(initialDeviceVolume ?? 0)
-  const volumeSyncReadyRef = useRef(false)
+  const volumeUpdateSourceRef = useRef('device')
   const dislikeTimeoutRef = useRef(null)
   const dislikeRequestControllerRef = useRef(null)
   const channelRequestControllerRef = useRef(null)
@@ -1031,17 +1031,17 @@ const RetailPlayerDashboard = () => {
 
     setIsMuted(Boolean(device?.isMuted) || (hasResolvedVolume && deviceVolume === 0))
     if (hasResolvedVolume) {
+      volumeUpdateSourceRef.current = 'device'
       setVolume(deviceVolume)
       setDisplayVolume(deviceVolume)
       if (deviceVolume > 0) {
         previousVolumeRef.current = deviceVolume
       }
     }
-    volumeSyncReadyRef.current = false
   }, [device?.apiId, device?.id, device?.isMuted, deviceVolume])
 
   useEffect(() => {
-    volumeSyncReadyRef.current = false
+    volumeUpdateSourceRef.current = 'device'
   }, [deviceApiId, isApiEnabled])
 
   useEffect(() => {
@@ -1057,14 +1057,15 @@ const RetailPlayerDashboard = () => {
       return undefined
     }
 
-    if (!volumeSyncReadyRef.current) {
-      volumeSyncReadyRef.current = true
+    if (volumeUpdateSourceRef.current !== 'user') {
+      volumeUpdateSourceRef.current = null
       return undefined
     }
 
     const abortController = new AbortController()
     const headers = new Headers({ 'Content-Type': 'application/json' })
 
+    volumeUpdateSourceRef.current = null
     httpClient(`/api/retailplayer/devices/${encodeURIComponent(deviceApiId)}/volume`, {
       method: 'POST',
       headers,
@@ -1407,6 +1408,7 @@ const trackPool = useMemo(() => {
           previousVolumeRef.current = clamped
         }
         volumeTimeoutRef.current = window.setTimeout(() => {
+          volumeUpdateSourceRef.current = 'user'
           setVolume(clamped)
           volumeTimeoutRef.current = null
         }, 150)

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -746,13 +746,19 @@ const RetailPlayerDashboard = () => {
     notFound,
     isApiEnabled,
   } = useRetailPlayerDeviceStatus(deviceSlug)
+  const initialDeviceVolume =
+    typeof resolvedDevice?.volume === 'number' && !Number.isNaN(resolvedDevice.volume)
+      ? clamp(Math.round(resolvedDevice.volume), 0, 100)
+      : null
   const [device, setDevice] = useState(resolvedDevice)
   const [deviceTime, setDeviceTime] = useState(() => new Date())
-  const [isMuted, setIsMuted] = useState(false)
-  const [volume, setVolume] = useState(50)
-  const [displayVolume, setDisplayVolume] = useState(50)
+  const [isMuted, setIsMuted] = useState(
+    () => Boolean(resolvedDevice?.isMuted) || initialDeviceVolume === 0,
+  )
+  const [volume, setVolume] = useState(() => initialDeviceVolume ?? 0)
+  const [displayVolume, setDisplayVolume] = useState(() => initialDeviceVolume ?? 0)
   const volumeTimeoutRef = useRef(null)
-  const previousVolumeRef = useRef(50)
+  const previousVolumeRef = useRef(initialDeviceVolume ?? 0)
   const volumeSyncReadyRef = useRef(false)
   const dislikeTimeoutRef = useRef(null)
   const dislikeRequestControllerRef = useRef(null)
@@ -1014,18 +1020,22 @@ const RetailPlayerDashboard = () => {
 
   const deviceVolume = useMemo(() => {
     if (typeof device?.volume === 'number' && !Number.isNaN(device.volume)) {
-      return device.volume
+      return clamp(Math.round(device.volume), 0, 100)
     }
 
-    return 50
+    return null
   }, [device?.volume])
 
   useEffect(() => {
-    setIsMuted(Boolean(device?.isMuted) || deviceVolume === 0)
-    setVolume(deviceVolume)
-    setDisplayVolume(deviceVolume)
-    if (deviceVolume > 0) {
-      previousVolumeRef.current = deviceVolume
+    const hasResolvedVolume = typeof deviceVolume === 'number'
+
+    setIsMuted(Boolean(device?.isMuted) || (hasResolvedVolume && deviceVolume === 0))
+    if (hasResolvedVolume) {
+      setVolume(deviceVolume)
+      setDisplayVolume(deviceVolume)
+      if (deviceVolume > 0) {
+        previousVolumeRef.current = deviceVolume
+      }
     }
     volumeSyncReadyRef.current = false
   }, [device?.apiId, device?.id, device?.isMuted, deviceVolume])
@@ -1409,7 +1419,9 @@ const trackPool = useMemo(() => {
   const handleToggleMute = useCallback(() => {
     if (isMuted) {
       const restoredVolume =
-        previousVolumeRef.current > 0 ? previousVolumeRef.current : 50
+        previousVolumeRef.current > 0
+          ? previousVolumeRef.current
+          : Math.max(displayVolume, 1)
       updateVolume(restoredVolume)
       return
     }
@@ -1420,7 +1432,7 @@ const trackPool = useMemo(() => {
       }
       return 0
     })
-  }, [isMuted, updateVolume])
+  }, [displayVolume, isMuted, updateVolume])
 
   const handleVolumeChange = useCallback((_, newValue) => {
     const resolvedValue = Array.isArray(newValue) ? newValue[0] : newValue

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -18,15 +18,65 @@ const buildStatusUrl = (deviceId) =>
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max)
 
 const parseVolume = (value) => {
+  if (value === undefined || value === null) {
+    return null
+  }
+
   if (typeof value === 'number' && Number.isFinite(value)) {
     return clamp(Math.round(value), 0, 100)
   }
+
   if (typeof value === 'string') {
     const parsed = Number.parseFloat(value)
     if (Number.isFinite(parsed)) {
       return clamp(Math.round(parsed), 0, 100)
     }
   }
+
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      const parsed = parseVolume(value[index])
+      if (parsed !== null) {
+        return parsed
+      }
+    }
+    return null
+  }
+
+  if (typeof value === 'object') {
+    const candidateKeys = [
+      'value',
+      'level',
+      'percent',
+      'percentage',
+      'volume',
+      'master',
+      'masterVolume',
+      'master_volume',
+      'current',
+      'currentVolume',
+      'current_volume',
+    ]
+
+    for (let index = 0; index < candidateKeys.length; index += 1) {
+      const key = candidateKeys[index]
+      if (key in value) {
+        const parsed = parseVolume(value[key])
+        if (parsed !== null) {
+          return parsed
+        }
+      }
+    }
+
+    const objectValues = Object.values(value)
+    for (let index = 0; index < objectValues.length; index += 1) {
+      const parsed = parseVolume(objectValues[index])
+      if (parsed !== null) {
+        return parsed
+      }
+    }
+  }
+
   return null
 }
 
@@ -549,7 +599,8 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
     nowPlayingArtist = ''
   }
 
-  const volume = combinedMetadata.volume ?? parseVolume(status.volume)
+  const metadataVolume = parseVolume(combinedMetadata.volume)
+  const volume = metadataVolume ?? parseVolume(status.volume)
 
   const scheduleStatus = normalizeValue(status.scheduleStatus).toLowerCase()
   const isConnected =


### PR DESCRIPTION
## Summary
- expand retail player volume parsing to handle nested API responses and reuse parsed metadata
- initialize the dashboard volume state from the fetched device volume instead of a hardcoded default
- keep the mute toggle restore logic aligned with the current slider value

## Testing
- npm run lint *(fails: existing no-console and undefined errors in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69161561324c8322a4240b36e25076bb)