### PR TITLE
Add retail player cue trigger drawer

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -199,20 +199,23 @@ type retailPlayerNotificationOptions struct {
 }
 
 type retailPlayerOptions struct {
-	Enabled           bool
-	BaseURL           string
-	OrgID             string
-	APIKey            string
-	APIKeyHeader      string
-	PageSize          int
-	Page              int
-	Filters           string
-	OrderBy           string
-	OrderDirection    string
-	Search            string
-	Fields            []string                        `json:",omitempty"`
-	AdditionalHeaders map[string]string               `json:",omitempty"`
-	Notifications     retailPlayerNotificationOptions `json:",omitempty"`
+	Enabled                   bool
+	BaseURL                   string
+	OrgID                     string
+	APIKey                    string
+	APIKeyHeader              string
+	RemoteControlBaseURL      string
+	RemoteControlAPIKey       string
+	RemoteControlAPIKeyHeader string
+	PageSize                  int
+	Page                      int
+	Filters                   string
+	OrderBy                   string
+	OrderDirection            string
+	Search                    string
+	Fields                    []string                        `json:",omitempty"`
+	AdditionalHeaders         map[string]string               `json:",omitempty"`
+	Notifications             retailPlayerNotificationOptions `json:",omitempty"`
 }
 
 type secureOptions struct {

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -208,6 +208,17 @@ type retailPlayerDevice struct {
 	FolderIDs      []string `json:"folderIds,omitempty"`
 }
 
+type retailPlayerDeviceConfigResponse struct {
+	ID                  string `json:"id"`
+	OrgUnit             string `json:"orgUnit"`
+	Organization        string `json:"organization"`
+	Name                string `json:"name"`
+	Channel             string `json:"channel"`
+	ChannelList         string `json:"channelList"`
+	OrgButtonTriggerSet string `json:"orgButtonTriggerSet"`
+	InstalledFirmware   string `json:"installedFirmwareVersion"`
+}
+
 type retailPlayerDevicesResponse struct {
 	Data         []retailPlayerDevice       `json:"data"`
 	Folders      []retailPlayerFolder       `json:"folders,omitempty"`
@@ -309,6 +320,7 @@ type retailPlayerRemoteControl struct {
 
 func (n *Router) addRetailPlayerPublicRoutes(r chi.Router) {
 	r.Route("/retailplayer", func(r chi.Router) {
+		r.Get("/devices/{deviceID}/config", n.handleRetailPlayerDeviceConfig())
 		r.Get("/devices/{deviceID}/status", n.handleRetailPlayerDeviceStatus())
 		r.Get("/devices/{deviceID}/triggers", n.handleRetailPlayerDeviceTriggers())
 		r.Get("/channel-lists/{channelListID}/channels", n.handleRetailPlayerChannelListChannels())
@@ -665,6 +677,68 @@ func (n *Router) handleRetailPlayerDeviceTriggers() http.HandlerFunc {
 		}
 
 		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{"triggers": triggers})
+	}
+}
+
+func (n *Router) handleRetailPlayerDeviceConfig() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		deviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		if deviceID == "" {
+			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
+			return
+		}
+
+		normalizedID := normalizeRetailPlayerIdentifier(deviceID)
+		if normalizedID == "" {
+			http.Error(w, "Retail player device identifier is required", http.StatusBadRequest)
+			return
+		}
+
+		log.Info(ctx, "Fetching retail player device config", "identifier", normalizedID, "rawIdentifier", deviceID)
+
+		device, err := n.resolveRetailPlayerDevice(ctx, normalizedID)
+		if err != nil {
+			if errors.Is(err, errRetailPlayerDeviceNotFound) {
+				http.Error(w, "Retail player device not found", http.StatusNotFound)
+				return
+			}
+
+			log.Error(ctx, "Unable to resolve retail player device for config", "identifier", normalizedID, "rawIdentifier", deviceID, "err", err)
+			http.Error(w, "Unable to fetch retail player device config", http.StatusBadGateway)
+			return
+		}
+
+		resolvedID := strings.TrimSpace(device.ID)
+		if resolvedID == "" {
+			log.Info(ctx, "Retail player device missing resolved id for config", "identifier", normalizedID)
+			http.Error(w, "Retail player device not found", http.StatusNotFound)
+			return
+		}
+
+		config, err := fetchRetailPlayerDeviceConfig(ctx, resolvedID)
+		if err != nil {
+			if errors.Is(err, errRetailPlayerDeviceNotFound) {
+				http.Error(w, "Retail player device not found", http.StatusNotFound)
+				return
+			}
+
+			log.Error(ctx, "Unable to fetch retail player device config", "identifier", normalizedID, "rawIdentifier", deviceID, "resolvedID", resolvedID, "err", err)
+			http.Error(w, "Unable to fetch retail player device config", http.StatusBadGateway)
+			return
+		}
+
+		if strings.TrimSpace(config.ID) == "" {
+			config.ID = resolvedID
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusOK, config)
 	}
 }
 
@@ -1495,6 +1569,66 @@ func fetchRetailPlayerDevice(ctx context.Context, deviceID string) (retailPlayer
 	return device, nil
 }
 
+func fetchRetailPlayerDeviceConfig(ctx context.Context, deviceID string) (retailPlayerDeviceConfigResponse, error) {
+	cfg := conf.Server.RetailPlayer
+	if cfg.BaseURL == "" || cfg.OrgID == "" {
+		return retailPlayerDeviceConfigResponse{}, errors.New("retail player API not configured")
+	}
+
+	trimmedID := strings.TrimSpace(deviceID)
+	if trimmedID == "" {
+		return retailPlayerDeviceConfigResponse{}, errors.New("retail player device id is empty")
+	}
+
+	requestConfig := retailPlayerConfig{
+		BaseURL:           cfg.BaseURL,
+		OrgID:             cfg.OrgID,
+		APIKey:            cfg.APIKey,
+		APIKeyHeader:      cfg.APIKeyHeader,
+		AdditionalHeaders: cfg.AdditionalHeaders,
+	}
+
+	req, err := buildRetailPlayerRequest(ctx, requestConfig, trimmedID)
+	if err != nil {
+		return retailPlayerDeviceConfigResponse{}, err
+	}
+
+	resp, err := retailPlayerHTTPClient.Do(req)
+	if err != nil {
+		return retailPlayerDeviceConfigResponse{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusBadRequest {
+		return retailPlayerDeviceConfigResponse{}, errRetailPlayerDeviceNotFound
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return retailPlayerDeviceConfigResponse{}, fmt.Errorf("retail player API request failed with status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return retailPlayerDeviceConfigResponse{}, err
+	}
+
+	var config retailPlayerDeviceConfigResponse
+	if err := json.Unmarshal(body, &config); err != nil || isRetailPlayerDeviceConfigEmpty(config) {
+		var wrapped struct {
+			Data retailPlayerDeviceConfigResponse `json:"data"`
+		}
+		if err := json.Unmarshal(body, &wrapped); err != nil || isRetailPlayerDeviceConfigEmpty(wrapped.Data) {
+			return retailPlayerDeviceConfigResponse{}, errors.New("unable to parse retail player device config response")
+		}
+		config = wrapped.Data
+	}
+
+	if strings.TrimSpace(config.ID) == "" {
+		config.ID = trimmedID
+	}
+
+	return config, nil
+}
+
 func fetchRetailPlayerDeviceTriggers(ctx context.Context, deviceID string) ([]retailPlayerTrigger, error) {
 	cfg := conf.Server.RetailPlayer
 	baseURL := strings.TrimSpace(cfg.RemoteControlBaseURL)
@@ -1653,9 +1787,20 @@ func fetchRetailPlayerRemoteControlID(ctx context.Context, deviceID string) (str
 		return "", errors.New("retail player device id is empty")
 	}
 
-	organizationID, err := fetchRetailPlayerDeviceOrganizationID(ctx, deviceKey)
+	config, err := fetchRetailPlayerDeviceConfig(ctx, deviceKey)
 	if err != nil {
 		return "", err
+	}
+
+	organizationID := strings.TrimSpace(config.OrgUnit)
+	if organizationID == "" {
+		organizationID = strings.TrimSpace(config.Organization)
+	}
+	if organizationID == "" {
+		organizationID, err = fetchRetailPlayerDeviceOrganizationID(ctx, deviceKey)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	dependents, err := fetchRetailPlayerDependents(ctx, organizationID)
@@ -2304,6 +2449,42 @@ func applyRetailPlayerRemoteControlHeaders(req *http.Request, cfg retailPlayerRe
 			req.Header.Set(trimmedKey, trimmedValue)
 		}
 	}
+}
+
+func isRetailPlayerDeviceConfigEmpty(config retailPlayerDeviceConfigResponse) bool {
+	if strings.TrimSpace(config.ID) != "" {
+		return false
+	}
+
+	if strings.TrimSpace(config.OrgUnit) != "" {
+		return false
+	}
+
+	if strings.TrimSpace(config.Organization) != "" {
+		return false
+	}
+
+	if strings.TrimSpace(config.Name) != "" {
+		return false
+	}
+
+	if strings.TrimSpace(config.Channel) != "" {
+		return false
+	}
+
+	if strings.TrimSpace(config.ChannelList) != "" {
+		return false
+	}
+
+	if strings.TrimSpace(config.OrgButtonTriggerSet) != "" {
+		return false
+	}
+
+	if strings.TrimSpace(config.InstalledFirmware) != "" {
+		return false
+	}
+
+	return true
 }
 
 func isRetailPlayerAPIDeviceEmpty(device retailPlayerAPIDevice) bool {

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -197,13 +197,15 @@ type retailPlayerChannelListAPIResponse struct {
 }
 
 type retailPlayerDevice struct {
-	ID           string   `json:"id"`
-	Name         string   `json:"name"`
-	Channel      string   `json:"channel"`
-	ChannelList  string   `json:"channelList"`
-	Organization string   `json:"organization"`
-	TimeZone     string   `json:"timeZone,omitempty"`
-	FolderIDs    []string `json:"folderIds,omitempty"`
+	ID             string   `json:"id"`
+	Name           string   `json:"name"`
+	OrganizationID string   `json:"organizationId,omitempty"`
+	OrganisationID string   `json:"organisationid,omitempty"`
+	Channel        string   `json:"channel"`
+	ChannelList    string   `json:"channelList"`
+	Organization   string   `json:"organization"`
+	TimeZone       string   `json:"timeZone,omitempty"`
+	FolderIDs      []string `json:"folderIds,omitempty"`
 }
 
 type retailPlayerDevicesResponse struct {
@@ -1588,13 +1590,75 @@ func fetchRetailPlayerDeviceTriggers(ctx context.Context, deviceID string) ([]re
 	return triggers, nil
 }
 
+func fetchRetailPlayerDeviceOrganizationID(ctx context.Context, deviceID string) (string, error) {
+	cfg := conf.Server.RetailPlayer
+	if cfg.BaseURL == "" || cfg.OrgID == "" {
+		return "", errors.New("retail player API not configured")
+	}
+
+	trimmedID := strings.TrimSpace(deviceID)
+	if trimmedID == "" {
+		return "", errors.New("retail player device id is empty")
+	}
+
+	requestConfig := retailPlayerConfig{
+		BaseURL:           cfg.BaseURL,
+		OrgID:             cfg.OrgID,
+		APIKey:            cfg.APIKey,
+		APIKeyHeader:      cfg.APIKeyHeader,
+		AdditionalHeaders: cfg.AdditionalHeaders,
+	}
+
+	req, err := buildRetailPlayerRequest(ctx, requestConfig, trimmedID, "status")
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := retailPlayerHTTPClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", errRetailPlayerDeviceNotFound
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("retail player API request failed with status %d", resp.StatusCode)
+	}
+
+	var payload retailPlayerDeviceStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", err
+	}
+
+	if payload.Device != nil {
+		if orgID := strings.TrimSpace(payload.Device.OrganizationID); orgID != "" {
+			return orgID, nil
+		}
+		if orgID := strings.TrimSpace(payload.Device.OrganisationID); orgID != "" {
+			return orgID, nil
+		}
+		if orgID := strings.TrimSpace(payload.Device.Organization); orgID != "" {
+			return orgID, nil
+		}
+	}
+
+	return "", errors.New("retail player device organization id not found")
+}
+
 func fetchRetailPlayerRemoteControlID(ctx context.Context, deviceID string) (string, error) {
 	deviceKey := strings.TrimSpace(deviceID)
 	if deviceKey == "" {
 		return "", errors.New("retail player device id is empty")
 	}
 
-	dependents, err := fetchRetailPlayerDependents(ctx)
+	organizationID, err := fetchRetailPlayerDeviceOrganizationID(ctx, deviceKey)
+	if err != nil {
+		return "", err
+	}
+
+	dependents, err := fetchRetailPlayerDependents(ctx, organizationID)
 	if err != nil {
 		return "", err
 	}
@@ -1621,15 +1685,20 @@ func fetchRetailPlayerRemoteControlID(ctx context.Context, deviceID string) (str
 	return "", errors.New("retail player remote control id not found")
 }
 
-func fetchRetailPlayerDependents(ctx context.Context) (retailPlayerDependentsResponse, error) {
+func fetchRetailPlayerDependents(ctx context.Context, orgID string) (retailPlayerDependentsResponse, error) {
 	cfg := conf.Server.RetailPlayer
-	if cfg.BaseURL == "" || cfg.OrgID == "" {
+	if cfg.BaseURL == "" {
 		return retailPlayerDependentsResponse{}, errors.New("retail player API not configured")
+	}
+
+	trimmedOrgID := strings.TrimSpace(orgID)
+	if trimmedOrgID == "" {
+		return retailPlayerDependentsResponse{}, errors.New("retail player organization id is empty")
 	}
 
 	requestConfig := retailPlayerConfig{
 		BaseURL:           cfg.BaseURL,
-		OrgID:             cfg.OrgID,
+		OrgID:             trimmedOrgID,
 		APIKey:            cfg.APIKey,
 		APIKeyHeader:      cfg.APIKeyHeader,
 		AdditionalHeaders: cfg.AdditionalHeaders,

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -323,6 +323,7 @@ func (n *Router) addRetailPlayerPublicRoutes(r chi.Router) {
 		r.Get("/devices/{deviceID}/config", n.handleRetailPlayerDeviceConfig())
 		r.Get("/devices/{deviceID}/status", n.handleRetailPlayerDeviceStatus())
 		r.Get("/devices/{deviceID}/triggers", n.handleRetailPlayerDeviceTriggers())
+		r.Post("/devices/{deviceID}/triggers", n.handleRetailPlayerDeviceTriggerAction())
 		r.Get("/channel-lists/{channelListID}/channels", n.handleRetailPlayerChannelListChannels())
 		r.Post("/devices/{deviceID}/volume", n.handleRetailPlayerDeviceVolume())
 		r.Post("/devices/{deviceID}/channel", n.handleRetailPlayerDeviceChannel())
@@ -677,6 +678,63 @@ func (n *Router) handleRetailPlayerDeviceTriggers() http.HandlerFunc {
 		}
 
 		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{"triggers": triggers})
+	}
+}
+
+func (n *Router) handleRetailPlayerDeviceTriggerAction() http.HandlerFunc {
+	type triggerActionRequest struct {
+		Action string `json:"action"`
+		Value  string `json:"value"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		deviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		if deviceID == "" {
+			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
+			return
+		}
+
+		decoder := json.NewDecoder(r.Body)
+		decoder.DisallowUnknownFields()
+
+		var payload triggerActionRequest
+		if err := decoder.Decode(&payload); err != nil {
+			http.Error(w, "Invalid trigger payload", http.StatusBadRequest)
+			return
+		}
+
+		action := strings.TrimSpace(payload.Action)
+		value := strings.TrimSpace(payload.Value)
+		if action == "" || value == "" {
+			http.Error(w, "Trigger action and value are required", http.StatusBadRequest)
+			return
+		}
+
+		log.Info(ctx, "Sending retail player trigger action", "deviceID", deviceID, "action", action, "value", value)
+
+		if err := sendRetailPlayerTriggerAction(ctx, deviceID, action, value); err != nil {
+			if errors.Is(err, errRetailPlayerDeviceNotFound) {
+				http.Error(w, "Retail player device not found", http.StatusNotFound)
+				return
+			}
+
+			log.Error(ctx, "Unable to send retail player trigger action", "deviceID", deviceID, "err", err)
+			http.Error(w, "Unable to send trigger action", http.StatusBadGateway)
+			return
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{
+			"success": true,
+			"action":  action,
+			"value":   value,
+		})
 	}
 }
 
@@ -1724,6 +1782,87 @@ func fetchRetailPlayerDeviceTriggers(ctx context.Context, deviceID string) ([]re
 	return triggers, nil
 }
 
+func sendRetailPlayerTriggerAction(ctx context.Context, deviceID, action, value string) error {
+	cfg := conf.Server.RetailPlayer
+	baseURL := strings.TrimSpace(cfg.RemoteControlBaseURL)
+	if baseURL == "" {
+		baseURL = cfg.BaseURL
+	}
+
+	apiKey := strings.TrimSpace(cfg.RemoteControlAPIKey)
+	if apiKey == "" {
+		apiKey = cfg.APIKey
+	}
+
+	apiKeyHeader := strings.TrimSpace(cfg.RemoteControlAPIKeyHeader)
+	if apiKeyHeader == "" {
+		apiKeyHeader = retailPlayerRemoteControlDefaultKeyHeader
+	}
+
+	if baseURL == "" {
+		return errors.New("retail player remote control API not configured")
+	}
+
+	trimmedID := strings.TrimSpace(deviceID)
+	if trimmedID == "" {
+		return errors.New("retail player device id is empty")
+	}
+
+	remoteControlID, err := fetchRetailPlayerRemoteControlID(ctx, trimmedID)
+	if err != nil {
+		return err
+	}
+
+	requestConfig := retailPlayerRemoteControlConfig{
+		BaseURL:           baseURL,
+		APIKey:            apiKey,
+		APIKeyHeader:      apiKeyHeader,
+		AdditionalHeaders: cfg.AdditionalHeaders,
+	}
+
+	body, err := json.Marshal(map[string]string{"action": action, "value": value})
+	if err != nil {
+		return err
+	}
+
+	req, err := buildRetailPlayerRemoteControlRequestWithMethod(
+		ctx,
+		requestConfig,
+		remoteControlID,
+		http.MethodPost,
+		bytes.NewReader(body),
+		"triggers",
+	)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := retailPlayerHTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusBadRequest {
+		return errRetailPlayerDeviceNotFound
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf(
+			"retail player trigger action failed with status %d: %s",
+			resp.StatusCode,
+			strings.TrimSpace(string(bodyBytes)),
+		)
+	}
+
+	io.Copy(io.Discard, resp.Body)
+
+	return nil
+}
+
 func fetchRetailPlayerDeviceOrganizationID(ctx context.Context, deviceID string) (string, error) {
 	cfg := conf.Server.RetailPlayer
 	if cfg.BaseURL == "" || cfg.OrgID == "" {
@@ -2389,6 +2528,17 @@ func applyRetailPlayerHeaders(req *http.Request, cfg retailPlayerConfig) {
 }
 
 func buildRetailPlayerRemoteControlRequest(ctx context.Context, cfg retailPlayerRemoteControlConfig, deviceID string, pathParts ...string) (*http.Request, error) {
+	return buildRetailPlayerRemoteControlRequestWithMethod(ctx, cfg, deviceID, http.MethodGet, nil, pathParts...)
+}
+
+func buildRetailPlayerRemoteControlRequestWithMethod(
+	ctx context.Context,
+	cfg retailPlayerRemoteControlConfig,
+	deviceID string,
+	method string,
+	body io.Reader,
+	pathParts ...string,
+) (*http.Request, error) {
 	baseURL := strings.TrimRight(cfg.BaseURL, "/")
 	if baseURL == "" {
 		return nil, errors.New("retail player remote control base URL is empty")
@@ -2408,7 +2558,12 @@ func buildRetailPlayerRemoteControlRequest(ctx context.Context, cfg retailPlayer
 		endpoint = fmt.Sprintf("%s/%s", endpoint, url.PathEscape(trimmed))
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	verb := strings.TrimSpace(method)
+	if verb == "" {
+		verb = http.MethodGet
+	}
+
+	req, err := http.NewRequestWithContext(ctx, verb, endpoint, body)
 	if err != nil {
 		return nil, err
 	}

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	retailPlayerDefaultKeyHeader = "x-retailplayer-apikey"
-	retailPlayerLegacyKeyHeader  = "X-API-Key"
+	retailPlayerDefaultKeyHeader              = "x-retailplayer-apikey"
+	retailPlayerLegacyKeyHeader               = "X-API-Key"
+	retailPlayerRemoteControlDefaultKeyHeader = "x-retailplayer-rc-apikey"
 )
 
 var retailPlayerHTTPClient = &http.Client{Timeout: 15 * time.Second}
@@ -256,6 +257,23 @@ type retailPlayerChannelsResponse struct {
 	Channels []retailPlayerChannel `json:"channels"`
 }
 
+type retailPlayerTriggerAsset struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	MIME string `json:"mime"`
+}
+
+type retailPlayerTrigger struct {
+	ID      string                    `json:"id"`
+	Name    string                    `json:"name"`
+	Ordinal int                       `json:"ordinal"`
+	Asset   *retailPlayerTriggerAsset `json:"asset,omitempty"`
+}
+
+type retailPlayerTriggerAPIResponse struct {
+	Value []retailPlayerTrigger `json:"value"`
+}
+
 type retailPlayerConfig struct {
 	BaseURL           string
 	OrgID             string
@@ -271,9 +289,17 @@ type retailPlayerConfig struct {
 	AdditionalHeaders map[string]string
 }
 
+type retailPlayerRemoteControlConfig struct {
+	BaseURL           string
+	APIKey            string
+	APIKeyHeader      string
+	AdditionalHeaders map[string]string
+}
+
 func (n *Router) addRetailPlayerPublicRoutes(r chi.Router) {
 	r.Route("/retailplayer", func(r chi.Router) {
 		r.Get("/devices/{deviceID}/status", n.handleRetailPlayerDeviceStatus())
+		r.Get("/devices/{deviceID}/triggers", n.handleRetailPlayerDeviceTriggers())
 		r.Get("/channel-lists/{channelListID}/channels", n.handleRetailPlayerChannelListChannels())
 		r.Post("/devices/{deviceID}/volume", n.handleRetailPlayerDeviceVolume())
 		r.Post("/devices/{deviceID}/channel", n.handleRetailPlayerDeviceChannel())
@@ -595,6 +621,39 @@ func (n *Router) handleAssignRetailPlayerDeviceFolders() http.HandlerFunc {
 		}
 
 		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{"data": map[string]any{"deviceId": deviceID, "folderIds": normalized}})
+	}
+}
+
+func (n *Router) handleRetailPlayerDeviceTriggers() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		deviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		if deviceID == "" {
+			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
+			return
+		}
+
+		log.Info(ctx, "Fetching retail player device triggers", "deviceID", deviceID)
+
+		triggers, err := fetchRetailPlayerDeviceTriggers(ctx, deviceID)
+		if err != nil {
+			if errors.Is(err, errRetailPlayerDeviceNotFound) {
+				http.Error(w, "Retail player device not found", http.StatusNotFound)
+				return
+			}
+
+			log.Error(ctx, "Unable to fetch retail player device triggers", "deviceID", deviceID, "err", err)
+			http.Error(w, "Unable to fetch retail player device triggers", http.StatusBadGateway)
+			return
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{"triggers": triggers})
 	}
 }
 
@@ -1425,6 +1484,96 @@ func fetchRetailPlayerDevice(ctx context.Context, deviceID string) (retailPlayer
 	return device, nil
 }
 
+func fetchRetailPlayerDeviceTriggers(ctx context.Context, deviceID string) ([]retailPlayerTrigger, error) {
+	cfg := conf.Server.RetailPlayer
+	baseURL := strings.TrimSpace(cfg.RemoteControlBaseURL)
+	if baseURL == "" {
+		baseURL = cfg.BaseURL
+	}
+
+	apiKey := strings.TrimSpace(cfg.RemoteControlAPIKey)
+	if apiKey == "" {
+		apiKey = cfg.APIKey
+	}
+
+	apiKeyHeader := strings.TrimSpace(cfg.RemoteControlAPIKeyHeader)
+	if apiKeyHeader == "" {
+		apiKeyHeader = retailPlayerRemoteControlDefaultKeyHeader
+	}
+
+	if baseURL == "" {
+		return nil, errors.New("retail player remote control API not configured")
+	}
+
+	trimmedID := strings.TrimSpace(deviceID)
+	if trimmedID == "" {
+		return nil, errors.New("retail player device id is empty")
+	}
+
+	requestConfig := retailPlayerRemoteControlConfig{
+		BaseURL:           baseURL,
+		APIKey:            apiKey,
+		APIKeyHeader:      apiKeyHeader,
+		AdditionalHeaders: cfg.AdditionalHeaders,
+	}
+
+	req, err := buildRetailPlayerRemoteControlRequest(ctx, requestConfig, trimmedID, "triggers")
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := retailPlayerHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusBadRequest {
+		return nil, errRetailPlayerDeviceNotFound
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("retail player triggers request failed with status %d", resp.StatusCode)
+	}
+
+	var payload retailPlayerTriggerAPIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+
+	triggers := make([]retailPlayerTrigger, 0, len(payload.Value))
+	for _, trigger := range payload.Value {
+		id := strings.TrimSpace(trigger.ID)
+		name := strings.TrimSpace(trigger.Name)
+		if id == "" && name == "" {
+			continue
+		}
+
+		ordinal := trigger.Ordinal
+		if ordinal < 0 {
+			ordinal = 0
+		}
+
+		var asset *retailPlayerTriggerAsset
+		if trigger.Asset != nil {
+			assetID := strings.TrimSpace(trigger.Asset.ID)
+			assetName := strings.TrimSpace(trigger.Asset.Name)
+			assetMIME := strings.TrimSpace(trigger.Asset.MIME)
+			if assetID != "" || assetName != "" || assetMIME != "" {
+				asset = &retailPlayerTriggerAsset{ID: assetID, Name: assetName, MIME: assetMIME}
+			}
+		}
+
+		triggers = append(triggers, retailPlayerTrigger{
+			ID:      id,
+			Name:    name,
+			Ordinal: ordinal,
+			Asset:   asset,
+		})
+	}
+
+	return triggers, nil
+}
+
 func fetchRetailPlayerChannelListChannels(ctx context.Context, channelListID string) (retailPlayerChannelsResponse, error) {
 	cfg := conf.Server.RetailPlayer
 	if cfg.BaseURL == "" || cfg.OrgID == "" {
@@ -1909,6 +2058,69 @@ func applyRetailPlayerHeaders(req *http.Request, cfg retailPlayerConfig) {
 
 		if !strings.EqualFold(headerName, retailPlayerDefaultKeyHeader) {
 			req.Header.Set(retailPlayerDefaultKeyHeader, apiKey)
+		}
+		if !strings.EqualFold(headerName, retailPlayerLegacyKeyHeader) {
+			req.Header.Set(retailPlayerLegacyKeyHeader, apiKey)
+		}
+	}
+
+	for key, value := range cfg.AdditionalHeaders {
+		trimmedKey := strings.TrimSpace(key)
+		trimmedValue := strings.TrimSpace(value)
+		if trimmedKey != "" && trimmedValue != "" {
+			req.Header.Set(trimmedKey, trimmedValue)
+		}
+	}
+}
+
+func buildRetailPlayerRemoteControlRequest(ctx context.Context, cfg retailPlayerRemoteControlConfig, deviceID string, pathParts ...string) (*http.Request, error) {
+	baseURL := strings.TrimRight(cfg.BaseURL, "/")
+	if baseURL == "" {
+		return nil, errors.New("retail player remote control base URL is empty")
+	}
+
+	trimmedID := strings.TrimSpace(deviceID)
+	if trimmedID == "" {
+		return nil, errors.New("retail player device id is empty")
+	}
+
+	endpoint := fmt.Sprintf("%s/device-control/%s", baseURL, url.PathEscape(trimmedID))
+	for _, part := range pathParts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		endpoint = fmt.Sprintf("%s/%s", endpoint, url.PathEscape(trimmed))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	applyRetailPlayerRemoteControlHeaders(req, cfg)
+
+	return req, nil
+}
+
+func applyRetailPlayerRemoteControlHeaders(req *http.Request, cfg retailPlayerRemoteControlConfig) {
+	if req == nil {
+		return
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	apiKey := strings.TrimSpace(cfg.APIKey)
+	if apiKey != "" {
+		headerName := strings.TrimSpace(cfg.APIKeyHeader)
+		if headerName == "" {
+			headerName = retailPlayerRemoteControlDefaultKeyHeader
+		}
+
+		req.Header.Set(headerName, apiKey)
+
+		if !strings.EqualFold(headerName, retailPlayerRemoteControlDefaultKeyHeader) {
+			req.Header.Set(retailPlayerRemoteControlDefaultKeyHeader, apiKey)
 		}
 		if !strings.EqualFold(headerName, retailPlayerLegacyKeyHeader) {
 			req.Header.Set(retailPlayerLegacyKeyHeader, apiKey)

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -296,6 +296,15 @@ type retailPlayerRemoteControlConfig struct {
 	AdditionalHeaders map[string]string
 }
 
+type retailPlayerDependentsResponse struct {
+	RemoteControls []retailPlayerRemoteControl `json:"remoteControls"`
+}
+
+type retailPlayerRemoteControl struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
 func (n *Router) addRetailPlayerPublicRoutes(r chi.Router) {
 	r.Route("/retailplayer", func(r chi.Router) {
 		r.Get("/devices/{deviceID}/status", n.handleRetailPlayerDeviceStatus())
@@ -1510,6 +1519,11 @@ func fetchRetailPlayerDeviceTriggers(ctx context.Context, deviceID string) ([]re
 		return nil, errors.New("retail player device id is empty")
 	}
 
+	remoteControlID, err := fetchRetailPlayerRemoteControlID(ctx, trimmedID)
+	if err != nil {
+		return nil, err
+	}
+
 	requestConfig := retailPlayerRemoteControlConfig{
 		BaseURL:           baseURL,
 		APIKey:            apiKey,
@@ -1517,7 +1531,7 @@ func fetchRetailPlayerDeviceTriggers(ctx context.Context, deviceID string) ([]re
 		AdditionalHeaders: cfg.AdditionalHeaders,
 	}
 
-	req, err := buildRetailPlayerRemoteControlRequest(ctx, requestConfig, trimmedID, "triggers")
+	req, err := buildRetailPlayerRemoteControlRequest(ctx, requestConfig, remoteControlID, "triggers")
 	if err != nil {
 		return nil, err
 	}
@@ -1572,6 +1586,76 @@ func fetchRetailPlayerDeviceTriggers(ctx context.Context, deviceID string) ([]re
 	}
 
 	return triggers, nil
+}
+
+func fetchRetailPlayerRemoteControlID(ctx context.Context, deviceID string) (string, error) {
+	deviceKey := strings.TrimSpace(deviceID)
+	if deviceKey == "" {
+		return "", errors.New("retail player device id is empty")
+	}
+
+	dependents, err := fetchRetailPlayerDependents(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	for _, remoteControl := range dependents.RemoteControls {
+		trimmedID := strings.TrimSpace(remoteControl.ID)
+		if trimmedID == "" {
+			continue
+		}
+
+		trimmedName := strings.TrimSpace(remoteControl.Name)
+		if strings.EqualFold(trimmedID, deviceKey) || strings.EqualFold(trimmedName, deviceKey) {
+			return trimmedID, nil
+		}
+	}
+
+	for _, remoteControl := range dependents.RemoteControls {
+		trimmedID := strings.TrimSpace(remoteControl.ID)
+		if trimmedID != "" {
+			return trimmedID, nil
+		}
+	}
+
+	return "", errors.New("retail player remote control id not found")
+}
+
+func fetchRetailPlayerDependents(ctx context.Context) (retailPlayerDependentsResponse, error) {
+	cfg := conf.Server.RetailPlayer
+	if cfg.BaseURL == "" || cfg.OrgID == "" {
+		return retailPlayerDependentsResponse{}, errors.New("retail player API not configured")
+	}
+
+	requestConfig := retailPlayerConfig{
+		BaseURL:           cfg.BaseURL,
+		OrgID:             cfg.OrgID,
+		APIKey:            cfg.APIKey,
+		APIKeyHeader:      cfg.APIKeyHeader,
+		AdditionalHeaders: cfg.AdditionalHeaders,
+	}
+
+	req, err := buildRetailPlayerDependentsRequest(ctx, requestConfig)
+	if err != nil {
+		return retailPlayerDependentsResponse{}, err
+	}
+
+	resp, err := retailPlayerHTTPClient.Do(req)
+	if err != nil {
+		return retailPlayerDependentsResponse{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return retailPlayerDependentsResponse{}, fmt.Errorf("retail player dependents request failed with status %d", resp.StatusCode)
+	}
+
+	var payload retailPlayerDependentsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return retailPlayerDependentsResponse{}, err
+	}
+
+	return payload, nil
 }
 
 func fetchRetailPlayerChannelListChannels(ctx context.Context, channelListID string) (retailPlayerChannelsResponse, error) {
@@ -2008,6 +2092,23 @@ func buildRetailPlayerRequest(ctx context.Context, cfg retailPlayerConfig, pathP
 			}
 		}
 		req.URL.RawQuery = query.Encode()
+	}
+
+	applyRetailPlayerHeaders(req, cfg)
+
+	return req, nil
+}
+
+func buildRetailPlayerDependentsRequest(ctx context.Context, cfg retailPlayerConfig) (*http.Request, error) {
+	baseURL := strings.TrimRight(cfg.BaseURL, "/")
+	if baseURL == "" {
+		return nil, errors.New("retail player base URL is empty")
+	}
+
+	endpoint := fmt.Sprintf("%s/orgs/%s/dependents", baseURL, url.PathEscape(cfg.OrgID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
 	}
 
 	applyRetailPlayerHeaders(req, cfg)

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -112,6 +112,7 @@ const formatDetailedTime = (date, timeZone) => {
 
 const useStyles = makeStyles((theme) => {
   const headerHeight = 60
+  const cueDrawerWidth = '25vw'
   const successMain =
     (theme.palette.success && theme.palette.success.main) ||
     (theme.palette.secondary && theme.palette.secondary.main) ||
@@ -738,14 +739,25 @@ const useStyles = makeStyles((theme) => {
       },
     },
     cueDrawer: {
-      width: 360,
-      maxWidth: '90vw',
+      width: cueDrawerWidth,
+      maxWidth: cueDrawerWidth,
+      minWidth: 240,
+      flexShrink: 0,
+    },
+    cueDrawerOpen: {
+      paddingRight: cueDrawerWidth,
+      transition: theme.transitions.create('padding-right', {
+        duration: theme.transitions.duration.standard,
+        easing: theme.transitions.easing.easeInOut,
+      }),
       [theme.breakpoints.down('sm')]: {
-        width: 320,
+        paddingRight: 0,
       },
     },
     cueDrawerPaper: {
-      width: '100%',
+      width: cueDrawerWidth,
+      maxWidth: cueDrawerWidth,
+      minWidth: 240,
       boxSizing: 'border-box',
       padding: theme.spacing(2.5),
       display: 'flex',
@@ -1068,6 +1080,32 @@ const RetailPlayerDashboard = () => {
     return fetchCueTriggers()
   }, [fetchCueTriggers, isCueDrawerOpen])
 
+  const sendCueTriggerAction = useCallback(
+    (trigger) => {
+      const triggerId =
+        (typeof trigger?.id === 'string' && trigger.id) ||
+        (typeof trigger?.ID === 'string' && trigger.ID) ||
+        ''
+
+      if (!deviceApiId || !triggerId) {
+        return
+      }
+
+      const headers = new Headers({ 'Content-Type': 'application/json' })
+
+      httpClient(`/api/retailplayer/devices/${encodeURIComponent(deviceApiId)}/triggers`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ action: 'PLAY', value: triggerId }),
+      }).catch((err) => {
+        if (err?.name !== 'AbortError') {
+          setCueError(err)
+        }
+      })
+    },
+    [deviceApiId],
+  )
+
   const activeSchedule = useMemo(() => {
     if (!schedules.length) {
       return null
@@ -1075,6 +1113,11 @@ const RetailPlayerDashboard = () => {
     const matched = schedules.find((schedule) => schedule.key === effectiveActiveChannelKey)
     return matched || schedules[0]
   }, [effectiveActiveChannelKey, schedules])
+
+  const rootClassName = useMemo(
+    () => combineClasses(classes.root, isCueDrawerOpen ? classes.cueDrawerOpen : null),
+    [classes.root, classes.cueDrawerOpen, isCueDrawerOpen],
+  )
 
   const sendDislikeNotification = useCallback(() => {
     if (!isApiEnabled || !deviceApiId) {
@@ -1786,7 +1829,7 @@ const trackPool = useMemo(() => {
   }
 
   return (
-    <div className={classes.root}>
+    <div className={rootClassName}>
       <Title title="Retail Player" />
 
       <header className={classes.headerBar}>
@@ -2085,6 +2128,7 @@ const trackPool = useMemo(() => {
         anchor="right"
         open={isCueDrawerOpen}
         onClose={handleCloseCueDrawer}
+        variant="persistent"
         classes={{ paper: classes.cueDrawerPaper }}
         className={classes.cueDrawer}
       >
@@ -2121,7 +2165,12 @@ const trackPool = useMemo(() => {
                 }
 
                 return (
-                  <ListItem key={trigger?.id || primaryText} className={classes.cueListItem}>
+                  <ListItem
+                    key={trigger?.id || primaryText}
+                    className={classes.cueListItem}
+                    button
+                    onClick={() => sendCueTriggerAction(trigger)}
+                  >
                     <ListItemText
                       primary={primaryText}
                       secondary={secondaryParts.join(' • ')}

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1,6 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { alpha, makeStyles } from '@material-ui/core/styles'
-import { ButtonBase, Slider, Typography } from '@material-ui/core'
+import {
+  ButtonBase,
+  Drawer,
+  List,
+  ListItem,
+  ListItemText,
+  Slider,
+  Typography,
+} from '@material-ui/core'
 import Tooltip from '@material-ui/core/Tooltip'
 import { Title } from 'react-admin'
 import LinkIcon from '@material-ui/icons/Link'
@@ -12,6 +20,8 @@ import DescriptionIcon from '@material-ui/icons/Description'
 import CachedIcon from '@material-ui/icons/Cached'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import ArrowBackIcon from '@material-ui/icons/ArrowBack'
+import CloseIcon from '@material-ui/icons/Close'
+import QueueMusicIcon from '@material-ui/icons/QueueMusic'
 import { useHistory, useParams } from 'react-router-dom'
 import { BiDislike } from 'react-icons/bi'
 import { MdSkipNext } from 'react-icons/md'
@@ -727,6 +737,53 @@ const useStyles = makeStyles((theme) => {
         backgroundColor: theme.palette.action.hover,
       },
     },
+    cueDrawer: {
+      width: 360,
+      maxWidth: '90vw',
+      [theme.breakpoints.down('sm')]: {
+        width: 320,
+      },
+    },
+    cueDrawerPaper: {
+      width: '100%',
+      boxSizing: 'border-box',
+      padding: theme.spacing(2.5),
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(2),
+    },
+    cueDrawerHeader: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: theme.spacing(1.5),
+    },
+    cueDrawerTitle: {
+      fontWeight: theme.typography.fontWeightBold,
+      fontSize: theme.typography.pxToRem(20),
+    },
+    cueList: {
+      flex: 1,
+      overflowY: 'auto',
+    },
+    cueListItem: {
+      border: `1px solid ${theme.palette.divider}`,
+      borderRadius: theme.shape.borderRadius,
+      marginBottom: theme.spacing(1),
+    },
+    cueListPrimary: {
+      fontWeight: theme.typography.fontWeightMedium,
+    },
+    cueListSecondary: {
+      color: theme.palette.text.secondary,
+    },
+    cueError: {
+      color: theme.palette.error.main,
+    },
+    cueEmpty: {
+      color: theme.palette.text.secondary,
+      fontStyle: 'italic',
+    },
   }
 })
 
@@ -761,6 +818,10 @@ const RetailPlayerDashboard = () => {
   const [previousNowPlaying, setPreviousNowPlaying] = useState(null)
   const [currentTrackIndex, setCurrentTrackIndex] = useState(0)
   const [isScheduleMenuOpen, setScheduleMenuOpen] = useState(false)
+  const [isCueDrawerOpen, setCueDrawerOpen] = useState(false)
+  const [cueTriggers, setCueTriggers] = useState([])
+  const [cueError, setCueError] = useState(null)
+  const [isCueLoading, setCueLoading] = useState(false)
   const scheduleDropdownRef = useRef(null)
   const isBusy = retailLoading || statusLoading
   const combinedError = integrationError || statusError || devicesError
@@ -911,6 +972,18 @@ const RetailPlayerDashboard = () => {
   )
   const availableSchedulesCount = availableSchedules.length
 
+  const sortedCueTriggers = useMemo(() => {
+    if (!cueTriggers || !cueTriggers.length) {
+      return []
+    }
+
+    return [...cueTriggers].sort((a, b) => {
+      const aOrdinal = typeof a?.ordinal === 'number' ? a.ordinal : 0
+      const bOrdinal = typeof b?.ordinal === 'number' ? b.ordinal : 0
+      return aOrdinal - bOrdinal
+    })
+  }, [cueTriggers])
+
   useEffect(() => {
     if (!isScheduleMenuOpen) {
       return undefined
@@ -949,6 +1022,51 @@ const RetailPlayerDashboard = () => {
       setScheduleMenuOpen(false)
     }
   }, [availableSchedulesCount])
+
+  useEffect(() => {
+    setCueTriggers([])
+    setCueError(null)
+  }, [deviceApiId])
+
+  const fetchCueTriggers = useCallback(() => {
+    if (!deviceApiId) {
+      setCueError(new Error('Retail player device id unavailable'))
+      setCueTriggers([])
+      return undefined
+    }
+
+    const abortController = new AbortController()
+    setCueLoading(true)
+    setCueError(null)
+
+    httpClient(
+      `/api/retailplayer/devices/${encodeURIComponent(deviceApiId)}/triggers`,
+      { signal: abortController.signal },
+    )
+      .then(({ json }) => {
+        const triggers = Array.isArray(json?.triggers) ? json.triggers : []
+        setCueTriggers(triggers)
+      })
+      .catch((err) => {
+        if (err?.name !== 'AbortError') {
+          setCueError(err)
+          setCueTriggers([])
+        }
+      })
+      .finally(() => {
+        setCueLoading(false)
+      })
+
+    return () => abortController.abort()
+  }, [deviceApiId])
+
+  useEffect(() => {
+    if (!isCueDrawerOpen) {
+      return undefined
+    }
+
+    return fetchCueTriggers()
+  }, [fetchCueTriggers, isCueDrawerOpen])
 
   const activeSchedule = useMemo(() => {
     if (!schedules.length) {
@@ -1299,6 +1417,14 @@ const trackPool = useMemo(() => {
     }
     setScheduleMenuOpen((prev) => !prev)
   }, [availableSchedulesCount])
+
+  const handleOpenCueDrawer = useCallback(() => {
+    setCueDrawerOpen(true)
+  }, [])
+
+  const handleCloseCueDrawer = useCallback(() => {
+    setCueDrawerOpen(false)
+  }, [])
 
   const handleSelectChannel = useCallback(
     (schedule) => {
@@ -1803,6 +1929,17 @@ const trackPool = useMemo(() => {
                     <MdSkipNext fontSize="inherit" />
                   </span>
                 </ButtonBase>
+                <ButtonBase
+                  className={classes.controlButton}
+                  aria-label="Open cue controls"
+                  onClick={handleOpenCueDrawer}
+                  focusRipple
+                  disabled={!deviceApiId}
+                >
+                  <span className={classes.controlIcon} role="img" aria-hidden="true">
+                    <QueueMusicIcon fontSize="inherit" />
+                  </span>
+                </ButtonBase>
               </section>
 
               <section className={classes.volumeSection} aria-label="Volume">
@@ -1944,6 +2081,62 @@ const trackPool = useMemo(() => {
           </div>
         </section>
       </div>
+      <Drawer
+        anchor="right"
+        open={isCueDrawerOpen}
+        onClose={handleCloseCueDrawer}
+        classes={{ paper: classes.cueDrawerPaper }}
+        className={classes.cueDrawer}
+      >
+        <div className={classes.cueDrawerHeader}>
+          <Typography component="h2" className={classes.cueDrawerTitle}>
+            Cue Buttons
+          </Typography>
+          <ButtonBase
+            onClick={handleCloseCueDrawer}
+            aria-label="Close cue drawer"
+            focusRipple
+            className={classes.headerBackButton}
+          >
+            <CloseIcon className={classes.headerBackIcon} />
+          </ButtonBase>
+        </div>
+        <div className={classes.cueList} role="region" aria-label="Cue buttons list">
+          {isCueLoading ? (
+            <Typography>Loading cue buttons…</Typography>
+          ) : cueError ? (
+            <Typography className={classes.cueError}>
+              {cueError.message || 'Unable to load cue buttons'}
+            </Typography>
+          ) : sortedCueTriggers.length ? (
+            <List disablePadding>
+              {sortedCueTriggers.map((trigger) => {
+                const primaryText = trigger?.name || trigger?.id || 'Unnamed trigger'
+                const secondaryParts = []
+                if (trigger?.ordinal || trigger?.ordinal === 0) {
+                  secondaryParts.push(`Button ${trigger.ordinal}`)
+                }
+                if (trigger?.asset?.name) {
+                  secondaryParts.push(trigger.asset.name)
+                }
+
+                return (
+                  <ListItem key={trigger?.id || primaryText} className={classes.cueListItem}>
+                    <ListItemText
+                      primary={primaryText}
+                      secondary={secondaryParts.join(' • ')}
+                      primaryTypographyProps={{ className: classes.cueListPrimary }}
+                      secondaryTypographyProps={{ className: classes.cueListSecondary }}
+                    />
+                  </ListItem>
+                )
+              })}
+            </List>
+          ) : (
+            <Typography className={classes.cueEmpty}>No cue buttons available</Typography>
+          )}
+        </div>
+      </Drawer>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add configuration options for retail player remote control requests
- expose an API endpoint to retrieve retail player device triggers
- add a cue button and sidebar on the retail player dashboard to display triggers from the device

## Testing
- npm test *(fails: missing @dnd-kit/core dependency in existing tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69263288106c83228a9bcfc9aa26cba8)