### PR TITLE
Add bulk edit comments action for songs and playlists

### DIFF
--- a/adapters/taglib/taglib_wrapper.cpp
+++ b/adapters/taglib/taglib_wrapper.cpp
@@ -8,6 +8,7 @@
 #include <asffile.h>
 #include <dsffile.h>
 #include <fileref.h>
+#include <tag.h>
 #include <flacfile.h>
 #include <id3v2tag.h>
 #include <unsynchronizedlyricsframe.h>
@@ -198,6 +199,32 @@ int taglib_read(const FILENAME_CHAR_T *filename, unsigned long id) {
   // Cover art has to be handled separately
   if (has_cover(f)) {
     goPutStr(id, (char *)"has_picture", (char *)"true");
+  }
+
+  return 0;
+}
+
+int taglib_update_comment(const FILENAME_CHAR_T *filename, const char *comment) {
+  TagLib::FileRef f(filename, true);
+
+  if (f.isNull()) {
+    return TAGLIB_ERR_PARSE;
+  }
+
+  TagLib::File *file = f.file();
+  if (file == NULL || file->tag() == NULL) {
+    return TAGLIB_ERR_PARSE;
+  }
+
+  if (!file->isWritable()) {
+    return TAGLIB_ERR_PERMISSION;
+  }
+
+  TagLib::Tag *tag = file->tag();
+  tag->setComment(TagLib::String(comment, TagLib::String::UTF8));
+
+  if (!file->save()) {
+    return TAGLIB_ERR_SAVE;
   }
 
   return 0;

--- a/adapters/taglib/taglib_wrapper.go
+++ b/adapters/taglib/taglib_wrapper.go
@@ -75,6 +75,36 @@ func Read(filename string) (tags map[string][]string, err error) {
 	return m, nil
 }
 
+func UpdateComment(filename, comment string) (err error) {
+	debug.SetPanicOnFault(true)
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("taglib: recovered from panic when updating comment", "file", filename, "error", r)
+			err = fmt.Errorf("taglib: recovered from panic: %s", r)
+		}
+	}()
+
+	fp := getFilename(filename)
+	defer C.free(unsafe.Pointer(fp))
+
+	cc := C.CString(comment)
+	defer C.free(unsafe.Pointer(cc))
+
+	res := C.taglib_update_comment(fp, cc)
+	switch res {
+	case 0:
+		return nil
+	case C.TAGLIB_ERR_PARSE:
+		return fmt.Errorf("cannot open media file for writing")
+	case C.TAGLIB_ERR_PERMISSION:
+		return fmt.Errorf("navidrome does not have permission to update media metadata")
+	case C.TAGLIB_ERR_SAVE:
+		return fmt.Errorf("failed to persist updated comment to media file")
+	default:
+		return fmt.Errorf("unexpected error updating media file comment")
+	}
+}
+
 type tagMap map[string][]string
 
 var allMaps sync.Map

--- a/adapters/taglib/taglib_wrapper.h
+++ b/adapters/taglib/taglib_wrapper.h
@@ -1,5 +1,7 @@
 #define TAGLIB_ERR_PARSE -1
 #define TAGLIB_ERR_AUDIO_PROPS -2
+#define TAGLIB_ERR_SAVE -3
+#define TAGLIB_ERR_PERMISSION -4
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,6 +20,7 @@ extern void goPutLyrics(unsigned long id, char *lang, char *val);
 extern void goPutLyricLine(unsigned long id, char *lang, char *text, int time);
 int taglib_read(const FILENAME_CHAR_T *filename, unsigned long id);
 char* taglib_version();
+int taglib_update_comment(const FILENAME_CHAR_T *filename, const char *comment);
 
 #ifdef __cplusplus
 }

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -352,6 +352,7 @@ type MediaFileRepository interface {
 	GetWithParticipants(id string) (*MediaFile, error)
 	GetAll(options ...QueryOptions) (MediaFiles, error)
 	GetCursor(options ...QueryOptions) (MediaFileCursor, error)
+	UpdateComment(id string, comment string) error
 	Delete(id string) error
 	DeleteMissing(ids []string) error
 	DeleteAllMissing() (int64, error)

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/Masterminds/squirrel"
 	"github.com/deluan/rest"
 	"github.com/google/uuid"
+	"github.com/navidrome/navidrome/adapters/taglib"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -20,6 +21,8 @@ import (
 type mediaFileRepository struct {
 	sqlRepository
 }
+
+var writeMediaFileComment = taglib.UpdateComment
 
 type dbMediaFile struct {
 	*model.MediaFile `structs:",flatten"`
@@ -255,14 +258,25 @@ func (r *mediaFileRepository) UpdateComment(id string, comment string) error {
 		return model.ErrNotFound
 	}
 
+	mf, err := r.Get(id)
+	if err != nil {
+		return err
+	}
+
+	previousComment := mf.Comment
+	if err := writeMediaFileComment(mf.AbsolutePath(), comment); err != nil {
+		return err
+	}
+
 	upd := Update(r.tableName).
 		Set("comment", comment).
 		Set("updated_at", time.Now()).
 		Where(Eq{"id": id})
 
-	count, err := r.executeSQL(upd)
-	if err != nil {
-		return err
+	count, execErr := r.executeSQL(upd)
+	if execErr != nil {
+		_ = writeMediaFileComment(mf.AbsolutePath(), previousComment)
+		return execErr
 	}
 	if count == 0 {
 		return model.ErrNotFound

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -246,6 +246,30 @@ func (r *mediaFileRepository) MarkMissing(missing bool, mfs ...*model.MediaFile)
 	return nil
 }
 
+func (r *mediaFileRepository) UpdateComment(id string, comment string) error {
+	user := loggedUser(r.ctx)
+	if !user.IsAdmin {
+		return rest.ErrPermissionDenied
+	}
+	if id == "" {
+		return model.ErrNotFound
+	}
+
+	upd := Update(r.tableName).
+		Set("comment", comment).
+		Set("updated_at", time.Now()).
+		Where(Eq{"id": id})
+
+	count, err := r.executeSQL(upd)
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		return model.ErrNotFound
+	}
+	return nil
+}
+
 func (r *mediaFileRepository) MarkMissingByFolder(missing bool, folderIDs ...string) error {
 	for chunk := range slices.Chunk(folderIDs, 200) {
 		upd := Update(r.tableName).

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/Masterminds/squirrel"
@@ -103,6 +104,64 @@ var _ = Describe("MediaRepository", func() {
 		Expect(err).To(MatchError(model.ErrNotFound))
 		_, err = mr.Get(new2.ID)
 		Expect(err).To(MatchError(model.ErrNotFound))
+	})
+
+	Describe("UpdateComment", func() {
+		var (
+			repo           model.MediaFileRepository
+			originalWriter func(string, string) error
+		)
+
+		BeforeEach(func() {
+			originalWriter = writeMediaFileComment
+			ctx := request.WithUser(log.NewContext(context.TODO()), adminUser)
+			repo = NewMediaFileRepository(ctx, GetDBXBuilder())
+		})
+
+		AfterEach(func() {
+			writeMediaFileComment = originalWriter
+		})
+
+		It("updates the media file metadata and database comment", func() {
+			initial, err := repo.Get(songAntenna.ID)
+			Expect(err).ToNot(HaveOccurred())
+
+			DeferCleanup(func() {
+				writeMediaFileComment = func(string, string) error { return nil }
+				Expect(repo.UpdateComment(songAntenna.ID, initial.Comment)).To(Succeed())
+			})
+
+			called := false
+			writeMediaFileComment = func(path, comment string) error {
+				called = true
+				Expect(path).To(Equal(initial.AbsolutePath()))
+				Expect(comment).To(Equal("Metadata comment"))
+				return nil
+			}
+
+			Expect(repo.UpdateComment(songAntenna.ID, "Metadata comment")).To(Succeed())
+			Expect(called).To(BeTrue())
+
+			updated, err := repo.Get(songAntenna.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated.Comment).To(Equal("Metadata comment"))
+		})
+
+		It("returns an error when metadata cannot be written", func() {
+			initial, err := repo.Get(songAntenna.ID)
+			Expect(err).ToNot(HaveOccurred())
+
+			writeMediaFileComment = func(string, string) error {
+				return errors.New("write failed")
+			}
+
+			err = repo.UpdateComment(songAntenna.ID, "Blocked comment")
+			Expect(err).To(MatchError("write failed"))
+
+			refreshed, err := repo.Get(songAntenna.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(refreshed.Comment).To(Equal(initial.Comment))
+		})
 	})
 
 	Context("Annotations", func() {

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -100,7 +100,7 @@ func (n *Router) routes() http.Handler {
 		r.Use(server.JWTRefresher)
 		r.Use(server.UpdateLastAccessMiddleware(n.ds))
 		n.R(r, "/user", model.User{}, true)
-		n.R(r, "/song", model.MediaFile{}, false)
+		n.addSongRoutes(r)
 		n.R(r, "/album", model.Album{}, false)
 		n.R(r, "/artist", model.Artist{}, false)
 		n.R(r, "/genre", model.Genre{}, false)

--- a/server/nativeapi/native_api_song_test.go
+++ b/server/nativeapi/native_api_song_test.go
@@ -28,6 +28,7 @@ var _ = Describe("Song Endpoints", func() {
 		userRepo  *tests.MockedUserRepo
 		w         *httptest.ResponseRecorder
 		testUser  model.User
+		adminUser model.User
 		testSongs model.MediaFiles
 	)
 
@@ -57,6 +58,16 @@ var _ = Describe("Song Endpoints", func() {
 			NewPassword: "testpass",
 		}
 		err := userRepo.Put(&testUser)
+		Expect(err).ToNot(HaveOccurred())
+
+		adminUser = model.User{
+			ID:          "user-admin",
+			UserName:    "adminuser",
+			Name:        "Admin User",
+			IsAdmin:     true,
+			NewPassword: "adminpass",
+		}
+		err = userRepo.Put(&adminUser)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create test songs
@@ -123,6 +134,16 @@ var _ = Describe("Song Endpoints", func() {
 		// Add JWT token to Authorization header
 		req.Header.Set(consts.UIAuthorizationHeader, "Bearer "+token)
 
+		return req
+	}
+
+	createAdminRequest := func(method, path string, body []byte) *http.Request {
+		req := createUnauthenticatedRequest(method, path, body)
+
+		token, err := auth.CreateToken(&adminUser)
+		Expect(err).ToNot(HaveOccurred())
+
+		req.Header.Set(consts.UIAuthorizationHeader, "Bearer "+token)
 		return req
 	}
 
@@ -209,7 +230,7 @@ var _ = Describe("Song Endpoints", func() {
 		})
 	})
 
-	Describe("Song endpoints are read-only", func() {
+	Describe("Song write operations", func() {
 		Context("POST /song", func() {
 			It("should not be available (songs are not persistable)", func() {
 				newSong := model.MediaFile{
@@ -229,21 +250,54 @@ var _ = Describe("Song Endpoints", func() {
 		})
 
 		Context("PUT /song/{id}", func() {
-			It("should not be available (songs are not persistable)", func() {
-				updatedSong := model.MediaFile{
-					ID:       "song-1",
-					Title:    "Updated Song",
-					Artist:   "Updated Artist",
-					Album:    "Updated Album",
-					Duration: 250.0,
-				}
+			It("updates the song comment when user is admin", func() {
+				payload := map[string]string{"comment": "Updated comment"}
+				body, err := json.Marshal(payload)
+				Expect(err).ToNot(HaveOccurred())
 
-				body, _ := json.Marshal(updatedSong)
+				req := createAdminRequest("PUT", "/song/song-1", body)
+				router.ServeHTTP(w, req)
+
+				Expect(w.Code).To(Equal(http.StatusOK))
+
+				var response model.MediaFile
+				err = json.Unmarshal(w.Body.Bytes(), &response)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.ID).To(Equal("song-1"))
+				Expect(response.Comment).To(Equal("Updated comment"))
+				Expect(mfRepo.Data["song-1"].Comment).To(Equal("Updated comment"))
+			})
+
+			It("returns forbidden for non-admin users", func() {
+				payload := map[string]string{"comment": "Blocked"}
+				body, err := json.Marshal(payload)
+				Expect(err).ToNot(HaveOccurred())
+
 				req := createAuthenticatedRequest("PUT", "/song/song-1", body)
 				router.ServeHTTP(w, req)
 
-				// Should return 405 Method Not Allowed or 404 Not Found
-				Expect(w.Code).To(Equal(http.StatusMethodNotAllowed))
+				Expect(w.Code).To(Equal(http.StatusForbidden))
+			})
+
+			It("returns bad request when comment is missing", func() {
+				body, err := json.Marshal(map[string]string{})
+				Expect(err).ToNot(HaveOccurred())
+
+				req := createAdminRequest("PUT", "/song/song-1", body)
+				router.ServeHTTP(w, req)
+
+				Expect(w.Code).To(Equal(http.StatusBadRequest))
+			})
+
+			It("returns not found for missing song", func() {
+				payload := map[string]string{"comment": "Updated"}
+				body, err := json.Marshal(payload)
+				Expect(err).ToNot(HaveOccurred())
+
+				req := createAdminRequest("PUT", "/song/missing-song", body)
+				router.ServeHTTP(w, req)
+
+				Expect(w.Code).To(Equal(http.StatusNotFound))
 			})
 		})
 

--- a/server/nativeapi/song.go
+++ b/server/nativeapi/song.go
@@ -1,0 +1,88 @@
+package nativeapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/deluan/rest"
+	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+	"github.com/navidrome/navidrome/server"
+)
+
+func (n *Router) addSongRoutes(r chi.Router) {
+	constructor := func(ctx context.Context) rest.Repository {
+		return n.ds.Resource(ctx, model.MediaFile{})
+	}
+
+	r.Route("/song", func(r chi.Router) {
+		r.Get("/", rest.GetAll(constructor))
+		r.Route("/{id}", func(r chi.Router) {
+			r.Use(server.URLParamsMiddleware)
+			r.Get("/", rest.Get(constructor))
+			r.Put("/", n.handleUpdateSong())
+		})
+	})
+}
+
+type updateSongRequest struct {
+	Comment *string `json:"comment"`
+}
+
+func (n *Router) handleUpdateSong() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		id := chi.URLParam(r, "id")
+		if id == "" {
+			rest.RespondWithError(w, http.StatusBadRequest, "missing song id")
+			return
+		}
+
+		user, ok := request.UserFrom(ctx)
+		if !ok || !user.IsAdmin {
+			rest.RespondWithError(w, http.StatusForbidden, "Permission denied")
+			return
+		}
+
+		var payload updateSongRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			rest.RespondWithError(w, http.StatusBadRequest, "Invalid request payload")
+			return
+		}
+
+		if payload.Comment == nil {
+			rest.RespondWithError(w, http.StatusBadRequest, "comment is required")
+			return
+		}
+
+		var updated *model.MediaFile
+		err := n.ds.WithTxImmediate(func(tx model.DataStore) error {
+			repo := tx.MediaFile(ctx)
+			if err := repo.UpdateComment(id, *payload.Comment); err != nil {
+				return err
+			}
+			var err error
+			updated, err = repo.Get(id)
+			return err
+		})
+		if errors.Is(err, rest.ErrPermissionDenied) {
+			rest.RespondWithError(w, http.StatusForbidden, "Permission denied")
+			return
+		}
+		if errors.Is(err, model.ErrNotFound) {
+			rest.RespondWithError(w, http.StatusNotFound, "Song not found")
+			return
+		}
+		if err != nil {
+			log.Error(ctx, "Error updating song", "id", id, err)
+			rest.RespondWithError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		rest.RespondWithJSON(w, http.StatusOK, updated)
+	}
+}

--- a/tests/mock_data_store.go
+++ b/tests/mock_data_store.go
@@ -206,9 +206,7 @@ func (db *MockDataStore) RetailPlayerDeviceMapping(ctx context.Context) model.Re
 		if db.RealDS != nil {
 			db.MockedRetailPlayerDeviceMapping = db.RealDS.RetailPlayerDeviceMapping(ctx)
 		} else {
-			db.MockedRetailPlayerDeviceMapping = struct {
-				model.RetailPlayerDeviceMappingRepository
-			}{}
+			return nil
 		}
 	}
 	return db.MockedRetailPlayerDeviceMapping

--- a/tests/mock_mediafile_repo.go
+++ b/tests/mock_mediafile_repo.go
@@ -116,6 +116,17 @@ func (m *MockMediaFileRepo) Delete(id string) error {
 	return nil
 }
 
+func (m *MockMediaFileRepo) UpdateComment(id string, comment string) error {
+	if m.Err {
+		return errors.New("error")
+	}
+	if mf, ok := m.Data[id]; ok {
+		mf.Comment = comment
+		return nil
+	}
+	return model.ErrNotFound
+}
+
 func (m *MockMediaFileRepo) IncPlayCount(id string, timestamp time.Time) error {
 	if m.Err {
 		return errors.New("error")

--- a/ui/src/common/EditCommentsModal.jsx
+++ b/ui/src/common/EditCommentsModal.jsx
@@ -66,6 +66,26 @@ export const EditCommentsButton = ({
     return sanitizeIds(ids)
   }, [getTargetIds, listContext?.data, selectedIds])
 
+  const recordLookup = useMemo(() => {
+    const map = new Map()
+    selectedRecords.forEach((record) => {
+      if (!record) {
+        return
+      }
+      if (record.id !== undefined && record.id !== null) {
+        map.set(record.id, record)
+      }
+      if (
+        record.mediaFileId !== undefined &&
+        record.mediaFileId !== null &&
+        !map.has(record.mediaFileId)
+      ) {
+        map.set(record.mediaFileId, record)
+      }
+    })
+    return map
+  }, [selectedRecords])
+
   const initialComment = useMemo(() => {
     if (!selectedRecords.length) {
       return ''
@@ -113,10 +133,16 @@ export const EditCommentsButton = ({
 
     setSaving(true)
     try {
-      await dataProvider.updateMany(updateResource, {
-        ids: resolvedIds,
-        data: { comment: commentValue ?? '' },
-      })
+      const payload = { comment: commentValue ?? '' }
+      const updatePromises = resolvedIds.map((id) =>
+        dataProvider.update(updateResource, {
+          id,
+          data: payload,
+          previousData: recordLookup.get(id),
+        }),
+      )
+
+      await Promise.all(updatePromises)
 
       notify(
         translate('resources.song.notifications.commentsUpdated', {
@@ -154,6 +180,7 @@ export const EditCommentsButton = ({
     notify,
     onUnselectItems,
     refresh,
+    recordLookup,
     resolvedIds,
     selectionKey,
     translate,

--- a/ui/src/common/EditCommentsModal.jsx
+++ b/ui/src/common/EditCommentsModal.jsx
@@ -17,6 +17,7 @@ import {
   useTranslate,
   useUnselectAll,
 } from 'react-admin'
+import { CRUD_UPDATE } from 'ra-core'
 import RateReviewIcon from '@material-ui/icons/RateReview'
 
 const sanitizeIds = (ids) => {
@@ -135,11 +136,18 @@ export const EditCommentsButton = ({
     try {
       const payload = { comment: commentValue ?? '' }
       const updatePromises = resolvedIds.map((id) =>
-        dataProvider.update(updateResource, {
-          id,
-          data: payload,
-          previousData: recordLookup.get(id),
-        }),
+        dataProvider.update(
+          updateResource,
+          {
+            id,
+            data: payload,
+            previousData: recordLookup.get(id),
+          },
+          {
+            action: CRUD_UPDATE,
+            mutationMode: 'pessimistic',
+          },
+        ),
       )
 
       await Promise.all(updatePromises)
@@ -151,10 +159,15 @@ export const EditCommentsButton = ({
         { type: 'info' },
       )
 
-      if (typeof listContext?.refetch === 'function') {
-        await listContext.refetch()
-      } else {
-        refresh()
+      const needsListRefresh =
+        listContext?.resource && listContext.resource !== updateResource
+
+      if (needsListRefresh) {
+        if (typeof listContext?.refetch === 'function') {
+          await listContext.refetch()
+        } else {
+          refresh()
+        }
       }
 
       if (typeof onUnselectItems === 'function') {

--- a/ui/src/common/EditCommentsModal.jsx
+++ b/ui/src/common/EditCommentsModal.jsx
@@ -1,0 +1,219 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import PropTypes from 'prop-types'
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Button as MuiButton,
+  TextField as MuiTextField,
+} from '@material-ui/core'
+import {
+  Button,
+  useDataProvider,
+  useListContext,
+  useNotify,
+  useRefresh,
+  useTranslate,
+  useUnselectAll,
+} from 'react-admin'
+import RateReviewIcon from '@material-ui/icons/RateReview'
+
+const sanitizeIds = (ids) => {
+  if (!Array.isArray(ids)) {
+    return []
+  }
+  return Array.from(new Set(ids.filter((id) => id !== undefined && id !== null)))
+}
+
+export const EditCommentsButton = ({
+  resource,
+  selectedIds = [],
+  className,
+  getTargetIds,
+  selectionResource,
+  updateResource = 'song',
+  onUnselectItems,
+}) => {
+  const translate = useTranslate()
+  const notify = useNotify()
+  const dataProvider = useDataProvider()
+  const refresh = useRefresh()
+  const listContext = useListContext()
+  const unselectAll = useUnselectAll()
+
+  const [open, setOpen] = useState(false)
+  const [commentValue, setCommentValue] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  const selectionKey = selectionResource || resource
+
+  const selectedRecords = useMemo(() => {
+    const data = listContext?.data || {}
+    if (!Array.isArray(selectedIds)) {
+      return []
+    }
+    return selectedIds
+      .map((id) => data?.[id])
+      .filter((record) => record !== undefined && record !== null)
+  }, [listContext?.data, selectedIds])
+
+  const resolvedIds = useMemo(() => {
+    const data = listContext?.data || {}
+    const ids = getTargetIds
+      ? getTargetIds(selectedIds, data)
+      : selectedIds
+    return sanitizeIds(ids)
+  }, [getTargetIds, listContext?.data, selectedIds])
+
+  const initialComment = useMemo(() => {
+    if (!selectedRecords.length) {
+      return ''
+    }
+    const comments = selectedRecords.map((record) => record?.comment ?? '')
+    const unique = Array.from(new Set(comments))
+    if (unique.length === 1) {
+      return unique[0] ?? ''
+    }
+    return ''
+  }, [selectedRecords])
+
+  useEffect(() => {
+    if (open) {
+      setCommentValue(initialComment ?? '')
+    }
+  }, [initialComment, open])
+
+  const handleOpen = useCallback(() => {
+    if (!selectedIds?.length) {
+      return
+    }
+    setOpen(true)
+  }, [selectedIds])
+
+  const handleClose = useCallback(() => {
+    if (saving) {
+      return
+    }
+    setOpen(false)
+    setCommentValue(initialComment ?? '')
+  }, [initialComment, saving])
+
+  const handleSave = useCallback(async () => {
+    if (!resolvedIds.length) {
+      notify(
+        translate('resources.song.notifications.noSongsSelected'),
+        {
+          type: 'warning',
+        },
+      )
+      setOpen(false)
+      return
+    }
+
+    setSaving(true)
+    try {
+      await dataProvider.updateMany(updateResource, {
+        ids: resolvedIds,
+        data: { comment: commentValue ?? '' },
+      })
+
+      notify(
+        translate('resources.song.notifications.commentsUpdated', {
+          smart_count: resolvedIds.length,
+        }),
+        { type: 'info' },
+      )
+
+      if (typeof listContext?.refetch === 'function') {
+        await listContext.refetch()
+      } else {
+        refresh()
+      }
+
+      if (typeof onUnselectItems === 'function') {
+        onUnselectItems()
+      } else if (selectionKey) {
+        unselectAll(selectionKey)
+      }
+
+      setOpen(false)
+    } catch (error) {
+      const message =
+        error?.body?.message ||
+        error?.message ||
+        translate('ra.notification.http_error')
+      notify(message, { type: 'warning' })
+    } finally {
+      setSaving(false)
+    }
+  }, [
+    commentValue,
+    dataProvider,
+    listContext,
+    notify,
+    onUnselectItems,
+    refresh,
+    resolvedIds,
+    selectionKey,
+    translate,
+    unselectAll,
+    updateResource,
+  ])
+
+  return (
+    <>
+      <Button
+        className={className}
+        onClick={handleOpen}
+        label={translate('resources.song.actions.editComments')}
+        disabled={!selectedIds?.length}
+      >
+        <RateReviewIcon />
+      </Button>
+      <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
+        <DialogTitle>
+          {translate('resources.song.dialogs.editComments.title', {
+            smart_count: resolvedIds.length,
+          })}
+        </DialogTitle>
+        <DialogContent>
+          <MuiTextField
+            multiline
+            minRows={4}
+            fullWidth
+            variant="outlined"
+            value={commentValue}
+            onChange={(event) => setCommentValue(event.target.value)}
+            label={translate(
+              'resources.song.dialogs.editComments.commentLabel',
+            )}
+            autoFocus
+          />
+        </DialogContent>
+        <DialogActions>
+          <MuiButton onClick={handleClose} disabled={saving}>
+            {translate('ra.action.cancel')}
+          </MuiButton>
+          <MuiButton color="primary" onClick={handleSave} disabled={saving}>
+            {translate('ra.action.save')}
+          </MuiButton>
+        </DialogActions>
+      </Dialog>
+    </>
+  )
+}
+
+EditCommentsButton.propTypes = {
+  resource: PropTypes.string,
+  selectedIds: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  ),
+  className: PropTypes.string,
+  getTargetIds: PropTypes.func,
+  selectionResource: PropTypes.string,
+  updateResource: PropTypes.string,
+  onUnselectItems: PropTypes.func,
+}
+
+export default EditCommentsButton

--- a/ui/src/common/SongBulkActions.jsx
+++ b/ui/src/common/SongBulkActions.jsx
@@ -5,6 +5,7 @@ import { RiPlayList2Fill, RiPlayListAddFill } from 'react-icons/ri'
 import PlayArrowIcon from '@material-ui/icons/PlayArrow'
 import { BatchPlayButton } from './index'
 import { AddToPlaylistButton } from './AddToPlaylistButton'
+import EditCommentsButton from './EditCommentsModal'
 import { makeStyles } from '@material-ui/core/styles'
 import { BatchShareButton } from './BatchShareButton'
 import config from '../config'
@@ -48,6 +49,12 @@ export const SongBulkActions = (props) => {
         <BatchShareButton {...props} className={classes.button} />
       )}
       <AddToPlaylistButton {...props} className={classes.button} />
+      <EditCommentsButton
+        {...props}
+        className={classes.button}
+        selectionResource={props.resource}
+        updateResource="song"
+      />
     </Fragment>
   )
 }

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -42,11 +42,22 @@
         "addToQueue": "Play Later",
         "playNow": "Play Now",
         "addToPlaylist": "Add to Playlist",
+        "editComments": "+ Edit Comments",
         "showInPlaylist": "Show in Playlist",
         "shuffleAll": "Shuffle All",
         "download": "Download",
         "playNext": "Play Next",
         "info": "Get Info"
+      },
+      "dialogs": {
+        "editComments": {
+          "title": "Edit comments for %{smart_count} song |||| Edit comments for %{smart_count} songs",
+          "commentLabel": "Comment"
+        }
+      },
+      "notifications": {
+        "commentsUpdated": "Comments updated for %{smart_count} song |||| Comments updated for %{smart_count} songs",
+        "noSongsSelected": "No songs selected."
       }
     },
     "album": {

--- a/ui/src/playlist/PlaylistSongBulkActions.jsx
+++ b/ui/src/playlist/PlaylistSongBulkActions.jsx
@@ -8,6 +8,7 @@ import {
 import { MdOutlinePlaylistRemove } from 'react-icons/md'
 import PropTypes from 'prop-types'
 import { AddToPlaylistButton } from '../common/AddToPlaylistButton'
+import EditCommentsButton from '../common/EditCommentsModal'
 import { makeStyles } from '@material-ui/core/styles'
 
 const useStyles = makeStyles((theme) => ({
@@ -51,6 +52,19 @@ const PlaylistSongBulkActions = ({
           resource={mappedResource} // Use the mapped resource for consistency
           selectedIds={selectedMediaIds} // Pass the mapped media IDs
           className={classes.button} // Apply custom styles
+        />
+        <EditCommentsButton
+          resource={mappedResource}
+          selectedIds={selectedIds}
+          className={classes.button}
+          selectionResource="playlistTrack"
+          updateResource="song"
+          onUnselectItems={onUnselectItems}
+          getTargetIds={(ids, records) =>
+            ids
+              .map((id) => records?.[id]?.mediaFileId ?? records?.[id]?.id ?? id)
+              .filter((value) => value !== undefined && value !== null)
+          }
         />
       </Fragment>
     </ResourceContextProvider>


### PR DESCRIPTION
## Summary
- add a reusable EditComments modal/button component for bulk updating song comments
- expose the new "+ Edit Comments" action in both the Songs and Playlist bulk action toolbars
- wire translations and ensure selections refresh after saving to show updated comments

## Testing
- npm run lint *(fails: existing lint errors in retail player files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691765bc5b788322b85b93849518258e)