### PR TITLE
Add configurable deleted playlists path

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -52,6 +52,7 @@ type configOptions struct {
 	AutoImportPlaylists             bool
 	DefaultPlaylistPublicVisibility bool
 	PlaylistsPath                   string
+	DeletedPlaylistsPath            string
 	DiscoveryPath                   string
 	SyncFolder                      string
 	SmartPlaylistRefreshDelay       time.Duration
@@ -541,6 +542,7 @@ func setViperDefaults() {
 	viper.SetDefault("autoimportplaylists", true)
 	viper.SetDefault("defaultplaylistpublicvisibility", false)
 	viper.SetDefault("playlistspath", "")
+	viper.SetDefault("deletedplaylistspath", "")
 	viper.SetDefault("discoverypath", "")
 	viper.SetDefault("smartPlaylistRefreshDelay", 5*time.Second)
 	viper.SetDefault("enabledownloads", true)

--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -134,9 +134,18 @@ func (r *playlistRepository) movePlaylistFile(pls *model.Playlist) error {
 
 	playlistDir := filepath.Dir(pls.Path)
 	parentDir := filepath.Dir(playlistDir)
-	destDir := filepath.Join(parentDir, "deleted playlists")
+	destDir := conf.Server.DeletedPlaylistsPath
+	if destDir == "" {
+		destDir = filepath.Join(parentDir, "deleted playlists")
+	}
+	destDir = filepath.Clean(destDir)
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		return fmt.Errorf("creating deleted playlist folder %s: %w", destDir, err)
+	}
+	if info, err := os.Stat(destDir); err != nil {
+		return fmt.Errorf("invalid deleted playlist folder %s: %w", destDir, err)
+	} else if !info.IsDir() {
+		return fmt.Errorf("invalid deleted playlist folder %s: not a directory", destDir)
 	}
 
 	destPath := filepath.Join(destDir, filepath.Base(pls.Path))

--- a/persistence/playlist_repository_test.go
+++ b/persistence/playlist_repository_test.go
@@ -135,6 +135,39 @@ var _ = Describe("PlaylistRepository", func() {
 		Expect(moved).To(BeTrue())
 	})
 
+	It("moves synced playlist files into a configured deleted folder", func() {
+		playlistDir := filepath.Join(GinkgoT().TempDir(), "playlist")
+		Expect(os.MkdirAll(playlistDir, 0o755)).To(Succeed())
+		playlistPath := filepath.Join(playlistDir, "to-delete.m3u")
+		Expect(os.WriteFile(playlistPath, []byte("song1\n"), 0o644)).To(Succeed())
+
+		customDeleteDir := filepath.Join(GinkgoT().TempDir(), "custom", "deleted")
+		originalPath := conf.Server.DeletedPlaylistsPath
+		conf.Server.DeletedPlaylistsPath = customDeleteDir
+		DeferCleanup(func() { conf.Server.DeletedPlaylistsPath = originalPath })
+
+		syncedPls := model.Playlist{Name: "To Delete", OwnerID: "userid", Path: playlistPath, Sync: true}
+		Expect(repo.Put(&syncedPls)).To(Succeed())
+
+		Expect(repo.Delete(syncedPls.ID)).To(Succeed())
+
+		_, err := os.Stat(playlistPath)
+		Expect(os.IsNotExist(err)).To(BeTrue())
+
+		entries, err := os.ReadDir(customDeleteDir)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(entries).ToNot(BeEmpty())
+
+		baseName := filepath.Base(playlistPath)
+		moved := false
+		for _, entry := range entries {
+			if entry.Name() == baseName || strings.HasPrefix(entry.Name(), baseName+"-") {
+				moved = true
+			}
+		}
+		Expect(moved).To(BeTrue())
+	})
+
 	Describe("GetAll", func() {
 		It("returns all playlists from DB", func() {
 			all, err := repo.GetAll()


### PR DESCRIPTION
## Summary
- add a DeletedPlaylistsPath configuration option for custom delete destinations
- validate and use the configured path when moving deleted playlist files
- extend playlist repository tests to cover the default and custom deleted playlist destinations

## Testing
- gofmt
- go test ./persistence -run "TestPlaylistRepository/moves" (hangs in this environment; interrupted)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef88d98488322bad7fcfbc42ea2ba)