### PR TITLE
Enable editing song comments from playlists

### DIFF
--- a/ui/src/common/EditSongCommentButton.jsx
+++ b/ui/src/common/EditSongCommentButton.jsx
@@ -51,6 +51,9 @@ export const EditSongCommentButton = ({
   resource,
   selectedIds,
   className,
+  recordIds,
+  unselectResource,
+  onSuccess,
 }) => {
   const classes = useStyles()
   const translate = useTranslate()
@@ -65,16 +68,18 @@ export const EditSongCommentButton = ({
   const [comment, setComment] = useState('')
   const [saving, setSaving] = useState(false)
 
+  const idsForRecords = recordIds ?? selectedIds
+
   const selectedRecords = useMemo(() => {
-    if (!selectedIds?.length) {
+    if (!idsForRecords?.length) {
       return []
     }
 
     const data = listContext?.data
-    return selectedIds
+    return idsForRecords
       .map((id) => findRecord(data, id))
       .filter((record) => record != null)
-  }, [listContext?.data, selectedIds])
+  }, [idsForRecords, listContext?.data])
 
   const sharedComment = useMemo(() => {
     if (!selectedRecords.length) {
@@ -134,8 +139,12 @@ export const EditSongCommentButton = ({
           })
         }
 
+        if (typeof onSuccess === 'function') {
+          onSuccess(updatedIds)
+        }
+
         setOpen(false)
-        unselectAll(resource)
+        unselectAll(unselectResource ?? resource)
         refresh({ hard: true })
       } catch (error) {
         notify(error?.message || 'ra.notification.http_error', {
@@ -150,10 +159,12 @@ export const EditSongCommentButton = ({
       dataProvider,
       notify,
       refresh,
-      resource,
       saving,
       selectedIds,
       unselectAll,
+      resource,
+      unselectResource,
+      onSuccess,
     ],
   )
 
@@ -227,11 +238,19 @@ EditSongCommentButton.propTypes = {
     PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   ),
   className: PropTypes.string,
+  recordIds: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  ),
+  unselectResource: PropTypes.string,
+  onSuccess: PropTypes.func,
 }
 
 EditSongCommentButton.defaultProps = {
   selectedIds: [],
   className: undefined,
+  recordIds: undefined,
+  unselectResource: undefined,
+  onSuccess: undefined,
 }
 
 export default EditSongCommentButton

--- a/ui/src/playlist/PlaylistSongBulkActions.jsx
+++ b/ui/src/playlist/PlaylistSongBulkActions.jsx
@@ -8,6 +8,7 @@ import {
 import { MdOutlinePlaylistRemove } from 'react-icons/md'
 import PropTypes from 'prop-types'
 import { AddToPlaylistButton } from '../common/AddToPlaylistButton'
+import { EditSongCommentButton } from '../common/EditSongCommentButton'
 import { makeStyles } from '@material-ui/core/styles'
 
 const useStyles = makeStyles((theme) => ({
@@ -19,7 +20,6 @@ const useStyles = makeStyles((theme) => ({
 // Replace original resource with "fake" one for removing tracks from playlist
 const PlaylistSongBulkActions = ({
   playlistId,
-  resource,
   selectedIds,
   onUnselectItems,
   ...rest
@@ -33,7 +33,7 @@ const PlaylistSongBulkActions = ({
   }, [unselectAll])
 
   const mappedResource = `playlist/${playlistId}/tracks`
-  const selectedMediaIds = selectedIds.map(
+  const selectedMediaIds = (selectedIds || []).map(
     (id) => data?.[id]?.mediaFileId ?? id,
   )
   return (
@@ -52,6 +52,13 @@ const PlaylistSongBulkActions = ({
           selectedIds={selectedMediaIds} // Pass the mapped media IDs
           className={classes.button} // Apply custom styles
         />
+        <EditSongCommentButton
+          resource={'song'}
+          selectedIds={selectedMediaIds}
+          recordIds={selectedIds}
+          unselectResource={'playlistTrack'}
+          className={classes.button}
+        />
       </Fragment>
     </ResourceContextProvider>
   )
@@ -59,7 +66,6 @@ const PlaylistSongBulkActions = ({
 
 PlaylistSongBulkActions.propTypes = {
   playlistId: PropTypes.string.isRequired,
-  resource: PropTypes.string.isRequired,
   selectedIds: PropTypes.arrayOf(
     PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   ).isRequired,


### PR DESCRIPTION
## Summary
- allow the song comment bulk editor to resolve records using different ids and custom unselect resources
- add the edit comment bulk action to playlist songs so playlist selections can update song metadata

## Testing
- npm --prefix ui run lint *(fails: existing lint errors unrelated to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69184375f9388322950b5ea914fecc30)