### PR TITLE
Add RetailPlayer cue controls and trigger proxy

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -619,7 +619,7 @@ func setViperDefaults() {
 	viper.SetDefault("retailplayer.enabled", false)
 	viper.SetDefault("retailplayer.baseurl", "")
 	viper.SetDefault("retailplayer.orgid", "")
-	viper.SetDefault("retailplayer.apikey", "")
+	viper.SetDefault("retailplayer.apikey", "DUMMY_API_KEY")
 	viper.SetDefault("retailplayer.apikeyheader", "x-retailplayer-apikey")
 	viper.SetDefault("retailplayer.pagesize", 0)
 	viper.SetDefault("retailplayer.page", 0)

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -27,12 +27,7 @@ import (
 	"github.com/navidrome/navidrome/utils"
 )
 
-const (
-	retailPlayerDefaultKeyHeader = "x-retailplayer-apikey"
-	retailPlayerLegacyKeyHeader  = "X-API-Key"
-)
-
-var RetailPlayerApiKey = "DUMMY_API_KEY"
+const retailPlayerRemoteControlKeyHeader = "x-retailplayer-rc-apikey"
 
 var retailPlayerHTTPClient = &http.Client{Timeout: 15 * time.Second}
 
@@ -1720,15 +1715,10 @@ func (n *Router) sendRetailPlayerDeviceCommand(ctx context.Context, deviceID str
 func retailPlayerRequestConfigWithDefaults() retailPlayerConfig {
 	cfg := conf.Server.RetailPlayer
 
-	apiKey := strings.TrimSpace(cfg.APIKey)
-	if apiKey == "" {
-		apiKey = RetailPlayerApiKey
-	}
-
 	return retailPlayerConfig{
 		BaseURL:           cfg.BaseURL,
 		OrgID:             cfg.OrgID,
-		APIKey:            apiKey,
+		APIKey:            strings.TrimSpace(cfg.APIKey),
 		APIKeyHeader:      cfg.APIKeyHeader,
 		PageSize:          cfg.PageSize,
 		Page:              cfg.Page,
@@ -1743,7 +1733,7 @@ func retailPlayerRequestConfigWithDefaults() retailPlayerConfig {
 
 func (n *Router) fetchRetailPlayerTriggers(ctx context.Context, deviceID string) ([]retailPlayerTrigger, error) {
 	cfg := retailPlayerRequestConfigWithDefaults()
-	if cfg.BaseURL == "" || cfg.OrgID == "" {
+	if cfg.BaseURL == "" {
 		return nil, errors.New("retail player API not configured")
 	}
 
@@ -1752,10 +1742,15 @@ func (n *Router) fetchRetailPlayerTriggers(ctx context.Context, deviceID string)
 		return nil, errors.New("retail player device id is empty")
 	}
 
-	req, err := buildRetailPlayerRequest(ctx, cfg, trimmedID, "triggers")
+	baseURL := strings.TrimRight(cfg.BaseURL, "/")
+	endpoint := fmt.Sprintf("%s/rest/v1/device-control/%s/triggers", baseURL, url.PathEscape(trimmedID))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
+
+	applyRetailPlayerHeaders(req, cfg)
 
 	resp, err := retailPlayerHTTPClient.Do(req)
 	if err != nil {
@@ -1788,7 +1783,7 @@ func (n *Router) fetchRetailPlayerTriggers(ctx context.Context, deviceID string)
 
 func (n *Router) sendRetailPlayerCueAction(ctx context.Context, deviceID, action string, payload map[string]string) (string, error) {
 	cfg := retailPlayerRequestConfigWithDefaults()
-	if cfg.BaseURL == "" || cfg.OrgID == "" {
+	if cfg.BaseURL == "" {
 		return "", errors.New("retail player API not configured")
 	}
 
@@ -1802,13 +1797,28 @@ func (n *Router) sendRetailPlayerCueAction(ctx context.Context, deviceID, action
 		return "", errors.New("retail player action is empty")
 	}
 
-	body, err := json.Marshal(payload)
+	baseURL := strings.TrimRight(cfg.BaseURL, "/")
+	endpoint := fmt.Sprintf("%s/rest/v1/device-control/%s/triggers", baseURL, url.PathEscape(trimmedID))
+
+	var bodyPayload map[string]string
+
+	switch strings.ToLower(trimmedAction) {
+	case "play":
+		cueID := strings.TrimSpace(payload["cue"])
+		if cueID == "" {
+			return "", errors.New("retail player cue id is empty")
+		}
+		bodyPayload = map[string]string{"action": "PLAY", "value": cueID}
+	case "stop":
+		bodyPayload = map[string]string{"action": "STOP"}
+	default:
+		return "", fmt.Errorf("unsupported retail player action: %s", trimmedAction)
+	}
+
+	body, err := json.Marshal(bodyPayload)
 	if err != nil {
 		return "", err
 	}
-
-	baseURL := strings.TrimRight(cfg.BaseURL, "/")
-	endpoint := fmt.Sprintf("%s/orgs/%s/devices/%s/%s", baseURL, url.PathEscape(cfg.OrgID), url.PathEscape(trimmedID), url.PathEscape(trimmedAction))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
@@ -2145,19 +2155,7 @@ func applyRetailPlayerHeaders(req *http.Request, cfg retailPlayerConfig) {
 
 	apiKey := strings.TrimSpace(cfg.APIKey)
 	if apiKey != "" {
-		headerName := strings.TrimSpace(cfg.APIKeyHeader)
-		if headerName == "" {
-			headerName = retailPlayerDefaultKeyHeader
-		}
-
-		req.Header.Set(headerName, apiKey)
-
-		if !strings.EqualFold(headerName, retailPlayerDefaultKeyHeader) {
-			req.Header.Set(retailPlayerDefaultKeyHeader, apiKey)
-		}
-		if !strings.EqualFold(headerName, retailPlayerLegacyKeyHeader) {
-			req.Header.Set(retailPlayerLegacyKeyHeader, apiKey)
-		}
+		req.Header.Set(retailPlayerRemoteControlKeyHeader, apiKey)
 	}
 
 	for key, value := range cfg.AdditionalHeaders {

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -32,6 +32,8 @@ const (
 	retailPlayerLegacyKeyHeader  = "X-API-Key"
 )
 
+var RetailPlayerApiKey = "DUMMY_API_KEY"
+
 var retailPlayerHTTPClient = &http.Client{Timeout: 15 * time.Second}
 
 type retailPlayerDeviceResolver struct {
@@ -279,6 +281,9 @@ func (n *Router) addRetailPlayerPublicRoutes(r chi.Router) {
 		r.Post("/devices/{deviceID}/channel", n.handleRetailPlayerDeviceChannel())
 		r.Post("/devices/{deviceID}/channel/toggle", n.handleRetailPlayerDeviceToggleChannel())
 		r.Post("/devices/{deviceID}/dislike", n.handleRetailPlayerDeviceDislike())
+		r.Get("/triggers", n.handleRetailPlayerTriggers())
+		r.Post("/play", n.handleRetailPlayerPlayCue())
+		r.Post("/stop", n.handleRetailPlayerStop())
 	})
 }
 
@@ -1255,6 +1260,112 @@ func (n *Router) handleRetailPlayerDeviceDislike() http.HandlerFunc {
 	}
 }
 
+func (n *Router) handleRetailPlayerTriggers() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		deviceID := strings.TrimSpace(r.URL.Query().Get("device"))
+		if deviceID == "" {
+			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
+			return
+		}
+
+		response, err := n.fetchRetailPlayerTriggers(ctx, deviceID)
+		if err != nil {
+			log.Error(ctx, "Unable to fetch retail player triggers", "deviceID", deviceID, "err", err)
+			http.Error(w, "Unable to fetch retail player triggers", http.StatusBadGateway)
+			return
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{"triggers": response})
+	}
+}
+
+func (n *Router) handleRetailPlayerPlayCue() http.HandlerFunc {
+	type playRequest struct {
+		Device string `json:"device"`
+		Cue    string `json:"cue"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		decoder := json.NewDecoder(r.Body)
+		decoder.DisallowUnknownFields()
+
+		var payload playRequest
+		if err := decoder.Decode(&payload); err != nil {
+			http.Error(w, "Invalid play payload", http.StatusBadRequest)
+			return
+		}
+
+		deviceID := strings.TrimSpace(payload.Device)
+		cueID := strings.TrimSpace(payload.Cue)
+		if deviceID == "" || cueID == "" {
+			http.Error(w, "Device id and cue id are required", http.StatusBadRequest)
+			return
+		}
+
+		responseBody, err := n.sendRetailPlayerCueAction(ctx, deviceID, "play", map[string]string{"device": deviceID, "cue": cueID})
+		if err != nil {
+			log.Error(ctx, "Unable to send retail player cue command", "deviceID", deviceID, "cueID", cueID, "err", err)
+			http.Error(w, "Unable to play cue", http.StatusBadGateway)
+			return
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{"success": true, "message": responseBody})
+	}
+}
+
+func (n *Router) handleRetailPlayerStop() http.HandlerFunc {
+	type stopRequest struct {
+		Device string `json:"device"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		decoder := json.NewDecoder(r.Body)
+		decoder.DisallowUnknownFields()
+
+		var payload stopRequest
+		if err := decoder.Decode(&payload); err != nil {
+			http.Error(w, "Invalid stop payload", http.StatusBadRequest)
+			return
+		}
+
+		deviceID := strings.TrimSpace(payload.Device)
+		if deviceID == "" {
+			http.Error(w, "Device id is required", http.StatusBadRequest)
+			return
+		}
+
+		responseBody, err := n.sendRetailPlayerCueAction(ctx, deviceID, "stop", map[string]string{"device": deviceID})
+		if err != nil {
+			log.Error(ctx, "Unable to send retail player stop command", "deviceID", deviceID, "err", err)
+			http.Error(w, "Unable to stop device", http.StatusBadGateway)
+			return
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{"success": true, "message": responseBody})
+	}
+}
+
 func fetchRetailPlayerDevices(ctx context.Context) (retailPlayerDevicesResponse, error) {
 	cfg := conf.Server.RetailPlayer
 	if cfg.BaseURL == "" || cfg.OrgID == "" {
@@ -1534,6 +1645,12 @@ type retailPlayerStatusArtwork struct {
 	URL         string `json:"url,omitempty"`
 }
 
+type retailPlayerTrigger struct {
+	ID    string `json:"id"`
+	Name  string `json:"name,omitempty"`
+	Label string `json:"label,omitempty"`
+}
+
 func (n *Router) sendRetailPlayerDeviceCommand(ctx context.Context, deviceID string, command retailPlayerCommandRequest) (string, error) {
 	cfg := conf.Server.RetailPlayer
 	if cfg.BaseURL == "" || cfg.OrgID == "" {
@@ -1598,6 +1715,134 @@ func (n *Router) sendRetailPlayerDeviceCommand(ctx context.Context, deviceID str
 	}
 
 	return trimmedBody, nil
+}
+
+func retailPlayerRequestConfigWithDefaults() retailPlayerConfig {
+	cfg := conf.Server.RetailPlayer
+
+	apiKey := strings.TrimSpace(cfg.APIKey)
+	if apiKey == "" {
+		apiKey = RetailPlayerApiKey
+	}
+
+	return retailPlayerConfig{
+		BaseURL:           cfg.BaseURL,
+		OrgID:             cfg.OrgID,
+		APIKey:            apiKey,
+		APIKeyHeader:      cfg.APIKeyHeader,
+		PageSize:          cfg.PageSize,
+		Page:              cfg.Page,
+		Filters:           cfg.Filters,
+		OrderBy:           cfg.OrderBy,
+		OrderDirection:    cfg.OrderDirection,
+		Search:            cfg.Search,
+		Fields:            cfg.Fields,
+		AdditionalHeaders: cfg.AdditionalHeaders,
+	}
+}
+
+func (n *Router) fetchRetailPlayerTriggers(ctx context.Context, deviceID string) ([]retailPlayerTrigger, error) {
+	cfg := retailPlayerRequestConfigWithDefaults()
+	if cfg.BaseURL == "" || cfg.OrgID == "" {
+		return nil, errors.New("retail player API not configured")
+	}
+
+	trimmedID := strings.TrimSpace(deviceID)
+	if trimmedID == "" {
+		return nil, errors.New("retail player device id is empty")
+	}
+
+	req, err := buildRetailPlayerRequest(ctx, cfg, trimmedID, "triggers")
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := retailPlayerHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, errRetailPlayerDeviceNotFound
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("retail player API request failed with status %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Triggers []retailPlayerTrigger `json:"triggers"`
+		Data     []retailPlayerTrigger `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+
+	triggers := payload.Triggers
+	if len(triggers) == 0 {
+		triggers = payload.Data
+	}
+
+	return triggers, nil
+}
+
+func (n *Router) sendRetailPlayerCueAction(ctx context.Context, deviceID, action string, payload map[string]string) (string, error) {
+	cfg := retailPlayerRequestConfigWithDefaults()
+	if cfg.BaseURL == "" || cfg.OrgID == "" {
+		return "", errors.New("retail player API not configured")
+	}
+
+	trimmedID := strings.TrimSpace(deviceID)
+	if trimmedID == "" {
+		return "", errors.New("retail player device id is empty")
+	}
+
+	trimmedAction := strings.Trim(strings.TrimSpace(action), "/")
+	if trimmedAction == "" {
+		return "", errors.New("retail player action is empty")
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+
+	baseURL := strings.TrimRight(cfg.BaseURL, "/")
+	endpoint := fmt.Sprintf("%s/orgs/%s/devices/%s/%s", baseURL, url.PathEscape(cfg.OrgID), url.PathEscape(trimmedID), url.PathEscape(trimmedAction))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	req.ContentLength = int64(len(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	applyRetailPlayerHeaders(req, cfg)
+
+	resp, err := retailPlayerHTTPClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		if len(bodyBytes) > 0 {
+			return "", fmt.Errorf("retail player action failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(bodyBytes)))
+		}
+		return "", fmt.Errorf("retail player action failed with status %d", resp.StatusCode)
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(bodyBytes)), nil
 }
 
 func (n *Router) fetchRetailPlayerDeviceStatus(ctx context.Context, r *http.Request, deviceID string) (retailPlayerDeviceStatusResponse, error) {

--- a/ui/src/retailPlayer/RetailPlayerCueDrawer.jsx
+++ b/ui/src/retailPlayer/RetailPlayerCueDrawer.jsx
@@ -1,0 +1,212 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import Drawer from '@material-ui/core/Drawer'
+import { Button, CircularProgress, Divider, Typography } from '@material-ui/core'
+import { makeStyles } from '@material-ui/core/styles'
+import httpClient from '../dataProvider/httpClient'
+
+const useStyles = makeStyles((theme) => ({
+  drawerPaper: {
+    width: 360,
+    maxWidth: '100vw',
+    padding: theme.spacing(3),
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+  },
+  headerRow: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing(2),
+  },
+  cueButtons: {
+    display: 'grid',
+    gridTemplateColumns: '1fr',
+    gap: theme.spacing(1),
+  },
+  stopButton: {
+    alignSelf: 'flex-start',
+  },
+  helperText: {
+    color: theme.palette.text.secondary,
+  },
+}))
+
+const RetailPlayerCueDrawer = ({ open, onClose, deviceId, onActionComplete }) => {
+  const classes = useStyles()
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [triggers, setTriggers] = useState([])
+  const [isSending, setIsSending] = useState(false)
+
+  const normalizedDeviceId = useMemo(() => (deviceId || '').trim(), [deviceId])
+
+  const loadTriggers = useCallback(() => {
+    if (!open || !normalizedDeviceId) {
+      return undefined
+    }
+
+    const abortController = new AbortController()
+    setIsLoading(true)
+    setError('')
+
+    httpClient(`/api/retailplayer/triggers?device=${encodeURIComponent(normalizedDeviceId)}`, {
+      signal: abortController.signal,
+    })
+      .then(({ json }) => {
+        const loadedTriggers = Array.isArray(json?.triggers) ? json.triggers : []
+        setTriggers(loadedTriggers)
+      })
+      .catch((err) => {
+        if (err?.name !== 'AbortError') {
+          // eslint-disable-next-line no-console
+          console.error('Unable to fetch retail player triggers', err)
+          setError('Unable to load cues')
+        }
+      })
+      .finally(() => {
+        setIsLoading(false)
+      })
+
+    return () => {
+      abortController.abort()
+    }
+  }, [normalizedDeviceId, open])
+
+  useEffect(() => loadTriggers(), [loadTriggers])
+
+  const handleStop = useCallback(() => {
+    if (!normalizedDeviceId) {
+      return
+    }
+
+    setIsSending(true)
+    httpClient('/api/retailplayer/stop', {
+      method: 'POST',
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({ device: normalizedDeviceId }),
+    })
+      .then(() => {
+        if (typeof onActionComplete === 'function') {
+          onActionComplete()
+        }
+      })
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.error('Unable to stop retail player device', err)
+      })
+      .finally(() => {
+        setIsSending(false)
+      })
+  }, [normalizedDeviceId, onActionComplete])
+
+  const handlePlayCue = useCallback(
+    (cueId) => {
+      if (!normalizedDeviceId || !cueId) {
+        return
+      }
+
+      setIsSending(true)
+      httpClient('/api/retailplayer/play', {
+        method: 'POST',
+        headers: new Headers({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({ device: normalizedDeviceId, cue: cueId }),
+      })
+        .then(() => {
+          if (typeof onActionComplete === 'function') {
+            onActionComplete()
+          }
+        })
+        .catch((err) => {
+          // eslint-disable-next-line no-console
+          console.error('Unable to play retail player cue', err)
+        })
+        .finally(() => {
+          setIsSending(false)
+        })
+    },
+    [normalizedDeviceId, onActionComplete]
+  )
+
+  const renderBody = () => {
+    if (isLoading) {
+      return (
+        <div aria-live="polite">
+          <CircularProgress size={24} />
+        </div>
+      )
+    }
+
+    if (error) {
+      return (
+        <Typography variant="body2" className={classes.helperText} aria-live="polite">
+          {error}
+        </Typography>
+      )
+    }
+
+    if (!triggers.length) {
+      return (
+        <Typography variant="body2" className={classes.helperText} aria-live="polite">
+          No cues available for this device.
+        </Typography>
+      )
+    }
+
+    return (
+      <div className={classes.cueButtons}>
+        {triggers.map((trigger) => {
+          const { id, name, label } = trigger || {}
+          const displayName = name || label || id || 'Cue'
+          return (
+            <Button
+              key={id || displayName}
+              variant="outlined"
+              color="primary"
+              onClick={() => handlePlayCue(id)}
+              disabled={isSending}
+            >
+              {displayName}
+            </Button>
+          )
+        })}
+      </div>
+    )
+  }
+
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      classes={{ paper: classes.drawerPaper }}
+      ModalProps={{ keepMounted: true }}
+    >
+      <div className={classes.headerRow}>
+        <Typography variant="h6" component="h2">
+          Cues
+        </Typography>
+        <Button
+          onClick={handleStop}
+          color="secondary"
+          variant="contained"
+          className={classes.stopButton}
+          disabled={isSending}
+        >
+          STOP
+        </Button>
+      </div>
+
+      <Divider />
+
+      {renderBody()}
+    </Drawer>
+  )
+}
+
+RetailPlayerCueDrawer.defaultProps = {
+  onClose: undefined,
+  onActionComplete: undefined,
+}
+
+export default RetailPlayerCueDrawer

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -15,8 +15,10 @@ import ArrowBackIcon from '@material-ui/icons/ArrowBack'
 import { useHistory, useParams } from 'react-router-dom'
 import { BiDislike } from 'react-icons/bi'
 import { MdSkipNext } from 'react-icons/md'
+import { BsRecordCircle } from 'react-icons/bs'
 import useRetailPlayerDeviceStatus from './useRetailPlayerDeviceStatus'
 import { normalizeValue } from './deviceUtils'
+import RetailPlayerCueDrawer from './RetailPlayerCueDrawer'
 import httpClient from '../dataProvider/httpClient'
 
 const combineClasses = (...classNames) => classNames.filter(Boolean).join(' ')
@@ -637,6 +639,9 @@ const useStyles = makeStyles((theme) => {
       fontSize: theme.typography.pxToRem(28),
       display: 'inline-flex',
     },
+    cueControlIcon: {
+      color: '#2196f3',
+    },
     volumeSection: {
       display: 'flex',
       flexDirection: 'column',
@@ -761,6 +766,7 @@ const RetailPlayerDashboard = () => {
   const [previousNowPlaying, setPreviousNowPlaying] = useState(null)
   const [currentTrackIndex, setCurrentTrackIndex] = useState(0)
   const [isScheduleMenuOpen, setScheduleMenuOpen] = useState(false)
+  const [isCueDrawerOpen, setCueDrawerOpen] = useState(false)
   const scheduleDropdownRef = useRef(null)
   const isBusy = retailLoading || statusLoading
   const combinedError = integrationError || statusError || devicesError
@@ -829,6 +835,16 @@ const RetailPlayerDashboard = () => {
     () => Boolean(isApiEnabled && deviceApiId),
     [deviceApiId, isApiEnabled],
   )
+
+  const handleOpenCueDrawer = useCallback(() => {
+    if (canControlDevice) {
+      setCueDrawerOpen(true)
+    }
+  }, [canControlDevice])
+
+  const handleCloseCueDrawer = useCallback(() => {
+    setCueDrawerOpen(false)
+  }, [])
 
   const resolveDeviceTime = useCallback((sourceDevice) => {
     if (!sourceDevice) {
@@ -1803,6 +1819,20 @@ const trackPool = useMemo(() => {
                     <MdSkipNext fontSize="inherit" />
                   </span>
                 </ButtonBase>
+                <ButtonBase
+                  className={classes.controlButton}
+                  aria-label="Cue"
+                  onClick={handleOpenCueDrawer}
+                  focusRipple
+                >
+                  <span
+                    className={combineClasses(classes.controlIcon, classes.cueControlIcon)}
+                    role="img"
+                    aria-hidden="true"
+                  >
+                    <BsRecordCircle fontSize="inherit" />
+                  </span>
+                </ButtonBase>
               </section>
 
               <section className={classes.volumeSection} aria-label="Volume">
@@ -1944,6 +1974,13 @@ const trackPool = useMemo(() => {
           </div>
         </section>
       </div>
+
+      <RetailPlayerCueDrawer
+        open={isCueDrawerOpen}
+        onClose={handleCloseCueDrawer}
+        deviceId={deviceApiId}
+        onActionComplete={refreshStatus}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add public API endpoints to proxy RetailPlayer triggers, play, and stop actions with default API key
- introduce cue drawer component and wiring to fetch triggers and send play/stop commands
- add cue control button beside the next control in the RetailPlayer device UI

## Testing
- go test ./... (fails: missing system dependency taglib)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692619cb50dc832291839a5ed770545a)