### PR TITLE
Add public remote control WebSocket

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1045,8 +1045,9 @@ const RetailPlayerDashboard = () => {
     resolvedDevice?.id,
   ])
 
-  const remoteControlId = useMemo(
-    () => normalizeValue(deviceApiId) || 'fda915dd-a953-489e-980a-e3385faa2f5f',
+  const remoteControlId = 'fda915dd-a953-489e-980a-e3385faa2f5f'
+  const remoteControlDeviceId = useMemo(
+    () => normalizeValue(deviceApiId),
     [deviceApiId],
   )
 
@@ -1063,6 +1064,48 @@ const RetailPlayerDashboard = () => {
 
     sendRemoteControlMessage({ type: 'HELLO', deviceUUID: remoteControlId })
   }, [isRemoteControlConnected, remoteControlId, sendRemoteControlMessage])
+
+  useEffect(() => {
+    if (!isRemoteControlConnected || !remoteControlDeviceId || !remoteControlId) {
+      return
+    }
+
+    const subscriptionMessages = [
+      {
+        type: 'subscribe',
+        payload: {
+          subsId: 'remote-control',
+          topic: 'triggerSet-diff',
+          objId: remoteControlDeviceId,
+        },
+      },
+      {
+        type: 'subscribe',
+        payload: {
+          subsId: 'remote-control',
+          topic: 'channelList-diff',
+          objId: remoteControlDeviceId,
+        },
+      },
+      {
+        type: 'subscribe',
+        payload: {
+          subsId: 'remote-control',
+          topic: 'device-diff',
+          objId: remoteControlDeviceId,
+        },
+      },
+    ]
+
+    subscriptionMessages.forEach((message) => {
+      sendRemoteControlMessage(message)
+    })
+  }, [
+    isRemoteControlConnected,
+    remoteControlDeviceId,
+    remoteControlId,
+    sendRemoteControlMessage,
+  ])
 
   useEffect(() => {
     if (!remoteControlMessage) {

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -27,6 +27,7 @@ import { MdSkipNext } from 'react-icons/md'
 import useRetailPlayerDeviceStatus from './useRetailPlayerDeviceStatus'
 import { normalizeValue } from './deviceUtils'
 import httpClient from '../dataProvider/httpClient'
+import useRemoteControlSocket from './useRemoteControlSocket'
 
 const combineClasses = (...classNames) => classNames.filter(Boolean).join(' ')
 
@@ -1043,6 +1044,31 @@ const RetailPlayerDashboard = () => {
     resolvedDevice?.apiId,
     resolvedDevice?.id,
   ])
+
+  const remoteControlId = useMemo(
+    () => normalizeValue(deviceApiId) || 'fda915dd-a953-489e-980a-e3385faa2f5f',
+    [deviceApiId],
+  )
+
+  const {
+    isConnected: isRemoteControlConnected,
+    lastMessage: remoteControlMessage,
+    sendMessage: sendRemoteControlMessage,
+  } = useRemoteControlSocket(remoteControlId)
+
+  useEffect(() => {
+    if (!isRemoteControlConnected || !remoteControlId) {
+      return
+    }
+
+    sendRemoteControlMessage({ type: 'HELLO', deviceUUID: remoteControlId })
+  }, [isRemoteControlConnected, remoteControlId, sendRemoteControlMessage])
+
+  useEffect(() => {
+    if (!remoteControlMessage) {
+      return
+    }
+  }, [remoteControlMessage])
 
   const canControlDevice = useMemo(
     () => Boolean(isApiEnabled && deviceApiId),

--- a/ui/src/retailPlayer/useRemoteControlSocket.js
+++ b/ui/src/retailPlayer/useRemoteControlSocket.js
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+const REMOTE_CONTROL_BASE_URL = 'wss://rc.jareddietch.com/remote-control'
+
+const stringifyMessage = (message) => {
+  if (typeof message === 'string') {
+    return message
+  }
+
+  try {
+    return JSON.stringify(message)
+  } catch (error) {
+    return ''
+  }
+}
+
+const useRemoteControlSocket = (deviceUUID) => {
+  const [isConnected, setIsConnected] = useState(false)
+  const [lastMessage, setLastMessage] = useState(null)
+  const [connectionError, setConnectionError] = useState(null)
+  const socketRef = useRef(null)
+
+  const socketUrl = useMemo(() => {
+    if (!deviceUUID) {
+      return ''
+    }
+
+    return `${REMOTE_CONTROL_BASE_URL}/${encodeURIComponent(deviceUUID)}`
+  }, [deviceUUID])
+
+  const cleanupSocket = useCallback(() => {
+    if (socketRef.current) {
+      socketRef.current.close()
+      socketRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!socketUrl) {
+      cleanupSocket()
+      setIsConnected(false)
+      setLastMessage(null)
+      return undefined
+    }
+
+    const socket = new WebSocket(socketUrl)
+    socketRef.current = socket
+
+    socket.onopen = () => {
+      setIsConnected(true)
+      setConnectionError(null)
+    }
+
+    socket.onmessage = (event) => {
+      setLastMessage(event.data)
+    }
+
+    socket.onerror = () => {
+      setConnectionError(new Error('Remote control socket error'))
+    }
+
+    socket.onclose = () => {
+      setIsConnected(false)
+    }
+
+    return () => {
+      cleanupSocket()
+    }
+  }, [cleanupSocket, socketUrl])
+
+  const sendMessage = useCallback((message) => {
+    const socket = socketRef.current
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      return false
+    }
+
+    const payload = stringifyMessage(message)
+    if (!payload) {
+      return false
+    }
+
+    socket.send(payload)
+    return true
+  }, [])
+
+  return {
+    connectionError,
+    isConnected,
+    lastMessage,
+    sendMessage,
+  }
+}
+
+export default useRemoteControlSocket


### PR DESCRIPTION
## Summary
- add a reusable hook for connecting to the public remote-control WebSocket endpoint
- wire the retail player dashboard to establish the WebSocket using the device/QR identifier and send an initial hello payload

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a1e48ccd08322b31b4a5c8536aaf4)