### PR TITLE
Improve retail player cover art lookup

### DIFF
--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -3,7 +3,9 @@ package persistence
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -102,6 +104,17 @@ var mediaFileFilter = sync.OnceValue(func() map[string]filterFunc {
 		"missing":    booleanFilter,
 		"artists_id": artistFilter,
 		"library_id": libraryIdFilter,
+		"filename": func(_ string, value any) Sqlizer {
+			filename := strings.TrimSpace(value.(string))
+			if filename == "" {
+				return nil
+			}
+			base := filepath.Base(filename)
+			if base == "" {
+				return nil
+			}
+			return containsFilter("path")("path", base)
+		},
 	}
 	// Add all album tags as filters
 	for tag := range model.TagMappings() {

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -104,17 +104,17 @@ var mediaFileFilter = sync.OnceValue(func() map[string]filterFunc {
 		"missing":    booleanFilter,
 		"artists_id": artistFilter,
 		"library_id": libraryIdFilter,
-		"filename": func(_ string, value any) Sqlizer {
-			filename := strings.TrimSpace(value.(string))
-			if filename == "" {
-				return nil
-			}
-			base := filepath.Base(filename)
-			if base == "" {
-				return nil
-			}
-			return containsFilter("path")("path", base)
-		},
+"filename": func(_ string, value any) Sqlizer {
+filename := strings.TrimSpace(value.(string))
+if filename == "" {
+return nil
+}
+base := filepath.Base(filename)
+if base == "" {
+return nil
+}
+return containsFilter("media_file.path")("media_file.path", base)
+},
 	}
 	// Add all album tags as filters
 	for tag := range model.TagMappings() {

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -1108,6 +1108,8 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
   const nowPlayingMetadata = nowPlaying.metadata || {}
   const metadataTitle = normalizeValue(nowPlayingMetadata.title)
   const metadataArtist = normalizeValue(nowPlayingMetadata.artist)
+  const streamFileName =
+    normalizeValue(nowPlayingMetadata.filename) || normalizeValue(nowPlaying.streamName)
 
   const lastArtworkSignatureRef = useRef(null)
 
@@ -1134,7 +1136,7 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
       return undefined
     }
 
-    if (!metadataTitle) {
+    if (!metadataTitle && !streamFileName) {
       setArtworkUrl(defaultCoverArtUrl())
       lastArtworkSignatureRef.current = artworkSignature
       return undefined
@@ -1156,9 +1158,14 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
       if (!isAdminUser()) {
         params.set('missing', 'false')
       }
-      params.set('title', metadataTitle)
+      if (metadataTitle) {
+        params.set('title', metadataTitle)
+      }
       if (metadataArtist) {
         params.set('artist', metadataArtist)
+      }
+      if (streamFileName) {
+        params.set('filename', streamFileName)
       }
 
       appendLibraryFilters(params)


### PR DESCRIPTION
## Summary
- add filename support to the public getcoverart query so media can be matched by file basename
- include stream filename in retail player cover art lookup to populate thumbnails when metadata is missing

## Testing
- go test ./... *(interrupted)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f6ba87d188322a9689ecf3e0bf765)