### PR TITLE
Use stream name to find retail player cover art

### DIFF
--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -1151,42 +1151,75 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
     lastArtworkSignatureRef.current = artworkSignature
 
     let isCancelled = false
+    const addSearch = (list, title, artist) => {
+      const normalizedTitle = normalizeValue(title)
+      if (!normalizedTitle) {
+        return
+      }
+      const normalizedArtist = normalizeValue(artist)
+      const signature = `${normalizedTitle}::${normalizedArtist}`
+      if (list.some((entry) => entry.signature === signature)) {
+        return
+      }
+      list.push({ title: normalizedTitle, artist: normalizedArtist, signature })
+    }
+
+    const streamBaseName = normalizeValue(streamName).replace(/\.[^./\\]+$/, '')
+    const searchCandidates = []
+    addSearch(searchCandidates, lookupTitle, lookupArtist)
+    addSearch(searchCandidates, lookupTitle, '')
+    if (streamTitle && streamTitle !== lookupTitle) {
+      addSearch(searchCandidates, streamTitle, streamArtist)
+    }
+    if (streamBaseName && streamBaseName !== lookupTitle) {
+      addSearch(searchCandidates, streamBaseName, lookupArtist)
+      addSearch(searchCandidates, streamBaseName, '')
+    }
+
     const fetchArtwork = async () => {
-      const params = new URLSearchParams()
-      params.set('_start', '0')
-      params.set('_end', '1')
-      params.set('_sort', 'id')
-      params.set('_order', 'ASC')
-      if (!isAdminUser()) {
-        params.set('missing', 'false')
-      }
-      params.set('title', lookupTitle)
-      if (lookupArtist) {
-        params.set('artist', lookupArtist)
-      }
-
-      appendLibraryFilters(params)
-
-      try {
-        const rootPath = config.publicBaseUrl || '/share'
-        const normalizedRoot = rootPath.endsWith('/')
-          ? rootPath.slice(0, -1)
-          : rootPath
-        const requestPath = `${normalizedRoot}/getcoverart?${params.toString()}`
-        const response = await httpClient(requestPath)
-        if (isCancelled) {
-          return
-        }
-        const songs = Array.isArray(response?.json) ? response.json : []
-        if (songs.length > 0) {
-          setArtworkUrl(subsonic.getCoverArtUrl(songs[0], 300, true))
-          return
-        }
+      if (!searchCandidates.length) {
         setArtworkUrl(defaultCoverArtUrl())
-      } catch (err) {
-        if (!isCancelled) {
-          setArtworkUrl(defaultCoverArtUrl())
+        return
+      }
+
+      const rootPath = config.publicBaseUrl || '/share'
+      const normalizedRoot = rootPath.endsWith('/') ? rootPath.slice(0, -1) : rootPath
+
+      for (let index = 0; index < searchCandidates.length; index += 1) {
+        const { title, artist } = searchCandidates[index]
+        const params = new URLSearchParams()
+        params.set('_start', '0')
+        params.set('_end', '1')
+        params.set('_sort', 'id')
+        params.set('_order', 'ASC')
+        if (!isAdminUser()) {
+          params.set('missing', 'false')
         }
+        params.set('title', title)
+        if (artist) {
+          params.set('artist', artist)
+        }
+
+        appendLibraryFilters(params)
+
+        try {
+          const requestPath = `${normalizedRoot}/getcoverart?${params.toString()}`
+          const response = await httpClient(requestPath)
+          if (isCancelled) {
+            return
+          }
+          const songs = Array.isArray(response?.json) ? response.json : []
+          if (songs.length > 0) {
+            setArtworkUrl(subsonic.getCoverArtUrl(songs[0], 300, true))
+            return
+          }
+        } catch (err) {
+          // Continue to the next candidate if this search fails
+        }
+      }
+
+      if (!isCancelled) {
+        setArtworkUrl(defaultCoverArtUrl())
       }
     }
 
@@ -1202,6 +1235,9 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
     lookupArtist,
     lookupTitle,
     normalizedDevice,
+    streamArtist,
+    streamName,
+    streamTitle,
   ])
 
   const deviceWithArtwork = useMemo(() => {

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -1164,16 +1164,14 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
       list.push({ title: normalizedTitle, artist: normalizedArtist, signature })
     }
 
-    const streamBaseName = normalizeValue(streamName).replace(/\.[^./\\]+$/, '')
     const searchCandidates = []
-    addSearch(searchCandidates, lookupTitle, lookupArtist)
-    addSearch(searchCandidates, lookupTitle, '')
-    if (streamTitle && streamTitle !== lookupTitle) {
-      addSearch(searchCandidates, streamTitle, streamArtist)
-    }
-    if (streamBaseName && streamBaseName !== lookupTitle) {
-      addSearch(searchCandidates, streamBaseName, lookupArtist)
-      addSearch(searchCandidates, streamBaseName, '')
+    const normalizedStreamName = normalizeValue(streamName)
+    if (normalizedStreamName) {
+      addSearch(searchCandidates, normalizedStreamName, '')
+      const streamBaseName = normalizedStreamName.replace(/\.[^./\\]+$/, '')
+      if (streamBaseName && streamBaseName !== normalizedStreamName) {
+        addSearch(searchCandidates, streamBaseName, '')
+      }
     }
 
     const fetchArtwork = async () => {
@@ -1186,7 +1184,7 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
       const normalizedRoot = rootPath.endsWith('/') ? rootPath.slice(0, -1) : rootPath
 
       for (let index = 0; index < searchCandidates.length; index += 1) {
-        const { title, artist } = searchCandidates[index]
+        const { title } = searchCandidates[index]
         const params = new URLSearchParams()
         params.set('_start', '0')
         params.set('_end', '1')
@@ -1195,10 +1193,7 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
         if (!isAdminUser()) {
           params.set('missing', 'false')
         }
-        params.set('title', title)
-        if (artist) {
-          params.set('artist', artist)
-        }
+        params.set('path', title)
 
         appendLibraryFilters(params)
 

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -1108,6 +1108,10 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
   const nowPlayingMetadata = nowPlaying.metadata || {}
   const metadataTitle = normalizeValue(nowPlayingMetadata.title)
   const metadataArtist = normalizeValue(nowPlayingMetadata.artist)
+  const streamName = normalizeValue(nowPlaying.streamName)
+  const { title: streamTitle, artist: streamArtist } = parseActiveStreamInfo(streamName)
+  const lookupTitle = metadataTitle || streamTitle
+  const lookupArtist = metadataArtist || streamArtist
 
   const lastArtworkSignatureRef = useRef(null)
 
@@ -1134,7 +1138,7 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
       return undefined
     }
 
-    if (!metadataTitle) {
+    if (!lookupTitle) {
       setArtworkUrl(defaultCoverArtUrl())
       lastArtworkSignatureRef.current = artworkSignature
       return undefined
@@ -1156,9 +1160,9 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
       if (!isAdminUser()) {
         params.set('missing', 'false')
       }
-      params.set('title', metadataTitle)
-      if (metadataArtist) {
-        params.set('artist', metadataArtist)
+      params.set('title', lookupTitle)
+      if (lookupArtist) {
+        params.set('artist', lookupArtist)
       }
 
       appendLibraryFilters(params)
@@ -1195,8 +1199,8 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
     artworkSignature,
     backendArtworkId,
     existingArtwork,
-    metadataArtist,
-    metadataTitle,
+    lookupArtist,
+    lookupTitle,
     normalizedDevice,
   ])
 


### PR DESCRIPTION
## Summary
- derive lookup titles and artists from the retail player stream name
- fall back to the parsed stream info when fetching cover art so cached thumbnails can be reused

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f7232e8648322a9536a46d98c5061)