### PR TITLE
Revert artwork handling to final-retail-3 behavior

### DIFF
--- a/server/public/handle_images.go
+++ b/server/public/handle_images.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/navidrome/navidrome/core/artwork"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/utils/req"
@@ -38,12 +39,16 @@ func (pub *Router) handleImages(w http.ResponseWriter, r *http.Request) {
 	size := p.IntOr("size", 0)
 	square := p.BoolOr("square", false)
 
-	imgReader, lastUpdate, err := pub.artwork.GetOrPlaceholder(ctx, artId.String(), size, square)
+	imgReader, lastUpdate, err := pub.artwork.Get(ctx, artId, size, square)
 	switch {
 	case errors.Is(err, context.Canceled):
 		return
 	case errors.Is(err, model.ErrNotFound):
 		log.Warn(r, "Couldn't find coverArt", "id", id, err)
+		http.Error(w, "Artwork not found", http.StatusNotFound)
+		return
+	case errors.Is(err, artwork.ErrUnavailable):
+		log.Debug(r, "Item does not have artwork", "id", id, err)
 		http.Error(w, "Artwork not found", http.StatusNotFound)
 		return
 	case err != nil:

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -1107,18 +1107,14 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
   const metadataTitle = normalizeValue(nowPlayingMetadata.title)
   const metadataArtist = normalizeValue(nowPlayingMetadata.artist)
 
-  const lastArtworkSignatureRef = useRef(null)
-
   useEffect(() => {
     if (!normalizedDevice) {
       setArtworkUrl(null)
-      lastArtworkSignatureRef.current = null
       return undefined
     }
 
     if (existingArtwork) {
       setArtworkUrl(existingArtwork)
-      lastArtworkSignatureRef.current = artworkSignature
       return undefined
     }
 
@@ -1128,21 +1124,18 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
         square: true,
       })
       setArtworkUrl(baseUrl(coverArtPath))
-      lastArtworkSignatureRef.current = artworkSignature
+      return undefined
+    }
+
+    if (!statusState.data) {
+      setArtworkUrl(null)
       return undefined
     }
 
     if (!metadataTitle) {
       setArtworkUrl(null)
-      lastArtworkSignatureRef.current = artworkSignature
       return undefined
     }
-
-    if (lastArtworkSignatureRef.current === artworkSignature) {
-      return undefined
-    }
-
-    lastArtworkSignatureRef.current = artworkSignature
 
     let isCancelled = false
     const fetchArtwork = async () => {
@@ -1196,6 +1189,7 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
     metadataArtist,
     metadataTitle,
     normalizedDevice,
+    statusState.data,
   ])
 
   const deviceWithArtwork = useMemo(() => {


### PR DESCRIPTION
## Summary
- restore the public images handler to use the original artwork retrieval logic and availability checks
- revert the retail player artwork lookup effect to the earlier getcoverart flow from final-retail-3

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e158c9dfc8322bc7561f75c25b207)