### PR TITLE
Fix retail player now playing and volume updates

### DIFF
--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -163,7 +163,11 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
     return null
   }
 
-  const status = payload && typeof payload === 'object' ? payload.status || {} : {}
+  const hasStatusPayload = payload && typeof payload === 'object'
+  const payloadDevice = hasStatusPayload && payload.device && typeof payload.device === 'object'
+    ? payload.device
+    : null
+  const status = hasStatusPayload && typeof payload.status === 'object' ? payload.status || {} : {}
   const streamMetadata = ensureArray(payload?.streamMetadata).filter(
     (item) => item && typeof item === 'object',
   )
@@ -538,11 +542,21 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
   const scheduleArtist = normalizeValue(activeSchedule?.artist)
   const { title: parsedStreamTitle, artist: parsedStreamArtist } = parseActiveStreamInfo(streamName)
 
+  const hasNowPlayingDetails = Boolean(
+    metadataTitle ||
+      statusTitle ||
+      parsedStreamTitle ||
+      streamName ||
+      metadataArtist ||
+      statusArtist ||
+      parsedStreamArtist,
+  )
+
   let nowPlayingTitle =
     metadataTitle ||
     statusTitle ||
     parsedStreamTitle ||
-    scheduleLabel ||
+    (hasNowPlayingDetails ? scheduleLabel : '') ||
     streamName ||
     baseDevice.name
 
@@ -550,7 +564,9 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
     metadataArtist ||
     statusArtist ||
     parsedStreamArtist ||
-    scheduleArtist ||
+    (hasNowPlayingDetails ? scheduleArtist : '') ||
+    normalizeValue(baseDevice.organization) ||
+    baseDevice.name ||
     normalizeValue(baseDevice.channel) ||
     'Retail Player'
 
@@ -558,14 +574,16 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
   const metadataAlbum = normalizeValue(combinedMetadata.album)
 
   const isLoadingNowPlaying =
-    normalizedActiveResource === 'none' && !streamName && !metadataTitle && !metadataArtist
+    (!hasNowPlayingDetails && !streamMetadata.length) ||
+    (normalizedActiveResource === 'none' && !streamName && !metadataTitle && !metadataArtist)
 
   if (isLoadingNowPlaying) {
     nowPlayingTitle = 'Loading'
     nowPlayingArtist = ''
   }
 
-  const volume = combinedMetadata.volume ?? parseVolume(status.volume)
+  const volume =
+    combinedMetadata.volume ?? parseVolume(status.volume) ?? parseVolume(payloadDevice?.volume)
 
   const scheduleStatus = normalizeValue(status.scheduleStatus).toLowerCase()
   const isConnected =


### PR DESCRIPTION
## Summary
- avoid rendering placeholder now playing details from channel IDs by requiring actual metadata before mapping, defaulting to loading otherwise
- honor volume values from websocket update payloads so UI volume reflects remote changes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692af89c3b288322846726a77334f790)