### PR TITLE
Prioritize device volume from websocket updates

### DIFF
--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -582,8 +582,10 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
     nowPlayingArtist = ''
   }
 
+  const payloadVolume = parseVolume(payloadDevice?.volume)
+
   const volume =
-    combinedMetadata.volume ?? parseVolume(status.volume) ?? parseVolume(payloadDevice?.volume)
+    payloadVolume ?? parseVolume(combinedMetadata.volume) ?? parseVolume(status.volume)
 
   const scheduleStatus = normalizeValue(status.scheduleStatus).toLowerCase()
   const isConnected =


### PR DESCRIPTION
## Summary
- prioritize parsing the device volume provided in retail player websocket payloads
- ensure volume updates use parsed values before falling back to other metadata

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e21a1a8248322ba1621d685ca386e)