### PR TITLE
Add Cover Art Archive metadata enrichment

### DIFF
--- a/server/nativeapi/metadata.go
+++ b/server/nativeapi/metadata.go
@@ -158,13 +158,11 @@ func (f *metadataFetcher) Enrich(ctx context.Context, song metadataSongPayload) 
 			updated.Year = year
 		}
 	}
-	if strings.TrimSpace(updated.CoverArt) == "" {
-		if releaseID := recording.PrimaryReleaseID(); releaseID != "" {
-			if artURL, artErr := f.fetchCoverArt(ctx, releaseID); artErr == nil && artURL != "" {
-				updated.ArtworkURL = artURL
-			} else if artErr != nil {
-				log.Warn(ctx, "Unable to fetch cover art", "songId", song.ID, "err", artErr)
-			}
+	if strings.TrimSpace(updated.ArtworkURL) == "" {
+		if artURL, artErr := f.fetchCoverArtForRecording(ctx, recording); artErr == nil && artURL != "" {
+			updated.ArtworkURL = artURL
+		} else if artErr != nil {
+			log.Warn(ctx, "Unable to fetch cover art", "songId", song.ID, "err", artErr)
 		}
 	}
 
@@ -212,6 +210,32 @@ func (f *metadataFetcher) lookupRecording(ctx context.Context, title, artist str
 	}
 
 	return &result.Recordings[0], nil
+}
+
+func (f *metadataFetcher) fetchCoverArtForRecording(ctx context.Context, recording *musicBrainzRecording) (string, error) {
+	if recording == nil {
+		return "", nil
+	}
+
+	var firstErr error
+	for _, release := range recording.Releases {
+		releaseID := strings.TrimSpace(release.ID)
+		if releaseID == "" {
+			continue
+		}
+		artURL, err := f.fetchCoverArt(ctx, releaseID)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("release %s: %w", releaseID, err)
+			}
+			continue
+		}
+		if artURL != "" {
+			return artURL, nil
+		}
+	}
+
+	return "", firstErr
 }
 
 func (f *metadataFetcher) fetchCoverArt(ctx context.Context, releaseID string) (string, error) {

--- a/server/nativeapi/metadata.go
+++ b/server/nativeapi/metadata.go
@@ -245,15 +245,44 @@ func (f *metadataFetcher) fetchCoverArt(ctx context.Context, releaseID string) (
 		log.Warn(ctx, "Unable to decode cover art response", "err", err)
 		return "", nil
 	}
-	for _, image := range payload.Images {
-		if image.Front && image.Image != "" {
-			return ensureHTTPSURL(image.Image), nil
-		}
+	if len(payload.Images) == 0 {
+		return "", nil
 	}
-	if len(payload.Images) > 0 {
-		return ensureHTTPSURL(payload.Images[0].Image), nil
+	selected := selectBestCoverArtImage(payload.Images)
+	if selected == nil {
+		return "", nil
+	}
+	if url := ensureHTTPSURL(selected.bestURL()); url != "" {
+		return url, nil
 	}
 	return "", nil
+}
+
+func selectBestCoverArtImage(images []coverArtImage) *coverArtImage {
+	if len(images) == 0 {
+		return nil
+	}
+	var fallback *coverArtImage
+	for i := range images {
+		img := &images[i]
+		if fallback == nil {
+			fallback = img
+		}
+		if img.Front {
+			return img
+		}
+	}
+	return fallback
+}
+
+func (img coverArtImage) bestURL() string {
+	if strings.TrimSpace(img.Image) != "" {
+		return img.Image
+	}
+	if strings.TrimSpace(img.Thumbnails.Size500) != "" {
+		return img.Thumbnails.Size500
+	}
+	return ""
 }
 
 func (f *metadataFetcher) applyRateLimit() {
@@ -298,8 +327,13 @@ type coverArtResponse struct {
 }
 
 type coverArtImage struct {
-	Image string `json:"image"`
-	Front bool   `json:"front"`
+	Image      string             `json:"image"`
+	Front      bool               `json:"front"`
+	Thumbnails coverArtThumbnails `json:"thumbnails"`
+}
+
+type coverArtThumbnails struct {
+	Size500 string `json:"500"`
 }
 
 func (m musicBrainzRecording) PrimaryArtist() string {

--- a/ui/src/pages/MetadataPage.jsx
+++ b/ui/src/pages/MetadataPage.jsx
@@ -62,6 +62,14 @@ const mergeUpdatedMetadata = (oldSongs = [], updatedSongs = []) => {
       }
     })
 
+    if (nextSong.artworkUrl) {
+      const artworkUrl = nextSong.artworkUrl
+      if (nextSong.coverArt !== artworkUrl) {
+        nextSong.coverArt = artworkUrl
+        changed = true
+      }
+    }
+
     if (changed) {
       didUpdate = true
       return nextSong


### PR DESCRIPTION
## Summary
- fetch release artwork from Cover Art Archive after the MusicBrainz lookup, selecting the best available image and forcing HTTPS URLs
- expose the new `artworkUrl` in the metadata payload so the frontend can display it without reloading
- update the metadata page merge logic to sync `coverArt` with any fetched `artworkUrl`, refreshing the UI immediately

## Testing
- ⚠️ `go test ./server/nativeapi` *(hangs in this environment, so the run was aborted)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cc40d98a88322ad254f36cfeb42a0)