### PR TITLE
Use websocket writeDate and muted status

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1072,7 +1072,11 @@ const RetailPlayerDashboard = () => {
         : {}
 
     const localTimeValue =
-      typeof status.localTime === 'string' ? status.localTime : null
+      typeof status.writeDate === 'string'
+        ? status.writeDate
+        : typeof status.localTime === 'string'
+          ? status.localTime
+          : null
     if (localTimeValue) {
       const parsedLocal = new Date(localTimeValue)
       if (!Number.isNaN(parsedLocal.getTime())) {
@@ -1081,7 +1085,11 @@ const RetailPlayerDashboard = () => {
     }
 
     const systemTimeValue =
-      typeof status.localTime === 'string' ? status.localTime : null
+      typeof status.writeDate === 'string'
+        ? status.writeDate
+        : typeof status.localTime === 'string'
+          ? status.localTime
+          : null
     if (systemTimeValue) {
       const parsedSystem = new Date(systemTimeValue)
       if (!Number.isNaN(parsedSystem.getTime())) {

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -596,7 +596,12 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
 
   const deviceTimeZone =
     normalizeValue(baseDevice.timeZone) || normalizeValue(status.timeZone)
-  const localTime = typeof status.localTime === 'string' ? status.localTime : null
+  const localTime =
+    typeof status.writeDate === 'string'
+      ? status.writeDate
+      : typeof status.localTime === 'string'
+        ? status.localTime
+        : null
 
   const normalizedStatus = { ...status }
   if (deviceTimeZone && !normalizedStatus.timeZone) {
@@ -606,11 +611,14 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
     normalizedStatus.localTime = localTime
   }
 
+  const isMuted =
+    typeof payloadDevice?.muted === 'boolean' ? payloadDevice.muted : volume === 0
+
   return {
     ...baseDevice,
     isConnected,
     hasSignal,
-    isMuted: volume === 0,
+    isMuted,
     volume: Number.isFinite(volume) ? volume : null,
     schedules,
     nowPlaying: {


### PR DESCRIPTION
## Summary
- use websocket writeDate field to derive retail player local time
- honor websocket device muted flag when toggling UI mute state

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692db2bc744c8322bd04da94f9e0085c)