### PR TITLE
Avoid duplicating playlist extensions on rename

### DIFF
--- a/core/playlists.go
+++ b/core/playlists.go
@@ -648,7 +648,11 @@ func (s *playlists) buildPlaylistPath(ctx context.Context, ds model.DataStore, f
 		}
 		rel = filepath.Join(parts...)
 	}
-	filename := sanitizeName(name) + ext
+	sanitizedName := sanitizeName(name)
+	if strings.HasSuffix(strings.ToLower(sanitizedName), strings.ToLower(ext)) {
+		sanitizedName = strings.TrimSuffix(sanitizedName, ext)
+	}
+	filename := sanitizedName + ext
 	if rel != "" {
 		return filepath.Join(root, rel, filename), nil
 	}

--- a/core/playlists_test.go
+++ b/core/playlists_test.go
@@ -139,6 +139,20 @@ var _ = Describe("Playlists", func() {
 				Expect(pls.Tracks[0].Path).To(Equal("Discovery-Specialty/Specialty/Asian/Jun Hyung Yong, 10cm - Sudden Shower.mp3"))
 			})
 
+			Describe("buildPlaylistPath", func() {
+				It("does not duplicate the extension when it is part of the name", func() {
+					DeferCleanup(configtest.SetupConfig())
+
+					playlistsDir := GinkgoT().TempDir()
+					conf.Server.PlaylistsPath = playlistsDir
+
+					ps := &playlists{}
+					path, err := ps.buildPlaylistPath(ctx, ds, nil, "6.m3u", ".m3u")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(filepath.Base(path)).To(Equal("6.m3u"))
+				})
+			})
+
 			Describe("writePlaylistFile", func() {
 				It("writes file to sync folder when configured", func() {
 					DeferCleanup(configtest.SetupConfig())


### PR DESCRIPTION
## Summary
- prevent playlist path generation from appending duplicate extensions when the playlist name already includes one
- add a regression test ensuring buildPlaylistPath produces paths without duplicated extensions

## Testing
- go test ./core -run BuildPlaylistPath -count=1 -timeout 2m *(fails: missing pkg-config taglib dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693033c77f7c8322b05b5707e4b07ccb)