### PR TITLE
Limit retail player device listing to requested device

### DIFF
--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -353,6 +353,79 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 			return
 		}
 
+		if identifier := strings.TrimSpace(r.URL.Query().Get("identifier")); identifier != "" {
+			device, err := n.resolveRetailPlayerDevice(ctx, identifier)
+			if err != nil {
+				status := http.StatusBadGateway
+				if errors.Is(err, errRetailPlayerDeviceNotFound) {
+					status = http.StatusNotFound
+				}
+				log.Error(ctx, "Unable to resolve retail player device", "identifier", identifier, "err", err)
+				http.Error(w, "Unable to fetch retail player device", status)
+				return
+			}
+
+			response := retailPlayerDevicesResponse{
+				Data:         []retailPlayerDevice{device},
+				Page:         1,
+				Total:        1,
+				Folders:      []retailPlayerFolder{},
+				DeviceFolder: []retailPlayerDeviceFolder{},
+			}
+
+			deviceID := strings.TrimSpace(device.ID)
+			if deviceID != "" {
+				folders, deviceFolders, err := n.loadRetailPlayerFolderData(ctx)
+				if err != nil {
+					log.Error(ctx, "Unable to load retail player folder data", "err", err)
+					http.Error(w, "Unable to load retail player folders", http.StatusInternalServerError)
+					return
+				}
+
+				folderSet := make(map[string]struct{})
+				assignments := make([]retailPlayerDeviceFolder, 0)
+				for _, deviceFolder := range deviceFolders {
+					if strings.TrimSpace(deviceFolder.DeviceID) != deviceID {
+						continue
+					}
+					assignments = append(assignments, deviceFolder)
+					folderID := strings.TrimSpace(deviceFolder.FolderID)
+					if folderID != "" {
+						folderSet[folderID] = struct{}{}
+					}
+				}
+
+				if len(assignments) > 0 {
+					folderIDs := make([]string, 0, len(assignments))
+					for _, assignment := range assignments {
+						folderIDs = append(folderIDs, assignment.FolderID)
+					}
+					response.Data[0].FolderIDs = append([]string(nil), folderIDs...)
+
+					response.DeviceFolder = make([]retailPlayerDeviceFolder, 0, len(assignments))
+					for _, assignment := range assignments {
+						response.DeviceFolder = append(response.DeviceFolder, mapModelRetailPlayerDeviceFolder(assignment))
+					}
+				}
+
+				if len(folderSet) > 0 {
+					response.Folders = make([]retailPlayerFolder, 0, len(folderSet))
+					for _, folder := range folders {
+						if _, ok := folderSet[folder.ID]; !ok {
+							continue
+						}
+						response.Folders = append(response.Folders, mapModelRetailPlayerFolder(folder))
+					}
+				}
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(response); err != nil {
+				log.Error(ctx, "Unable to encode retail player device response", "identifier", identifier, "err", err)
+			}
+			return
+		}
+
 		log.Info(ctx, "Fetching retail player devices from remote API")
 		response, err := fetchRetailPlayerDevices(ctx)
 		if err != nil {

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -687,7 +687,7 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
     error: deviceListError,
     isApiEnabled,
     isLoading: deviceListLoading,
-  } = useRetailPlayerDevices()
+  } = useRetailPlayerDevices(slugParam)
 
   const baseDevice = useMemo(() => {
     const ensureMatchingDevice = (device) => {

--- a/ui/src/retailPlayer/useRetailPlayerDevices.js
+++ b/ui/src/retailPlayer/useRetailPlayerDevices.js
@@ -4,10 +4,21 @@ import httpClient from '../dataProvider/httpClient'
 import RetailPlayerMockService from './RetailPlayerMockService'
 import { mapRetailPlayerDevice } from './deviceUtils'
 
-const buildDevicesUrl = () => '/api/retailplayer/devices'
+const buildDevicesUrl = (identifier) => {
+  if (!identifier) {
+    return '/api/retailplayer/devices'
+  }
 
-const fetchRetailPlayerDevices = async (signal) => {
-  const url = buildDevicesUrl()
+  try {
+    const params = new URLSearchParams({ identifier })
+    return `/api/retailplayer/devices?${params.toString()}`
+  } catch (err) {
+    return `/api/retailplayer/devices?identifier=${encodeURIComponent(identifier)}`
+  }
+}
+
+const fetchRetailPlayerDevices = async (signal, identifier) => {
+  const url = buildDevicesUrl(identifier)
 
   if (!url) {
     return { devices: null, folders: null, deviceFolders: null, enabled: false }
@@ -42,7 +53,7 @@ const fetchRetailPlayerDevices = async (signal) => {
   return { devices, folders, deviceFolders, enabled: true }
 }
 
-const useRetailPlayerDevices = () => {
+const useRetailPlayerDevices = (identifier) => {
   const [devices, setDevices] = useState(() => {
     if (config.retailPlayerDevicesEnabled) {
       return []
@@ -58,7 +69,7 @@ const useRetailPlayerDevices = () => {
   )
 
   useEffect(() => {
-    const url = buildDevicesUrl()
+    const url = buildDevicesUrl(identifier)
     if (!url) {
       setIsApiEnabled(false)
       return undefined
@@ -68,7 +79,7 @@ const useRetailPlayerDevices = () => {
     setIsLoading(true)
     setError(null)
 
-    fetchRetailPlayerDevices(abortController.signal)
+    fetchRetailPlayerDevices(abortController.signal, identifier)
       .then((result) => {
         const enabled = Boolean(result?.enabled)
         setIsApiEnabled(enabled)
@@ -100,7 +111,7 @@ const useRetailPlayerDevices = () => {
     return () => {
       abortController.abort()
     }
-  }, [])
+  }, [identifier])
 
   return {
     devices,


### PR DESCRIPTION
## Summary
- add support for requesting a specific retail player device via the devices API without exposing the full list
- return only relevant folder assignments for a targeted device request
- update the retail player device status hook to request only the current device when accessed by slug

## Testing
- go test ./... *(interrupted)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b26f160d083228f0280d89e49f266)