### PR TITLE
Restore desktop song list on mobile

### DIFF
--- a/ui/src/playlist/PlaylistActions.jsx
+++ b/ui/src/playlist/PlaylistActions.jsx
@@ -52,7 +52,6 @@ const PlaylistActions = ({
   const dataProvider = useDataProvider()
   const notify = useNotify()
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
-  const isNotSmall = useMediaQuery((theme) => theme.breakpoints.up('sm'))
 
   const getAllSongsAndDispatch = React.useCallback(
     (action) => {
@@ -182,7 +181,9 @@ const PlaylistActions = ({
             <FilterNoneIcon />
           </Button>
         </div>
-        <div>{isNotSmall && <ToggleFieldsMenu resource="playlistTrack" />}</div>
+        <div>
+          <ToggleFieldsMenu resource="playlistTrack" />
+        </div>
       </div>
     </TopToolbar>
   )

--- a/ui/src/playlist/PlaylistListActions.jsx
+++ b/ui/src/playlist/PlaylistListActions.jsx
@@ -5,11 +5,9 @@ import {
   CreateButton,
   useTranslate,
 } from 'react-admin'
-import { useMediaQuery } from '@material-ui/core'
 import { ToggleFieldsMenu } from '../common'
 
 const PlaylistListActions = ({ className, ...rest }) => {
-  const isNotSmall = useMediaQuery((theme) => theme.breakpoints.up('sm'))
   const translate = useTranslate()
 
   return (
@@ -18,7 +16,7 @@ const PlaylistListActions = ({ className, ...rest }) => {
       <CreateButton basePath="/playlist">
         {translate('ra.action.create')}
       </CreateButton>
-      {isNotSmall && <ToggleFieldsMenu resource="playlist" />}
+      <ToggleFieldsMenu resource="playlist" />
     </TopToolbar>
   )
 }

--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -23,7 +23,6 @@ import {
   SongContextMenu,
   SongDatagrid,
   SongTitleField,
-  SongSimpleList,
   QualityInfo,
   useSelectedFields,
   useResourceRefresh,
@@ -198,7 +197,6 @@ const PlaylistSongs = ({
   const ids = contextIds
   const data = contextData
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
-  const isMobile = useMediaQuery('(max-width:768px)')
   const classes = useStyles({ isDesktop })
   const dispatch = useDispatch()
   const dataProvider = useDataProvider()
@@ -507,34 +505,23 @@ const PlaylistSongs = ({
               />
             </BulkActionsToolbar>
             {showDuplicatesOnly && listContext.loading && <LinearProgress />}
-            {isMobile ? (
-              <SongSimpleList
+            <ReorderableList
+              readOnly={readOnly}
+              onDragEnd={handleDragEnd}
+              nodeSelector={'tr'}
+              handleSelector={'.draggable'}
+            >
+              <SongDatagrid
+                rowClick={handleRowClick}
                 {...filteredListContext}
                 hasBulkActions={!readOnly}
-                selectedIds={selectedIds}
-                contextMenuProps={contextMenuProps}
-              />
-            ) : (
-              <ReorderableList
-                readOnly={readOnly}
-                onDragEnd={handleDragEnd}
-                nodeSelector={'tr'}
-                handleSelector={'.draggable'}
+                contextAlwaysVisible={!isDesktop}
+                classes={{ row: classes.row }}
               >
-                <SongDatagrid
-                  rowClick={handleRowClick}
-                  {...filteredListContext}
-                  hasBulkActions={!readOnly}
-                  contextAlwaysVisible={!isDesktop}
-                  classes={{ row: classes.row }}
-                >
-                  {columns}
-                  <SongContextMenu
-                    {...contextMenuProps}
-                  />
-                </SongDatagrid>
-              </ReorderableList>
-            )}
+                {columns}
+                <SongContextMenu {...contextMenuProps} />
+              </SongDatagrid>
+            </ReorderableList>
           </Card>
         </div>
       </ListContextProvider>

--- a/ui/src/song/ReorderableSongList.jsx
+++ b/ui/src/song/ReorderableSongList.jsx
@@ -28,7 +28,6 @@ import {
   SongInfo,
   QuickFilter,
   SongTitleField,
-  SongSimpleList,
   RatingField,
   useResourceRefresh,
   ArtistLinkField,
@@ -164,7 +163,6 @@ const SongFilter = (props) => {
 const ReorderableSongList = (props) => {
   const classes = useStyles()
   const dispatch = useDispatch()
-  const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   useResourceRefresh('song')
 
@@ -400,33 +398,29 @@ const ReorderableSongList = (props) => {
         bulkActionButtons={<SongBulkActions />}
         actions={<SongListActions />}
         filters={<SongFilter />}
-        perPage={isXsmall ? 50 : 50}
+        perPage={50}
       >
-        {isXsmall ? (
-          <SongSimpleList />
-        ) : (
-          <SongDatagrid
-            rowClick={handleRowClick}
-            contextAlwaysVisible={!isDesktop}
-            classes={{ row: classes.row }}
-          >
-            {visibleColumns}
-            <SongContextMenu
-              source={'starred_at'}
-              sortByOrder={'DESC'}
-              sortable={config.enableFavourites}
-              className={classes.contextMenu}
-              label={
-                config.enableFavourites && (
-                  <FavoriteBorderIcon
-                    fontSize={'small'}
-                    className={classes.contextHeader}
-                  />
-                )
-              }
-            />
-          </SongDatagrid>
-        )}
+        <SongDatagrid
+          rowClick={handleRowClick}
+          contextAlwaysVisible={!isDesktop}
+          classes={{ row: classes.row }}
+        >
+          {visibleColumns}
+          <SongContextMenu
+            source={'starred_at'}
+            sortByOrder={'DESC'}
+            sortable={config.enableFavourites}
+            className={classes.contextMenu}
+            label={
+              config.enableFavourites && (
+                <FavoriteBorderIcon
+                  fontSize={'small'}
+                  className={classes.contextHeader}
+                />
+              )
+            }
+          />
+        </SongDatagrid>
       </List>
       <ExpandInfoDialog content={<SongInfo />} />
     </>

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -135,40 +135,54 @@ const SongList = (props) => {
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   useResourceRefresh('song')
 
-  const songs = useSelector((state) => state.admin.resources.song)
+  const songsState =
+    useSelector((state) => state.admin.resources.song) ?? {}
+  const songsData = songsState.data
+  const listIds = songsState.list?.ids
 
-  const handleRowClick = useCallback((id, basePath, record) => {
-      // Convert songs.data to an array if it's an object
-      const songsArray = Array.isArray(songs.data) ? songs.data : Object.values(songs.data);
+  const handleRowClick = useCallback(
+    (id, basePath, record) => {
+      const normalizedSongs = Array.isArray(songsData)
+        ? songsData
+        : songsData
+        ? Object.values(songsData)
+        : []
 
-      if (songsArray.length > 0 && Array.isArray(songs.list?.ids)) {
-        // Filter songs to include only those whose IDs exist in songs.list.ids
-        const filteredSongs = songsArray.filter(song => songs.list.ids.includes(song.id));
-
-        // Find the index of the selected song
-        const index = filteredSongs.findIndex(song => song.id === record.id);
-
-        if (index !== -1) {
-          // Rearrange array to start from the selected song
-          const orderedSongs = [
-            ...filteredSongs.slice(index),
-            ...filteredSongs.slice(0, index)
-          ];
-
-          // Convert the array into an object where key = song.id, value = song
-          // const updatedSongs = Object.fromEntries(orderedSongs.map(song => [song.id, song]));
-
-          // Convert array to an object with index-based keys, updating the song id as well
-          const updatedSongs = Object.fromEntries(
-            orderedSongs.map((song, idx) => 
-               [idx, song] // Setting both the key and `id` inside each song
-            )
-          );
-
-          dispatch(playTracks(updatedSongs,0));
-        }
+      if (normalizedSongs.length === 0 || !Array.isArray(listIds)) {
+        return
       }
-    }, [dispatch, songs.data, songs.list?.ids]);
+
+      const filteredSongs = normalizedSongs.filter((song) =>
+        listIds.includes(song.id),
+      )
+
+      if (filteredSongs.length === 0) {
+        return
+      }
+
+      if (!record?.id) {
+        return
+      }
+
+      const index = filteredSongs.findIndex((song) => song.id === record.id)
+
+      if (index === -1) {
+        return
+      }
+
+      const orderedSongs = [
+        ...filteredSongs.slice(index),
+        ...filteredSongs.slice(0, index),
+      ]
+
+      const updatedSongs = Object.fromEntries(
+        orderedSongs.map((song, idx) => [idx, song]),
+      )
+
+      dispatch(playTracks(updatedSongs, 0))
+    },
+    [dispatch, songsData, listIds],
+  )
 
   const toggleableFields = useMemo(() => {
     return {

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -22,7 +22,6 @@ import {
   SongInfo,
   QuickFilter,
   SongTitleField,
-  SongSimpleList,
   RatingField,
   useResourceRefresh,
   ArtistLinkField,
@@ -133,7 +132,6 @@ const SongFilter = (props) => {
 const SongList = (props) => {
   const classes = useStyles()
   const dispatch = useDispatch()
-  const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   useResourceRefresh('song')
 
@@ -243,34 +241,30 @@ const SongList = (props) => {
         bulkActionButtons={<SongBulkActions />}
         actions={<SongListActions />}
         filters={<SongFilter />}
-        perPage={isXsmall ? 50 : 50}
+        perPage={50}
       >
-        {isXsmall ? (
-          <SongSimpleList />
-        ) : (
-          <SongDatagrid
-            rowClick={handleRowClick}
-            contextAlwaysVisible={!isDesktop}
-            classes={{ row: classes.row }}
-          >
-            <SongTitleField source="title" showTrackNumbers={false} />
-            {columns}
-            <SongContextMenu
-              source={'starred_at'}
-              sortByOrder={'DESC'}
-              sortable={config.enableFavourites}
-              className={classes.contextMenu}
-              label={
-                config.enableFavourites && (
-                  <FavoriteBorderIcon
-                    fontSize={'small'}
-                    className={classes.contextHeader}
-                  />
-                )
-              }
-            />
-          </SongDatagrid>
-        )}
+        <SongDatagrid
+          rowClick={handleRowClick}
+          contextAlwaysVisible={!isDesktop}
+          classes={{ row: classes.row }}
+        >
+          <SongTitleField source="title" showTrackNumbers={false} />
+          {columns}
+          <SongContextMenu
+            source={'starred_at'}
+            sortByOrder={'DESC'}
+            sortable={config.enableFavourites}
+            className={classes.contextMenu}
+            label={
+              config.enableFavourites && (
+                <FavoriteBorderIcon
+                  fontSize={'small'}
+                  className={classes.contextHeader}
+                />
+              )
+            }
+          />
+        </SongDatagrid>
       </List>
       <ExpandInfoDialog content={<SongInfo />} />
     </>

--- a/ui/src/song/SongListActions.jsx
+++ b/ui/src/song/SongListActions.jsx
@@ -1,6 +1,5 @@
 import React, { cloneElement } from 'react'
 import { sanitizeListRestProps, TopToolbar } from 'react-admin'
-import { useMediaQuery } from '@material-ui/core'
 import { ShuffleAllButton, ToggleFieldsMenu } from '../common'
 
 export const SongListActions = ({
@@ -21,7 +20,6 @@ export const SongListActions = ({
   ids,
   ...rest
 }) => {
-  const isNotSmall = useMediaQuery((theme) => theme.breakpoints.up('sm'))
   return (
     <TopToolbar className={className} {...sanitizeListRestProps(rest)}>
       <ShuffleAllButton filters={filterValues} />
@@ -33,7 +31,7 @@ export const SongListActions = ({
           filterValues,
           context: 'button',
         })}
-      {isNotSmall && <ToggleFieldsMenu resource="song" />}
+      <ToggleFieldsMenu resource="song" />
     </TopToolbar>
   )
 }


### PR DESCRIPTION
## Summary
- ensure the Songs list always renders the SongDatagrid so that mobile view matches desktop
- remove the unused `SongSimpleList` hook up and simplify the per-page handling

## Testing
- `npx eslint src/song/SongList.jsx`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a29b3301883228cc7de88a37a54c0)