### PR TITLE
Fix retail player volume parsing after page refresh

### DIFF
--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -17,20 +17,28 @@ const buildStatusUrl = (deviceId) =>
 
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max)
 
+const normalizeVolumeNumber = (value) => {
+  if (!Number.isFinite(value)) {
+    return null
+  }
+
+  const scaled = value > 0 && value < 1 ? value * 100 : value
+
+  return clamp(Math.round(scaled), 0, 100)
+}
+
 const parseVolume = (value) => {
   if (value === undefined || value === null) {
     return null
   }
 
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return clamp(Math.round(value), 0, 100)
+  if (typeof value === 'number') {
+    return normalizeVolumeNumber(value)
   }
 
   if (typeof value === 'string') {
     const parsed = Number.parseFloat(value)
-    if (Number.isFinite(parsed)) {
-      return clamp(Math.round(parsed), 0, 100)
-    }
+    return normalizeVolumeNumber(parsed)
   }
 
   if (Array.isArray(value)) {


### PR DESCRIPTION
## Summary
- normalize retail player volume parsing to handle 0-1 fractional values from the API
- prevent device volume from resetting to zero after page refreshes by preserving the intended percentage

## Testing
- npm test -- --run Tests *(fails: No test files found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69161f20b16c8322aa52a47ef8ca4b4a)