### PR TITLE
Sync playlist renames with filesystem

### DIFF
--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -180,7 +180,7 @@ func (n *Router) addPlaylistRoute(r chi.Router) {
 		r.Route("/{id}", func(r chi.Router) {
 			r.Use(server.URLParamsMiddleware)
 			r.Get("/", rest.Get(constructor))
-			r.Put("/", rest.Put(constructor))
+			r.Put("/", updatePlaylist(n.ds, n.playlists, constructor))
 			r.Delete("/", rest.Delete(constructor))
 
 			r.Post("/publish", publishPlaylist(n.ds, n.playlists))
@@ -222,7 +222,7 @@ func (n *Router) addPlaylistFolderRoute(r chi.Router) {
 		r.Route("/{id}", func(r chi.Router) {
 			r.Use(server.URLParamsMiddleware)
 			r.Get("/", rest.Get(constructor))
-			r.Put("/", rest.Put(constructor))
+			r.Put("/", updatePlaylistFolder(n.ds, n.playlists, constructor))
 			r.Delete("/", rest.Delete(constructor))
 
 			r.Patch("/parent", MoveFolder(n.ds))

--- a/server/nativeapi/playlist_folder.go
+++ b/server/nativeapi/playlist_folder.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	. "github.com/Masterminds/squirrel"
+	"github.com/deluan/rest"
 	"github.com/go-chi/chi/v5"
 	"github.com/navidrome/navidrome/core"
 	"github.com/navidrome/navidrome/model"
@@ -385,4 +386,52 @@ func collectDescendantFolderIDs(ctx context.Context, repo model.PlaylistFolderRe
 	}
 
 	return result, nil
+}
+
+func updatePlaylistFolder(ds model.DataStore, playlists core.Playlists, constructor rest.RepositoryConstructor) http.HandlerFunc {
+	put := rest.Put(constructor)
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		catcher := newResponseCatcher(w)
+		put(catcher, r)
+
+		if catcher.status >= http.StatusBadRequest {
+			catcher.Flush()
+			return
+		}
+
+		id := chi.URLParam(r, "id")
+		if err := syncPlaylistsUnderFolder(playlists, ds, r.Context(), id); err != nil {
+			http.Error(w, err.Error(), statusFor(err))
+			return
+		}
+
+		catcher.Flush()
+	}
+}
+
+func syncPlaylistsUnderFolder(playlists core.Playlists, ds model.DataStore, ctx context.Context, folderID string) error {
+	folder := folderID
+	descendants, err := collectDescendantFolderIDs(ctx, ds.PlaylistFolder(ctx), &folder)
+	if err != nil {
+		return err
+	}
+
+	ids := append([]string{folderID}, descendants...)
+	filter := Eq{"folder_id": uniqueStrings(ids)}
+	playlistsInFolder, err := ds.Playlist(ctx).GetAll(model.QueryOptions{Filters: filter})
+	if err != nil {
+		return err
+	}
+
+	for _, pls := range playlistsInFolder {
+		if !pls.Sync {
+			continue
+		}
+		if err := playlists.Update(ctx, pls.ID, &pls.Name, &pls.Comment, &pls.Public, nil, nil); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/server/nativeapi/playlists.go
+++ b/server/nativeapi/playlists.go
@@ -97,6 +97,28 @@ func createPlaylist(ds model.DataStore, playlists core.Playlists) http.HandlerFu
 	}
 }
 
+func updatePlaylist(ds model.DataStore, playlists core.Playlists, constructor rest.RepositoryConstructor) http.HandlerFunc {
+	put := rest.Put(constructor)
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		catcher := newResponseCatcher(w)
+		put(catcher, r)
+
+		if catcher.status >= http.StatusBadRequest {
+			catcher.Flush()
+			return
+		}
+
+		playlistId := chi.URLParam(r, "id")
+		if err := syncPlaylist(playlists, ds, r.Context(), playlistId); err != nil {
+			http.Error(w, err.Error(), statusFor(err))
+			return
+		}
+
+		catcher.Flush()
+	}
+}
+
 func createPlaylistFromM3U(playlists core.Playlists) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()

--- a/server/nativeapi/response_catcher.go
+++ b/server/nativeapi/response_catcher.go
@@ -1,0 +1,39 @@
+package nativeapi
+
+import (
+	"bytes"
+	"net/http"
+)
+
+type responseCatcher struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+	buf         bytes.Buffer
+}
+
+func newResponseCatcher(w http.ResponseWriter) *responseCatcher {
+	return &responseCatcher{ResponseWriter: w, status: http.StatusOK}
+}
+
+func (r *responseCatcher) WriteHeader(status int) {
+	if r.wroteHeader {
+		return
+	}
+	r.status = status
+	r.wroteHeader = true
+}
+
+func (r *responseCatcher) Write(b []byte) (int, error) {
+	return r.buf.Write(b)
+}
+
+func (r *responseCatcher) Flush() {
+	if !r.wroteHeader {
+		r.status = http.StatusOK
+	}
+	r.ResponseWriter.WriteHeader(r.status)
+	if r.buf.Len() > 0 {
+		_, _ = r.ResponseWriter.Write(r.buf.Bytes())
+	}
+}


### PR DESCRIPTION
## Summary
- route playlist updates through a sync step so name changes rewrite the corresponding playlist files
- ensure playlist folder edits trigger resync of all synced playlists within the folder hierarchy
- add a response catcher helper to buffer REST responses until filesystem syncing succeeds

## Testing
- ⚠️ `go test ./server/nativeapi` *(hangs in this environment; interrupted with Ctrl+C)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f6c39e59c8322a7736764d92575c6)