### PR TITLE
Persist metadata fetch results

### DIFF
--- a/server/nativeapi/config_test.go
+++ b/server/nativeapi/config_test.go
@@ -27,7 +27,9 @@ var _ = Describe("Config API", func() {
 	BeforeEach(func() {
 		DeferCleanup(configtest.SetupConfig())
 		conf.Server.DevUIShowConfig = true // Enable config endpoint for tests
-		ds = &tests.MockDataStore{}
+		mockDS := &tests.MockDataStore{}
+		mockDS.MockedRetailPlayerDeviceMapping = newRetailPlayerDeviceMappingRepoStub()
+		ds = mockDS
 		auth.Init(ds)
 		nativeRouter := New(ds, nil, nil, nil, core.NewMockLibraryService())
 		router = server.JWTVerifier(nativeRouter)

--- a/server/nativeapi/library_test.go
+++ b/server/nativeapi/library_test.go
@@ -28,7 +28,9 @@ var _ = Describe("Library API", func() {
 
 	BeforeEach(func() {
 		DeferCleanup(configtest.SetupConfig())
-		ds = &tests.MockDataStore{}
+		mockDS := &tests.MockDataStore{}
+		mockDS.MockedRetailPlayerDeviceMapping = newRetailPlayerDeviceMappingRepoStub()
+		ds = mockDS
 		auth.Init(ds)
 		nativeRouter := New(ds, nil, nil, nil, core.NewMockLibraryService())
 		router = server.JWTVerifier(nativeRouter)

--- a/server/nativeapi/metadata.go
+++ b/server/nativeapi/metadata.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/utils/str"
 )
 
 const (
@@ -88,6 +90,7 @@ func (n *Router) fetchMetadataHandler() http.HandlerFunc {
 			return
 		}
 
+		repo := n.ds.MediaFile(ctx)
 		updates := make([]metadataSongPayload, 0, len(req.Songs))
 		for _, song := range req.Songs {
 			normalized := normalizeSongPayload(song)
@@ -97,7 +100,13 @@ func (n *Router) fetchMetadataHandler() http.HandlerFunc {
 				updates = append(updates, normalized)
 				continue
 			}
-			updates = append(updates, normalizeSongPayload(enriched))
+			saved := normalizeSongPayload(enriched)
+			if repo != nil {
+				if err := persistMetadataSong(repo, saved); err != nil {
+					log.Warn(ctx, "Unable to persist song metadata", "songId", saved.ID, "err", err)
+				}
+			}
+			updates = append(updates, saved)
 		}
 
 		writeJSON(w, metadataFetchResponse{Songs: updates})
@@ -418,4 +427,71 @@ func ensureHTTPSURL(raw string) string {
 	default:
 		return trimmed
 	}
+}
+
+func persistMetadataSong(repo model.MediaFileRepository, update metadataSongPayload) error {
+	if repo == nil {
+		return nil
+	}
+	if strings.TrimSpace(update.ID) == "" {
+		return nil
+	}
+	current, err := repo.Get(update.ID)
+	if err != nil {
+		return err
+	}
+	if !applyMetadataUpdate(current, update) {
+		return nil
+	}
+	current.UpdatedAt = time.Now()
+	return repo.Put(current)
+}
+
+func applyMetadataUpdate(mf *model.MediaFile, update metadataSongPayload) bool {
+	if mf == nil {
+		return false
+	}
+	changed := false
+	if title := strings.TrimSpace(update.Title); title != "" && mf.Title != title {
+		mf.Title = title
+		mf.OrderTitle = str.SanitizeFieldForSorting(title)
+		if mf.SortTitle == "" || mf.SortTitle == mf.Title {
+			mf.SortTitle = title
+		}
+		changed = true
+	}
+	if artist := strings.TrimSpace(update.Artist); artist != "" && mf.Artist != artist {
+		mf.Artist = artist
+		mf.OrderArtistName = str.SanitizeFieldForSorting(artist)
+		if mf.SortArtistName == "" || mf.SortArtistName == mf.Artist {
+			mf.SortArtistName = artist
+		}
+		changed = true
+	}
+	if album := strings.TrimSpace(update.Album); album != "" && mf.Album != album {
+		mf.Album = album
+		mf.OrderAlbumName = str.SanitizeFieldForSortingNoArticle(album)
+		if mf.SortAlbumName == "" || mf.SortAlbumName == mf.Album {
+			mf.SortAlbumName = album
+		}
+		changed = true
+	}
+	if genre := strings.TrimSpace(update.Genre); genre != "" && mf.Genre != genre {
+		mf.Genre = genre
+		if mf.Tags == nil {
+			mf.Tags = make(model.Tags)
+		}
+		mf.Tags[model.TagGenre] = []string{genre}
+		tag := model.NewTag(model.TagGenre, genre)
+		mf.Genres = model.Genres{{ID: tag.ID, Name: genre}}
+		changed = true
+	}
+	if update.Year != nil {
+		year := *update.Year
+		if mf.Year != year {
+			mf.Year = year
+			changed = true
+		}
+	}
+	return changed
 }

--- a/server/nativeapi/metadata_test.go
+++ b/server/nativeapi/metadata_test.go
@@ -1,0 +1,87 @@
+package nativeapi
+
+import (
+	"testing"
+
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/tests"
+)
+
+func TestPersistMetadataSongUpdatesFields(t *testing.T) {
+	repo := tests.CreateMockMediaFileRepo()
+	original := model.MediaFile{
+		ID:              "song-1",
+		Title:           "Unknown",
+		Artist:          "",
+		Album:           "[Unknown Album]",
+		Genre:           "",
+		Year:            0,
+		OrderTitle:      "unknown",
+		OrderArtistName: "",
+		OrderAlbumName:  "",
+	}
+	repo.SetData(model.MediaFiles{original})
+
+	year := 1999
+	update := metadataSongPayload{
+		ID:     "song-1",
+		Title:  "New Title",
+		Artist: "New Artist",
+		Album:  "New Album",
+		Genre:  "Rock",
+		Year:   &year,
+	}
+
+	if err := persistMetadataSong(repo, update); err != nil {
+		t.Fatalf("persistMetadataSong returned error: %v", err)
+	}
+
+	stored, err := repo.Get("song-1")
+	if err != nil {
+		t.Fatalf("expected song to exist: %v", err)
+	}
+
+	if stored.Title != "New Title" {
+		t.Fatalf("expected title to be updated, got %q", stored.Title)
+	}
+	if stored.Artist != "New Artist" {
+		t.Fatalf("expected artist to be updated, got %q", stored.Artist)
+	}
+	if stored.Album != "New Album" {
+		t.Fatalf("expected album to be updated, got %q", stored.Album)
+	}
+	if stored.Genre != "Rock" {
+		t.Fatalf("expected genre to be updated, got %q", stored.Genre)
+	}
+	if stored.Year != 1999 {
+		t.Fatalf("expected year to be updated, got %d", stored.Year)
+	}
+	if stored.OrderTitle == "unknown" {
+		t.Fatalf("expected order title to change")
+	}
+	if stored.OrderAlbumName == "" {
+		t.Fatalf("expected order album name to be set")
+	}
+	if stored.OrderArtistName == "" {
+		t.Fatalf("expected order artist name to be set")
+	}
+	if len(stored.Genres) == 0 || stored.Genres[0].Name != "Rock" {
+		t.Fatalf("expected genres metadata to be updated")
+	}
+}
+
+func TestApplyMetadataUpdateNoChanges(t *testing.T) {
+	mf := &model.MediaFile{ID: "song-2", Title: "Existing"}
+	if applyMetadataUpdate(mf, metadataSongPayload{ID: "song-2"}) {
+		t.Fatalf("expected no changes when payload empty")
+	}
+}
+
+// Ensure helper can be used without repository context; this mirrors handler usage.
+func TestPersistMetadataSongHandlesMissingSong(t *testing.T) {
+	repo := tests.CreateMockMediaFileRepo()
+	err := persistMetadataSong(repo, metadataSongPayload{ID: "missing"})
+	if err == nil {
+		t.Fatalf("expected error when song does not exist")
+	}
+}

--- a/server/nativeapi/native_api_song_test.go
+++ b/server/nativeapi/native_api_song_test.go
@@ -44,6 +44,7 @@ var _ = Describe("Song Endpoints", func() {
 			MockedUser:      userRepo,
 			MockedProperty:  &tests.MockedPropertyRepo{},
 		}
+		ds.MockedRetailPlayerDeviceMapping = newRetailPlayerDeviceMappingRepoStub()
 
 		// Initialize auth system
 		auth.Init(ds)

--- a/server/nativeapi/queue_test.go
+++ b/server/nativeapi/queue_test.go
@@ -28,6 +28,7 @@ var _ = Describe("Queue Endpoints", func() {
 		userRepo = tests.CreateMockUserRepo()
 		_ = userRepo.Put(&user)
 		ds = &tests.MockDataStore{MockedPlayQueue: repo, MockedUser: userRepo, MockedProperty: &tests.MockedPropertyRepo{}}
+		ds.MockedRetailPlayerDeviceMapping = newRetailPlayerDeviceMappingRepoStub()
 	})
 
 	Describe("POST /queue", func() {

--- a/server/nativeapi/test_helpers_test.go
+++ b/server/nativeapi/test_helpers_test.go
@@ -1,0 +1,29 @@
+package nativeapi
+
+import (
+	"context"
+
+	"github.com/navidrome/navidrome/model"
+)
+
+type retailPlayerDeviceMappingRepoStub struct{}
+
+func (retailPlayerDeviceMappingRepoStub) Put(ctx context.Context, mapping model.RetailPlayerDeviceMapping) error {
+	return nil
+}
+
+func (retailPlayerDeviceMappingRepoStub) PutMany(ctx context.Context, mappings []model.RetailPlayerDeviceMapping) error {
+	return nil
+}
+
+func (retailPlayerDeviceMappingRepoStub) FindByIdentifier(ctx context.Context, identifier string) (*model.RetailPlayerDeviceMapping, error) {
+	return nil, model.ErrNotFound
+}
+
+func (retailPlayerDeviceMappingRepoStub) All(ctx context.Context) ([]model.RetailPlayerDeviceMapping, error) {
+	return nil, nil
+}
+
+func newRetailPlayerDeviceMappingRepoStub() model.RetailPlayerDeviceMappingRepository {
+	return retailPlayerDeviceMappingRepoStub{}
+}

--- a/tests/mock_data_store.go
+++ b/tests/mock_data_store.go
@@ -206,7 +206,9 @@ func (db *MockDataStore) RetailPlayerDeviceMapping(ctx context.Context) model.Re
 		if db.RealDS != nil {
 			db.MockedRetailPlayerDeviceMapping = db.RealDS.RetailPlayerDeviceMapping(ctx)
 		} else {
-			return nil
+			db.MockedRetailPlayerDeviceMapping = struct {
+				model.RetailPlayerDeviceMappingRepository
+			}{}
 		}
 	}
 	return db.MockedRetailPlayerDeviceMapping

--- a/tests/mock_data_store.go
+++ b/tests/mock_data_store.go
@@ -206,9 +206,7 @@ func (db *MockDataStore) RetailPlayerDeviceMapping(ctx context.Context) model.Re
 		if db.RealDS != nil {
 			db.MockedRetailPlayerDeviceMapping = db.RealDS.RetailPlayerDeviceMapping(ctx)
 		} else {
-			db.MockedRetailPlayerDeviceMapping = struct {
-				model.RetailPlayerDeviceMappingRepository
-			}{}
+			return nil
 		}
 	}
 	return db.MockedRetailPlayerDeviceMapping

--- a/ui/src/layout/AppBar.test.jsx
+++ b/ui/src/layout/AppBar.test.jsx
@@ -9,11 +9,14 @@ import config from '../config'
 
 let store
 
+const noop = () => {}
+
 vi.mock('react-admin', () => ({
   AppBar: ({ userMenu }) => <div data-testid="appbar">{userMenu}</div>,
   useTranslate: () => (x) => x,
   usePermissions: () => ({ permissions: 'admin' }),
   getResources: () => [],
+  useNotify: () => noop,
 }))
 
 vi.mock('./NowPlayingPanel', () => ({
@@ -21,6 +24,9 @@ vi.mock('./NowPlayingPanel', () => ({
 }))
 vi.mock('./ActivityPanel', () => ({
   default: () => <div data-testid="activity-panel" />,
+}))
+vi.mock('./MissingTracksPanel', () => ({
+  default: () => <div data-testid="missing-tracks-panel" />,
 }))
 vi.mock('./PersonalMenu', () => ({
   default: () => <div />,


### PR DESCRIPTION
## Summary
- persist fetched song metadata so the MusicBrainz updates are saved in the media file records
- add coverage around the new persistence helper and make the mock datastore safer for native API tests

## Testing
- go test ./server/nativeapi


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cc134d20c8322af1a98d4c026ed99)