### PR TITLE
Fix playlist track drag column label

### DIFF
--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -240,6 +240,11 @@
         "setPositionConfirm": "Set position"
       }
     },
+    "playlistTrack": {
+      "fields": {
+        "dragHandle": "Drag"
+      }
+    },
     "discovery": {
       "name": "Discovery |||| Discoveries",
       "fields": {

--- a/ui/src/i18n/provider.js
+++ b/ui/src/i18n/provider.js
@@ -40,12 +40,35 @@ const removeEmpty = (obj) => {
   }
 }
 
+const mergeResources = (baseResource, overrideResource) => {
+  if (!baseResource) {
+    return overrideResource
+  }
+
+  if (!overrideResource) {
+    return baseResource
+  }
+
+  return deepmerge(baseResource, overrideResource, {
+    arrayMerge: (_destinationArray, sourceArray) => sourceArray,
+  })
+}
+
 const prepareLanguage = (lang) => {
   removeEmpty(lang)
-  // Make "albumSong" and "playlistTrack" resource use the same translations as "song"
-  lang.resources.albumSong = lang.resources.song
-  lang.resources.playlistTrack = lang.resources.song
-  lang.resources.discoveryTrack = lang.resources.song
+  // Make "albumSong", "playlistTrack" and "discoveryTrack" resources inherit translations from "song"
+  lang.resources.albumSong = mergeResources(
+    lang.resources.song,
+    lang.resources.albumSong,
+  )
+  lang.resources.playlistTrack = mergeResources(
+    lang.resources.song,
+    lang.resources.playlistTrack,
+  )
+  lang.resources.discoveryTrack = mergeResources(
+    lang.resources.song,
+    lang.resources.discoveryTrack,
+  )
   if (lang.resources.playlist) {
     lang.resources.discovery = lang.resources.playlist
   }


### PR DESCRIPTION
## Summary
- add a translation entry for the playlist track drag handle column so it renders as "Drag" instead of the raw key

## Testing
- npm test *(fails: existing react-admin mock missing `useNotify` export in src/layout/AppBar.test.jsx)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916179628fc8322948c3f22100d781b)