### PR TITLE
Reset cue UI when cue playback ends

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1613,6 +1613,14 @@ const trackPool = useMemo(() => {
     [activeCueTriggerId, activeCueTriggerOrdinal],
   )
 
+  const hasCueMetadata = useMemo(
+    () =>
+      Boolean(
+        detectedCuePlayback.triggerId || Number.isFinite(detectedCuePlayback.triggerOrdinal),
+      ),
+    [detectedCuePlayback],
+  )
+
   useEffect(() => {
     const normalizedResource = normalizeValue(activeResource)
     const loweredResource = normalizedResource.toLowerCase()
@@ -1627,6 +1635,20 @@ const trackPool = useMemo(() => {
 
     previousActiveResourceRef.current = normalizedResource || ''
   }, [activeResource, isCuePlaybackActive, persistActiveCueState])
+
+  useEffect(() => {
+    if (!isCuePlaybackActive) {
+      return
+    }
+
+    const normalizedResource = normalizeValue(activeResource)
+    const loweredResource = normalizedResource.toLowerCase()
+    const isCueResource = loweredResource === 'cue'
+
+    if (!isCueResource && !hasCueMetadata) {
+      persistActiveCueState('', null)
+    }
+  }, [activeResource, hasCueMetadata, isCuePlaybackActive, persistActiveCueState])
 
   useEffect(() => {
     previousActiveResourceRef.current = ''

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -900,6 +900,7 @@ const RetailPlayerDashboard = () => {
   const [isCueLoading, setCueLoading] = useState(false)
   const [activeCueTriggerId, setActiveCueTriggerId] = useState('')
   const [activeCueTriggerOrdinal, setActiveCueTriggerOrdinal] = useState(null)
+  const previousActiveResourceRef = useRef('')
   const scheduleDropdownRef = useRef(null)
   const isBusy = retailLoading || statusLoading
   const combinedError = integrationError || statusError || devicesError
@@ -1589,10 +1590,47 @@ const trackPool = useMemo(() => {
     null
   const resolvedArtworkUrl = artworkUrl || currentTrack?.artworkUrl || null
 
+  const activeResource = useMemo(() => {
+    if (!device) {
+      return ''
+    }
+
+    const statusActiveResource = normalizeValue(device?.status?.activeResource)
+    if (statusActiveResource) {
+      return statusActiveResource
+    }
+
+    const metadataActiveResource = normalizeValue(device?.nowPlaying?.metadata?.activeResource)
+    if (metadataActiveResource) {
+      return metadataActiveResource
+    }
+
+    return ''
+  }, [device])
+
   const isCuePlaybackActive = useMemo(
     () => Boolean(activeCueTriggerId || Number.isFinite(activeCueTriggerOrdinal)),
     [activeCueTriggerId, activeCueTriggerOrdinal],
   )
+
+  useEffect(() => {
+    const normalizedResource = normalizeValue(activeResource)
+    const loweredResource = normalizedResource.toLowerCase()
+    const previousResource = previousActiveResourceRef.current
+    const previousLowered = previousResource.toLowerCase()
+    const wasCueResource = previousLowered === 'cue'
+    const isCueResource = loweredResource === 'cue'
+
+    if (wasCueResource && !isCueResource && isCuePlaybackActive) {
+      persistActiveCueState('', null)
+    }
+
+    previousActiveResourceRef.current = normalizedResource || ''
+  }, [activeResource, isCuePlaybackActive, persistActiveCueState])
+
+  useEffect(() => {
+    previousActiveResourceRef.current = ''
+  }, [deviceTrackKey])
 
   const deviceTimeZone = useMemo(() => {
     if (device && typeof status.timeZone === 'string') {


### PR DESCRIPTION
## Summary
- detect transitions away from cue playback using the device active resource
- clear active cue state so highlights and stop controls reset when cue ends
- reset stored active resource tracking when switching devices to avoid stale cue status

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69289d6a22ec8322a81ea41c296a3c05)