### PR TITLE
Store CoverArtArchive artwork in media store

### DIFF
--- a/core/artwork/artwork.go
+++ b/core/artwork/artwork.go
@@ -27,7 +27,7 @@ type Artwork interface {
 }
 
 func NewArtwork(ds model.DataStore, cache cache.FileCache, ffmpeg ffmpeg.FFmpeg, provider external.Provider) Artwork {
-	return &artwork{ds: ds, cache: cache, ffmpeg: ffmpeg, provider: provider}
+	return &artwork{ds: ds, cache: cache, ffmpeg: ffmpeg, provider: provider, store: NewMediaStore()}
 }
 
 type artwork struct {
@@ -35,6 +35,7 @@ type artwork struct {
 	cache    cache.FileCache
 	ffmpeg   ffmpeg.FFmpeg
 	provider external.Provider
+	store    MediaStore
 }
 
 type artworkReader interface {

--- a/core/artwork/media_store.go
+++ b/core/artwork/media_store.go
@@ -1,0 +1,129 @@
+package artwork
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+)
+
+var invalidMediaID = regexp.MustCompile(`[^A-Za-z0-9_-]`)
+
+// MediaStore provides persistent storage for media-specific artwork files.
+type MediaStore interface {
+	SaveMediaArtwork(ctx context.Context, mediaID string, data []byte) (model.ArtworkID, error)
+	HasMediaArtwork(mediaID string) bool
+	OpenMediaArtwork(mediaID string) (io.ReadCloser, string, error)
+}
+
+type mediaStore struct {
+	basePath string
+	once     sync.Once
+}
+
+// NewMediaStore builds a MediaStore rooted inside Navidrome's data folder.
+func NewMediaStore() MediaStore {
+	return &mediaStore{basePath: filepath.Join(conf.Server.DataFolder, "artwork")}
+}
+
+func (s *mediaStore) ensureBasePath() {
+	s.once.Do(func() {
+		if err := os.MkdirAll(s.basePath, 0o755); err != nil {
+			log.Error("Unable to create artwork store", "path", s.basePath, "err", err)
+		}
+	})
+}
+
+func (s *mediaStore) SaveMediaArtwork(ctx context.Context, mediaID string, data []byte) (model.ArtworkID, error) {
+	if err := ctx.Err(); err != nil {
+		return model.ArtworkID{}, err
+	}
+	mediaID = strings.TrimSpace(mediaID)
+	if mediaID == "" {
+		return model.ArtworkID{}, errors.New("media id is required")
+	}
+	if len(data) == 0 {
+		return model.ArtworkID{}, errors.New("artwork data is empty")
+	}
+	s.ensureBasePath()
+	path := s.pathFor(mediaID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return model.ArtworkID{}, fmt.Errorf("creating artwork folder: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), "nd-art-*")
+	if err != nil {
+		return model.ArtworkID{}, fmt.Errorf("creating temp artwork file: %w", err)
+	}
+	defer func() {
+		_ = os.Remove(tmp.Name())
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return model.ArtworkID{}, fmt.Errorf("writing artwork data: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return model.ArtworkID{}, fmt.Errorf("closing artwork file: %w", err)
+	}
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		return model.ArtworkID{}, fmt.Errorf("saving artwork: %w", err)
+	}
+	now := time.Now()
+	_ = os.Chtimes(path, now, now)
+	artID := model.NewArtworkID(model.KindMediaFileArtwork, mediaID, &now)
+	return artID, nil
+}
+
+func (s *mediaStore) HasMediaArtwork(mediaID string) bool {
+	s.ensureBasePath()
+	path := s.pathFor(mediaID)
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func (s *mediaStore) OpenMediaArtwork(mediaID string) (io.ReadCloser, string, error) {
+	s.ensureBasePath()
+	path := s.pathFor(mediaID)
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, "", ErrUnavailable
+		}
+		return nil, "", err
+	}
+	return f, path, nil
+}
+
+func (s *mediaStore) pathFor(mediaID string) string {
+	sanitized := invalidMediaID.ReplaceAllString(mediaID, "")
+	if sanitized == "" {
+		sanitized = fmt.Sprintf("%x", time.Now().UnixNano())
+	}
+	sanitized = strings.ToLower(sanitized)
+	switch {
+	case len(sanitized) <= 2:
+		return filepath.Join(s.basePath, sanitized)
+	case len(sanitized) <= 4:
+		return filepath.Join(s.basePath, sanitized[:2], sanitized)
+	default:
+		return filepath.Join(s.basePath, sanitized[:2], sanitized[2:4], sanitized)
+	}
+}
+
+func fromMediaStore(_ context.Context, store MediaStore, mediaID string) sourceFunc {
+	return func() (io.ReadCloser, string, error) {
+		if store == nil {
+			return nil, "", ErrUnavailable
+		}
+		return store.OpenMediaArtwork(mediaID)
+	}
+}

--- a/core/artwork/media_store_test.go
+++ b/core/artwork/media_store_test.go
@@ -1,0 +1,40 @@
+package artwork
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/model"
+)
+
+func TestMediaStoreSaveAndRead(t *testing.T) {
+	conf.Server.DataFolder = t.TempDir()
+	store := NewMediaStore()
+	ctx := context.Background()
+
+	artID, err := store.SaveMediaArtwork(ctx, "track-1", []byte("art"))
+	if err != nil {
+		t.Fatalf("SaveMediaArtwork returned error: %v", err)
+	}
+	if artID.Kind != model.KindMediaFileArtwork {
+		t.Fatalf("unexpected kind: %s", artID.Kind)
+	}
+	if !store.HasMediaArtwork("track-1") {
+		t.Fatalf("expected artwork to exist")
+	}
+
+	reader, _, err := store.OpenMediaArtwork("track-1")
+	if err != nil {
+		t.Fatalf("OpenMediaArtwork returned error: %v", err)
+	}
+	defer reader.Close()
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll returned error: %v", err)
+	}
+	if string(data) != "art" {
+		t.Fatalf("unexpected data: %s", data)
+	}
+}

--- a/core/artwork/reader_mediafile.go
+++ b/core/artwork/reader_mediafile.go
@@ -53,6 +53,9 @@ func (a *mediafileArtworkReader) LastUpdated() time.Time {
 
 func (a *mediafileArtworkReader) Reader(ctx context.Context) (io.ReadCloser, string, error) {
 	var ff []sourceFunc
+	if a.a.store != nil && a.a.store.HasMediaArtwork(a.mediafile.ID) {
+		ff = append(ff, fromMediaStore(ctx, a.a.store, a.mediafile.ID))
+	}
 	if a.mediafile.CoverArtID().Kind == model.KindMediaFileArtwork {
 		path := a.mediafile.AbsolutePath()
 		ff = []sourceFunc{

--- a/server/nativeapi/metadata.go
+++ b/server/nativeapi/metadata.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/core/artwork"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/utils/str"
@@ -21,6 +23,7 @@ const (
 	musicBrainzRecordingURL = "https://musicbrainz.org/ws/2/recording/"
 	coverArtArchiveURL      = "https://coverartarchive.org/release/"
 	metadataUserAgent       = "NavidromeMetadataFetcher/1.0 (+https://www.navidrome.org)"
+	maxCoverArtBytes        = 10 * 1024 * 1024
 )
 
 type metadataFetchRequest struct {
@@ -123,6 +126,7 @@ func writeJSON(w http.ResponseWriter, payload interface{}) {
 type metadataFetcher struct {
 	client        *http.Client
 	coverClient   *http.Client
+	store         artwork.MediaStore
 	mu            sync.Mutex
 	nextAvailable time.Time
 }
@@ -134,6 +138,7 @@ func newMetadataFetcher() *metadataFetcher {
 	return &metadataFetcher{
 		client:      &http.Client{Timeout: timeout},
 		coverClient: &http.Client{Timeout: timeout},
+		store:       artwork.NewMediaStore(),
 	}
 }
 
@@ -167,12 +172,17 @@ func (f *metadataFetcher) Enrich(ctx context.Context, song metadataSongPayload) 
 			updated.Year = year
 		}
 	}
-	if strings.TrimSpace(updated.CoverArt) == "" {
+	if strings.TrimSpace(updated.CoverArt) == "" && strings.TrimSpace(song.ID) != "" {
 		if releaseID := recording.PrimaryReleaseID(); releaseID != "" {
-			if artURL, artErr := f.fetchCoverArt(ctx, releaseID); artErr == nil && artURL != "" {
-				updated.ArtworkURL = artURL
-			} else if artErr != nil {
+			if art, artErr := f.fetchCoverArt(ctx, releaseID); artErr != nil {
 				log.Warn(ctx, "Unable to fetch cover art", "songId", song.ID, "err", artErr)
+			} else if art != nil && len(art.Data) > 0 {
+				if artID, storeErr := f.store.SaveMediaArtwork(ctx, song.ID, art.Data); storeErr != nil {
+					log.Warn(ctx, "Unable to persist cover art", "songId", song.ID, "err", storeErr)
+				} else {
+					updated.CoverArt = artID.String()
+					updated.ArtworkURL = internalArtworkURL(artID)
+				}
 			}
 		}
 	}
@@ -223,46 +233,131 @@ func (f *metadataFetcher) lookupRecording(ctx context.Context, title, artist str
 	return &result.Recordings[0], nil
 }
 
-func (f *metadataFetcher) fetchCoverArt(ctx context.Context, releaseID string) (string, error) {
+func (f *metadataFetcher) fetchCoverArt(ctx context.Context, releaseID string) (*coverArtData, error) {
 	if releaseID == "" {
-		return "", nil
+		return nil, nil
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, coverArtArchiveURL+releaseID, nil)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	req.Header.Set("User-Agent", metadataUserAgent)
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := f.coverClient.Do(req)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return "", nil
+		return nil, nil
 	}
 	if resp.StatusCode != http.StatusOK {
 		log.Warn(ctx, "Cover Art Archive request failed", "status", resp.Status)
-		return "", nil
+		return nil, nil
 	}
 
 	var payload coverArtResponse
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		log.Warn(ctx, "Unable to decode cover art response", "err", err)
-		return "", nil
+		return nil, nil
 	}
-	for _, image := range payload.Images {
-		if image.Front && image.Image != "" {
-			return ensureHTTPSURL(image.Image), nil
+	bestURL := selectBestCoverArtURL(payload.Images)
+	if bestURL == "" {
+		return nil, nil
+	}
+	data, err := f.downloadCoverArt(ctx, bestURL)
+	if err != nil {
+		return nil, err
+	}
+	return &coverArtData{URL: bestURL, Data: data}, nil
+}
+
+func (f *metadataFetcher) downloadCoverArt(ctx context.Context, artURL string) ([]byte, error) {
+	if artURL == "" {
+		return nil, nil
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, artURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", metadataUserAgent)
+	resp, err := f.coverClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("cover art download failed: %s", resp.Status)
+	}
+	reader := io.LimitReader(resp.Body, maxCoverArtBytes+1)
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxCoverArtBytes {
+		return nil, fmt.Errorf("cover art exceeds %d bytes", maxCoverArtBytes)
+	}
+	return data, nil
+}
+
+func selectBestCoverArtURL(images []coverArtImage) string {
+	var fallback string
+	for _, image := range images {
+		candidate := bestCoverArtCandidate(image)
+		if candidate == "" {
+			continue
+		}
+		if image.Front {
+			return candidate
+		}
+		if fallback == "" {
+			fallback = candidate
 		}
 	}
-	if len(payload.Images) > 0 {
-		return ensureHTTPSURL(payload.Images[0].Image), nil
+	return fallback
+}
+
+func bestCoverArtCandidate(image coverArtImage) string {
+	switch {
+	case strings.TrimSpace(image.Image) != "":
+		return ensureHTTPSURL(image.Image)
+	case len(image.Thumbnails) == 0:
+		return ""
 	}
-	return "", nil
+	if url := image.Thumbnails["1200"]; strings.TrimSpace(url) != "" {
+		return ensureHTTPSURL(url)
+	}
+	bestURL := ""
+	bestSize := 0
+	for size, candidate := range image.Thumbnails {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if parsed, err := strconv.Atoi(size); err == nil {
+			if parsed > bestSize {
+				bestSize = parsed
+				bestURL = candidate
+			}
+		} else if bestURL == "" {
+			bestURL = candidate
+		}
+	}
+	return ensureHTTPSURL(bestURL)
+}
+
+func internalArtworkURL(artID model.ArtworkID) string {
+	id := strings.TrimSpace(artID.String())
+	if id == "" {
+		return ""
+	}
+	values := url.Values{}
+	values.Set("id", id)
+	values.Set("size", "600")
+	return "/rest/getCoverArt?" + values.Encode()
 }
 
 func (f *metadataFetcher) applyRateLimit() {
@@ -306,9 +401,15 @@ type coverArtResponse struct {
 	Images []coverArtImage `json:"images"`
 }
 
+type coverArtData struct {
+	URL  string
+	Data []byte
+}
+
 type coverArtImage struct {
-	Image string `json:"image"`
-	Front bool   `json:"front"`
+	Image      string            `json:"image"`
+	Front      bool              `json:"front"`
+	Thumbnails map[string]string `json:"thumbnails"`
 }
 
 func (m musicBrainzRecording) PrimaryArtist() string {
@@ -490,6 +591,12 @@ func applyMetadataUpdate(mf *model.MediaFile, update metadataSongPayload) bool {
 		year := *update.Year
 		if mf.Year != year {
 			mf.Year = year
+			changed = true
+		}
+	}
+	if coverArt := strings.TrimSpace(update.CoverArt); coverArt != "" {
+		if mf.CoverArtID().String() != coverArt || !mf.HasCoverArt {
+			mf.HasCoverArt = true
 			changed = true
 		}
 	}

--- a/server/nativeapi/metadata_test.go
+++ b/server/nativeapi/metadata_test.go
@@ -70,6 +70,24 @@ func TestPersistMetadataSongUpdatesFields(t *testing.T) {
 	}
 }
 
+func TestPersistMetadataSongUpdatesCoverArt(t *testing.T) {
+	repo := tests.CreateMockMediaFileRepo()
+	original := model.MediaFile{ID: "song-3", AlbumID: "album-9"}
+	repo.SetData(model.MediaFiles{original})
+	coverID := model.NewArtworkID(model.KindMediaFileArtwork, "song-3", nil)
+	update := metadataSongPayload{ID: "song-3", CoverArt: coverID.String()}
+	if err := persistMetadataSong(repo, update); err != nil {
+		t.Fatalf("persistMetadataSong returned error: %v", err)
+	}
+	stored, err := repo.Get("song-3")
+	if err != nil {
+		t.Fatalf("expected song to exist: %v", err)
+	}
+	if !stored.HasCoverArt {
+		t.Fatalf("expected cover art flag to be set")
+	}
+}
+
 func TestApplyMetadataUpdateNoChanges(t *testing.T) {
 	mf := &model.MediaFile{ID: "song-2", Title: "Existing"}
 	if applyMetadataUpdate(mf, metadataSongPayload{ID: "song-2"}) {

--- a/ui/src/pages/MetadataPage.jsx
+++ b/ui/src/pages/MetadataPage.jsx
@@ -288,28 +288,32 @@ const MetadataPage = () => {
     setFetchSuccess(false)
   }, [])
 
-  const renderArtwork = (record) => {
-    if (!record) {
-      return null
-    }
+const renderArtwork = (record) => {
+if (!record) {
+return null
+}
 
-    const artworkUrl = record.artworkUrl
-      || (record.coverArt
-        ? baseUrl(subsonic.url('getCoverArt', record.coverArt || record.id, { size: 120 }))
-        : '')
+let artworkUrl = ''
+if (record.coverArt) {
+artworkUrl = baseUrl(subsonic.url('getCoverArt', record.coverArt, { size: 120 }))
+} else if (record.artworkUrl) {
+artworkUrl = record.artworkUrl
+} else if (record.id) {
+artworkUrl = baseUrl(subsonic.url('getCoverArt', record.id, { size: 120 }))
+}
 
     if (!artworkUrl) {
       return <div className={classes.artworkPlaceholder} />
     }
 
-    return (
-      <img
-        src={artworkUrl}
-        alt={`${record.title || 'Song'} artwork`}
-        className={classes.artwork}
-      />
-    )
-  }
+return (
+<img
+src={artworkUrl}
+alt={`${record.title || 'Song'} artwork`}
+className={classes.artwork}
+/>
+)
+}
 
   return (
     <Container maxWidth="lg" className={classes.pageWrapper}>


### PR DESCRIPTION
## Summary
- add a media artwork store so downloaded cover art can be saved under the media file ID and served by the artwork subsystem
- extend the metadata enrichment pipeline to download CoverArtArchive images, persist them via the new store, update media files, and surface the internal coverArt ID to the UI
- update the metadata UI to prefer coverArt IDs when rendering artwork thumbnails

## Testing
- go test -run TestMediaStoreSaveAndRead -count=1 -v ./core/artwork
- go test ./server/nativeapi -run TestPersistMetadataSong -count=1


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cd1cff7448322b43c11d41692a4ea)