### PR TITLE
Add bulk comment editing for playlist tracks

### DIFF
--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/Masterminds/squirrel"
 	"github.com/deluan/rest"
@@ -928,6 +929,44 @@ func (r *playlistTrackRepository) Reorder(pos int, newPos int) error {
 	}
 	newOrder := slice.Move(ids, pos-1, newPos-1)
 	return r.playlistRepo.updatePlaylist(r.playlistId, newOrder)
+}
+
+func (r *playlistTrackRepository) UpdateComment(id string, comment *string) error {
+	if !r.isTracksEditable() {
+		return rest.ErrPermissionDenied
+	}
+	if comment == nil {
+		return nil
+	}
+
+	track, err := r.Read(id)
+	if err != nil {
+		return err
+	}
+
+	plt, ok := track.(*model.PlaylistTrack)
+	if !ok || plt == nil {
+		return fmt.Errorf("invalid playlist track type: %T", track)
+	}
+
+	if plt.MediaFileID == "" {
+		return model.ErrNotFound
+	}
+
+	upd := Update("media_file").
+		Set("comment", *comment).
+		Set("updated_at", time.Now()).
+		Where(Eq{"id": plt.MediaFileID})
+
+	count, err := r.executeSQL(upd)
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		return model.ErrNotFound
+	}
+
+	return nil
 }
 
 var _ model.PlaylistTrackRepository = (*playlistTrackRepository)(nil)

--- a/server/nativeapi/playlists.go
+++ b/server/nativeapi/playlists.go
@@ -244,49 +244,86 @@ func addToPlaylist(ds model.DataStore, playlists core.Playlists) http.HandlerFun
 }
 
 func reorderItem(ds model.DataStore, playlists core.Playlists) http.HandlerFunc {
-	type reorderPayload struct {
-		InsertBefore string `json:"insert_before"`
+	type updatePayload struct {
+		InsertBefore *string `json:"insert_before"`
+		Comment      *string `json:"comment"`
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		p := req.Params(r)
 		playlistId, _ := p.String(":playlistId")
-		id := p.IntOr(":id", 0)
-		if id == 0 {
-			http.Error(w, "invalid id", http.StatusBadRequest)
-			return
-		}
-		var payload reorderPayload
-		err := json.NewDecoder(r.Body).Decode(&payload)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		newPos, err := strconv.Atoi(payload.InsertBefore)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		tracksRepo := ds.Playlist(r.Context()).Tracks(playlistId, true)
-		err = tracksRepo.Reorder(id, newPos)
-		if errors.Is(err, rest.ErrPermissionDenied) {
-			http.Error(w, err.Error(), http.StatusForbidden)
-			return
-		}
-		if err != nil {
+		idStr, _ := p.String(":id")
+
+		var payload updatePayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 
-		if err := syncPlaylist(playlists, ds, r.Context(), playlistId); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+		if payload.InsertBefore != nil {
+			id, err := strconv.Atoi(idStr)
+			if err != nil || id == 0 {
+				http.Error(w, "invalid id", http.StatusBadRequest)
+				return
+			}
+			newPos, err := strconv.Atoi(*payload.InsertBefore)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			tracksRepo := ds.Playlist(r.Context()).Tracks(playlistId, true)
+			err = tracksRepo.Reorder(id, newPos)
+			if errors.Is(err, rest.ErrPermissionDenied) {
+				http.Error(w, err.Error(), http.StatusForbidden)
+				return
+			}
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			if err := syncPlaylist(playlists, ds, r.Context(), playlistId); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			_, err = w.Write([]byte(fmt.Sprintf(`{"id":"%d"}`, id)))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
 			return
 		}
 
-		_, err = w.Write([]byte(fmt.Sprintf(`{"id":"%d"}`, id)))
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+		if payload.Comment != nil {
+			tracksRepo := ds.Playlist(r.Context()).Tracks(playlistId, true)
+			updater, ok := tracksRepo.(interface {
+				UpdateComment(id string, comment *string) error
+			})
+			if !ok {
+				http.Error(w, "unsupported operation", http.StatusNotImplemented)
+				return
+			}
+			err := updater.UpdateComment(idStr, payload.Comment)
+			switch {
+			case errors.Is(err, rest.ErrPermissionDenied):
+				http.Error(w, err.Error(), http.StatusForbidden)
+				return
+			case errors.Is(err, model.ErrNotFound):
+				http.Error(w, err.Error(), http.StatusNotFound)
+				return
+			case err != nil:
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			_, err = w.Write([]byte(fmt.Sprintf(`{"id":"%s"}`, idStr)))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+			return
 		}
+
+		http.Error(w, "invalid request", http.StatusBadRequest)
 	}
 }
 

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -221,23 +221,30 @@
         "searchOrCreate": "Search playlists or type to create new...",
         "pressEnterToCreate": "Press Enter to create new playlist",
         "removeFromSelection": "Remove from selection",
-        "setPosition": "Set song position"
+        "setPosition": "Set song position",
+        "bulkEditComment": "Edit comment"
       },
       "notifications": {
-        "published": "%{smart_count} song from %{name} published to Sync folder |||| %{smart_count} songs from %{name} published to Sync folder"
+        "published": "%{smart_count} song from %{name} published to Sync folder |||| %{smart_count} songs from %{name} published to Sync folder",
+        "commentUpdated": "Updated comment for %{smart_count} song |||| Updated comment for %{smart_count} songs"
       },
       "message": {
         "duplicate_song": "Add duplicated songs",
         "song_exist": "There are duplicates being added to the playlist. Would you like to add the duplicates or skip them?",
         "noPlaylistsFound": "No playlists found",
-        "noPlaylists": "No playlists available"
+        "noPlaylists": "No playlists available",
+        "noEditableComment": "Selected songs cannot be updated."
       },
       "dialog": {
         "setPositionTitle": "Set song position",
         "setPositionLabel": "New position",
         "setPositionHint": "Enter a value between 1 and %{max}.",
         "setPositionError": "Please enter a value between 1 and %{max}.",
-        "setPositionConfirm": "Set position"
+        "setPositionConfirm": "Set position",
+        "bulkCommentTitle": "Edit comment",
+        "bulkCommentLabel": "Comment",
+        "bulkCommentHelper": "Set a new comment for the selected songs.",
+        "bulkCommentConfirm": "Apply"
       }
     },
     "playlistTrack": {

--- a/ui/src/playlist/PlaylistSongBulkActions.jsx
+++ b/ui/src/playlist/PlaylistSongBulkActions.jsx
@@ -8,6 +8,7 @@ import {
 import { MdOutlinePlaylistRemove } from 'react-icons/md'
 import PropTypes from 'prop-types'
 import { AddToPlaylistButton } from '../common/AddToPlaylistButton'
+import PlaylistSongCommentBulkEditButton from './PlaylistSongCommentBulkEditButton'
 import { makeStyles } from '@material-ui/core/styles'
 
 const useStyles = makeStyles((theme) => ({
@@ -45,6 +46,13 @@ const PlaylistSongBulkActions = ({
           icon={<MdOutlinePlaylistRemove />}
           resource={mappedResource}
           onClick={onUnselectItems}
+        />
+        <PlaylistSongCommentBulkEditButton
+          playlistId={playlistId}
+          resource={resource}
+          selectedIds={selectedIds}
+          onUnselectItems={onUnselectItems}
+          className={classes.button}
         />
         {/* Add the AddToPlaylistButton */}
         <AddToPlaylistButton

--- a/ui/src/playlist/PlaylistSongCommentBulkEditButton.jsx
+++ b/ui/src/playlist/PlaylistSongCommentBulkEditButton.jsx
@@ -1,0 +1,188 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import PropTypes from 'prop-types'
+import {
+  Button as RaButton,
+  useDataProvider,
+  useListContext,
+  useNotify,
+  useTranslate,
+  useUnselectAll,
+} from 'react-admin'
+import Button from '@material-ui/core/Button'
+import Dialog from '@material-ui/core/Dialog'
+import DialogTitle from '@material-ui/core/DialogTitle'
+import DialogContent from '@material-ui/core/DialogContent'
+import DialogActions from '@material-ui/core/DialogActions'
+import TextField from '@material-ui/core/TextField'
+import CommentIcon from '@material-ui/icons/Comment'
+
+const getRecord = (data, id) =>
+  Array.isArray(data) ? data.find((record) => record && record.id === id) : data?.[id]
+
+const PlaylistSongCommentBulkEditButton = ({
+  playlistId,
+  resource,
+  selectedIds,
+  onUnselectItems,
+  className,
+}) => {
+  const translate = useTranslate()
+  const notify = useNotify()
+  const dataProvider = useDataProvider()
+  const unselectAll = useUnselectAll()
+  const { data } = useListContext()
+  const [open, setOpen] = useState(false)
+  const [comment, setComment] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  const editableIds = useMemo(() => {
+    if (!Array.isArray(selectedIds)) {
+      return []
+    }
+    return selectedIds.filter((id) => {
+      const record = getRecord(data, id)
+      if (!record) {
+        return false
+      }
+      if (record.missing) {
+        return false
+      }
+      return Boolean(record.mediaFileId)
+    })
+  }, [selectedIds, data])
+
+  const computeInitialComment = useCallback(() => {
+    if (!editableIds.length) {
+      return ''
+    }
+    const firstRecord = getRecord(data, editableIds[0])
+    const baseComment = firstRecord?.comment ?? ''
+    const allSame = editableIds.every((id) => {
+      const record = getRecord(data, id)
+      return (record?.comment ?? '') === baseComment
+    })
+    return allSame ? baseComment : ''
+  }, [data, editableIds])
+
+  const handleOpen = useCallback(() => {
+    if (!selectedIds?.length) {
+      notify('resources.playlist.message.noEditableComment', { type: 'warning' })
+      return
+    }
+    const initialComment = computeInitialComment()
+    setComment(initialComment)
+    setOpen(true)
+  }, [selectedIds, computeInitialComment, notify])
+
+  const handleClose = useCallback(() => {
+    if (!saving) {
+      setOpen(false)
+    }
+  }, [saving])
+
+  const handleSubmit = useCallback(
+    async (event) => {
+      event.preventDefault()
+      if (!playlistId || !editableIds.length) {
+        notify('resources.playlist.message.noEditableComment', { type: 'warning' })
+        return
+      }
+      setSaving(true)
+      try {
+        await dataProvider.updateMany('playlistTrack', {
+          ids: editableIds,
+          data: { comment },
+          filter: { playlist_id: playlistId },
+        })
+        notify('resources.playlist.notifications.commentUpdated', {
+          type: 'info',
+          messageArgs: { smart_count: editableIds.length },
+        })
+        if (typeof onUnselectItems === 'function') {
+          onUnselectItems()
+        }
+        unselectAll(resource || 'playlistTrack')
+        setOpen(false)
+      } catch (error) {
+        const message =
+          error?.body?.message || error?.message || 'ra.notification.http_error'
+        notify(message, { type: 'warning' })
+      } finally {
+        setSaving(false)
+      }
+    },
+    [comment, dataProvider, editableIds, notify, onUnselectItems, playlistId, resource, unselectAll],
+  )
+
+  const label = translate('resources.playlist.actions.bulkEditComment')
+
+  return (
+    <>
+      <RaButton
+        aria-label={label}
+        onClick={handleOpen}
+        className={className}
+        label={label}
+        disabled={!selectedIds?.length}
+      >
+        <CommentIcon />
+      </RaButton>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        fullWidth
+        maxWidth="sm"
+        aria-labelledby="bulk-comment-dialog-title"
+      >
+        <form onSubmit={handleSubmit}>
+          <DialogTitle id="bulk-comment-dialog-title">
+            {translate('resources.playlist.dialog.bulkCommentTitle')}
+          </DialogTitle>
+          <DialogContent>
+            <TextField
+              label={translate('resources.playlist.dialog.bulkCommentLabel')}
+              value={comment}
+              onChange={(event) => setComment(event.target.value)}
+              fullWidth
+              multiline
+              rows={3}
+              variant="filled"
+              helperText={translate('resources.playlist.dialog.bulkCommentHelper')}
+              autoFocus
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleClose} disabled={saving}>
+              {translate('ra.action.cancel')}
+            </Button>
+            <Button
+              type="submit"
+              color="primary"
+              disabled={saving || !editableIds.length}
+            >
+              {translate('resources.playlist.dialog.bulkCommentConfirm')}
+            </Button>
+          </DialogActions>
+        </form>
+      </Dialog>
+    </>
+  )
+}
+
+PlaylistSongCommentBulkEditButton.propTypes = {
+  playlistId: PropTypes.string.isRequired,
+  resource: PropTypes.string,
+  selectedIds: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  ).isRequired,
+  onUnselectItems: PropTypes.func,
+  className: PropTypes.string,
+}
+
+PlaylistSongCommentBulkEditButton.defaultProps = {
+  resource: 'playlistTrack',
+  onUnselectItems: undefined,
+  className: undefined,
+}
+
+export default PlaylistSongCommentBulkEditButton


### PR DESCRIPTION
## Summary
- allow playlist track repository to update media file comments for playlist tracks
- extend the native API handler so PUT requests can either reorder tracks or update comments
- add a bulk action with dialog and translations to edit comments for selected playlist songs

## Testing
- go test ./... *(fails: pkg-config cannot find taglib)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916e043a2b08322b879cc2c9fc94832)