### PR TITLE
Fix cue playback active state reset

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1210,14 +1210,15 @@ const RetailPlayerDashboard = () => {
   }, [getTriggerIdentifier, getTriggerOrdinal, nowPlayingCueMetadata, sortedCueTriggers])
 
   useEffect(() => {
-    if (detectedCuePlayback.triggerId || Number.isFinite(detectedCuePlayback.triggerOrdinal)) {
-      persistActiveCueState(
-        detectedCuePlayback.triggerId || '',
-        Number.isFinite(detectedCuePlayback.triggerOrdinal)
-          ? detectedCuePlayback.triggerOrdinal
-          : null,
-      )
-    }
+    const hasDetectedCue =
+      detectedCuePlayback.triggerId || Number.isFinite(detectedCuePlayback.triggerOrdinal)
+
+    persistActiveCueState(
+      hasDetectedCue ? detectedCuePlayback.triggerId || '' : '',
+      hasDetectedCue && Number.isFinite(detectedCuePlayback.triggerOrdinal)
+        ? detectedCuePlayback.triggerOrdinal
+        : null,
+    )
   }, [detectedCuePlayback, persistActiveCueState])
 
   useEffect(() => {
@@ -1590,8 +1591,8 @@ const trackPool = useMemo(() => {
   const resolvedArtworkUrl = artworkUrl || currentTrack?.artworkUrl || null
 
   const isCuePlaybackActive = useMemo(
-    () => Boolean(activeCueTriggerId || Number.isFinite(activeCueTriggerOrdinal)),
-    [activeCueTriggerId, activeCueTriggerOrdinal],
+    () => Boolean(detectedCuePlayback.triggerId || Number.isFinite(detectedCuePlayback.triggerOrdinal)),
+    [detectedCuePlayback],
   )
 
   const deviceTimeZone = useMemo(() => {


### PR DESCRIPTION
## Summary
- derive cue active state from detected playback metadata instead of stored selection
- reset persisted cue selection when playback no longer indicates an active cue
- drive cue UI styling from detected cue playback state so it reverts automatically

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928a5d03c3c8322890df638fe993789)