### PR TITLE
Add RetailPlayer cue control UI and backend proxy

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -85,6 +85,7 @@ type configOptions struct {
 	EnableCoverAnimation            bool
 	EnableNowPlaying                bool
 	GATrackingID                    string
+	RetailPlayerApiKey              string
 	EnableLogRedacting              bool
 	AuthRequestLimit                int
 	AuthWindowLength                time.Duration
@@ -617,6 +618,7 @@ func setViperDefaults() {
 	viper.SetDefault("retailplayer.enabled", false)
 	viper.SetDefault("retailplayer.baseurl", "")
 	viper.SetDefault("retailplayer.orgid", "")
+	viper.SetDefault("retailplayerapikey", "DUMMY_API_KEY")
 	viper.SetDefault("retailplayer.apikey", "")
 	viper.SetDefault("retailplayer.apikeyheader", "x-retailplayer-apikey")
 	viper.SetDefault("retailplayer.pagesize", 0)

--- a/server/api/retailplayer.go
+++ b/server/api/retailplayer.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/log"
+)
+
+const retailPlayerBaseURL = "https://rpp.jareddietch.com"
+
+// AddRetailPlayerRoutes registers proxy endpoints used by the UI to interact with RetailPlayer.
+func AddRetailPlayerRoutes(r chi.Router) {
+	handler := retailPlayerHandler{client: &http.Client{Timeout: 10 * time.Second}}
+	r.Get("/retailplayer/triggers", handler.getTriggers)
+	r.Post("/retailplayer/play", handler.playCue)
+	r.Post("/retailplayer/stop", handler.stopCue)
+}
+
+type retailPlayerHandler struct {
+	client *http.Client
+}
+
+type playCueRequest struct {
+	Device string `json:"device"`
+	Cue    string `json:"cue"`
+}
+
+type stopCueRequest struct {
+	Device string `json:"device"`
+}
+
+func (h retailPlayerHandler) getTriggers(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	deviceID := r.URL.Query().Get("device")
+	if deviceID == "" {
+		http.Error(w, "device is required", http.StatusBadRequest)
+		return
+	}
+
+	upstreamURL := fmt.Sprintf("%s/rest/v1/device-control/%s/triggers", retailPlayerBaseURL, deviceID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, upstreamURL, nil)
+	if err != nil {
+		log.Error(ctx, "creating retailplayer triggers request", err)
+		http.Error(w, "unable to create request", http.StatusInternalServerError)
+		return
+	}
+	req.Header.Set("x-retailplayer-rc-apikey", conf.Server.RetailPlayerApiKey)
+
+	h.forward(w, req)
+}
+
+func (h retailPlayerHandler) playCue(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	var body playCueRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if body.Device == "" || body.Cue == "" {
+		http.Error(w, "device and cue are required", http.StatusBadRequest)
+		return
+	}
+
+	payload, _ := json.Marshal(map[string]string{
+		"action": "PLAY",
+		"value":  body.Cue,
+	})
+	upstreamURL := fmt.Sprintf("%s/rest/v1/device-control/%s/triggers", retailPlayerBaseURL, body.Device)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, upstreamURL, bytes.NewReader(payload))
+	if err != nil {
+		log.Error(ctx, "creating retailplayer play request", err)
+		http.Error(w, "unable to create request", http.StatusInternalServerError)
+		return
+	}
+	req.Header.Set("x-retailplayer-rc-apikey", conf.Server.RetailPlayerApiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	h.forward(w, req)
+}
+
+func (h retailPlayerHandler) stopCue(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	var body stopCueRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if body.Device == "" {
+		http.Error(w, "device is required", http.StatusBadRequest)
+		return
+	}
+
+	payload, _ := json.Marshal(map[string]string{
+		"action": "STOP",
+	})
+	upstreamURL := fmt.Sprintf("%s/rest/v1/device-control/%s/triggers", retailPlayerBaseURL, body.Device)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, upstreamURL, bytes.NewReader(payload))
+	if err != nil {
+		log.Error(ctx, "creating retailplayer stop request", err)
+		http.Error(w, "unable to create request", http.StatusInternalServerError)
+		return
+	}
+	req.Header.Set("x-retailplayer-rc-apikey", conf.Server.RetailPlayerApiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	h.forward(w, req)
+}
+
+func (h retailPlayerHandler) forward(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	resp, err := h.client.Do(req)
+	if err != nil {
+		log.Error(ctx, "forwarding retailplayer request", err)
+		http.Error(w, "retailplayer request failed", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	for key, values := range resp.Header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}

--- a/server/nativeapi/config.go
+++ b/server/nativeapi/config.go
@@ -33,6 +33,7 @@ var sensitiveFieldsFullMask = []string{
 	"PasswordEncryptionKey",
 	"Prometheus.Password",
 	"RetailPlayer.APIKey",
+	"RetailPlayerApiKey",
 }
 
 type configResponse struct {

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -20,6 +20,7 @@ import (
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/server"
+	"github.com/navidrome/navidrome/server/api"
 )
 
 type Router struct {
@@ -99,6 +100,7 @@ func (n *Router) routes() http.Handler {
 		r.Use(server.Authenticator(n.ds))
 		r.Use(server.JWTRefresher)
 		r.Use(server.UpdateLastAccessMiddleware(n.ds))
+		api.AddRetailPlayerRoutes(r)
 		n.R(r, "/user", model.User{}, true)
 		n.R(r, "/song", model.MediaFile{}, false)
 		n.R(r, "/album", model.Album{}, false)

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -23,7 +23,7 @@ import {
   setVolume,
   syncQueue,
 } from '../actions'
-import PlayerToolbar from './PlayerToolbar'
+import PlayerControls from '../components/PlayerControls'
 import { sendNotification } from '../utils'
 import subsonic from '../subsonic'
 import locale from './locale'
@@ -193,7 +193,7 @@ const Player = () => {
       autoPlay: playerState.clear || playerState.playIndex === 0,
       clearPriorAudioLists: playerState.clear,
       extendsContent: (
-        <PlayerToolbar id={current.trackId} isRadio={current.isRadio} />
+        <PlayerControls id={current.trackId} isRadio={current.isRadio} />
       ),
       defaultVolume: isMobilePlayer ? 1 : playerState.volume,
       showMediaSession: !current.isRadio,

--- a/ui/src/components/CueDrawerPage.tsx
+++ b/ui/src/components/CueDrawerPage.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useState } from 'react'
+import { FaTimes } from 'react-icons/fa'
+
+const DEVICE_ID = 'b2f2a1c7-cf47-46fa-8d11-3d77ed15e65d'
+
+type CueTrigger = {
+  id?: string
+  name?: string
+  description?: string
+  triggerID?: string
+}
+
+type CueDrawerPageProps = {
+  open: boolean
+  onClose: () => void
+}
+
+const CueDrawerPage: React.FC<CueDrawerPageProps> = ({ open, onClose }) => {
+  const [cues, setCues] = useState<CueTrigger[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+    const fetchCues = async () => {
+      setLoading(true)
+      try {
+        const response = await fetch(`/api/retailplayer/triggers?device=${DEVICE_ID}`)
+        if (!response.ok) {
+          throw new Error('Unable to load cues')
+        }
+        const data = await response.json()
+        const triggers = Array.isArray(data?.data) ? data.data : data?.triggers || data
+        setCues(triggers || [])
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error(err)
+        setCues([])
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchCues()
+  }, [open])
+
+  const playCue = async (cueId?: string) => {
+    if (!cueId) return
+    try {
+      await fetch('/api/retailplayer/play', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ device: DEVICE_ID, cue: cueId }),
+      })
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err)
+    }
+  }
+
+  const stopCue = async () => {
+    try {
+      await fetch('/api/retailplayer/stop', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ device: DEVICE_ID }),
+      })
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err)
+    }
+  }
+
+  return (
+    <div className={`cue-drawer ${open ? 'open' : ''}`}>
+      <div className="cue-drawer-header">
+        <h3>RetailPlayer Cues</h3>
+        <button className="cue-close" onClick={onClose} aria-label="Close cue drawer">
+          <FaTimes />
+        </button>
+      </div>
+      <div className="cue-drawer-actions">
+        <button className="cue-stop" onClick={stopCue}>
+          Stop
+        </button>
+      </div>
+      <div className="cue-drawer-body">
+        {loading ? (
+          <div className="cue-loading">Loading cues...</div>
+        ) : cues.length === 0 ? (
+          <div className="cue-empty">No cues available.</div>
+        ) : (
+          cues.map((cue) => {
+            const cueId = cue.id || cue.triggerID
+            const label = cue.name || cue.description || cueId || 'Cue'
+            return (
+              <button
+                key={cueId || label}
+                className="cue-entry"
+                onClick={() => playCue(cueId)}
+              >
+                {label}
+              </button>
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default CueDrawerPage

--- a/ui/src/components/PlayerControls.tsx
+++ b/ui/src/components/PlayerControls.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react'
+import { FaBullhorn } from 'react-icons/fa'
+import PlayerToolbar from '../audioplayer/PlayerToolbar'
+import CueDrawerPage from './CueDrawerPage'
+
+type PlayerControlsProps = {
+  id?: string
+  isRadio?: boolean
+}
+
+const PlayerControls: React.FC<PlayerControlsProps> = ({ id, isRadio }) => {
+  const [cueOpen, setCueOpen] = useState(false)
+
+  return (
+    <>
+      <div className="cue-control-wrapper">
+        <PlayerToolbar id={id} isRadio={isRadio} />
+        <button
+          className="cue-button"
+          onClick={() => setCueOpen(true)}
+          aria-label="Open cue drawer"
+        >
+          <div className="cue-icon">
+            <FaBullhorn />
+          </div>
+        </button>
+      </div>
+      <CueDrawerPage open={cueOpen} onClose={() => setCueOpen(false)} />
+    </>
+  )
+}
+
+export default PlayerControls

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -16,3 +16,109 @@ code {
   z-index: 78;
 }
 
+.cue-control-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.cue-button {
+  background: none;
+  border: none;
+  margin-left: 10px;
+  cursor: pointer;
+  padding: 0;
+}
+
+.cue-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: linear-gradient(145deg, #2f5feb, #1c46c9);
+  color: #e8ecf7;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+}
+
+.cue-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 350px;
+  height: 100vh;
+  background: #111;
+  color: #f5f5f5;
+  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.4);
+  transform: translateX(100%);
+  transition: transform 0.3s ease-in-out;
+  z-index: 2000;
+  display: flex;
+  flex-direction: column;
+}
+
+.cue-drawer.open {
+  transform: translateX(0);
+}
+
+.cue-drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.cue-close {
+  background: none;
+  border: none;
+  color: #f5f5f5;
+  cursor: pointer;
+  font-size: 1.1rem;
+}
+
+.cue-drawer-actions {
+  padding: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.cue-stop {
+  background: #e74c3c;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.cue-drawer-body {
+  padding: 1rem;
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cue-entry {
+  width: 100%;
+  text-align: left;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: #f5f5f5;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.cue-entry:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.cue-loading,
+.cue-empty {
+  color: #aaa;
+}
+


### PR DESCRIPTION
## Summary
- add backend RetailPlayer proxy routes for triggers, play, and stop requests using the configured API key
- extend configuration with a RetailPlayer API key default and mask it from config output
- integrate a cue drawer UI with a new cue control button and styling alongside existing player controls

## Testing
- go test ./... *(fails: missing system dependency `taglib` during pkg-config lookup)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692611061a608322a3804505dd775ba9)