### PR TITLE
Fix playlist sorting for metadata columns

### DIFF
--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -100,6 +100,7 @@ var playlistTrackMediaFileSorts = map[string]struct{}{
 	"genre":                   {},
 	"comment":                 {},
 	"track_number":            {},
+	"created_at":              {},
 }
 
 func qualifyPlaylistTrackSort(sort string) string {
@@ -177,7 +178,7 @@ func (r *playlistRepository) Tracks(playlistId string, refreshSmartPlaylist bool
 			"order_album_artist_name": "order_album_artist_name",
 			"order_album_name":        "order_album_name",
 			"order_title":             "order_title",
-			"created_at":              "playlist_tracks.created_at",
+			"created_at":              "created_at",
 		},
 		"f") // TODO I don't like this solution, but I won't change it now as it's not the focus of BFR.
 

--- a/persistence/playlist_track_repository_internal_test.go
+++ b/persistence/playlist_track_repository_internal_test.go
@@ -1,0 +1,17 @@
+package persistence
+
+import "testing"
+
+func TestQualifyPlaylistTrackSort(t *testing.T) {
+	cases := map[string]string{
+		"genre":        "f.genre",
+		"comment desc": "f.comment desc",
+		"created_at":   "f.created_at",
+	}
+
+	for input, expected := range cases {
+		if got := qualifyPlaylistTrackSort(input); got != expected {
+			t.Fatalf("qualifyPlaylistTrackSort(%q) = %q, want %q", input, got, expected)
+		}
+	}
+}

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -414,18 +414,12 @@ const PlaylistSongs = ({
       playDate: isDesktop && (
         <DateField source="playDate" sortByOrder={'DESC'} showTime />
       ),
-      createdAt: (
-        <DateField
-          source="createdAt"
-          sortBy="playlist_tracks.created_at"
-          showTime
-        />
-      ),
+      createdAt: <DateField source="createdAt" showTime />,
       quality: isDesktop && <QualityInfo source="quality" sortable={false} />,
       channels: isDesktop && <NumberField source="channels" />,
       bpm: isDesktop && <NumberField source="bpm" />,
-      genre: <TextField source="genre" sortBy="genre" />,
-      comment: <TextField source="comment" sortBy="comment" />,
+      genre: <TextField source="genre" />,
+      comment: <TextField source="comment" />,
       path: <PathField source="path" />,
       rating: config.enableStarRating && (
         <RatingField


### PR DESCRIPTION
## Summary
- qualify playlist track sorting for the genre, comment, and created_at fields so they use the media file alias
- add a focused unit test covering the qualifier behaviour for the new fields
- simplify playlist song column definitions to rely on the shared sorting logic

## Testing
- ⚠️ `go test ./persistence -run TestQualifyPlaylistTrackSort -count=1 -v` *(aborted due to long runtime in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691656e019b483229cb4a81ee2e01ffe)