### PR TITLE
Move deleted playlists to deleted folder

### DIFF
--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -132,7 +132,9 @@ func (r *playlistRepository) movePlaylistFile(pls *model.Playlist) error {
 		return nil
 	}
 
-	destDir := filepath.Join(filepath.Dir(pls.Path), "deleted playlist")
+	playlistDir := filepath.Dir(pls.Path)
+	parentDir := filepath.Dir(playlistDir)
+	destDir := filepath.Join(parentDir, "deleted playlists")
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		return fmt.Errorf("creating deleted playlist folder %s: %w", destDir, err)
 	}

--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -99,17 +99,56 @@ func (r *playlistRepository) Exists(id string) (bool, error) {
 }
 
 func (r *playlistRepository) Delete(id string) error {
-	usr := loggedUser(r.ctx)
-	if !usr.IsAdmin {
-		pls, err := r.Get(id)
-		if err != nil {
-			return err
-		}
-		if pls.OwnerID != usr.ID {
-			return rest.ErrPermissionDenied
-		}
+	pls, err := r.Get(id)
+	if err != nil {
+		return err
 	}
+
+	usr := loggedUser(r.ctx)
+	if !usr.IsAdmin && pls.OwnerID != usr.ID {
+		return rest.ErrPermissionDenied
+	}
+
+	if err := r.movePlaylistFile(pls); err != nil {
+		return err
+	}
+
 	return r.delete(And{Eq{"id": id}, r.userFilter()})
+}
+
+func (r *playlistRepository) movePlaylistFile(pls *model.Playlist) error {
+	if pls == nil || pls.Path == "" || !pls.Sync {
+		return nil
+	}
+
+	info, err := os.Stat(pls.Path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat playlist file %s: %w", pls.Path, err)
+	}
+	if info.IsDir() {
+		return nil
+	}
+
+	destDir := filepath.Join(filepath.Dir(pls.Path), "deleted playlist")
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return fmt.Errorf("creating deleted playlist folder %s: %w", destDir, err)
+	}
+
+	destPath := filepath.Join(destDir, filepath.Base(pls.Path))
+	if _, err := os.Stat(destPath); err == nil {
+		ext := filepath.Ext(pls.Path)
+		name := strings.TrimSuffix(filepath.Base(pls.Path), ext)
+		destPath = filepath.Join(destDir, fmt.Sprintf("%s-%d%s", name, time.Now().UnixNano(), ext))
+	}
+
+	if err := os.Rename(pls.Path, destPath); err != nil {
+		return fmt.Errorf("moving playlist file to %s: %w", destPath, err)
+	}
+
+	return nil
 }
 
 func (r *playlistRepository) Put(p *model.Playlist) error {

--- a/persistence/playlist_repository_test.go
+++ b/persistence/playlist_repository_test.go
@@ -120,7 +120,7 @@ var _ = Describe("PlaylistRepository", func() {
 		_, err := os.Stat(playlistPath)
 		Expect(os.IsNotExist(err)).To(BeTrue())
 
-		deletedDir := filepath.Join(playlistDir, "deleted playlist")
+		deletedDir := filepath.Join(filepath.Dir(playlistDir), "deleted playlists")
 		entries, err := os.ReadDir(deletedDir)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(entries).ToNot(BeEmpty())

--- a/persistence/playlist_repository_test.go
+++ b/persistence/playlist_repository_test.go
@@ -2,6 +2,9 @@ package persistence
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/navidrome/navidrome/conf"
@@ -101,6 +104,35 @@ var _ = Describe("PlaylistRepository", func() {
 
 		By("returns error if tries to retrieve the deleted playlist")
 		Expect(repo.Exists(newPls.ID)).To(BeFalse())
+	})
+
+	It("moves synced playlist files into a deleted folder", func() {
+		playlistDir := filepath.Join(GinkgoT().TempDir(), "playlist")
+		Expect(os.MkdirAll(playlistDir, 0o755)).To(Succeed())
+		playlistPath := filepath.Join(playlistDir, "to-delete.m3u")
+		Expect(os.WriteFile(playlistPath, []byte("song1\n"), 0o644)).To(Succeed())
+
+		syncedPls := model.Playlist{Name: "To Delete", OwnerID: "userid", Path: playlistPath, Sync: true}
+		Expect(repo.Put(&syncedPls)).To(Succeed())
+
+		Expect(repo.Delete(syncedPls.ID)).To(Succeed())
+
+		_, err := os.Stat(playlistPath)
+		Expect(os.IsNotExist(err)).To(BeTrue())
+
+		deletedDir := filepath.Join(playlistDir, "deleted playlist")
+		entries, err := os.ReadDir(deletedDir)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(entries).ToNot(BeEmpty())
+
+		baseName := filepath.Base(playlistPath)
+		moved := false
+		for _, entry := range entries {
+			if entry.Name() == baseName || strings.HasPrefix(entry.Name(), baseName+"-") {
+				moved = true
+			}
+		}
+		Expect(moved).To(BeTrue())
 	})
 
 	Describe("GetAll", func() {


### PR DESCRIPTION
## Summary
- move deleted synced playlist files into a dedicated "deleted playlist" folder before removing the record
- ensure destination folder exists and avoid name collisions when archiving
- add regression test covering playlist file archival during deletion

## Testing
- go test ./persistence -count=1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e3754db448322ae3cf0d0e580140b)