### PR TITLE
Ensure playlist renames update synced files

### DIFF
--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -180,7 +180,7 @@ func (n *Router) addPlaylistRoute(r chi.Router) {
 		r.Route("/{id}", func(r chi.Router) {
 			r.Use(server.URLParamsMiddleware)
 			r.Get("/", rest.Get(constructor))
-			r.Put("/", rest.Put(constructor))
+			r.Put("/", updatePlaylist(n.playlists, n.ds))
 			r.Delete("/", rest.Delete(constructor))
 
 			r.Post("/publish", publishPlaylist(n.ds, n.playlists))

--- a/server/nativeapi/playlists.go
+++ b/server/nativeapi/playlists.go
@@ -97,6 +97,39 @@ func createPlaylist(ds model.DataStore, playlists core.Playlists) http.HandlerFu
 	}
 }
 
+func updatePlaylist(playlists core.Playlists, ds model.DataStore) http.HandlerFunc {
+	type updatePlaylistRequest struct {
+		Name    *string `json:"name"`
+		Comment *string `json:"comment"`
+		Public  *bool   `json:"public"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+
+		var body updatePlaylistRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if err := playlists.Update(r.Context(), id, body.Name, body.Comment, body.Public, nil, nil); err != nil {
+			http.Error(w, err.Error(), statusFor(err))
+			return
+		}
+
+		pls, err := ds.Playlist(r.Context()).Get(id)
+		if err != nil {
+			http.Error(w, err.Error(), statusFor(err))
+			return
+		}
+
+		if err := rest.RespondWithJSON(w, http.StatusOK, pls); err != nil {
+			log.Error(r.Context(), "Error responding with playlist", "playlistId", id, err)
+		}
+	}
+}
+
 func createPlaylistFromM3U(playlists core.Playlists) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()


### PR DESCRIPTION
## Summary
- route playlist updates through core playlist logic to update synced files when names change
- return updated playlist data from the dedicated update handler

## Testing
- go test ./server/nativeapi *(interrupted due to hang)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931ffa2ae548322899d4fbdca31335f)