### PR TITLE
Fix adding all playlist songs across pages

### DIFF
--- a/ui/src/playlist/PlaylistSongBulkActions.jsx
+++ b/ui/src/playlist/PlaylistSongBulkActions.jsx
@@ -1,9 +1,10 @@
-import React, { Fragment, useEffect } from 'react'
+import React, { Fragment, useEffect, useState } from 'react'
 import {
   BulkDeleteButton,
   useListContext,
   useUnselectAll,
   ResourceContextProvider,
+  useDataProvider,
 } from 'react-admin'
 import { MdOutlinePlaylistRemove } from 'react-icons/md'
 import PropTypes from 'prop-types'
@@ -17,6 +18,40 @@ const useStyles = makeStyles((theme) => ({
   },
 }))
 
+export const resolveSelectedMediaIds = async ({
+  selectedIds,
+  data = {},
+  playlistId,
+  dataProvider,
+}) => {
+  const resolveFromRecords = (records) => {
+    const lookup = { ...records }
+    return selectedIds.map((id) => lookup[id]?.mediaFileId ?? id)
+  }
+
+  const allIdsAreKnown = selectedIds.every((id) => data?.[id])
+  if (allIdsAreKnown) {
+    return resolveFromRecords(data)
+  }
+
+  try {
+    const { data: records } = await dataProvider.getList('playlistTrack', {
+      filter: { playlist_id: playlistId },
+      pagination: { page: 1, perPage: 0 },
+      sort: { field: 'id', order: 'ASC' },
+    })
+
+    const lookup = records.reduce(
+      (acc, record) => ({ ...acc, [record.id]: record }),
+      { ...data },
+    )
+
+    return resolveFromRecords(lookup)
+  } catch {
+    return selectedIds
+  }
+}
+
 // Replace original resource with "fake" one for removing tracks from playlist
 const PlaylistSongBulkActions = ({
   playlistId,
@@ -27,15 +62,32 @@ const PlaylistSongBulkActions = ({
   const classes = useStyles()
   const unselectAll = useUnselectAll()
   const listContext = useListContext()
+  const dataProvider = useDataProvider()
   const data = listContext?.data
+  const [selectedMediaIds, setSelectedMediaIds] = useState([])
   useEffect(() => {
     unselectAll('playlistTrack')
   }, [unselectAll])
 
   const mappedResource = `playlist/${playlistId}/tracks`
-  const selectedMediaIds = (selectedIds || []).map(
-    (id) => data?.[id]?.mediaFileId ?? id,
-  )
+  useEffect(() => {
+    let isActive = true
+
+    resolveSelectedMediaIds({
+      selectedIds: selectedIds || [],
+      data,
+      playlistId,
+      dataProvider,
+    }).then((mediaIds) => {
+      if (isActive) {
+        setSelectedMediaIds(mediaIds)
+      }
+    })
+
+    return () => {
+      isActive = false
+    }
+  }, [selectedIds, data, playlistId, dataProvider])
   return (
     <ResourceContextProvider value={mappedResource}>
       <Fragment>

--- a/ui/src/playlist/PlaylistSongBulkActions.test.jsx
+++ b/ui/src/playlist/PlaylistSongBulkActions.test.jsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest'
+import { resolveSelectedMediaIds } from './PlaylistSongBulkActions.jsx'
+
+describe('resolveSelectedMediaIds', () => {
+  it('returns media ids from the current page data when already loaded', async () => {
+    const data = {
+      '1': { id: '1', mediaFileId: 'media-1' },
+      '2': { id: '2', mediaFileId: 'media-2' },
+    }
+
+    const selectedIds = ['1', '2']
+    const dataProvider = { getList: vi.fn() }
+
+    const result = await resolveSelectedMediaIds({
+      selectedIds,
+      data,
+      playlistId: 'playlist-id',
+      dataProvider,
+    })
+
+    expect(dataProvider.getList).not.toHaveBeenCalled()
+    expect(result).toEqual(['media-1', 'media-2'])
+  })
+
+  it('fetches playlist tracks to resolve media ids when needed', async () => {
+    const selectedIds = ['1', '2', '3']
+    const data = { '1': { id: '1', mediaFileId: 'media-1' } }
+    const dataProvider = {
+      getList: vi.fn().mockResolvedValue({
+        data: [
+          { id: '1', mediaFileId: 'media-1' },
+          { id: '2', mediaFileId: 'media-2' },
+          { id: '3', mediaFileId: 'media-3' },
+        ],
+      }),
+    }
+
+    const result = await resolveSelectedMediaIds({
+      selectedIds,
+      data,
+      playlistId: 'playlist-id',
+      dataProvider,
+    })
+
+    expect(dataProvider.getList).toHaveBeenCalledWith('playlistTrack', {
+      filter: { playlist_id: 'playlist-id' },
+      pagination: { page: 1, perPage: 0 },
+      sort: { field: 'id', order: 'ASC' },
+    })
+    expect(result).toEqual(['media-1', 'media-2', 'media-3'])
+  })
+
+  it('falls back to the selected ids when the request fails', async () => {
+    const selectedIds = ['1', '2']
+    const dataProvider = {
+      getList: vi.fn().mockRejectedValue(new Error('network error')),
+    }
+
+    const result = await resolveSelectedMediaIds({
+      selectedIds,
+      data: {},
+      playlistId: 'playlist-id',
+      dataProvider,
+    })
+
+    expect(result).toEqual(selectedIds)
+  })
+})


### PR DESCRIPTION
## Summary
- ensure playlist bulk actions resolve media ids using full playlist data when selecting songs
- add tests covering playlist media id resolution for add-to-playlist flow

## Testing
- npm test -- PlaylistSongBulkActions.test.jsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ca14dd54832298dd162ec97cebeb)