### PR TITLE
Fetch cue triggers on player load

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1316,12 +1316,12 @@ const RetailPlayerDashboard = () => {
   }, [deviceApiId])
 
   useEffect(() => {
-    if (!isCueDrawerOpen) {
+    if (!deviceApiId) {
       return undefined
     }
 
     return fetchCueTriggers()
-  }, [fetchCueTriggers, isCueDrawerOpen])
+  }, [deviceApiId, fetchCueTriggers])
 
   const sendCueTriggerAction = useCallback(
     (trigger) => {


### PR DESCRIPTION
## Summary
- fetch cue triggers as soon as the retail player has a device id instead of waiting for the cue drawer
- keep the cue button as a simple toggle without triggering API requests

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a183cdee4832295f6b29229556938)