### PR TITLE
Use default cover art fallback

### DIFF
--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -1133,7 +1133,7 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
     }
 
     if (!metadataTitle) {
-      setArtworkUrl(defaultCoverArtUrl)
+      setArtworkUrl(defaultCoverArtUrl())
       lastArtworkSignatureRef.current = artworkSignature
       return undefined
     }
@@ -1176,10 +1176,10 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
           setArtworkUrl(subsonic.getCoverArtUrl(songs[0], 300, true))
           return
         }
-        setArtworkUrl(defaultCoverArtUrl)
+        setArtworkUrl(defaultCoverArtUrl())
       } catch (err) {
         if (!isCancelled) {
-          setArtworkUrl(defaultCoverArtUrl)
+          setArtworkUrl(defaultCoverArtUrl())
         }
       }
     }

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import subsonic from '../subsonic'
+import subsonic, { defaultCoverArtUrl } from '../subsonic'
 import httpClient from '../dataProvider/httpClient'
 import { baseUrl } from '../utils'
 import config from '../config'
@@ -1133,7 +1133,7 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
     }
 
     if (!metadataTitle) {
-      setArtworkUrl(null)
+      setArtworkUrl(defaultCoverArtUrl)
       lastArtworkSignatureRef.current = artworkSignature
       return undefined
     }
@@ -1176,10 +1176,10 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
           setArtworkUrl(subsonic.getCoverArtUrl(songs[0], 300, true))
           return
         }
-        setArtworkUrl(null)
+        setArtworkUrl(defaultCoverArtUrl)
       } catch (err) {
         if (!isCancelled) {
-          setArtworkUrl(null)
+          setArtworkUrl(defaultCoverArtUrl)
         }
       }
     }

--- a/ui/src/subsonic/index.js
+++ b/ui/src/subsonic/index.js
@@ -1,6 +1,9 @@
 import { baseUrl } from '../utils'
 
-const defaultCoverArtUrl = baseUrl('/android-chrome-512x512.png')
+const defaultCoverArtUrl = () => {
+  const coverArtPath = url('getCoverArt')
+  return coverArtPath ? baseUrl(coverArtPath) : ''
+}
 import { httpClient } from '../dataProvider'
 
 const url = (command, id, options) => {
@@ -89,7 +92,7 @@ const getCoverArtUrl = (record, size, square) => {
     coverArtUrl = baseUrl(url('getCoverArt', 'ar-' + record.id, options))
   }
 
-  return coverArtUrl || defaultCoverArtUrl
+  return coverArtUrl || defaultCoverArtUrl()
 }
 
 const getArtistInfo = (id) => {

--- a/ui/src/subsonic/index.js
+++ b/ui/src/subsonic/index.js
@@ -1,4 +1,6 @@
 import { baseUrl } from '../utils'
+
+const defaultCoverArtUrl = baseUrl('/android-chrome-512x512.png')
 import { httpClient } from '../dataProvider'
 
 const url = (command, id, options) => {
@@ -73,18 +75,21 @@ const getCoverArtUrl = (record, size, square) => {
   }
 
   // TODO Move this logic to server
+  let coverArtUrl = ''
   if (record.type === 'discovery') {
-    return baseUrl(url('getCoverArt', `dc-${record.id}`, options))
+    coverArtUrl = baseUrl(url('getCoverArt', `dc-${record.id}`, options))
   } else if (record.album) {
-    return baseUrl(url('getCoverArt', 'mf-' + record.id, options))
+    coverArtUrl = baseUrl(url('getCoverArt', 'mf-' + record.id, options))
   } else if (record.albumArtist) {
-    return baseUrl(url('getCoverArt', 'al-' + record.id, options))
+    coverArtUrl = baseUrl(url('getCoverArt', 'al-' + record.id, options))
   } else if (record.sync !== undefined) {
     // This is a playlist
-    return baseUrl(url('getCoverArt', 'pl-' + record.id, options))
+    coverArtUrl = baseUrl(url('getCoverArt', 'pl-' + record.id, options))
   } else {
-    return baseUrl(url('getCoverArt', 'ar-' + record.id, options))
+    coverArtUrl = baseUrl(url('getCoverArt', 'ar-' + record.id, options))
   }
+
+  return coverArtUrl || defaultCoverArtUrl
 }
 
 const getArtistInfo = (id) => {
@@ -132,3 +137,5 @@ export default {
   getTopSongs,
   getSimilarSongs2,
 }
+
+export { defaultCoverArtUrl }


### PR DESCRIPTION
## Summary
- add a default cover art URL fallback in the Subsonic helper
- ensure the retail player uses the default cover when metadata lookups return no artwork

## Testing
- npm test -- src/subsonic/index.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e1b49c7448322aaa2b2e5992065ea)