### PR TITLE
Fix playlist add-to-playlist selection for all tracks

### DIFF
--- a/ui/src/playlist/PlaylistSongBulkActions.jsx
+++ b/ui/src/playlist/PlaylistSongBulkActions.jsx
@@ -42,13 +42,18 @@ const PlaylistSongBulkActions = ({
       return
     }
 
+    const getMediaIdFromData = (id) => {
+      const track = data?.[id] ?? data?.[String(id)]
+      return track?.mediaFileId
+    }
+
     const missingIds = selectedIds.filter(
-      (id) => data?.[id]?.mediaFileId == null,
+      (id) => getMediaIdFromData(id) == null,
     )
 
     if (!missingIds.length) {
       setSelectedMediaIds(
-        selectedIds.map((id) => data?.[id]?.mediaFileId ?? id),
+        selectedIds.map((id) => String(getMediaIdFromData(id) ?? id)),
       )
       return
     }
@@ -57,17 +62,21 @@ const PlaylistSongBulkActions = ({
       .getMany('playlistTrack', { ids: missingIds })
       .then(({ data: tracks }) => {
         const missingMediaIds = tracks.reduce((acc, track) => {
-          acc[track.id] = track.mediaFileId ?? track.id
+          acc[String(track.id)] = track.mediaFileId ?? track.id
           return acc
         }, {})
 
         setSelectedMediaIds(
-          selectedIds.map(
-            (id) => data?.[id]?.mediaFileId ?? missingMediaIds[id] ?? id,
-          ),
+          selectedIds.map((id) => {
+            const mediaId =
+              getMediaIdFromData(id) ?? missingMediaIds[String(id)] ?? id
+            return String(mediaId)
+          }),
         )
       })
-      .catch(() => setSelectedMediaIds(selectedIds))
+      .catch(() =>
+        setSelectedMediaIds(selectedIds.map((id) => String(getMediaIdFromData(id) ?? id))),
+      )
   }, [dataProvider, data, selectedIds])
   return (
     <ResourceContextProvider value={mappedResource}>

--- a/ui/src/playlist/PlaylistSongBulkActions.jsx
+++ b/ui/src/playlist/PlaylistSongBulkActions.jsx
@@ -1,8 +1,9 @@
-import React, { Fragment, useEffect } from 'react'
+import React, { Fragment, useEffect, useState } from 'react'
 import {
   BulkDeleteButton,
   useListContext,
   useUnselectAll,
+  useDataProvider,
   ResourceContextProvider,
 } from 'react-admin'
 import { MdOutlinePlaylistRemove } from 'react-icons/md'
@@ -28,14 +29,46 @@ const PlaylistSongBulkActions = ({
   const unselectAll = useUnselectAll()
   const listContext = useListContext()
   const data = listContext?.data
+  const dataProvider = useDataProvider()
+  const [selectedMediaIds, setSelectedMediaIds] = useState([])
   useEffect(() => {
     unselectAll('playlistTrack')
   }, [unselectAll])
 
   const mappedResource = `playlist/${playlistId}/tracks`
-  const selectedMediaIds = (selectedIds || []).map(
-    (id) => data?.[id]?.mediaFileId ?? id,
-  )
+  useEffect(() => {
+    if (!selectedIds?.length) {
+      setSelectedMediaIds([])
+      return
+    }
+
+    const missingIds = selectedIds.filter(
+      (id) => data?.[id]?.mediaFileId == null,
+    )
+
+    if (!missingIds.length) {
+      setSelectedMediaIds(
+        selectedIds.map((id) => data?.[id]?.mediaFileId ?? id),
+      )
+      return
+    }
+
+    dataProvider
+      .getMany('playlistTrack', { ids: missingIds })
+      .then(({ data: tracks }) => {
+        const missingMediaIds = tracks.reduce((acc, track) => {
+          acc[track.id] = track.mediaFileId ?? track.id
+          return acc
+        }, {})
+
+        setSelectedMediaIds(
+          selectedIds.map(
+            (id) => data?.[id]?.mediaFileId ?? missingMediaIds[id] ?? id,
+          ),
+        )
+      })
+      .catch(() => setSelectedMediaIds(selectedIds))
+  }, [dataProvider, data, selectedIds])
   return (
     <ResourceContextProvider value={mappedResource}>
       <Fragment>


### PR DESCRIPTION
## Summary
- resolve media ids for selected playlist tracks even when they are not loaded on the current page
- keep bulk playlist actions operating on the full selection instead of only visible rows

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920c73f31408322a9759e33a4148fbc)