### PR TITLE
Handle playlist rename on filesystem

### DIFF
--- a/core/playlists.go
+++ b/core/playlists.go
@@ -464,6 +464,7 @@ func (s *playlists) Update(ctx context.Context, playlistID string,
 			return err
 		}
 		oldPath := pls.Path
+		newPath := oldPath
 
 		if len(idxToRemove) > 0 {
 			pls.RemoveTracks(idxToRemove)
@@ -487,10 +488,17 @@ func (s *playlists) Update(ctx context.Context, playlistID string,
 			if ext == "" {
 				ext = ".m3u"
 			}
-			newPath, err := s.buildPlaylistPath(ctx, tx, pls.FolderID, pls.Name, ext)
+			newPath, err = s.buildPlaylistPath(ctx, tx, pls.FolderID, pls.Name, ext)
 			if err != nil {
 				return err
 			}
+			pls.Path = newPath
+		} else if oldPath != "" && name != nil {
+			ext := filepath.Ext(oldPath)
+			if ext == "" {
+				ext = ".m3u"
+			}
+			newPath = filepath.Join(filepath.Dir(oldPath), sanitizeName(pls.Name)+ext)
 			pls.Path = newPath
 		}
 
@@ -504,7 +512,7 @@ func (s *playlists) Update(ctx context.Context, playlistID string,
 			return err
 		}
 
-		if pls.Sync {
+		if pls.Path != "" {
 			if err := os.MkdirAll(filepath.Dir(pls.Path), 0o755); err != nil {
 				return err
 			}
@@ -513,6 +521,9 @@ func (s *playlists) Update(ctx context.Context, playlistID string,
 					return err
 				}
 			}
+		}
+
+		if pls.Sync {
 			if err := s.writePlaylistFile(pls.Path, pls, false); err != nil {
 				return err
 			}

--- a/core/playlists_test.go
+++ b/core/playlists_test.go
@@ -183,6 +183,34 @@ var _ = Describe("Playlists", func() {
 
 				})
 			})
+
+			Describe("Update", func() {
+				It("renames playlist file on disk when name changes", func() {
+					DeferCleanup(configtest.SetupConfig())
+
+					playlistsDir := GinkgoT().TempDir()
+					conf.Server.PlaylistsPath = playlistsDir
+					ps = NewPlaylists(ds)
+
+					oldPath := filepath.Join(playlistsDir, "old-name.m3u")
+					Expect(os.WriteFile(oldPath, []byte("#EXTM3U\n"), 0o644)).To(Succeed())
+
+					pls := &model.Playlist{
+						ID:      "1",
+						Name:    "Old Name",
+						Path:    oldPath,
+						OwnerID: "123",
+					}
+					mockPlsRepo.stored = map[string]*model.Playlist{"1": pls}
+
+					newName := "New Name"
+					Expect(ps.Update(ctx, "1", &newName, nil, nil, nil, nil)).To(Succeed())
+
+					newPath := filepath.Join(playlistsDir, "New Name.m3u")
+					Expect(newPath).To(BeAnExistingFile())
+					Expect(oldPath).ToNot(BeAnExistingFile())
+				})
+			})
 		})
 
 		Describe("NSP", func() {


### PR DESCRIPTION
## Summary
- ensure playlist updates rename playlist files on disk when names change, even for non-synced playlists with existing paths
- keep synced playlists writing logic intact while moving file handling outside sync-only paths
- add coverage proving playlist rename updates filesystem entries

## Testing
- go test ./core -run Playlists *(fails: dependency download blocked in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f6e3698248322a4a0e592dbfec865)