### PR TITLE
Handle playlist rename sync filesystem and round retail time

### DIFF
--- a/core/playlists.go
+++ b/core/playlists.go
@@ -488,7 +488,7 @@ func (s *playlists) Update(ctx context.Context, playlistID string,
 			if ext == "" {
 				ext = ".m3u"
 			}
-			newPath, err := s.buildPlaylistPath(ctx, tx, pls.FolderID, pls.Name, ext)
+			newPath, err := s.resolvePlaylistPath(ctx, tx, pls.FolderID, pls.Name, ext, oldPath)
 			if err != nil {
 				return err
 			}
@@ -673,6 +673,19 @@ func (s *playlists) buildPlaylistPath(ctx context.Context, ds model.DataStore, f
 		return filepath.Join(root, rel, filename), nil
 	}
 	return filepath.Join(root, filename), nil
+}
+
+func (s *playlists) resolvePlaylistPath(ctx context.Context, ds model.DataStore, folderID *string, name, ext, previousPath string) (string, error) {
+	if path, err := s.buildPlaylistPath(ctx, ds, folderID, name, ext); err == nil {
+		return path, nil
+	}
+
+	if previousPath == "" {
+		return "", fmt.Errorf("playlist path not available")
+	}
+
+	dir := filepath.Dir(previousPath)
+	return filepath.Join(dir, sanitizeName(name)+ext), nil
 }
 
 type nspFile struct {

--- a/core/playlists.go
+++ b/core/playlists.go
@@ -482,6 +482,7 @@ func (s *playlists) Update(ctx context.Context, playlistID string,
 			pls.Public = *public
 		}
 
+		var oldSyncPath string
 		if pls.Sync {
 			ext := filepath.Ext(oldPath)
 			if ext == "" {
@@ -491,6 +492,7 @@ func (s *playlists) Update(ctx context.Context, playlistID string,
 			if err != nil {
 				return err
 			}
+			oldSyncPath = s.syncPath(oldPath)
 			pls.Path = newPath
 		}
 
@@ -513,8 +515,14 @@ func (s *playlists) Update(ctx context.Context, playlistID string,
 					return err
 				}
 			}
-			if err := s.writePlaylistFile(pls.Path, pls, false); err != nil {
+			if err := s.writePlaylistFile(pls.Path, pls, true); err != nil {
 				return err
+			}
+			if oldSyncPath != "" {
+				newSyncPath := s.syncPath(pls.Path)
+				if newSyncPath != "" && oldSyncPath != newSyncPath {
+					_ = os.Remove(oldSyncPath)
+				}
 			}
 		}
 		return nil
@@ -575,6 +583,24 @@ func (s *playlists) writePlaylistFile(path string, pls *model.Playlist, mirrorTo
 		return nil
 	}
 
+	syncPath := s.syncPath(path)
+	if syncPath == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(syncPath), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(syncPath, data, 0o644); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *playlists) syncPath(path string) string {
+	if conf.Server.SyncFolder == "" || path == "" {
+		return ""
+	}
+
 	rel := filepath.Base(path)
 	if conf.Server.PlaylistsPath != "" {
 		paths := strings.Split(conf.Server.PlaylistsPath, string(filepath.ListSeparator))
@@ -590,14 +616,8 @@ func (s *playlists) writePlaylistFile(path string, pls *model.Playlist, mirrorTo
 			}
 		}
 	}
-	syncPath := filepath.Join(conf.Server.SyncFolder, rel)
-	if err := os.MkdirAll(filepath.Dir(syncPath), 0o755); err != nil {
-		return err
-	}
-	if err := os.WriteFile(syncPath, data, 0o644); err != nil {
-		return err
-	}
-	return nil
+
+	return filepath.Join(conf.Server.SyncFolder, rel)
 }
 
 func (s *playlists) Publish(ctx context.Context, playlistID string) error {

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -44,6 +44,8 @@ const formatTime = (date, timeZone) => {
     return '--:--'
   }
 
+  const roundedDate = new Date(Math.ceil(date.getTime() / 60000) * 60000)
+
   try {
     return new Intl.DateTimeFormat([], {
       hour: '2-digit',
@@ -51,10 +53,10 @@ const formatTime = (date, timeZone) => {
       hour12: false,
       ...(timeZone ? { timeZone } : {}),
     })
-      .format(date)
+      .format(roundedDate)
       .replace(/^24:/, '00:')
   } catch (err) {
-    return date
+    return roundedDate
       .toLocaleTimeString([], {
         hour: '2-digit',
         minute: '2-digit',
@@ -69,6 +71,8 @@ const formatDetailedTime = (date, timeZone) => {
     return ''
   }
 
+  const roundedDate = new Date(Math.ceil(date.getTime() / 60000) * 60000)
+
   try {
     const formatter = new Intl.DateTimeFormat('en-CA', {
       year: 'numeric',
@@ -80,7 +84,7 @@ const formatDetailedTime = (date, timeZone) => {
       ...(timeZone ? { timeZone } : {}),
     })
 
-    const parts = formatter.formatToParts(date)
+    const parts = formatter.formatToParts(roundedDate)
     const values = parts.reduce((accumulator, part) => {
       if (part.type) {
         accumulator[part.type] = part.value
@@ -105,7 +109,7 @@ const formatDetailedTime = (date, timeZone) => {
 
     return `${year}-${month}-${day} ${hour}:${minute}${normalizedDayPeriod}`
   } catch (error) {
-    const isoString = date.toISOString()
+    const isoString = roundedDate.toISOString()
     const [isoDate, isoTime = ''] = isoString.split('T')
     const [hours = '', minutes = ''] = isoTime.split(':')
     if (!isoDate || !hours || !minutes) {


### PR DESCRIPTION
## Summary
- ensure synced playlist renames also update mirrored files and clean old copies
- add helper to resolve sync paths for playlist exports
- round retail player time display up to the next minute to avoid flicker

## Testing
- go test ./core -count=1 (fails: interrupted due to long runtime)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fd52bddd48322b15e7947601ba342)