### PR TITLE
Color online retail player devices in green

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -758,7 +758,6 @@ const RetailPlayerDeviceManagement = () => {
   const [addToFolderDialogOpen, setAddToFolderDialogOpen] = useState(false)
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [deviceStatusMap, setDeviceStatusMap] = useState(() => new Map())
-  const [statusLoading, setStatusLoading] = useState(false)
   const assignDeviceToFolder = useAssignRetailPlayerDeviceToFolder()
   const { countsByDeviceId: channelCountsByDeviceId } =
     useRetailPlayerChannelCounts(devices, isApiEnabled)
@@ -785,15 +784,33 @@ const RetailPlayerDeviceManagement = () => {
   }, [devices])
 
   useEffect(() => {
-    if (!isApiEnabled) {
+    if (!devices?.length) {
       setDeviceStatusMap(new Map())
-      setStatusLoading(false)
       return undefined
     }
 
-    if (!devices?.length) {
-      setDeviceStatusMap(new Map())
-      setStatusLoading(false)
+    try {
+      const rawCache = sessionStorage.getItem('retailPlayerDeviceStatusMap')
+      if (rawCache) {
+        const parsedCache = JSON.parse(rawCache)
+        if (parsedCache && typeof parsedCache === 'object') {
+          const hydrated = new Map()
+          devices.forEach((device) => {
+            const cachedValue = parsedCache[device.id]
+            if (typeof cachedValue === 'boolean') {
+              hydrated.set(device.id, cachedValue)
+            }
+          })
+          if (hydrated.size) {
+            setDeviceStatusMap(hydrated)
+          }
+        }
+      }
+    } catch (err) {
+      console.warn('Unable to hydrate retail player device statuses', err)
+    }
+
+    if (!isApiEnabled) {
       return undefined
     }
 
@@ -801,7 +818,6 @@ const RetailPlayerDeviceManagement = () => {
     let isCancelled = false
 
     const fetchStatuses = async () => {
-      setStatusLoading(true)
       const results = await Promise.all(
         devices.map(async (device) => {
           const deviceId = device.apiId || device.id
@@ -837,7 +853,21 @@ const RetailPlayerDeviceManagement = () => {
 
       const nextStatusMap = new Map(results.filter(Boolean))
       setDeviceStatusMap(nextStatusMap)
-      setStatusLoading(false)
+
+      try {
+        const cachePayload = {}
+        nextStatusMap.forEach((value, key) => {
+          if (typeof value === 'boolean') {
+            cachePayload[key] = value
+          }
+        })
+        sessionStorage.setItem(
+          'retailPlayerDeviceStatusMap',
+          JSON.stringify(cachePayload),
+        )
+      } catch (err) {
+        console.warn('Unable to cache retail player device statuses', err)
+      }
     }
 
     fetchStatuses()
@@ -845,7 +875,6 @@ const RetailPlayerDeviceManagement = () => {
     return () => {
       isCancelled = true
       abortController.abort()
-      setStatusLoading(false)
     }
   }, [devices, isApiEnabled])
 
@@ -1363,7 +1392,7 @@ const RetailPlayerDeviceManagement = () => {
     }, 0)
   }, [])
 
-  const isLoading = loading || statusLoading
+  const isLoading = loading
 
   const renderRows = (nodes) =>
     nodes.map((node) => {

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -646,43 +646,13 @@ const RetailPlayerDeviceRow = memo(
     onToggleSelection,
     onKeyDown,
     onEdit,
-    isApiEnabled,
+    isOnline,
   }) => {
     const { dragRef, isDragging } = useRetailPlayerDeviceDrag({
       deviceId: node.id,
       deviceName: node.name,
       origin: 'management-list',
     })
-
-    const [isOnline, setIsOnline] = useState(null)
-
-    useEffect(() => {
-      const deviceId = node.apiId || node.id
-      if (!isApiEnabled || !deviceId) {
-        setIsOnline(null)
-        return undefined
-      }
-
-      const abortController = new AbortController()
-      const statusUrl = `/api/retailplayer/devices/${encodeURIComponent(
-        deviceId,
-      )}/status`
-
-      httpClient(statusUrl, { signal: abortController.signal })
-        .then(({ json }) => {
-          const uptime = json?.status?.upTime ?? json?.status?.uptime
-          const hasStatus =
-            uptime !== undefined && uptime !== null && String(uptime).trim() !== ''
-          setIsOnline(hasStatus)
-        })
-        .catch((error) => {
-          if (error?.name !== 'AbortError') {
-            setIsOnline(false)
-          }
-        })
-
-      return () => abortController.abort()
-    }, [isApiEnabled, node.apiId, node.id])
 
     return (
       <div
@@ -757,11 +727,12 @@ RetailPlayerDeviceRow.propTypes = {
   onToggleSelection: PropTypes.func.isRequired,
   onKeyDown: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
-  isApiEnabled: PropTypes.bool.isRequired,
+  isOnline: PropTypes.bool,
 }
 
 RetailPlayerDeviceRow.defaultProps = {
   channelCount: null,
+  isOnline: null,
 }
 
 RetailPlayerDeviceRow.displayName = 'RetailPlayerDeviceRow'
@@ -786,6 +757,8 @@ const RetailPlayerDeviceManagement = () => {
   const [searchTerm, setSearchTerm] = useState('')
   const [addToFolderDialogOpen, setAddToFolderDialogOpen] = useState(false)
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [deviceStatusMap, setDeviceStatusMap] = useState(() => new Map())
+  const [statusLoading, setStatusLoading] = useState(false)
   const assignDeviceToFolder = useAssignRetailPlayerDeviceToFolder()
   const { countsByDeviceId: channelCountsByDeviceId } =
     useRetailPlayerChannelCounts(devices, isApiEnabled)
@@ -810,6 +783,71 @@ const RetailPlayerDeviceManagement = () => {
     })
     return map
   }, [devices])
+
+  useEffect(() => {
+    if (!isApiEnabled) {
+      setDeviceStatusMap(new Map())
+      setStatusLoading(false)
+      return undefined
+    }
+
+    if (!devices?.length) {
+      setDeviceStatusMap(new Map())
+      setStatusLoading(false)
+      return undefined
+    }
+
+    const abortController = new AbortController()
+    let isCancelled = false
+
+    const fetchStatuses = async () => {
+      setStatusLoading(true)
+      const results = await Promise.all(
+        devices.map(async (device) => {
+          const deviceId = device.apiId || device.id
+          if (!deviceId) {
+            return [device.id, null]
+          }
+
+          try {
+            const statusUrl = `/api/retailplayer/devices/${encodeURIComponent(
+              deviceId,
+            )}/status`
+            const { json } = await httpClient(statusUrl, {
+              signal: abortController.signal,
+            })
+            const uptime = json?.status?.upTime ?? json?.status?.uptime
+            const hasStatus =
+              uptime !== undefined &&
+              uptime !== null &&
+              String(uptime).trim() !== ''
+            return [device.id, hasStatus]
+          } catch (error) {
+            if (error?.name === 'AbortError') {
+              return null
+            }
+            return [device.id, false]
+          }
+        }),
+      )
+
+      if (isCancelled) {
+        return
+      }
+
+      const nextStatusMap = new Map(results.filter(Boolean))
+      setDeviceStatusMap(nextStatusMap)
+      setStatusLoading(false)
+    }
+
+    fetchStatuses()
+
+    return () => {
+      isCancelled = true
+      abortController.abort()
+      setStatusLoading(false)
+    }
+  }, [devices, isApiEnabled])
 
   const folderChildrenMap = useMemo(() => {
     const map = new Map()
@@ -1325,6 +1363,8 @@ const RetailPlayerDeviceManagement = () => {
     }, 0)
   }, [])
 
+  const isLoading = loading || statusLoading
+
   const renderRows = (nodes) =>
     nodes.map((node) => {
       if (node.type === 'folder') {
@@ -1348,19 +1388,20 @@ const RetailPlayerDeviceManagement = () => {
       const isSelected = selectedIds.has(node.id)
       const rowKey = node.treeKey || node.id
       const channelCount = channelCountsByDeviceId?.[node.id]
+      const isOnline = deviceStatusMap.get(node.id) ?? null
       return (
-          <RetailPlayerDeviceRow
-            key={`device-row-${rowKey}`}
-            node={node}
-            isSelected={isSelected}
-            classes={classes}
-            channelCount={channelCount}
-            onNavigate={handleNavigateToDevice}
-            onToggleSelection={toggleNodeSelection}
-            onKeyDown={handleRowKeyDown}
-            onEdit={handleEditDevice}
-            isApiEnabled={isApiEnabled}
-          />
+        <RetailPlayerDeviceRow
+          key={`device-row-${rowKey}`}
+          node={node}
+          isSelected={isSelected}
+          classes={classes}
+          channelCount={channelCount}
+          onNavigate={handleNavigateToDevice}
+          onToggleSelection={toggleNodeSelection}
+          onKeyDown={handleRowKeyDown}
+          onEdit={handleEditDevice}
+          isOnline={isOnline}
+        />
       )
     })
 
@@ -1493,7 +1534,7 @@ const RetailPlayerDeviceManagement = () => {
           <span>Devices / Channels</span>
           <span className={classes.headerActions}>Edit</span>
         </div>
-        {loading ? (
+        {isLoading ? (
           <div className={classes.loaderState}>
             <CircularProgress size={20} />
             <Typography variant="body2">Loading devices…</Typography>

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -35,6 +35,7 @@ import Link from '@material-ui/core/Link'
 import clsx from 'clsx'
 import PropTypes from 'prop-types'
 import { useHistory } from 'react-router-dom'
+import httpClient from '../dataProvider/httpClient'
 import { useRetailPlayerDeviceStore } from './RetailPlayerDeviceStoreContext'
 import AddToFolderDialog from './AddToFolderDialog'
 import useAssignRetailPlayerDeviceToFolder from './useAssignRetailPlayerDeviceToFolder'
@@ -249,6 +250,9 @@ row: {
   nameIcon: {
     color: theme.palette.primary.main,
     fontSize: theme.typography.pxToRem(16.5),
+  },
+  onlineIcon: {
+    color: theme.palette.success.main,
   },
   nameLabel: {
     display: 'flex',
@@ -642,12 +646,43 @@ const RetailPlayerDeviceRow = memo(
     onToggleSelection,
     onKeyDown,
     onEdit,
+    isApiEnabled,
   }) => {
     const { dragRef, isDragging } = useRetailPlayerDeviceDrag({
       deviceId: node.id,
       deviceName: node.name,
       origin: 'management-list',
     })
+
+    const [isOnline, setIsOnline] = useState(null)
+
+    useEffect(() => {
+      const deviceId = node.apiId || node.id
+      if (!isApiEnabled || !deviceId) {
+        setIsOnline(null)
+        return undefined
+      }
+
+      const abortController = new AbortController()
+      const statusUrl = `/api/retailplayer/devices/${encodeURIComponent(
+        deviceId,
+      )}/status`
+
+      httpClient(statusUrl, { signal: abortController.signal })
+        .then(({ json }) => {
+          const uptime = json?.status?.upTime ?? json?.status?.uptime
+          const hasStatus =
+            uptime !== undefined && uptime !== null && String(uptime).trim() !== ''
+          setIsOnline(hasStatus)
+        })
+        .catch((error) => {
+          if (error?.name !== 'AbortError') {
+            setIsOnline(false)
+          }
+        })
+
+      return () => abortController.abort()
+    }, [isApiEnabled, node.apiId, node.id])
 
     return (
       <div
@@ -678,7 +713,9 @@ const RetailPlayerDeviceRow = memo(
           />
         </div>
         <div className={classes.nameCell}>
-          <SpeakerGroupIcon className={classes.nameIcon} />
+          <SpeakerGroupIcon
+            className={clsx(classes.nameIcon, isOnline && classes.onlineIcon)}
+          />
           <div className={classes.nameLabel}>
             <Typography variant="body1" className={classes.nameTitle}>
               {node.name}
@@ -720,6 +757,7 @@ RetailPlayerDeviceRow.propTypes = {
   onToggleSelection: PropTypes.func.isRequired,
   onKeyDown: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
+  isApiEnabled: PropTypes.bool.isRequired,
 }
 
 RetailPlayerDeviceRow.defaultProps = {
@@ -1311,17 +1349,18 @@ const RetailPlayerDeviceManagement = () => {
       const rowKey = node.treeKey || node.id
       const channelCount = channelCountsByDeviceId?.[node.id]
       return (
-        <RetailPlayerDeviceRow
-          key={`device-row-${rowKey}`}
-          node={node}
-          isSelected={isSelected}
-          classes={classes}
-          channelCount={channelCount}
-          onNavigate={handleNavigateToDevice}
-          onToggleSelection={toggleNodeSelection}
-          onKeyDown={handleRowKeyDown}
-          onEdit={handleEditDevice}
-        />
+          <RetailPlayerDeviceRow
+            key={`device-row-${rowKey}`}
+            node={node}
+            isSelected={isSelected}
+            classes={classes}
+            channelCount={channelCount}
+            onNavigate={handleNavigateToDevice}
+            onToggleSelection={toggleNodeSelection}
+            onKeyDown={handleRowKeyDown}
+            onEdit={handleEditDevice}
+            isApiEnabled={isApiEnabled}
+          />
       )
     })
 


### PR DESCRIPTION
## Summary
- fetch device status for each retail player device row and detect online state
- render device icons in green when online while keeping offline devices in the existing pink color

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e383be3548322b9e4f8bd8ef256d2)