### PR TITLE
Add retail player device lookup endpoint

### DIFF
--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -330,12 +330,12 @@ func (n *Router) addRetailPlayerPublicRoutes(r chi.Router) {
 		r.Post("/devices/{deviceID}/channel", n.handleRetailPlayerDeviceChannel())
 		r.Post("/devices/{deviceID}/channel/toggle", n.handleRetailPlayerDeviceToggleChannel())
 		r.Post("/devices/{deviceID}/dislike", n.handleRetailPlayerDeviceDislike())
+		r.Post("/rc", n.handleRetailPlayerDeviceByName())
 	})
 }
 
 func (n *Router) addRetailPlayerPrivateRoutes(r chi.Router) {
 	r.Get("/retailplayer/devices", n.handleRetailPlayerDevices())
-	r.Post("/retailplayer/rc", n.handleRetailPlayerDeviceByName())
 	r.Post("/retailplayer/folders", n.handleCreateRetailPlayerFolder())
 	r.Patch("/retailplayer/folders/{folderID}", n.handleUpdateRetailPlayerFolder())
 	r.Post("/retailplayer/folders/delete", n.handleDeleteRetailPlayerFolders())

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -335,6 +335,7 @@ func (n *Router) addRetailPlayerPublicRoutes(r chi.Router) {
 
 func (n *Router) addRetailPlayerPrivateRoutes(r chi.Router) {
 	r.Get("/retailplayer/devices", n.handleRetailPlayerDevices())
+	r.Post("/retailplayer/rc", n.handleRetailPlayerDeviceByName())
 	r.Post("/retailplayer/folders", n.handleCreateRetailPlayerFolder())
 	r.Patch("/retailplayer/folders/{folderID}", n.handleUpdateRetailPlayerFolder())
 	r.Post("/retailplayer/folders/delete", n.handleDeleteRetailPlayerFolders())
@@ -443,6 +444,141 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(response); err != nil {
 			log.Error(ctx, "Unable to encode retail player devices response", "err", err)
+		}
+	}
+}
+
+func (n *Router) handleRetailPlayerDeviceByName() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		var payload struct {
+			Name string `json:"name"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "Invalid retail player device payload", http.StatusBadRequest)
+			return
+		}
+
+		deviceName := strings.TrimSpace(payload.Name)
+		if deviceName == "" {
+			http.Error(w, "Retail player device name is required", http.StatusBadRequest)
+			return
+		}
+
+		log.Info(ctx, "Fetching retail player device by name from remote API", "name", deviceName)
+		response, err := fetchRetailPlayerDevices(ctx)
+		if err != nil {
+			log.Error(ctx, "Unable to fetch retail player devices", "err", err)
+			http.Error(w, "Unable to fetch retail player devices", http.StatusBadGateway)
+			return
+		}
+
+		filtered := retailPlayerDevicesResponse{
+			Data: make([]retailPlayerDevice, 0, 1),
+		}
+		for _, device := range response.Data {
+			if strings.EqualFold(strings.TrimSpace(device.Name), deviceName) {
+				filtered.Data = append(filtered.Data, device)
+				break
+			}
+		}
+
+		if len(filtered.Data) == 0 {
+			http.Error(w, "Retail player device not found", http.StatusNotFound)
+			return
+		}
+
+		n.devices.RememberDevices(filtered.Data)
+		n.persistRetailPlayerDeviceMappings(ctx, filtered.Data)
+
+		folders, deviceFolders, err := n.loadRetailPlayerFolderData(ctx)
+		if err != nil {
+			log.Error(ctx, "Unable to load retail player folder data", "err", err)
+			http.Error(w, "Unable to load retail player folders", http.StatusInternalServerError)
+			return
+		}
+
+		if len(deviceFolders) > 0 {
+			folderSet := make(map[string]struct{}, len(folders))
+			for _, folder := range folders {
+				folderSet[folder.ID] = struct{}{}
+			}
+
+			assignments := make(map[string][]string)
+			for _, deviceFolder := range deviceFolders {
+				if _, ok := folderSet[deviceFolder.FolderID]; !ok {
+					continue
+				}
+
+				assignments[deviceFolder.DeviceID] = append(assignments[deviceFolder.DeviceID], deviceFolder.FolderID)
+			}
+
+			for index := range filtered.Data {
+				id := strings.TrimSpace(filtered.Data[index].ID)
+				if id == "" {
+					continue
+				}
+				if folderIDs, ok := assignments[id]; ok {
+					filtered.Data[index].FolderIDs = append([]string(nil), folderIDs...)
+				}
+			}
+		}
+
+		if repo := n.ds.RetailPlayerDeviceMapping(ctx); repo != nil {
+			mappings, err := repo.All(ctx)
+			if err != nil && !errors.Is(err, model.ErrNotFound) {
+				log.Warn(ctx, "Unable to load retail player device mappings", "err", err)
+			}
+
+			if len(mappings) > 0 {
+				remoteControlByID := make(map[string]string, len(mappings))
+				for _, mapping := range mappings {
+					id := strings.TrimSpace(mapping.DeviceID)
+					remoteControlID := strings.TrimSpace(mapping.RemoteCtrlID)
+					if id == "" || remoteControlID == "" {
+						continue
+					}
+					remoteControlByID[id] = remoteControlID
+				}
+
+				if len(remoteControlByID) > 0 {
+					for index := range filtered.Data {
+						id := strings.TrimSpace(filtered.Data[index].ID)
+						if id == "" {
+							continue
+						}
+						if remoteControlID, ok := remoteControlByID[id]; ok {
+							filtered.Data[index].RemoteControlID = remoteControlID
+						}
+					}
+				}
+			}
+		}
+
+		filtered.Folders = make([]retailPlayerFolder, 0, len(folders))
+		for _, folder := range folders {
+			filtered.Folders = append(filtered.Folders, mapModelRetailPlayerFolder(folder))
+		}
+
+		filtered.DeviceFolder = make([]retailPlayerDeviceFolder, 0, len(deviceFolders))
+		for _, deviceFolder := range deviceFolders {
+			filtered.DeviceFolder = append(filtered.DeviceFolder, mapModelRetailPlayerDeviceFolder(deviceFolder))
+		}
+
+		page := 1
+		total := len(filtered.Data)
+		filtered.Page = &page
+		filtered.Total = &total
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(filtered); err != nil {
+			log.Error(ctx, "Unable to encode retail player device response", "err", err)
 		}
 	}
 }

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -675,6 +675,17 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
     }
   }, [slugParam])
 
+  const deviceLookupName = useMemo(() => {
+    if (!slugParam) {
+      return ''
+    }
+    try {
+      return decodeURIComponent(slugParam)
+    } catch (err) {
+      return slugParam
+    }
+  }, [slugParam])
+
   const [deviceState, setDeviceState] = useState(initialDeviceState)
   const [statusState, setStatusState] = useState(initialStatusState)
   const [channelState, setChannelState] = useState(initialChannelState)
@@ -687,7 +698,7 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
     error: deviceListError,
     isApiEnabled,
     isLoading: deviceListLoading,
-  } = useRetailPlayerDevices()
+  } = useRetailPlayerDevices({ deviceName: deviceLookupName })
 
   const baseDevice = useMemo(() => {
     const ensureMatchingDevice = (device) => {

--- a/ui/src/retailPlayer/useRetailPlayerDevices.js
+++ b/ui/src/retailPlayer/useRetailPlayerDevices.js
@@ -4,10 +4,11 @@ import httpClient from '../dataProvider/httpClient'
 import RetailPlayerMockService from './RetailPlayerMockService'
 import { mapRetailPlayerDevice } from './deviceUtils'
 
-const buildDevicesUrl = () => '/api/retailplayer/devices'
+const buildDevicesUrl = (deviceName) =>
+  deviceName ? '/api/retailplayer/rc' : '/api/retailplayer/devices'
 
-const fetchRetailPlayerDevices = async (signal) => {
-  const url = buildDevicesUrl()
+const fetchRetailPlayerDevices = async (signal, deviceName) => {
+  const url = buildDevicesUrl(deviceName)
 
   if (!url) {
     return { devices: null, folders: null, deviceFolders: null, enabled: false }
@@ -15,7 +16,16 @@ const fetchRetailPlayerDevices = async (signal) => {
 
   let payload
   try {
-    const { json } = await httpClient(url, { signal })
+    const options = { signal }
+    if (deviceName) {
+      const headers = new Headers({ Accept: 'application/json' })
+      headers.set('Content-Type', 'application/json')
+      options.headers = headers
+      options.method = 'POST'
+      options.body = JSON.stringify({ name: deviceName })
+    }
+
+    const { json } = await httpClient(url, options)
     payload = json
   } catch (err) {
     if (err?.status === 404) {
@@ -42,7 +52,7 @@ const fetchRetailPlayerDevices = async (signal) => {
   return { devices, folders, deviceFolders, enabled: true }
 }
 
-const useRetailPlayerDevices = () => {
+const useRetailPlayerDevices = ({ deviceName = '' } = {}) => {
   const [devices, setDevices] = useState(() => {
     if (config.retailPlayerDevicesEnabled) {
       return []
@@ -58,7 +68,7 @@ const useRetailPlayerDevices = () => {
   )
 
   useEffect(() => {
-    const url = buildDevicesUrl()
+    const url = buildDevicesUrl(deviceName)
     if (!url) {
       setIsApiEnabled(false)
       return undefined
@@ -68,7 +78,7 @@ const useRetailPlayerDevices = () => {
     setIsLoading(true)
     setError(null)
 
-    fetchRetailPlayerDevices(abortController.signal)
+    fetchRetailPlayerDevices(abortController.signal, deviceName)
       .then((result) => {
         const enabled = Boolean(result?.enabled)
         setIsApiEnabled(enabled)
@@ -100,7 +110,7 @@ const useRetailPlayerDevices = () => {
     return () => {
       abortController.abort()
     }
-  }, [])
+  }, [deviceName])
 
   return {
     devices,


### PR DESCRIPTION
## Summary
- add a POST /api/retailplayer/rc endpoint to fetch a single retail player device by name
- include folder and remote control mappings when returning the filtered device
- update the retail player device view to use the new lookup API instead of the full device list

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b52eb67888322bbcf424813d206b7)