### PR TITLE
Add RetailPlayer cue control integration

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/navidrome/navidrome/resources"
 	"github.com/navidrome/navidrome/scanner"
 	"github.com/navidrome/navidrome/scheduler"
+	retailapi "github.com/navidrome/navidrome/server/api"
 	"github.com/navidrome/navidrome/server/backgrounds"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -111,6 +112,7 @@ func startServer(ctx context.Context) func() error {
 	return func() error {
 		a := CreateServer()
 		a.MountRouter("Native API", consts.URLPathNativeAPI, CreateNativeAPIRouter(ctx))
+		a.MountRouter("RetailPlayer Cue API", consts.URLPathNativeAPI+"/retailplayer", retailapi.NewRouter())
 		a.MountRouter("Subsonic API", consts.URLPathSubsonicAPI, CreateSubsonicAPIRouter(ctx))
 		a.MountRouter("Public Endpoints", consts.URLPathPublic, CreatePublicRouter())
 		if conf.Server.LastFM.Enabled {

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -109,6 +109,7 @@ type configOptions struct {
 	RetailPlayer                    retailPlayerOptions `json:",omitzero"`
 	Tags                            map[string]TagConf  `json:",omitempty"`
 	Agents                          string
+	RetailPlayerApiKey              string
 
 	// DevFlags. These are used to enable/disable debugging and incomplete features
 	DevLogLevels                     map[string]string `json:",omitempty"`
@@ -606,6 +607,7 @@ func setViperDefaults() {
 	viper.SetDefault("subsonic.defaultreportrealpath", false)
 	viper.SetDefault("subsonic.legacyclients", "DSub")
 	viper.SetDefault("agents", "lastfm,spotify,deezer")
+	viper.SetDefault("retailplayerapikey", "DUMMY_API_KEY")
 	viper.SetDefault("lastfm.enabled", true)
 	viper.SetDefault("lastfm.language", "en")
 	viper.SetDefault("lastfm.apikey", "")

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type Server struct{}
+
+func New() *Server {
+	return &Server{}
+}
+
+func NewRouter() http.Handler {
+	s := New()
+	ng := chi.NewRouter()
+
+	ng.MethodFunc(http.MethodGet, "/triggers", s.RetailPlayerGetTriggers)
+	ng.MethodFunc(http.MethodPost, "/play", s.RetailPlayerPlayCue)
+	ng.MethodFunc(http.MethodPost, "/stop", s.RetailPlayerStopCue)
+
+	return ng
+}

--- a/server/api/retailplayer.go
+++ b/server/api/retailplayer.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/log"
+)
+
+const retailPlayerBaseURL = "https://rpp.jareddietch.com"
+
+var retailPlayerClient = &http.Client{Timeout: 15 * time.Second}
+
+type triggerPlayRequest struct {
+	Device string `json:"device"`
+	Cue    string `json:"cue"`
+}
+
+type triggerStopRequest struct {
+	Device string `json:"device"`
+}
+
+type retailPlayerCommand struct {
+	Action string `json:"action"`
+	Value  string `json:"value,omitempty"`
+}
+
+func (s *Server) RetailPlayerGetTriggers(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	device := r.URL.Query().Get("device")
+	if device == "" {
+		http.Error(w, "device is required", http.StatusBadRequest)
+		return
+	}
+
+	url := fmt.Sprintf("%s/rest/v1/device-control/%s/triggers", retailPlayerBaseURL, device)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		http.Error(w, "unable to create request", http.StatusInternalServerError)
+		return
+	}
+	req.Header.Set("x-retailplayer-rc-apikey", conf.Server.RetailPlayerApiKey)
+
+	resp, err := retailPlayerClient.Do(req)
+	if err != nil {
+		log.Error(ctx, "Unable to fetch retail player triggers", "err", err)
+		http.Error(w, "unable to fetch triggers", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	copyRetailPlayerResponse(w, resp)
+}
+
+func (s *Server) RetailPlayerPlayCue(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var payload triggerPlayRequest
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	if payload.Device == "" || payload.Cue == "" {
+		http.Error(w, "device and cue are required", http.StatusBadRequest)
+		return
+	}
+
+	command := retailPlayerCommand{Action: "PLAY", Value: payload.Cue}
+	if err := s.sendRetailPlayerCommand(ctx, payload.Device, command, w); err != nil {
+		log.Error(ctx, "Unable to play retail player cue", "err", err)
+	}
+}
+
+func (s *Server) RetailPlayerStopCue(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var payload triggerStopRequest
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	if payload.Device == "" {
+		http.Error(w, "device is required", http.StatusBadRequest)
+		return
+	}
+
+	command := retailPlayerCommand{Action: "STOP"}
+	if err := s.sendRetailPlayerCommand(ctx, payload.Device, command, w); err != nil {
+		log.Error(ctx, "Unable to stop retail player cue", "err", err)
+	}
+}
+
+func (s *Server) sendRetailPlayerCommand(ctx context.Context, device string, command retailPlayerCommand, w http.ResponseWriter) error {
+	body, err := json.Marshal(command)
+	if err != nil {
+		http.Error(w, "unable to marshal command", http.StatusInternalServerError)
+		return err
+	}
+
+	url := fmt.Sprintf("%s/rest/v1/device-control/%s/triggers", retailPlayerBaseURL, device)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		http.Error(w, "unable to create request", http.StatusInternalServerError)
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-retailplayer-rc-apikey", conf.Server.RetailPlayerApiKey)
+
+	resp, err := retailPlayerClient.Do(req)
+	if err != nil {
+		http.Error(w, "unable to contact retail player", http.StatusBadGateway)
+		return err
+	}
+	defer resp.Body.Close()
+
+	copyRetailPlayerResponse(w, resp)
+	return nil
+}
+
+func copyRetailPlayerResponse(w http.ResponseWriter, resp *http.Response) {
+	for key, values := range resp.Header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -24,6 +24,7 @@ import {
   syncQueue,
 } from '../actions'
 import PlayerToolbar from './PlayerToolbar'
+import PlayerControls from '../components/PlayerControls'
 import { sendNotification } from '../utils'
 import subsonic from '../subsonic'
 import locale from './locale'
@@ -360,6 +361,7 @@ const Player = () => {
         onBeforeDestroy={onBeforeDestroy}
         getAudioInstance={setAudioInstance}
       />
+      <PlayerControls />
       <GlobalHotKeys handlers={handlers} keyMap={keyMap} allowChanges />
     </ThemeProvider>
   )

--- a/ui/src/components/CueDrawerPage.tsx
+++ b/ui/src/components/CueDrawerPage.tsx
@@ -1,0 +1,142 @@
+import React, { useEffect, useMemo, useState } from 'react'
+
+const RETAIL_PLAYER_DEVICE_ID = 'b2f2a1c7-cf47-46fa-8d11-3d77ed15e65d'
+
+type Trigger = {
+  id?: string
+  name?: string
+  label?: string
+  title?: string
+  description?: string
+}
+
+type CueDrawerPageProps = {
+  open: boolean
+  onClose: () => void
+}
+
+const CueDrawerPage: React.FC<CueDrawerPageProps> = ({ open, onClose }) => {
+  const [triggers, setTriggers] = useState<Trigger[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const triggerList = useMemo(() => {
+    if (Array.isArray(triggers)) {
+      return triggers
+    }
+    return []
+  }, [triggers])
+
+  useEffect(() => {
+    if (open) {
+      loadTriggers()
+    }
+  }, [open])
+
+  const loadTriggers = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetch(
+        `/api/retailplayer/triggers?device=${RETAIL_PLAYER_DEVICE_ID}`,
+      )
+      if (!response.ok) {
+        throw new Error('Failed to load cues')
+      }
+      const data = await response.json()
+      const entries = Array.isArray(data?.data)
+        ? data.data
+        : Array.isArray(data)
+          ? data
+          : []
+      setTriggers(entries)
+    } catch (err) {
+      setError('Unable to load cues')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handlePlay = async (cue: string | undefined) => {
+    if (!cue) return
+    try {
+      await fetch('/api/retailplayer/play', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          device: RETAIL_PLAYER_DEVICE_ID,
+          cue,
+        }),
+      })
+    } catch (err) {
+      setError('Unable to start cue')
+    }
+  }
+
+  const handleStop = async () => {
+    try {
+      await fetch('/api/retailplayer/stop', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ device: RETAIL_PLAYER_DEVICE_ID }),
+      })
+    } catch (err) {
+      setError('Unable to stop cue')
+    }
+  }
+
+  if (!open) {
+    return null
+  }
+
+  return (
+    <div className="cue-drawer-overlay">
+      <div className={`cue-drawer ${open ? 'open' : ''}`}>
+        <div className="cue-drawer-header">
+          <div className="cue-drawer-title">Cues</div>
+          <button
+            aria-label="Close cues"
+            className="cue-close"
+            onClick={onClose}
+            type="button"
+          >
+            ×
+          </button>
+        </div>
+        <div className="cue-drawer-subtitle">Press a button to Play</div>
+        <button
+          type="button"
+          className="cue-action stop"
+          onClick={handleStop}
+        >
+          Stop
+        </button>
+        <div className="cue-list">
+          {loading && <div className="cue-status">Loading cues…</div>}
+          {!loading && error && <div className="cue-status error">{error}</div>}
+          {!loading && !error && triggerList.length === 0 && (
+            <div className="cue-status">No cues available</div>
+          )}
+          {!loading &&
+            !error &&
+            triggerList.map((trigger) => {
+              const id = trigger.id || trigger.title || trigger.name || trigger.label
+              const label = trigger.label || trigger.name || trigger.title || 'Cue'
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  className="cue-action"
+                  onClick={() => handlePlay(id || '')}
+                >
+                  {label}
+                </button>
+              )
+            })}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CueDrawerPage

--- a/ui/src/components/PlayerControls.tsx
+++ b/ui/src/components/PlayerControls.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { FaBullhorn } from 'react-icons/fa'
+import CueDrawerPage from './CueDrawerPage'
+
+const PlayerControls: React.FC = () => {
+  const [cueOpen, setCueOpen] = useState(false)
+  const [controlGroup, setControlGroup] = useState<Element | null>(null)
+
+  useEffect(() => {
+    const handle = window.setTimeout(() => {
+      setControlGroup(
+        document.querySelector(
+          '.react-jinke-music-player-main .group, .react-jinke-music-player .group',
+        ),
+      )
+    }, 0)
+    return () => window.clearTimeout(handle)
+  }, [])
+
+  const cueButton = (
+    <button
+      type="button"
+      className="cue-button"
+      aria-label="Open cue drawer"
+      onClick={() => setCueOpen(true)}
+    >
+      <div className="cue-icon">
+        <FaBullhorn />
+      </div>
+    </button>
+  )
+
+  return (
+    <>
+      {controlGroup && createPortal(cueButton, controlGroup)}
+      <CueDrawerPage open={cueOpen} onClose={() => setCueOpen(false)} />
+    </>
+  )
+}
+
+export default PlayerControls

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -16,3 +16,116 @@ code {
   z-index: 78;
 }
 
+
+.cue-button {
+  background: none;
+  border: none;
+  margin-left: 10px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.cue-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: #1d4ed8;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.35);
+}
+
+.cue-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  justify-content: flex-end;
+  z-index: 1300;
+}
+
+.cue-drawer {
+  width: 350px;
+  max-width: 90vw;
+  height: 100vh;
+  background: #111;
+  color: #f5f5f5;
+  box-shadow: -4px 0 16px rgba(0, 0, 0, 0.4);
+  transform: translateX(100%);
+  transition: transform 0.3s ease-in-out;
+  display: flex;
+  flex-direction: column;
+}
+
+.cue-drawer.open {
+  transform: translateX(0);
+}
+
+.cue-drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.cue-drawer-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cue-close {
+  background: none;
+  border: none;
+  color: #f5f5f5;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.cue-drawer-subtitle {
+  padding: 0 16px;
+  color: #c0c0c0;
+  margin-bottom: 8px;
+}
+
+.cue-list {
+  padding: 0 16px 16px;
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.cue-action {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 6px;
+  border: none;
+  background: #2563eb;
+  color: #ffffff;
+  font-size: 16px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.cue-action.stop {
+  background: #2f2f2f;
+  color: #ffffff;
+  margin: 0 16px 12px;
+}
+
+.cue-status {
+  color: #c0c0c0;
+}
+
+.cue-status.error {
+  color: #f87171;
+}


### PR DESCRIPTION
## Summary
- add a dedicated RetailPlayer proxy router with endpoints to fetch triggers and proxy play/stop commands using the configured API key
- expose a single RetailPlayerApiKey configuration default and mount the new router under the native API path
- introduce a cue drawer UI and cue button in the player that opens the drawer and drives play/stop requests through the backend

## Testing
- go test ./... *(interrupted)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69261888a9bc83229d2722f42d461f14)