### PR TITLE
Fix retail player volume reset when status lacks volume

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1017,15 +1017,23 @@ const RetailPlayerDashboard = () => {
       return device.volume
     }
 
-    return 50
+    return null
   }, [device?.volume])
 
   useEffect(() => {
-    setIsMuted(Boolean(device?.isMuted) || deviceVolume === 0)
-    setVolume(deviceVolume)
-    setDisplayVolume(deviceVolume)
-    if (deviceVolume > 0) {
-      previousVolumeRef.current = deviceVolume
+    const resolvedDeviceVolume =
+      typeof deviceVolume === 'number' && !Number.isNaN(deviceVolume)
+        ? deviceVolume
+        : null
+
+    setIsMuted(Boolean(device?.isMuted) || resolvedDeviceVolume === 0)
+
+    if (resolvedDeviceVolume !== null) {
+      setVolume(resolvedDeviceVolume)
+      setDisplayVolume(resolvedDeviceVolume)
+      if (resolvedDeviceVolume > 0) {
+        previousVolumeRef.current = resolvedDeviceVolume
+      }
     }
     volumeSyncReadyRef.current = false
   }, [device?.apiId, device?.id, device?.isMuted, deviceVolume])


### PR DESCRIPTION
## Summary
- prevent the retail player volume slider from resetting to the default when the status API omits a numeric volume
- only sync UI volume state when the backend returns a valid numeric value

## Testing
- npm --prefix ui run test -- --run *(fails: existing vitest suite expects useNotify mock in AppBar tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691649f3ffe08322873450243f250ac9)