### PR TITLE
Update mask icon color to pink

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5b5fd5">
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#ec4899">
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="theme-color" content="#ffffff">
 


### PR DESCRIPTION
## Summary
- adjust the safari pinned tab mask icon color to use the pink brand tone

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e3696a2108322a6891d058d2a61ea)