### PR TITLE
Restrict retail player device fetch

### DIFF
--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -394,8 +394,12 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 			}
 
 			response.Data = filtered
-			response.Total = len(filtered)
-			response.Page = 1
+
+			total := len(filtered)
+			response.Total = &total
+
+			page := 1
+			response.Page = &page
 		}
 
 		n.devices.RememberDevices(response.Data)

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -209,6 +209,10 @@ type retailPlayerDevice struct {
 	RemoteControlID string   `json:"remoteControlId,omitempty"`
 }
 
+type retailPlayerDeviceFilterPayload struct {
+	Name string `json:"name"`
+}
+
 type retailPlayerDeviceConfigResponse struct {
 	ID                  string `json:"id"`
 	OrgUnit             string `json:"orgUnit"`
@@ -335,6 +339,7 @@ func (n *Router) addRetailPlayerPublicRoutes(r chi.Router) {
 
 func (n *Router) addRetailPlayerPrivateRoutes(r chi.Router) {
 	r.Get("/retailplayer/devices", n.handleRetailPlayerDevices())
+	r.Post("/retailplayer/devices", n.handleRetailPlayerDevices())
 	r.Post("/retailplayer/folders", n.handleCreateRetailPlayerFolder())
 	r.Patch("/retailplayer/folders/{folderID}", n.handleUpdateRetailPlayerFolder())
 	r.Post("/retailplayer/folders/delete", n.handleDeleteRetailPlayerFolders())
@@ -353,6 +358,24 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 			return
 		}
 
+		var deviceFilter string
+		if r.Method == http.MethodPost {
+			decoder := json.NewDecoder(r.Body)
+			decoder.DisallowUnknownFields()
+
+			var payload retailPlayerDeviceFilterPayload
+			if err := decoder.Decode(&payload); err != nil {
+				http.Error(w, "Invalid retail player device payload", http.StatusBadRequest)
+				return
+			}
+
+			deviceFilter = strings.TrimSpace(payload.Name)
+			if deviceFilter == "" {
+				http.Error(w, "Retail player device name is required", http.StatusBadRequest)
+				return
+			}
+		}
+
 		log.Info(ctx, "Fetching retail player devices from remote API")
 		response, err := fetchRetailPlayerDevices(ctx)
 		if err != nil {
@@ -363,6 +386,18 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 
 		log.Info(ctx, "Retail player devices fetched", "count", len(response.Data))
 
+		if deviceFilter != "" {
+			filtered := filterRetailPlayerDevices(response.Data, deviceFilter)
+			if len(filtered) == 0 {
+				http.Error(w, "Retail player device not found", http.StatusNotFound)
+				return
+			}
+
+			response.Data = filtered
+			response.Total = len(filtered)
+			response.Page = 1
+		}
+
 		n.devices.RememberDevices(response.Data)
 		n.persistRetailPlayerDeviceMappings(ctx, response.Data)
 
@@ -371,6 +406,43 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 			log.Error(ctx, "Unable to load retail player folder data", "err", err)
 			http.Error(w, "Unable to load retail player folders", http.StatusInternalServerError)
 			return
+		}
+
+		if deviceFilter != "" {
+			allowedDeviceIDs := make(map[string]struct{}, len(response.Data))
+			for _, device := range response.Data {
+				id := strings.TrimSpace(device.ID)
+				if id == "" {
+					continue
+				}
+
+				allowedDeviceIDs[id] = struct{}{}
+			}
+
+			filteredDeviceFolders := make([]model.RetailPlayerDeviceFolder, 0, len(deviceFolders))
+			for _, deviceFolder := range deviceFolders {
+				if _, ok := allowedDeviceIDs[deviceFolder.DeviceID]; ok {
+					filteredDeviceFolders = append(filteredDeviceFolders, deviceFolder)
+				}
+			}
+
+			deviceFolders = filteredDeviceFolders
+
+			if len(deviceFolders) > 0 {
+				folderIDs := make(map[string]struct{})
+				for _, deviceFolder := range deviceFolders {
+					folderIDs[deviceFolder.FolderID] = struct{}{}
+				}
+
+				filteredFolders := make([]model.RetailPlayerFolder, 0, len(folders))
+				for _, folder := range folders {
+					if _, ok := folderIDs[folder.ID]; ok {
+						filteredFolders = append(filteredFolders, folder)
+					}
+				}
+
+				folders = filteredFolders
+			}
 		}
 
 		if len(deviceFolders) > 0 {
@@ -1667,6 +1739,55 @@ func lookupRetailPlayerDevice(ctx context.Context, identifier string) (retailPla
 	}
 
 	return retailPlayerDevice{}, response.Data, errRetailPlayerDeviceNotFound
+}
+
+func filterRetailPlayerDevices(devices []retailPlayerDevice, identifier string) []retailPlayerDevice {
+	normalizedIdentifier := strings.TrimSpace(identifier)
+	if normalizedIdentifier == "" {
+		return nil
+	}
+
+	slugKey := retailPlayerDeviceSlugKey(normalizedIdentifier)
+	lowerIdentifier := strings.ToLower(normalizedIdentifier)
+	filtered := make([]retailPlayerDevice, 0, 1)
+
+	for _, device := range devices {
+		if strings.EqualFold(strings.TrimSpace(device.ID), normalizedIdentifier) {
+			return []retailPlayerDevice{device}
+		}
+		if strings.EqualFold(strings.TrimSpace(device.Name), normalizedIdentifier) {
+			return []retailPlayerDevice{device}
+		}
+
+		if slugKey == "" {
+			continue
+		}
+
+		if retailPlayerDeviceSlugKey(device.Name) == slugKey {
+			return []retailPlayerDevice{device}
+		}
+		if retailPlayerDeviceSlugKey(device.ID) == slugKey {
+			return []retailPlayerDevice{device}
+		}
+
+		if lowerIdentifier == "" {
+			continue
+		}
+
+		if retailPlayerDeviceSlugKey(device.Channel) == slugKey {
+			filtered = append(filtered, device)
+			continue
+		}
+		if retailPlayerDeviceSlugKey(device.ChannelList) == slugKey {
+			filtered = append(filtered, device)
+			continue
+		}
+		if retailPlayerDeviceSlugKey(device.Organization) == slugKey {
+			filtered = append(filtered, device)
+		}
+	}
+
+	return filtered
 }
 
 func retailPlayerDeviceSlugKey(value string) string {

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -173,6 +173,10 @@ func normalizeRetailPlayerIdentifier(value string) string {
 	return strings.TrimSpace(decoded)
 }
 
+func intPtr(value int) *int {
+	return &value
+}
+
 type retailPlayerAPIDevice struct {
 	Ordinal      *int   `json:"ordinal"`
 	ID           string `json:"id"`
@@ -395,11 +399,8 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 
 			response.Data = filtered
 
-			total := len(filtered)
-			response.Total = &total
-
-			page := 1
-			response.Page = &page
+			response.Total = intPtr(len(filtered))
+			response.Page = intPtr(1)
 		}
 
 		n.devices.RememberDevices(response.Data)

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react'
 import PropTypes from 'prop-types'
 import { v4 as uuidv4 } from 'uuid'
+import { useLocation } from 'react-router-dom'
 import useRetailPlayerDevices from './useRetailPlayerDevices'
 import httpClient from '../dataProvider/httpClient'
 import { buildDeviceSlug, deviceSlugKey, normalizeValue } from './deviceUtils'
@@ -488,6 +489,14 @@ const buildTree = (folders, devices) => {
 
 const RetailPlayerDeviceStoreProvider = ({ children }) => {
   const [state, dispatch] = useReducer(reducer, initialState)
+  const location = useLocation()
+  const deviceSlug = useMemo(() => {
+    const match = /^\/retailplayer\/([^/]+)$/i.exec(location.pathname)
+    if (match) {
+      return decodeURIComponent(match[1])
+    }
+    return null
+  }, [location.pathname])
   const {
     devices: remoteDevices,
     folders: remoteFolders,
@@ -495,7 +504,7 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
     error,
     isLoading,
     isApiEnabled,
-  } = useRetailPlayerDevices()
+  } = useRetailPlayerDevices(deviceSlug)
 
   useEffect(() => {
     dispatch({ type: 'SET_LOADING', payload: isLoading })

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -493,7 +493,12 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
   const deviceSlug = useMemo(() => {
     const match = /^\/retailplayer\/([^/]+)$/i.exec(location.pathname)
     if (match) {
-      return decodeURIComponent(match[1])
+      const rawSlug = match[1]
+      try {
+        return normalizeValue(decodeURIComponent(rawSlug)) || null
+      } catch (err) {
+        return normalizeValue(rawSlug) || null
+      }
     }
     return null
   }, [location.pathname])

--- a/ui/src/retailPlayer/useRetailPlayerDevices.js
+++ b/ui/src/retailPlayer/useRetailPlayerDevices.js
@@ -6,7 +6,7 @@ import { mapRetailPlayerDevice } from './deviceUtils'
 
 const buildDevicesUrl = () => '/api/retailplayer/devices'
 
-const fetchRetailPlayerDevices = async (signal) => {
+const fetchRetailPlayerDevices = async (signal, deviceSlug) => {
   const url = buildDevicesUrl()
 
   if (!url) {
@@ -15,7 +15,17 @@ const fetchRetailPlayerDevices = async (signal) => {
 
   let payload
   try {
-    const { json } = await httpClient(url, { signal })
+    const options = { signal }
+    if (deviceSlug) {
+      options.method = 'POST'
+      options.body = JSON.stringify({ name: deviceSlug })
+      options.headers = new Headers({
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      })
+    }
+
+    const { json } = await httpClient(url, options)
     payload = json
   } catch (err) {
     if (err?.status === 404) {
@@ -42,7 +52,7 @@ const fetchRetailPlayerDevices = async (signal) => {
   return { devices, folders, deviceFolders, enabled: true }
 }
 
-const useRetailPlayerDevices = () => {
+const useRetailPlayerDevices = (deviceSlug) => {
   const [devices, setDevices] = useState(() => {
     if (config.retailPlayerDevicesEnabled) {
       return []
@@ -68,7 +78,7 @@ const useRetailPlayerDevices = () => {
     setIsLoading(true)
     setError(null)
 
-    fetchRetailPlayerDevices(abortController.signal)
+    fetchRetailPlayerDevices(abortController.signal, deviceSlug)
       .then((result) => {
         const enabled = Boolean(result?.enabled)
         setIsApiEnabled(enabled)
@@ -100,7 +110,7 @@ const useRetailPlayerDevices = () => {
     return () => {
       abortController.abort()
     }
-  }, [])
+  }, [deviceSlug])
 
   return {
     devices,


### PR DESCRIPTION
## Summary
- allow the retail player devices endpoint to accept POST payloads for filtering and limit responses to the requested device
- trim folder and assignment data to match the filtered device results
- request device data by slug on the retail player client to avoid exposing unrelated devices

## Testing
- go test ./... *(interrupted)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b392f01ac832297e4a6492ed419c6)