### PR TITLE
Add QR sync endpoint and background job

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -109,6 +109,7 @@ type configOptions struct {
 	RetailPlayer                    retailPlayerOptions `json:",omitzero"`
 	Tags                            map[string]TagConf  `json:",omitempty"`
 	Agents                          string
+	QRSync                          qrSyncOptions
 
 	// DevFlags. These are used to enable/disable debugging and incomplete features
 	DevLogLevels                     map[string]string `json:",omitempty"`
@@ -216,6 +217,14 @@ type retailPlayerOptions struct {
 	Fields                    []string                        `json:",omitempty"`
 	AdditionalHeaders         map[string]string               `json:",omitempty"`
 	Notifications             retailPlayerNotificationOptions `json:",omitempty"`
+}
+
+type qrSyncOptions struct {
+	RPPLoginURL string `mapstructure:"rpp_login_url"`
+	RPPBaseURL  string `mapstructure:"rpp_base_url"`
+	RPPUsername string `mapstructure:"rpp_username"`
+	RPPPassword string `mapstructure:"rpp_password"`
+	Tenant      string `mapstructure:"tenant"`
 }
 
 type secureOptions struct {
@@ -619,6 +628,11 @@ func setViperDefaults() {
 	viper.SetDefault("deezer.enabled", true)
 	viper.SetDefault("listenbrainz.enabled", true)
 	viper.SetDefault("listenbrainz.baseurl", "https://api.listenbrainz.org/1/")
+	viper.SetDefault("qr_sync.rpp_login_url", "")
+	viper.SetDefault("qr_sync.rpp_base_url", "")
+	viper.SetDefault("qr_sync.rpp_username", "")
+	viper.SetDefault("qr_sync.rpp_password", "")
+	viper.SetDefault("qr_sync.tenant", "")
 	viper.SetDefault("retailplayer.enabled", false)
 	viper.SetDefault("retailplayer.baseurl", "")
 	viper.SetDefault("retailplayer.orgid", "")

--- a/release/linux/navidrome.toml
+++ b/release/linux/navidrome.toml
@@ -1,2 +1,9 @@
 DataFolder = "/var/lib/navidrome"
 MusicFolder = "/opt/navidrome/music"
+
+[qr_sync]
+rpp_login_url = "https://rpp.jareddietch.com/web/api/v1/login"
+rpp_base_url = "https://rpp.jareddietch.com/web/api/v2/org/ORG-ID"
+rpp_username = ""
+rpp_password = ""
+tenant = "barix"

--- a/server/handlers/populate_qr.go
+++ b/server/handlers/populate_qr.go
@@ -1,0 +1,21 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/navidrome/navidrome/log"
+)
+
+type QRHandler struct{}
+
+func NewQRHandler() *QRHandler {
+	return &QRHandler{}
+}
+
+func (h *QRHandler) PopulateQR(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"status":"started"}`))
+
+	log.Info(r.Context(), "Starting QR fetch job")
+	go h.RunQRFetchJob()
+}

--- a/server/handlers/qr_fetch_job.go
+++ b/server/handlers/qr_fetch_job.go
@@ -40,11 +40,16 @@ type deviceUpdate struct {
 func (h *QRHandler) RunQRFetchJob() {
 	ctx := log.NewContext(context.Background(), "job", "qr_fetch")
 
-	loginURL := conf.GetString("qr_sync.rpp_login_url")
-	baseURL := strings.TrimSuffix(conf.GetString("qr_sync.rpp_base_url"), "/")
-	username := conf.GetString("qr_sync.rpp_username")
-	password := conf.GetString("qr_sync.rpp_password")
-	tenant := conf.GetString("qr_sync.tenant")
+	loginURL := conf.Server.QRSync.RPPLoginURL
+	baseURL := strings.TrimSuffix(conf.Server.QRSync.RPPBaseURL, "/")
+	username := conf.Server.QRSync.RPPUsername
+	password := conf.Server.QRSync.RPPPassword
+	tenant := conf.Server.QRSync.Tenant
+
+	if loginURL == "" || baseURL == "" || username == "" || password == "" || tenant == "" {
+		log.Error(ctx, "Missing qr_sync configuration values")
+		return
+	}
 
 	jar, err := cookiejar.New(nil)
 	if err != nil {

--- a/server/handlers/qr_fetch_job.go
+++ b/server/handlers/qr_fetch_job.go
@@ -1,0 +1,220 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"strings"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/log"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+type deviceInfo struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type qrCodeResponse struct {
+	QRCode *struct {
+		ID string `json:"id"`
+	} `json:"qrCode"`
+}
+
+type deviceResponse struct {
+	Data    []deviceInfo `json:"data"`
+	Devices []deviceInfo `json:"devices"`
+}
+
+type deviceUpdate struct {
+	deviceID string
+	qrID     string
+}
+
+func (h *QRHandler) RunQRFetchJob() {
+	ctx := log.NewContext(context.Background(), "job", "qr_fetch")
+
+	loginURL := conf.GetString("qr_sync.rpp_login_url")
+	baseURL := strings.TrimSuffix(conf.GetString("qr_sync.rpp_base_url"), "/")
+	username := conf.GetString("qr_sync.rpp_username")
+	password := conf.GetString("qr_sync.rpp_password")
+	tenant := conf.GetString("qr_sync.tenant")
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		log.Error(ctx, "Failed to create cookie jar", err)
+		return
+	}
+
+	client := &http.Client{Jar: jar}
+
+	if err := h.login(ctx, client, loginURL, tenant, username, password); err != nil {
+		log.Error(ctx, "Failed to login to RPP", err)
+		return
+	}
+
+	devices, err := h.fetchDevices(ctx, client, baseURL)
+	if err != nil {
+		log.Error(ctx, "Failed to fetch devices", err)
+		return
+	}
+
+	updates := h.collectUpdates(ctx, client, baseURL, devices)
+	if len(updates) == 0 {
+		log.Warn(ctx, "No QR codes found for devices")
+		return
+	}
+
+	h.updateDatabase(ctx, updates)
+}
+
+func (h *QRHandler) login(ctx context.Context, client *http.Client, loginURL, tenant, username, password string) error {
+	payload := map[string]string{
+		"tenant":   tenant,
+		"username": username,
+		"password": password,
+		"platform": "WEB",
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal login payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, loginURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create login request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute login request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected login status: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (h *QRHandler) fetchDevices(ctx context.Context, client *http.Client, baseURL string) ([]deviceInfo, error) {
+	devicesURL := fmt.Sprintf("%s/device-table?pageSize=500&page=1", baseURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, devicesURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create devices request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("execute devices request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected devices status: %d", resp.StatusCode)
+	}
+
+	var dResp deviceResponse
+	if err := json.NewDecoder(resp.Body).Decode(&dResp); err != nil {
+		return nil, fmt.Errorf("decode devices response: %w", err)
+	}
+
+	if len(dResp.Data) > 0 {
+		return dResp.Data, nil
+	}
+
+	return dResp.Devices, nil
+}
+
+func (h *QRHandler) collectUpdates(ctx context.Context, client *http.Client, baseURL string, devices []deviceInfo) []deviceUpdate {
+	var updates []deviceUpdate
+
+	for _, device := range devices {
+		log.Info(ctx, "Updating device QR", "id", device.ID, "name", device.Name)
+		qrID, err := h.fetchQRCode(ctx, client, baseURL, device.ID)
+		if err != nil {
+			log.Error(ctx, "Failed to fetch QR code", err, "deviceID", device.ID)
+			continue
+		}
+		if qrID == "" {
+			log.Warn(ctx, "Missing QR code for device", "deviceID", device.ID)
+			continue
+		}
+		updates = append(updates, deviceUpdate{deviceID: device.ID, qrID: qrID})
+	}
+
+	return updates
+}
+
+func (h *QRHandler) fetchQRCode(ctx context.Context, client *http.Client, baseURL, deviceID string) (string, error) {
+	qrURL := fmt.Sprintf("%s/device/%s/qr-code", baseURL, deviceID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, qrURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("create qr request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("execute qr request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected qr status: %d", resp.StatusCode)
+	}
+
+	var qrResp qrCodeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&qrResp); err != nil {
+		return "", fmt.Errorf("decode qr response: %w", err)
+	}
+
+	if qrResp.QRCode == nil {
+		return "", nil
+	}
+
+	return qrResp.QRCode.ID, nil
+}
+
+func (h *QRHandler) updateDatabase(ctx context.Context, updates []deviceUpdate) {
+	db, err := sql.Open("sqlite3", "./data/navidrome.db")
+	if err != nil {
+		log.Error(ctx, "Failed to open database", err)
+		return
+	}
+	defer db.Close()
+
+	tx, err := db.Begin()
+	if err != nil {
+		log.Error(ctx, "Failed to start transaction", err)
+		return
+	}
+
+	stmt, err := tx.Prepare("UPDATE retail_player_device_mapping SET remote_control_id = ? WHERE device_id = ?")
+	if err != nil {
+		log.Error(ctx, "Failed to prepare statement", err)
+		_ = tx.Rollback()
+		return
+	}
+	defer stmt.Close()
+
+	for _, upd := range updates {
+		log.Info(ctx, "Updating device", "id", upd.deviceID)
+		if _, err := stmt.Exec(upd.qrID, upd.deviceID); err != nil {
+			log.Error(ctx, "Failed to update device", err, "id", upd.deviceID)
+			continue
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		log.Error(ctx, "Failed to commit transaction", err)
+	}
+}

--- a/server/handlers/qr_fetch_job.go
+++ b/server/handlers/qr_fetch_job.go
@@ -192,6 +192,11 @@ func (h *QRHandler) updateDatabase(ctx context.Context, updates []deviceUpdate) 
 	}
 	defer db.Close()
 
+	if err := ensureRemoteControlColumn(ctx, db); err != nil {
+		log.Error(ctx, "Failed to ensure remote_control_id column", err)
+		return
+	}
+
 	tx, err := db.Begin()
 	if err != nil {
 		log.Error(ctx, "Failed to start transaction", err)
@@ -217,4 +222,32 @@ func (h *QRHandler) updateDatabase(ctx context.Context, updates []deviceUpdate) 
 	if err := tx.Commit(); err != nil {
 		log.Error(ctx, "Failed to commit transaction", err)
 	}
+}
+
+func ensureRemoteControlColumn(ctx context.Context, db *sql.DB) error {
+	rows, err := db.Query("PRAGMA table_info(retail_player_device_mapping)")
+	if err != nil {
+		return fmt.Errorf("inspect table info: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var cid int
+		var name, colType string
+		var notNull, pk int
+		var defaultValue sql.NullString
+		if err := rows.Scan(&cid, &name, &colType, &notNull, &defaultValue, &pk); err != nil {
+			return fmt.Errorf("scan table info: %w", err)
+		}
+		if name == "remote_control_id" {
+			return nil
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate table info: %w", err)
+	}
+
+	_, err = db.Exec("ALTER TABLE retail_player_device_mapping ADD COLUMN remote_control_id TEXT DEFAULT ''")
+	return err
 }

--- a/server/server.go
+++ b/server/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/server/events"
+	"github.com/navidrome/navidrome/server/handlers"
 	"github.com/navidrome/navidrome/ui"
 )
 
@@ -190,6 +191,7 @@ func (s *Server) initRoutes() {
 	r.Group(func(r chi.Router) {
 		r.Use(defaultMiddlewares...)
 		r.Use(requestLogger)
+		r.Get("/populate_qr", handlers.NewQRHandler().PopulateQR)
 		s.router = r
 	})
 }


### PR DESCRIPTION
## Summary
- add a /populate_qr endpoint that starts an asynchronous QR fetch job
- implement the job to log into RPP, collect device QR codes, and update mappings transactionally
- add qr_sync configuration values to navidrome.toml

## Testing
- go test ./... *(fails: unable to download modules from proxy.golang.org; network access is restricted in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b78b820488322b1d3db07194e63df)