### PR TITLE
Add MetaData page and navigation entry

### DIFF
--- a/core/artwork/media_store.go
+++ b/core/artwork/media_store.go
@@ -1,0 +1,70 @@
+package artwork
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/navidrome/navidrome/conf"
+)
+
+const mediaArtworkFolder = "media-artwork"
+
+// mediaArtworkPath returns the path inside the cache folder where a media file's
+// downloaded artwork should live. The directory structure is spread to avoid
+// having too many files on the same level.
+func mediaArtworkPath(id string) string {
+	if id == "" {
+		return filepath.Join(conf.Server.CacheFolder, mediaArtworkFolder, "_invalid")
+	}
+	hash := fmt.Sprintf("%x", sha1.Sum([]byte(id)))
+	return filepath.Join(
+		conf.Server.CacheFolder,
+		mediaArtworkFolder,
+		hash[0:2],
+		hash[2:4],
+		fmt.Sprintf("%s.art", id),
+	)
+}
+
+// SaveMediaArtwork persists the provided artwork bytes on disk, making it
+// available for the mediafile artwork reader without requiring an additional
+// download.
+func SaveMediaArtwork(id string, r io.Reader) (string, error) {
+	path := mediaArtworkPath(id)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), "nd-art-*.tmp")
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_ = os.Remove(tmp.Name())
+	}()
+	if _, err = io.Copy(tmp, r); err != nil {
+		_ = tmp.Close()
+		return "", err
+	}
+	if err = tmp.Close(); err != nil {
+		return "", err
+	}
+	if err = os.Rename(tmp.Name(), path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// OpenMediaArtwork opens the stored artwork for the given media file id.
+func OpenMediaArtwork(id string) (*os.File, error) {
+	return os.Open(mediaArtworkPath(id))
+}
+
+// MediaArtworkExists reports whether there's a stored artwork file for the
+// provided media file id.
+func MediaArtworkExists(id string) bool {
+	_, err := os.Stat(mediaArtworkPath(id))
+	return err == nil
+}

--- a/core/artwork/reader_mediafile.go
+++ b/core/artwork/reader_mediafile.go
@@ -2,8 +2,10 @@ package artwork
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	"github.com/navidrome/navidrome/conf"
@@ -53,6 +55,9 @@ func (a *mediafileArtworkReader) LastUpdated() time.Time {
 
 func (a *mediafileArtworkReader) Reader(ctx context.Context) (io.ReadCloser, string, error) {
 	var ff []sourceFunc
+	if conf.Server.EnableMediaFileCoverArt {
+		ff = append(ff, fromStoredMediaArtwork(a.mediafile.ID))
+	}
 	if a.mediafile.CoverArtID().Kind == model.KindMediaFileArtwork {
 		path := a.mediafile.AbsolutePath()
 		ff = []sourceFunc{
@@ -62,4 +67,20 @@ func (a *mediafileArtworkReader) Reader(ctx context.Context) (io.ReadCloser, str
 	}
 	ff = append(ff, fromAlbum(ctx, a.a, a.mediafile.AlbumCoverArtID()))
 	return selectImageReader(ctx, a.artID, ff...)
+}
+
+func fromStoredMediaArtwork(mediafileID string) sourceFunc {
+	return func() (io.ReadCloser, string, error) {
+		if mediafileID == "" {
+			return nil, "", nil
+		}
+		r, err := OpenMediaArtwork(mediafileID)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil, "", nil
+			}
+			return nil, "", err
+		}
+		return r, mediaArtworkPath(mediafileID), nil
+	}
 }

--- a/server/nativeapi/metadata.go
+++ b/server/nativeapi/metadata.go
@@ -205,6 +205,7 @@ func (f *metadataFetcher) lookupRecording(ctx context.Context, title, artist str
 	query.Set("query", fmt.Sprintf("%s AND artist:%s", title, artist))
 	query.Set("fmt", "json")
 	query.Set("limit", "1")
+	query.Set("inc", "artist-credits+releases+release-groups+tags")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, musicBrainzRecordingURL+"?"+query.Encode(), nil)
 	if err != nil {

--- a/server/nativeapi/metadata.go
+++ b/server/nativeapi/metadata.go
@@ -35,9 +35,9 @@ type metadataSongPayload struct {
 	Artist     string `json:"artist"`
 	Album      string `json:"album"`
 	Genre      string `json:"genre"`
-	Year       *int   `json:"year,omitempty"`
+	Year       *int   `json:"year"`
 	CoverArt   string `json:"coverArt"`
-	ArtworkURL string `json:"artworkUrl,omitempty"`
+	ArtworkURL string `json:"artworkUrl"`
 }
 
 type metadataSongPayloadDTO struct {
@@ -90,13 +90,14 @@ func (n *Router) fetchMetadataHandler() http.HandlerFunc {
 
 		updates := make([]metadataSongPayload, 0, len(req.Songs))
 		for _, song := range req.Songs {
-			enriched, err := metadataEnricher.Enrich(ctx, song)
+			normalized := normalizeSongPayload(song)
+			enriched, err := metadataEnricher.Enrich(ctx, normalized)
 			if err != nil {
-				log.Warn(ctx, "Unable to enrich song metadata", "songId", song.ID, "err", err)
-				updates = append(updates, song)
+				log.Warn(ctx, "Unable to enrich song metadata", "songId", normalized.ID, "err", err)
+				updates = append(updates, normalized)
 				continue
 			}
-			updates = append(updates, enriched)
+			updates = append(updates, normalizeSongPayload(enriched))
 		}
 
 		writeJSON(w, metadataFetchResponse{Songs: updates})
@@ -157,9 +158,13 @@ func (f *metadataFetcher) Enrich(ctx context.Context, song metadataSongPayload) 
 			updated.Year = year
 		}
 	}
-	if updated.CoverArt == "" {
-		if artURL, err := f.fetchCoverArt(ctx, recording.PrimaryReleaseID()); err == nil && artURL != "" {
-			updated.ArtworkURL = artURL
+	if strings.TrimSpace(updated.CoverArt) == "" {
+		if releaseID := recording.PrimaryReleaseID(); releaseID != "" {
+			if artURL, artErr := f.fetchCoverArt(ctx, releaseID); artErr == nil && artURL != "" {
+				updated.ArtworkURL = artURL
+			} else if artErr != nil {
+				log.Warn(ctx, "Unable to fetch cover art", "songId", song.ID, "err", artErr)
+			}
 		}
 	}
 
@@ -231,20 +236,22 @@ func (f *metadataFetcher) fetchCoverArt(ctx context.Context, releaseID string) (
 		return "", nil
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("cover art request failed: %s", resp.Status)
+		log.Warn(ctx, "Cover Art Archive request failed", "status", resp.Status)
+		return "", nil
 	}
 
 	var payload coverArtResponse
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return "", err
+		log.Warn(ctx, "Unable to decode cover art response", "err", err)
+		return "", nil
 	}
 	for _, image := range payload.Images {
 		if image.Front && image.Image != "" {
-			return image.Image, nil
+			return ensureHTTPSURL(image.Image), nil
 		}
 	}
 	if len(payload.Images) > 0 {
-		return payload.Images[0].Image, nil
+		return ensureHTTPSURL(payload.Images[0].Image), nil
 	}
 	return "", nil
 }
@@ -378,4 +385,37 @@ func parseYearRaw(raw json.RawMessage) *int {
 		}
 	}
 	return nil
+}
+
+func normalizeSongPayload(song metadataSongPayload) metadataSongPayload {
+	song.ID = strings.TrimSpace(song.ID)
+	song.Title = strings.TrimSpace(song.Title)
+	song.Artist = strings.TrimSpace(song.Artist)
+	song.Album = strings.TrimSpace(song.Album)
+	song.Genre = strings.TrimSpace(song.Genre)
+	song.CoverArt = strings.TrimSpace(song.CoverArt)
+	song.ArtworkURL = ensureHTTPSURL(song.ArtworkURL)
+	if song.Year != nil {
+		year := *song.Year
+		if year == 0 {
+			song.Year = nil
+		}
+	}
+	return song
+}
+
+func ensureHTTPSURL(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	switch {
+	case trimmed == "":
+		return ""
+	case strings.HasPrefix(trimmed, "https://"):
+		return trimmed
+	case strings.HasPrefix(trimmed, "http://"):
+		return "https://" + strings.TrimPrefix(trimmed, "http://")
+	case strings.HasPrefix(trimmed, "//"):
+		return "https:" + trimmed
+	default:
+		return trimmed
+	}
 }

--- a/server/nativeapi/metadata.go
+++ b/server/nativeapi/metadata.go
@@ -1,0 +1,381 @@
+package nativeapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/log"
+)
+
+const (
+	musicBrainzRecordingURL = "https://musicbrainz.org/ws/2/recording/"
+	coverArtArchiveURL      = "https://coverartarchive.org/release/"
+	metadataUserAgent       = "NavidromeMetadataFetcher/1.0 (+https://www.navidrome.org)"
+)
+
+type metadataFetchRequest struct {
+	Songs []metadataSongPayload `json:"songs"`
+}
+
+type metadataFetchResponse struct {
+	Songs []metadataSongPayload `json:"songs"`
+}
+
+type metadataSongPayload struct {
+	ID         string `json:"id"`
+	Title      string `json:"title"`
+	Artist     string `json:"artist"`
+	Album      string `json:"album"`
+	Genre      string `json:"genre"`
+	Year       *int   `json:"year,omitempty"`
+	CoverArt   string `json:"coverArt"`
+	ArtworkURL string `json:"artworkUrl,omitempty"`
+}
+
+type metadataSongPayloadDTO struct {
+	ID         string          `json:"id"`
+	Title      string          `json:"title"`
+	Artist     string          `json:"artist"`
+	Album      string          `json:"album"`
+	Genre      string          `json:"genre"`
+	CoverArt   string          `json:"coverArt"`
+	ArtworkURL string          `json:"artworkUrl,omitempty"`
+	Year       json.RawMessage `json:"year"`
+}
+
+func (m *metadataSongPayload) UnmarshalJSON(data []byte) error {
+	var dto metadataSongPayloadDTO
+	if err := json.Unmarshal(data, &dto); err != nil {
+		return err
+	}
+
+	m.ID = dto.ID
+	m.Title = dto.Title
+	m.Artist = dto.Artist
+	m.Album = dto.Album
+	m.Genre = dto.Genre
+	m.CoverArt = dto.CoverArt
+	m.ArtworkURL = dto.ArtworkURL
+	m.Year = parseYearRaw(dto.Year)
+	return nil
+}
+
+func (n *Router) addMetadataRoute(r chi.Router) {
+	r.Route("/metadata", func(r chi.Router) {
+		r.Post("/fetch", n.fetchMetadataHandler())
+	})
+}
+
+func (n *Router) fetchMetadataHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		var req metadataFetchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if len(req.Songs) == 0 {
+			writeJSON(w, metadataFetchResponse{Songs: []metadataSongPayload{}})
+			return
+		}
+
+		updates := make([]metadataSongPayload, 0, len(req.Songs))
+		for _, song := range req.Songs {
+			enriched, err := metadataEnricher.Enrich(ctx, song)
+			if err != nil {
+				log.Warn(ctx, "Unable to enrich song metadata", "songId", song.ID, "err", err)
+				updates = append(updates, song)
+				continue
+			}
+			updates = append(updates, enriched)
+		}
+
+		writeJSON(w, metadataFetchResponse{Songs: updates})
+	}
+}
+
+func writeJSON(w http.ResponseWriter, payload interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+type metadataFetcher struct {
+	client        *http.Client
+	coverClient   *http.Client
+	mu            sync.Mutex
+	nextAvailable time.Time
+}
+
+var metadataEnricher = newMetadataFetcher()
+
+func newMetadataFetcher() *metadataFetcher {
+	timeout := 10 * time.Second
+	return &metadataFetcher{
+		client:      &http.Client{Timeout: timeout},
+		coverClient: &http.Client{Timeout: timeout},
+	}
+}
+
+func (f *metadataFetcher) Enrich(ctx context.Context, song metadataSongPayload) (metadataSongPayload, error) {
+	title := strings.TrimSpace(song.Title)
+	artist := strings.TrimSpace(song.Artist)
+	if title == "" || artist == "" {
+		return song, nil
+	}
+
+	recording, err := f.lookupRecording(ctx, title, artist)
+	if err != nil || recording == nil {
+		return song, err
+	}
+
+	updated := song
+	if strings.TrimSpace(updated.Artist) == "" && recording.PrimaryArtist() != "" {
+		updated.Artist = recording.PrimaryArtist()
+	}
+	if strings.TrimSpace(updated.Title) == "" && recording.Title != "" {
+		updated.Title = recording.Title
+	}
+	if needsAlbumUpdate(updated.Album) && recording.PrimaryReleaseTitle() != "" {
+		updated.Album = recording.PrimaryReleaseTitle()
+	}
+	if strings.TrimSpace(updated.Genre) == "" && recording.PrimaryTag() != "" {
+		updated.Genre = recording.PrimaryTag()
+	}
+	if updated.Year == nil || *updated.Year == 0 {
+		if year := recording.ReleaseYear(); year != nil {
+			updated.Year = year
+		}
+	}
+	if updated.CoverArt == "" {
+		if artURL, err := f.fetchCoverArt(ctx, recording.PrimaryReleaseID()); err == nil && artURL != "" {
+			updated.ArtworkURL = artURL
+		}
+	}
+
+	return updated, nil
+}
+
+func (f *metadataFetcher) lookupRecording(ctx context.Context, title, artist string) (*musicBrainzRecording, error) {
+	query := url.Values{}
+	query.Set("query", fmt.Sprintf("%s AND artist:%s", title, artist))
+	query.Set("fmt", "json")
+	query.Set("limit", "1")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, musicBrainzRecordingURL+"?"+query.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+	f.applyRateLimit()
+	req.Header.Set("User-Agent", metadataUserAgent)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		time.Sleep(time.Second)
+		return f.lookupRecording(ctx, title, artist)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("musicbrainz search failed: %s", resp.Status)
+	}
+
+	var result musicBrainzRecordingResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	if len(result.Recordings) == 0 {
+		return nil, nil
+	}
+
+	return &result.Recordings[0], nil
+}
+
+func (f *metadataFetcher) fetchCoverArt(ctx context.Context, releaseID string) (string, error) {
+	if releaseID == "" {
+		return "", nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, coverArtArchiveURL+releaseID, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", metadataUserAgent)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := f.coverClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("cover art request failed: %s", resp.Status)
+	}
+
+	var payload coverArtResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", err
+	}
+	for _, image := range payload.Images {
+		if image.Front && image.Image != "" {
+			return image.Image, nil
+		}
+	}
+	if len(payload.Images) > 0 {
+		return payload.Images[0].Image, nil
+	}
+	return "", nil
+}
+
+func (f *metadataFetcher) applyRateLimit() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	now := time.Now()
+	if wait := f.nextAvailable.Sub(now); wait > 0 {
+		time.Sleep(wait)
+	}
+	f.nextAvailable = time.Now().Add(time.Second)
+}
+
+type musicBrainzRecordingResponse struct {
+	Recordings []musicBrainzRecording `json:"recordings"`
+}
+
+type musicBrainzRecording struct {
+	Title            string                    `json:"title"`
+	ArtistCredit     []musicBrainzArtistCredit `json:"artist-credit"`
+	Releases         []musicBrainzRelease      `json:"releases"`
+	FirstReleaseDate string                    `json:"first-release-date"`
+	Tags             []musicBrainzRecordingTag `json:"tags"`
+}
+
+type musicBrainzArtistCredit struct {
+	Name string `json:"name"`
+}
+
+type musicBrainzRelease struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	Date  string `json:"date"`
+}
+
+type musicBrainzRecordingTag struct {
+	Name string `json:"name"`
+}
+
+type coverArtResponse struct {
+	Images []coverArtImage `json:"images"`
+}
+
+type coverArtImage struct {
+	Image string `json:"image"`
+	Front bool   `json:"front"`
+}
+
+func (m musicBrainzRecording) PrimaryArtist() string {
+	if len(m.ArtistCredit) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(m.ArtistCredit[0].Name)
+}
+
+func (m musicBrainzRecording) PrimaryReleaseTitle() string {
+	if len(m.Releases) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(m.Releases[0].Title)
+}
+
+func (m musicBrainzRecording) PrimaryReleaseID() string {
+	if len(m.Releases) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(m.Releases[0].ID)
+}
+
+func (m musicBrainzRecording) ReleaseYear() *int {
+	if len(m.Releases) > 0 {
+		if year := extractYear(m.Releases[0].Date); year != nil {
+			return year
+		}
+	}
+	if year := extractYear(m.FirstReleaseDate); year != nil {
+		return year
+	}
+	return nil
+}
+
+func (m musicBrainzRecording) PrimaryTag() string {
+	if len(m.Tags) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(m.Tags[0].Name)
+}
+
+func extractYear(date string) *int {
+	date = strings.TrimSpace(date)
+	if len(date) < 4 {
+		return nil
+	}
+	year, err := strconv.Atoi(date[:4])
+	if err != nil {
+		return nil
+	}
+	return &year
+}
+
+func needsAlbumUpdate(album string) bool {
+	album = strings.TrimSpace(album)
+	if album == "" {
+		return true
+	}
+	return strings.EqualFold(album, "[Unknown Album]")
+}
+
+func parseYearRaw(raw json.RawMessage) *int {
+	if raw == nil || len(raw) == 0 {
+		return nil
+	}
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || strings.EqualFold(trimmed, "null") {
+		return nil
+	}
+	var asInt int
+	if err := json.Unmarshal(raw, &asInt); err == nil {
+		return &asInt
+	}
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		asString = strings.TrimSpace(asString)
+		if asString == "" {
+			return nil
+		}
+		if parsed, err := strconv.Atoi(asString); err == nil {
+			return &parsed
+		}
+	}
+	return nil
+}

--- a/server/nativeapi/metadata.go
+++ b/server/nativeapi/metadata.go
@@ -1,9 +1,11 @@
 package nativeapi
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -12,7 +14,9 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/core/artwork"
 	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
 )
 
 const (
@@ -88,10 +92,15 @@ func (n *Router) fetchMetadataHandler() http.HandlerFunc {
 			return
 		}
 
+		if n.metadata == nil {
+			http.Error(w, "metadata fetcher unavailable", http.StatusServiceUnavailable)
+			return
+		}
 		updates := make([]metadataSongPayload, 0, len(req.Songs))
+		requestCtx := n.metadata.NewRequestContext()
 		for _, song := range req.Songs {
 			normalized := normalizeSongPayload(song)
-			enriched, err := metadataEnricher.Enrich(ctx, normalized)
+			enriched, err := n.metadata.Enrich(ctx, requestCtx, normalized)
 			if err != nil {
 				log.Warn(ctx, "Unable to enrich song metadata", "songId", normalized.ID, "err", err)
 				updates = append(updates, normalized)
@@ -111,24 +120,37 @@ func writeJSON(w http.ResponseWriter, payload interface{}) {
 	}
 }
 
+type metadataRequestContext struct {
+	coverCache map[string]*coverArtAsset
+}
+
+type coverArtAsset struct {
+	URL  string
+	Data []byte
+}
+
 type metadataFetcher struct {
 	client        *http.Client
 	coverClient   *http.Client
 	mu            sync.Mutex
 	nextAvailable time.Time
+	ds            model.DataStore
 }
 
-var metadataEnricher = newMetadataFetcher()
-
-func newMetadataFetcher() *metadataFetcher {
+func newMetadataFetcher(ds model.DataStore) *metadataFetcher {
 	timeout := 10 * time.Second
 	return &metadataFetcher{
 		client:      &http.Client{Timeout: timeout},
 		coverClient: &http.Client{Timeout: timeout},
+		ds:          ds,
 	}
 }
 
-func (f *metadataFetcher) Enrich(ctx context.Context, song metadataSongPayload) (metadataSongPayload, error) {
+func (f *metadataFetcher) NewRequestContext() *metadataRequestContext {
+	return &metadataRequestContext{coverCache: make(map[string]*coverArtAsset)}
+}
+
+func (f *metadataFetcher) Enrich(ctx context.Context, reqCtx *metadataRequestContext, song metadataSongPayload) (metadataSongPayload, error) {
 	title := strings.TrimSpace(song.Title)
 	artist := strings.TrimSpace(song.Artist)
 	if title == "" || artist == "" {
@@ -160,10 +182,17 @@ func (f *metadataFetcher) Enrich(ctx context.Context, song metadataSongPayload) 
 	}
 	if strings.TrimSpace(updated.CoverArt) == "" {
 		if releaseID := recording.PrimaryReleaseID(); releaseID != "" {
-			if artURL, artErr := f.fetchCoverArt(ctx, releaseID); artErr == nil && artURL != "" {
-				updated.ArtworkURL = artURL
-			} else if artErr != nil {
+			asset, artErr := f.fetchCoverArt(ctx, reqCtx, releaseID)
+			if artErr != nil {
 				log.Warn(ctx, "Unable to fetch cover art", "songId", song.ID, "err", artErr)
+			} else if asset != nil {
+				coverID, saveErr := f.saveCoverArt(ctx, song.ID, asset)
+				if saveErr != nil {
+					log.Warn(ctx, "Unable to store cover art", "songId", song.ID, "err", saveErr)
+				} else if coverID != "" {
+					updated.CoverArt = coverID
+					updated.ArtworkURL = asset.URL
+				}
 			}
 		}
 	}
@@ -214,46 +243,126 @@ func (f *metadataFetcher) lookupRecording(ctx context.Context, title, artist str
 	return &result.Recordings[0], nil
 }
 
-func (f *metadataFetcher) fetchCoverArt(ctx context.Context, releaseID string) (string, error) {
+func (f *metadataFetcher) fetchCoverArt(ctx context.Context, reqCtx *metadataRequestContext, releaseID string) (*coverArtAsset, error) {
 	if releaseID == "" {
-		return "", nil
+		return nil, nil
+	}
+	if reqCtx != nil {
+		if asset, ok := reqCtx.coverCache[releaseID]; ok {
+			return asset, nil
+		}
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, coverArtArchiveURL+releaseID, nil)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	req.Header.Set("User-Agent", metadataUserAgent)
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := f.coverClient.Do(req)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return "", nil
+		return nil, nil
 	}
 	if resp.StatusCode != http.StatusOK {
 		log.Warn(ctx, "Cover Art Archive request failed", "status", resp.Status)
-		return "", nil
+		return nil, nil
 	}
 
 	var payload coverArtResponse
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		log.Warn(ctx, "Unable to decode cover art response", "err", err)
-		return "", nil
+		return nil, nil
 	}
-	for _, image := range payload.Images {
-		if image.Front && image.Image != "" {
-			return ensureHTTPSURL(image.Image), nil
+	imageURL := selectCoverArtURL(payload.Images)
+	if imageURL == "" {
+		return nil, nil
+	}
+	normalized := ensureHTTPSURL(imageURL)
+	data, err := f.downloadCoverArt(ctx, normalized)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+	asset := &coverArtAsset{URL: normalized, Data: data}
+	if reqCtx != nil {
+		reqCtx.coverCache[releaseID] = asset
+	}
+	return asset, nil
+}
+
+func (f *metadataFetcher) downloadCoverArt(ctx context.Context, imageURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", metadataUserAgent)
+	resp, err := f.coverClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return body, nil
+	case http.StatusNotFound:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("cover art download failed: %s", resp.Status)
+	}
+}
+
+func selectCoverArtURL(images []coverArtImage) string {
+	for _, image := range images {
+		if image.Front && strings.TrimSpace(image.Image) != "" {
+			return image.Image
 		}
 	}
-	if len(payload.Images) > 0 {
-		return ensureHTTPSURL(payload.Images[0].Image), nil
+	for _, image := range images {
+		if strings.TrimSpace(image.Image) != "" {
+			return image.Image
+		}
 	}
-	return "", nil
+	return ""
+}
+
+func (f *metadataFetcher) saveCoverArt(ctx context.Context, songID string, asset *coverArtAsset) (string, error) {
+	if asset == nil || songID == "" || len(asset.Data) == 0 {
+		return "", nil
+	}
+	if _, err := artwork.SaveMediaArtwork(songID, bytes.NewReader(asset.Data)); err != nil {
+		return "", err
+	}
+	if f.ds == nil {
+		return model.NewArtworkID(model.KindMediaFileArtwork, songID, nil).String(), nil
+	}
+	mfRepo := f.ds.MediaFile(ctx)
+	if mfRepo == nil {
+		return model.NewArtworkID(model.KindMediaFileArtwork, songID, nil).String(), nil
+	}
+	mf, err := mfRepo.Get(songID)
+	if err != nil {
+		return "", err
+	}
+	mf.HasCoverArt = true
+	now := time.Now()
+	mf.UpdatedAt = now
+	if err := mfRepo.Put(mf); err != nil {
+		return "", err
+	}
+	return mf.CoverArtID().String(), nil
 }
 
 func (f *metadataFetcher) applyRateLimit() {

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -120,6 +120,7 @@ func (n *Router) routes() http.Handler {
 		n.addSongDiscoveriesRoute(r)
 		n.addQueueRoute(r)
 		n.addMissingFilesRoute(r)
+		n.addMetadataRoute(r)
 		n.addNotificationsRoute(r)
 		n.addKeepAliveRoute(r)
 		n.addInsightsRoute(r)

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -30,6 +30,7 @@ type Router struct {
 	insights  metrics.Insights
 	libs      core.Library
 	devices   *retailPlayerDeviceResolver
+	metadata  *metadataFetcher
 }
 
 func New(ds model.DataStore, share core.Share, playlists core.Playlists, insights metrics.Insights, libraryService core.Library) *Router {
@@ -40,6 +41,7 @@ func New(ds model.DataStore, share core.Share, playlists core.Playlists, insight
 		insights:  insights,
 		libs:      libraryService,
 		devices:   newRetailPlayerDeviceResolver(),
+		metadata:  newMetadataFetcher(ds),
 	}
 	r.preloadRetailPlayerDeviceMappings()
 	r.Handler = r.routes()

--- a/server/subsonic/album_lists.go
+++ b/server/subsonic/album_lists.go
@@ -251,6 +251,32 @@ func (api *Router) GetRandomSongs(r *http.Request) (*responses.Subsonic, error) 
 	return response, nil
 }
 
+func (api *Router) GetSongs(r *http.Request) (*responses.Subsonic, error) {
+	p := req.Params(r)
+	count := min(p.IntOr("count", 500), 500)
+	offset := p.IntOr("offset", 0)
+
+	// Get optional library IDs from musicFolderId parameter
+	musicFolderIds, err := selectedMusicFolderIds(r, false)
+	if err != nil {
+		return nil, err
+	}
+	opts := filter.Options{Sort: "title"}
+	opts = filter.ApplyLibraryFilter(opts, musicFolderIds)
+
+	ctx := r.Context()
+	songs, err := api.getSongs(ctx, offset, count, opts)
+	if err != nil {
+		log.Error(r, "Error retrieving songs", err)
+		return nil, err
+	}
+
+	response := newResponse()
+	response.Songs = &responses.Songs{}
+	response.Songs.Songs = slice.MapWithArg(songs, ctx, childFromMediaFile)
+	return response, nil
+}
+
 func (api *Router) GetSongsByGenre(r *http.Request) (*responses.Subsonic, error) {
 	p := req.Params(r)
 	count := min(p.IntOr("count", 10), 500)

--- a/server/subsonic/album_lists_test.go
+++ b/server/subsonic/album_lists_test.go
@@ -324,6 +324,101 @@ var _ = Describe("Album Lists", func() {
 		})
 	})
 
+	Describe("GetSongs", func() {
+		var mockMediaFileRepo *tests.MockMediaFileRepo
+
+		BeforeEach(func() {
+			mockMediaFileRepo = ds.MediaFile(ctx).(*tests.MockMediaFileRepo)
+		})
+
+		It("should return songs respecting pagination", func() {
+			mockMediaFileRepo.SetData(model.MediaFiles{
+				{ID: "1", Title: "Song 1"},
+				{ID: "2", Title: "Song 2"},
+			})
+			r := newGetRequest("count=2", "offset=0")
+
+			resp, err := router.GetSongs(r)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.Songs).ToNot(BeNil())
+			Expect(resp.Songs.Songs).To(HaveLen(2))
+			Expect(mockMediaFileRepo.Options.Max).To(Equal(2))
+			Expect(mockMediaFileRepo.Options.Offset).To(Equal(0))
+		})
+
+		Context("with musicFolderId parameter", func() {
+			var user model.User
+			var ctx context.Context
+
+			BeforeEach(func() {
+				user = model.User{
+					ID: "test-user",
+					Libraries: []model.Library{
+						{ID: 1, Name: "Library 1"},
+						{ID: 2, Name: "Library 2"},
+						{ID: 3, Name: "Library 3"},
+					},
+				}
+				ctx = request.WithUser(context.Background(), user)
+			})
+
+			It("should filter songs by specific library when musicFolderId is provided", func() {
+				mockMediaFileRepo.SetData(model.MediaFiles{
+					{ID: "1", Title: "Song 1"},
+					{ID: "2", Title: "Song 2"},
+				})
+				r := newGetRequest("count=2", "musicFolderId=1")
+				r = r.WithContext(ctx)
+
+				resp, err := router.GetSongs(r)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.Songs.Songs).To(HaveLen(2))
+				// Verify that library filter was applied
+				query, args, _ := mockMediaFileRepo.Options.Filters.ToSql()
+				Expect(query).To(ContainSubstring("library_id IN (?)"))
+				Expect(args).To(ContainElement(1))
+			})
+
+			It("should filter songs by multiple libraries when multiple musicFolderId are provided", func() {
+				mockMediaFileRepo.SetData(model.MediaFiles{
+					{ID: "1", Title: "Song 1"},
+					{ID: "2", Title: "Song 2"},
+				})
+				r := newGetRequest("count=2", "musicFolderId=1", "musicFolderId=2")
+				r = r.WithContext(ctx)
+
+				resp, err := router.GetSongs(r)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.Songs.Songs).To(HaveLen(2))
+				// Verify that library filter was applied
+				query, args, _ := mockMediaFileRepo.Options.Filters.ToSql()
+				Expect(query).To(ContainSubstring("library_id IN (?,?)"))
+				Expect(args).To(ContainElements(1, 2))
+			})
+
+			It("should return all accessible songs when no musicFolderId is provided", func() {
+				mockMediaFileRepo.SetData(model.MediaFiles{
+					{ID: "1", Title: "Song 1"},
+					{ID: "2", Title: "Song 2"},
+				})
+				r := newGetRequest("count=2")
+				r = r.WithContext(ctx)
+
+				resp, err := router.GetSongs(r)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.Songs.Songs).To(HaveLen(2))
+				// Verify that library filter was applied
+				query, args, _ := mockMediaFileRepo.Options.Filters.ToSql()
+				Expect(query).To(ContainSubstring("library_id IN (?,?,?)"))
+				Expect(args).To(ContainElements(1, 2, 3))
+			})
+		})
+	})
+
 	Describe("GetSongsByGenre", func() {
 		var mockMediaFileRepo *tests.MockMediaFileRepo
 

--- a/server/subsonic/api.go
+++ b/server/subsonic/api.go
@@ -124,6 +124,7 @@ func (api *Router) routes() http.Handler {
 			} else {
 				h501(r, "getNowPlaying")
 			}
+			h(r, "getSongs", api.GetSongs)
 			h(r, "getRandomSongs", api.GetRandomSongs)
 			h(r, "getSongsByGenre", api.GetSongsByGenre)
 		})

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -30,6 +30,7 @@ type Subsonic struct {
 	Starred2      *Starred2          `xml:"starred2,omitempty"                            json:"starred2,omitempty"`
 	NowPlaying    *NowPlaying        `xml:"nowPlaying,omitempty"                          json:"nowPlaying,omitempty"`
 	Song          *Child             `xml:"song,omitempty"                                json:"song,omitempty"`
+	Songs         *Songs             `xml:"songs,omitempty"                               json:"songs,omitempty"`
 	RandomSongs   *Songs             `xml:"randomSongs,omitempty"                         json:"randomSongs,omitempty"`
 	SongsByGenre  *Songs             `xml:"songsByGenre,omitempty"                        json:"songsByGenre,omitempty"`
 	Genres        *Genres            `xml:"genres,omitempty"                              json:"genres,omitempty"`

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -17,6 +17,7 @@ import SpeakerGroupIcon from '@material-ui/icons/SpeakerGroup'
 import ChevronRightIcon from '@material-ui/icons/ChevronRight'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import FolderIcon from '@material-ui/icons/Folder'
+import LibraryMusicIcon from '@material-ui/icons/LibraryMusic'
 import { useHistory } from 'react-router-dom'
 import { BiCog } from 'react-icons/bi'
 import SubMenu from './SubMenu'
@@ -279,6 +280,19 @@ const Menu = ({ dense = false }) => {
     )
   }
 
+  const renderMetadataMenuItemLink = () => (
+    <MenuItemLink
+      key="metadata"
+      to="/metadata"
+      activeClassName={classes.active}
+      primaryText="MetaData"
+      leftIcon={<LibraryMusicIcon />}
+      sidebarIsOpen={open}
+      dense={dense}
+      exact
+    />
+  )
+
   const subItems = (subMenu) => (resource) =>
     resource.hasList && resource.options && resource.options.subMenu === subMenu
 
@@ -443,6 +457,7 @@ const Menu = ({ dense = false }) => {
             sidebarIsOpen={open}
             dense={dense}
           />
+          {renderMetadataMenuItemLink()}
           <Divider />
           <PlaylistsSubMenu
             state={state}
@@ -455,6 +470,7 @@ const Menu = ({ dense = false }) => {
         <>
           {renderRetailPlayerMenu()}
           {resources.filter(subItems('discovery')).map(renderResourceMenuItemLink)}
+          {renderMetadataMenuItemLink()}
           {resources.filter(subItems('playlist')).map(renderResourceMenuItemLink)}
         </>
       )}

--- a/ui/src/pages/MetadataPage.jsx
+++ b/ui/src/pages/MetadataPage.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Container, Typography } from '@material-ui/core'
+
+const MetadataPage = () => (
+  <Container maxWidth="lg" style={{ padding: '2rem 1.5rem' }}>
+    <Typography variant="h4" component="h1" gutterBottom>
+      MetaData
+    </Typography>
+    <Typography variant="subtitle1" color="textSecondary">
+      Manage and enhance song metadata
+    </Typography>
+  </Container>
+)
+
+export default MetadataPage

--- a/ui/src/pages/MetadataPage.jsx
+++ b/ui/src/pages/MetadataPage.jsx
@@ -4,6 +4,7 @@ import {
   Button,
   Container,
   LinearProgress,
+  Snackbar,
   Typography,
 } from '@material-ui/core'
 import CircularProgress from '@material-ui/core/CircularProgress'
@@ -20,6 +21,57 @@ import {
   fetchMissingMetadata,
   getAllSongsMetadata,
 } from '../services/metadata'
+
+const MERGEABLE_FIELDS = ['title', 'artist', 'album', 'genre', 'year', 'coverArt', 'artworkUrl']
+
+const mergeUpdatedMetadata = (oldSongs = [], updatedSongs = []) => {
+  if (!Array.isArray(updatedSongs) || updatedSongs.length === 0) {
+    return oldSongs
+  }
+
+  const updates = new Map()
+  updatedSongs.forEach((song) => {
+    if (song?.id) {
+      updates.set(song.id, song)
+    }
+  })
+
+  if (updates.size === 0) {
+    return oldSongs
+  }
+
+  let didUpdate = false
+
+  const merged = oldSongs.map((song) => {
+    if (!song?.id || !updates.has(song.id)) {
+      return song
+    }
+
+    const update = updates.get(song.id)
+    let changed = false
+    const nextSong = { ...song }
+
+    MERGEABLE_FIELDS.forEach((field) => {
+      if (!Object.prototype.hasOwnProperty.call(update, field)) {
+        return
+      }
+      const nextValue = update[field]
+      if (nextSong[field] !== nextValue) {
+        nextSong[field] = nextValue
+        changed = true
+      }
+    })
+
+    if (changed) {
+      didUpdate = true
+      return nextSong
+    }
+
+    return song
+  })
+
+  return didUpdate ? merged : oldSongs
+}
 
 const parseYearValue = (year) => {
   if (year === null || year === undefined) {
@@ -39,7 +91,7 @@ const parseYearValue = (year) => {
   return null
 }
 
-export const findMissingFields = (song) => {
+const findMissingFields = (song) => {
   if (!song) {
     return false
   }
@@ -114,6 +166,7 @@ const MetadataPage = () => {
   const [error, setError] = useState(null)
   const [fetching, setFetching] = useState(false)
   const [fetchError, setFetchError] = useState(null)
+  const [fetchSuccess, setFetchSuccess] = useState(false)
 
   useEffect(() => {
     let isMounted = true
@@ -201,6 +254,7 @@ const MetadataPage = () => {
     }
 
     setFetchError(null)
+    setFetchSuccess(false)
     setFetching(true)
     try {
       const updates = await fetchMissingMetadata(
@@ -209,25 +263,17 @@ const MetadataPage = () => {
       if (!Array.isArray(updates) || updates.length === 0) {
         return
       }
-      const updatesById = updates.reduce((map, song) => {
-        if (song?.id) {
-          map.set(song.id, song)
+      let updated = false
+      setSongs((prevSongs) => {
+        const merged = mergeUpdatedMetadata(prevSongs, updates)
+        if (merged !== prevSongs) {
+          updated = true
         }
-        return map
-      }, new Map())
-
-      if (updatesById.size === 0) {
-        return
+        return merged
+      })
+      if (updated) {
+        setFetchSuccess(true)
       }
-
-      setSongs((prevSongs) =>
-        prevSongs.map((song) => {
-          if (!song?.id || !updatesById.has(song.id)) {
-            return song
-          }
-          return { ...song, ...updatesById.get(song.id) }
-        }),
-      )
     } catch (err) {
       setFetchError(err)
     } finally {
@@ -235,14 +281,22 @@ const MetadataPage = () => {
     }
   }, [fetching, hasMissingSongs, songsMissingMetadata])
 
+  const handleCloseToast = useCallback((_, reason) => {
+    if (reason === 'clickaway') {
+      return
+    }
+    setFetchSuccess(false)
+  }, [])
+
   const renderArtwork = (record) => {
     if (!record) {
       return null
     }
 
-    const artworkUrl = record.coverArt
-      ? baseUrl(subsonic.url('getCoverArt', record.coverArt || record.id, { size: 120 }))
-      : record.artworkUrl
+    const artworkUrl = record.artworkUrl
+      || (record.coverArt
+        ? baseUrl(subsonic.url('getCoverArt', record.coverArt || record.id, { size: 120 }))
+        : '')
 
     if (!artworkUrl) {
       return <div className={classes.artworkPlaceholder} />
@@ -274,12 +328,11 @@ const MetadataPage = () => {
             variant="contained"
             onClick={handleFetchMissingMetadata}
             disabled={!hasMissingSongs || fetching}
+            startIcon={
+              fetching ? <CircularProgress size={18} color="inherit" /> : null
+            }
           >
-            {fetching ? (
-              <CircularProgress size={20} color="inherit" />
-            ) : (
-              'Fetch Missing Metadata'
-            )}
+            Fetch Missing Metadata
           </Button>
         </div>
       </div>
@@ -341,6 +394,16 @@ const MetadataPage = () => {
           </ListContextProvider>
         </Box>
       </Box>
+      <Snackbar
+        open={fetchSuccess}
+        autoHideDuration={4000}
+        onClose={handleCloseToast}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      >
+        <Alert elevation={6} variant="filled" severity="success" onClose={handleCloseToast}>
+          Metadata updated
+        </Alert>
+      </Snackbar>
     </Container>
   )
 }

--- a/ui/src/pages/MetadataPage.jsx
+++ b/ui/src/pages/MetadataPage.jsx
@@ -293,10 +293,11 @@ const MetadataPage = () => {
       return null
     }
 
-    const artworkUrl = record.artworkUrl
-      || (record.coverArt
-        ? baseUrl(subsonic.url('getCoverArt', record.coverArt || record.id, { size: 120 }))
-        : '')
+    const coverArtId = record.coverArt && record.coverArt.trim()
+    const coverArtUrl = coverArtId
+      ? baseUrl(subsonic.url('getCoverArt', coverArtId, { size: 120 }))
+      : ''
+    const artworkUrl = coverArtUrl || record.artworkUrl
 
     if (!artworkUrl) {
       return <div className={classes.artworkPlaceholder} />

--- a/ui/src/pages/MetadataPage.jsx
+++ b/ui/src/pages/MetadataPage.jsx
@@ -1,10 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   Box,
+  Button,
   Container,
   LinearProgress,
   Typography,
 } from '@material-ui/core'
+import CircularProgress from '@material-ui/core/CircularProgress'
 import Alert from '@material-ui/lab/Alert'
 import { makeStyles } from '@material-ui/core/styles'
 import { FunctionField, ListContextProvider, TextField } from 'react-admin'
@@ -14,7 +16,53 @@ import { ArtistLinkField } from '../common/ArtistLinkField'
 import { AlbumLinkField } from '../song/AlbumLinkField'
 import subsonic from '../subsonic'
 import { baseUrl } from '../utils'
-import { getAllSongsMetadata } from '../services/metadata'
+import {
+  fetchMissingMetadata,
+  getAllSongsMetadata,
+} from '../services/metadata'
+
+const parseYearValue = (year) => {
+  if (year === null || year === undefined) {
+    return null
+  }
+  if (typeof year === 'number') {
+    return Number.isNaN(year) ? null : year
+  }
+  if (typeof year === 'string') {
+    const trimmed = year.trim()
+    if (!trimmed) {
+      return null
+    }
+    const parsed = Number.parseInt(trimmed, 10)
+    return Number.isNaN(parsed) ? null : parsed
+  }
+  return null
+}
+
+export const findMissingFields = (song) => {
+  if (!song) {
+    return false
+  }
+
+  const normalize = (value) => {
+    if (typeof value === 'string') {
+      return value.trim()
+    }
+    if (typeof value === 'number') {
+      return Number.isNaN(value) ? '' : `${value}`.trim()
+    }
+    return value || ''
+  }
+
+  const album = normalize(song.album)
+  const missingAlbum = !album || album.toLowerCase() === '[unknown album]'
+  const missingArtist = !normalize(song.artist)
+  const missingGenre = !normalize(song.genre)
+  const missingYear = parseYearValue(song.year) === null
+  const missingArtwork = !song.coverArt && !song.artworkUrl
+
+  return missingAlbum || missingArtist || missingGenre || missingYear || missingArtwork
+}
 
 const useStyles = makeStyles((theme) => ({
   pageWrapper: {
@@ -23,6 +71,10 @@ const useStyles = makeStyles((theme) => ({
   },
   header: {
     marginBottom: theme.spacing(3),
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing(2),
   },
   tableWrapper: {
     width: '100%',
@@ -50,6 +102,9 @@ const useStyles = makeStyles((theme) => ({
   alertWrapper: {
     padding: theme.spacing(2),
   },
+  buttonWrapper: {
+    whiteSpace: 'nowrap',
+  },
 }))
 
 const MetadataPage = () => {
@@ -57,6 +112,8 @@ const MetadataPage = () => {
   const [songs, setSongs] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  const [fetching, setFetching] = useState(false)
+  const [fetchError, setFetchError] = useState(null)
 
   useEffect(() => {
     let isMounted = true
@@ -135,21 +192,65 @@ const MetadataPage = () => {
     [songsById, songIds, loading, noop],
   )
 
+  const songsMissingMetadata = useMemo(() => songs.filter(findMissingFields), [songs])
+  const hasMissingSongs = songsMissingMetadata.length > 0
+
+  const handleFetchMissingMetadata = useCallback(async () => {
+    if (!hasMissingSongs || fetching) {
+      return
+    }
+
+    setFetchError(null)
+    setFetching(true)
+    try {
+      const updates = await fetchMissingMetadata(
+        songsMissingMetadata.filter((song) => song?.id),
+      )
+      if (!Array.isArray(updates) || updates.length === 0) {
+        return
+      }
+      const updatesById = updates.reduce((map, song) => {
+        if (song?.id) {
+          map.set(song.id, song)
+        }
+        return map
+      }, new Map())
+
+      if (updatesById.size === 0) {
+        return
+      }
+
+      setSongs((prevSongs) =>
+        prevSongs.map((song) => {
+          if (!song?.id || !updatesById.has(song.id)) {
+            return song
+          }
+          return { ...song, ...updatesById.get(song.id) }
+        }),
+      )
+    } catch (err) {
+      setFetchError(err)
+    } finally {
+      setFetching(false)
+    }
+  }, [fetching, hasMissingSongs, songsMissingMetadata])
+
   const renderArtwork = (record) => {
     if (!record) {
       return null
     }
 
-    if (!record.coverArt && !record.id) {
+    const artworkUrl = record.coverArt
+      ? baseUrl(subsonic.url('getCoverArt', record.coverArt || record.id, { size: 120 }))
+      : record.artworkUrl
+
+    if (!artworkUrl) {
       return <div className={classes.artworkPlaceholder} />
     }
 
-    const artId = record.coverArt || record.id
-    const imageUrl = baseUrl(subsonic.url('getCoverArt', artId, { size: 120 }))
-
     return (
       <img
-        src={imageUrl}
+        src={artworkUrl}
         alt={`${record.title || 'Song'} artwork`}
         className={classes.artwork}
       />
@@ -159,12 +260,28 @@ const MetadataPage = () => {
   return (
     <Container maxWidth="lg" className={classes.pageWrapper}>
       <div className={classes.header}>
-        <Typography variant="h3" component="h1" gutterBottom>
-          MetaData
-        </Typography>
-        <Typography variant="subtitle1" color="textSecondary">
-          Manage and enhance song metadata
-        </Typography>
+        <div>
+          <Typography variant="h3" component="h1" gutterBottom>
+            MetaData
+          </Typography>
+          <Typography variant="subtitle1" color="textSecondary">
+            Manage and enhance song metadata
+          </Typography>
+        </div>
+        <div className={classes.buttonWrapper}>
+          <Button
+            color="primary"
+            variant="contained"
+            onClick={handleFetchMissingMetadata}
+            disabled={!hasMissingSongs || fetching}
+          >
+            {fetching ? (
+              <CircularProgress size={20} color="inherit" />
+            ) : (
+              'Fetch Missing Metadata'
+            )}
+          </Button>
+        </div>
       </div>
       <Box className={classes.tableWrapper}>
         {loading && <LinearProgress />}
@@ -172,6 +289,13 @@ const MetadataPage = () => {
           <div className={classes.alertWrapper}>
             <Alert severity="error">
               {error.message || 'Unable to load song metadata.'}
+            </Alert>
+          </div>
+        )}
+        {fetchError && (
+          <div className={classes.alertWrapper}>
+            <Alert severity="warning">
+              {fetchError.message || 'Unable to fetch missing metadata.'}
             </Alert>
           </div>
         )}

--- a/ui/src/pages/MetadataPage.jsx
+++ b/ui/src/pages/MetadataPage.jsx
@@ -1,15 +1,224 @@
-import React from 'react'
-import { Container, Typography } from '@material-ui/core'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  Box,
+  Container,
+  LinearProgress,
+  Typography,
+} from '@material-ui/core'
+import Alert from '@material-ui/lab/Alert'
+import { makeStyles } from '@material-ui/core/styles'
+import { FunctionField, ListContextProvider, TextField } from 'react-admin'
+import { SongDatagrid } from '../common/SongDatagrid'
+import { SongTitleField } from '../common/SongTitleField'
+import { ArtistLinkField } from '../common/ArtistLinkField'
+import { AlbumLinkField } from '../song/AlbumLinkField'
+import subsonic from '../subsonic'
+import { baseUrl } from '../utils'
+import { getAllSongsMetadata } from '../services/metadata'
 
-const MetadataPage = () => (
-  <Container maxWidth="lg" style={{ padding: '2rem 1.5rem' }}>
-    <Typography variant="h4" component="h1" gutterBottom>
-      MetaData
-    </Typography>
-    <Typography variant="subtitle1" color="textSecondary">
-      Manage and enhance song metadata
-    </Typography>
-  </Container>
-)
+const useStyles = makeStyles((theme) => ({
+  pageWrapper: {
+    paddingTop: theme.spacing(4),
+    paddingBottom: theme.spacing(6),
+  },
+  header: {
+    marginBottom: theme.spacing(3),
+  },
+  tableWrapper: {
+    width: '100%',
+    backgroundColor: theme.palette.background.paper,
+    borderRadius: theme.shape.borderRadius,
+    boxShadow: theme.shadows[1],
+    overflow: 'hidden',
+  },
+  datagridContainer: {
+    width: '100%',
+  },
+  artwork: {
+    width: 56,
+    height: 56,
+    borderRadius: theme.shape.borderRadius,
+    objectFit: 'cover',
+    boxShadow: theme.shadows[2],
+  },
+  artworkPlaceholder: {
+    width: 56,
+    height: 56,
+    borderRadius: theme.shape.borderRadius,
+    backgroundColor: theme.palette.action.hover,
+  },
+  alertWrapper: {
+    padding: theme.spacing(2),
+  },
+}))
+
+const MetadataPage = () => {
+  const classes = useStyles()
+  const [songs, setSongs] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let isMounted = true
+
+    const loadMetadata = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const response = await getAllSongsMetadata()
+        if (!isMounted) {
+          return
+        }
+        setSongs(Array.isArray(response) ? response : [])
+      } catch (err) {
+        if (isMounted) {
+          setError(err)
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false)
+        }
+      }
+    }
+
+    loadMetadata()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  const { songIds, songsById } = useMemo(() => {
+    const ids = []
+    const map = {}
+
+    songs.forEach((song) => {
+      if (!song?.id) {
+        return
+      }
+      ids.push(song.id)
+      map[song.id] = song
+    })
+
+    return { songIds: ids, songsById: map }
+  }, [songs])
+
+  const noop = useCallback(() => {}, [])
+
+  const listContextValue = useMemo(
+    () => ({
+      data: songsById,
+      ids: songIds,
+      total: songIds.length,
+      resource: 'metadataSongs',
+      basePath: '/metadata',
+      currentSort: { field: 'title', order: 'ASC' },
+      sort: { field: 'title', order: 'ASC' },
+      filterValues: {},
+      displayedFilters: {},
+      selectedIds: [],
+      onSelect: noop,
+      onToggleItem: noop,
+      onUnselectItems: noop,
+      setFilters: noop,
+      setPage: noop,
+      setPerPage: noop,
+      setSort: noop,
+      showFilter: noop,
+      hideFilter: noop,
+      loading,
+      loaded: !loading,
+      page: 1,
+      perPage: songIds.length || 25,
+      version: songIds.length,
+    }),
+    [songsById, songIds, loading, noop],
+  )
+
+  const renderArtwork = (record) => {
+    if (!record) {
+      return null
+    }
+
+    if (!record.coverArt && !record.id) {
+      return <div className={classes.artworkPlaceholder} />
+    }
+
+    const artId = record.coverArt || record.id
+    const imageUrl = baseUrl(subsonic.url('getCoverArt', artId, { size: 120 }))
+
+    return (
+      <img
+        src={imageUrl}
+        alt={`${record.title || 'Song'} artwork`}
+        className={classes.artwork}
+      />
+    )
+  }
+
+  return (
+    <Container maxWidth="lg" className={classes.pageWrapper}>
+      <div className={classes.header}>
+        <Typography variant="h3" component="h1" gutterBottom>
+          MetaData
+        </Typography>
+        <Typography variant="subtitle1" color="textSecondary">
+          Manage and enhance song metadata
+        </Typography>
+      </div>
+      <Box className={classes.tableWrapper}>
+        {loading && <LinearProgress />}
+        {error && (
+          <div className={classes.alertWrapper}>
+            <Alert severity="error">
+              {error.message || 'Unable to load song metadata.'}
+            </Alert>
+          </div>
+        )}
+        <Box className={classes.datagridContainer}>
+          <ListContextProvider value={listContextValue}>
+            <SongDatagrid
+              {...listContextValue}
+              rowClick={false}
+              hasBulkActions={false}
+            >
+              <FunctionField
+                label="Artwork"
+                render={renderArtwork}
+                sortable={false}
+              />
+              <SongTitleField
+                label="Title"
+                source="title"
+                showTrackNumbers={false}
+                sortable={false}
+              />
+              <ArtistLinkField
+                label="Artist"
+                source="artist"
+                sortable={false}
+              />
+              <AlbumLinkField
+                label="Album"
+                source="album"
+                sortable={false}
+              />
+              <TextField
+                label="Genre"
+                source="genre"
+                sortable={false}
+              />
+              <FunctionField
+                label="Year"
+                render={(record) => record?.year || ''}
+                sortable={false}
+              />
+            </SongDatagrid>
+          </ListContextProvider>
+        </Box>
+      </Box>
+    </Container>
+  )
+}
 
 export default MetadataPage

--- a/ui/src/routes.jsx
+++ b/ui/src/routes.jsx
@@ -3,8 +3,10 @@ import { Redirect, Route } from 'react-router-dom'
 import Personal from './personal/Personal'
 import RetailPlayerDashboard from './retailPlayer/RetailPlayerDashboard'
 import RetailPlayerDeviceManagement from './retailPlayer/RetailPlayerDeviceManagement'
+import MetadataPage from './pages/MetadataPage'
 
 const routes = [
+  <Route exact path="/metadata" render={() => <MetadataPage />} key={'metadata'} />,
   <Route exact path="/personal" render={() => <Personal />} key={'personal'} />,
   <Route
     exact

--- a/ui/src/services/metadata.js
+++ b/ui/src/services/metadata.js
@@ -1,0 +1,11 @@
+import httpClient from '../dataProvider/httpClient'
+
+export const getAllSongsMetadata = async () => {
+  try {
+    const response = await httpClient('/rest/getSongs.view?f=json')
+    const payload = response?.data ?? response?.json
+    return payload?.['subsonic-response']?.songs?.song ?? []
+  } catch (error) {
+    throw error
+  }
+}

--- a/ui/src/services/metadata.js
+++ b/ui/src/services/metadata.js
@@ -1,11 +1,44 @@
 import httpClient from '../dataProvider/httpClient'
+import subsonic from '../subsonic'
+
+const PAGE_SIZE = 500
+
+const extractSongs = (payload) => {
+  const subsonicResponse = payload?.['subsonic-response']
+  if (!subsonicResponse) {
+    throw new Error('Invalid response from server')
+  }
+
+  if (subsonicResponse.status && subsonicResponse.status.toLowerCase() !== 'ok') {
+    throw new Error(subsonicResponse.error?.message || 'Unable to fetch songs metadata')
+  }
+
+  return Array.isArray(subsonicResponse?.songs?.song)
+    ? subsonicResponse.songs.song
+    : subsonicResponse?.songs?.song
+    ? [subsonicResponse.songs.song]
+    : []
+}
 
 export const getAllSongsMetadata = async () => {
-  try {
-    const response = await httpClient('/rest/getSongs.view?f=json')
-    const payload = response?.data ?? response?.json
-    return payload?.['subsonic-response']?.songs?.song ?? []
-  } catch (error) {
-    throw error
+  const allSongs = []
+  let offset = 0
+  let hasMore = true
+
+  while (hasMore) {
+    const response = await httpClient(
+      subsonic.url('getSongs', null, { count: PAGE_SIZE, offset }),
+    )
+    const payload = response?.json ?? response?.data
+    const songs = extractSongs(payload)
+    allSongs.push(...songs)
+
+    if (songs.length < PAGE_SIZE) {
+      hasMore = false
+    } else {
+      offset += songs.length
+    }
   }
+
+  return allSongs
 }

--- a/ui/src/services/metadata.js
+++ b/ui/src/services/metadata.js
@@ -42,3 +42,29 @@ export const getAllSongsMetadata = async () => {
 
   return allSongs
 }
+
+export const fetchMissingMetadata = async (songs = []) => {
+  if (!Array.isArray(songs) || songs.length === 0) {
+    return []
+  }
+
+  const response = await httpClient('/api/metadata/fetch', {
+    method: 'POST',
+    body: JSON.stringify({ songs }),
+    headers: new Headers({
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    }),
+  })
+
+  const payload = response?.json ?? response?.data
+  if (!payload) {
+    return []
+  }
+
+  if (Array.isArray(payload)) {
+    return payload
+  }
+
+  return Array.isArray(payload.songs) ? payload.songs : []
+}


### PR DESCRIPTION
## Summary
- add a basic MetaData page with a padded layout and descriptive text
- register the new page in the client routes
- expose the MetaData page from the sidebar right below the Discovery section

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b1692e06083229024819c34fb1f82)