### PR TITLE
Handle retail player dislikes: retry on loading, update synced M3U, and include IP location

### DIFF
--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -3,6 +3,7 @@ package nativeapi
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1734,7 +1735,8 @@ func (n *Router) handleRetailPlayerDeviceDislike() http.HandlerFunc {
 
 		log.Info(ctx, "Received retail player dislike", "deviceID", deviceID, "trackTitle", trackTitle, "playlistName", playlistName)
 
-		if err := updateSyncPlaylistForDislike(ctx, playlistName, trackTitle); err != nil {
+		syncPlaylistPath, err := updateSyncPlaylistForDislike(ctx, playlistName, trackTitle)
+		if err != nil {
 			log.Warn(ctx, "Unable to update sync playlist for dislike", "deviceID", deviceID, "playlistName", playlistName, "trackTitle", trackTitle, "err", err)
 		}
 
@@ -1744,7 +1746,7 @@ func (n *Router) handleRetailPlayerDeviceDislike() http.HandlerFunc {
 		if notifications.Enabled {
 			clientIP := extractClientIP(r)
 
-			if err := sendRetailPlayerDislikeNotification(ctx, clientIP, trackTitle, playlistName); err != nil {
+			if err := sendRetailPlayerDislikeNotification(ctx, clientIP, trackTitle, playlistName, syncPlaylistPath); err != nil {
 				log.Error(ctx, "Unable to send retail player dislike notification", "deviceID", deviceID, "err", err)
 				http.Error(w, "Unable to send dislike notification", http.StatusBadGateway)
 				return
@@ -3067,7 +3069,7 @@ func extractClientIP(r *http.Request) string {
 	return remoteAddr
 }
 
-func sendRetailPlayerDislikeNotification(ctx context.Context, clientIP, trackTitle, playlistName string) error {
+func sendRetailPlayerDislikeNotification(ctx context.Context, clientIP, trackTitle, playlistName, playlistPath string) error {
 	notifications := conf.Server.RetailPlayer.Notifications
 	if !notifications.Enabled {
 		return nil
@@ -3125,6 +3127,10 @@ func sendRetailPlayerDislikeNotification(ctx context.Context, clientIP, trackTit
 	body := strings.Join(bodyLines, "\n")
 	message := fmt.Sprintf("Subject: %s\n\n%s", subject, body)
 
+	if attachment, err := buildPlaylistAttachmentMessage(subject, body, playlistPath); err == nil && attachment != "" {
+		message = attachment
+	}
+
 	args := []string{
 		"--url", fmt.Sprintf("smtp://%s:%d", smtpServer, port),
 		"--ssl-reqd",
@@ -3170,15 +3176,15 @@ func fetchIPInfo(ctx context.Context, clientIP string) (ipInfo, error) {
 	return info, nil
 }
 
-func updateSyncPlaylistForDislike(ctx context.Context, playlistName, trackTitle string) error {
+func updateSyncPlaylistForDislike(ctx context.Context, playlistName, trackTitle string) (string, error) {
 	if strings.TrimSpace(conf.Server.SyncFolder) == "" {
-		return nil
+		return "", nil
 	}
 
 	normalizedPlaylistName := strings.TrimSpace(playlistName)
 	normalizedTrackTitle := strings.TrimSpace(trackTitle)
 	if normalizedPlaylistName == "" || normalizedTrackTitle == "" {
-		return nil
+		return "", nil
 	}
 
 	if filepath.Ext(normalizedPlaylistName) == "" {
@@ -3187,32 +3193,32 @@ func updateSyncPlaylistForDislike(ctx context.Context, playlistName, trackTitle 
 
 	playlistPath, rootPath, err := findPlaylistFile(conf.Server.PlaylistsPath, normalizedPlaylistName)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if playlistPath == "" {
-		return fmt.Errorf("playlist not found: %s", normalizedPlaylistName)
+		return "", fmt.Errorf("playlist not found: %s", normalizedPlaylistName)
 	}
 
 	data, err := os.ReadFile(playlistPath)
 	if err != nil {
-		return fmt.Errorf("unable to read playlist: %w", err)
+		return "", fmt.Errorf("unable to read playlist: %w", err)
 	}
 
 	updated, removed := removeTrackFromM3U(data, normalizedTrackTitle)
 	if !removed {
-		return nil
+		return "", nil
 	}
 
 	syncPath := buildSyncPlaylistPath(conf.Server.SyncFolder, rootPath, playlistPath)
 	if err := os.MkdirAll(filepath.Dir(syncPath), 0o755); err != nil {
-		return fmt.Errorf("unable to create sync playlist dir: %w", err)
+		return "", fmt.Errorf("unable to create sync playlist dir: %w", err)
 	}
 	if err := os.WriteFile(syncPath, updated, 0o644); err != nil {
-		return fmt.Errorf("unable to write sync playlist: %w", err)
+		return "", fmt.Errorf("unable to write sync playlist: %w", err)
 	}
 
 	log.Info(ctx, "Synced playlist updated after dislike", "playlist", normalizedPlaylistName, "syncPath", syncPath, "trackTitle", normalizedTrackTitle)
-	return nil
+	return syncPath, nil
 }
 
 func findPlaylistFile(playlistsPath, playlistFile string) (string, string, error) {
@@ -3314,6 +3320,63 @@ func removeTrackFromM3U(data []byte, trackTitle string) ([]byte, bool) {
 	}
 
 	return []byte(output), removed
+}
+
+func buildPlaylistAttachmentMessage(subject, body, playlistPath string) (string, error) {
+	if strings.TrimSpace(playlistPath) == "" {
+		return "", nil
+	}
+	stat, err := os.Stat(playlistPath)
+	if err != nil || stat.IsDir() {
+		return "", nil
+	}
+
+	data, err := os.ReadFile(playlistPath)
+	if err != nil {
+		return "", err
+	}
+
+	filename := filepath.Base(playlistPath)
+	boundary := fmt.Sprintf("mixed-%d", time.Now().UnixNano())
+	encoded := base64.StdEncoding.EncodeToString(data)
+	encoded = chunkBase64(encoded, 76)
+
+	message := strings.Join([]string{
+		fmt.Sprintf("Subject: %s", subject),
+		"MIME-Version: 1.0",
+		fmt.Sprintf("Content-Type: multipart/mixed; boundary=%q", boundary),
+		"",
+		fmt.Sprintf("--%s", boundary),
+		"Content-Type: text/plain; charset=utf-8",
+		"",
+		body,
+		"",
+		fmt.Sprintf("--%s", boundary),
+		fmt.Sprintf("Content-Type: audio/x-mpegurl; name=%q", filename),
+		fmt.Sprintf("Content-Disposition: attachment; filename=%q", filename),
+		"Content-Transfer-Encoding: base64",
+		"",
+		encoded,
+		"",
+		fmt.Sprintf("--%s--", boundary),
+		"",
+	}, "\n")
+
+	return message, nil
+}
+
+func chunkBase64(encoded string, width int) string {
+	if width <= 0 || len(encoded) <= width {
+		return encoded
+	}
+	var builder strings.Builder
+	for len(encoded) > width {
+		builder.WriteString(encoded[:width])
+		builder.WriteString("\n")
+		encoded = encoded[width:]
+	}
+	builder.WriteString(encoded)
+	return builder.String()
 }
 
 func (n *Router) syncRetailPlayerQR(ctx context.Context) ([]retailPlayerQRSyncResult, error) {

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -12,8 +12,10 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -1732,6 +1734,10 @@ func (n *Router) handleRetailPlayerDeviceDislike() http.HandlerFunc {
 
 		log.Info(ctx, "Received retail player dislike", "deviceID", deviceID, "trackTitle", trackTitle, "playlistName", playlistName)
 
+		if err := updateSyncPlaylistForDislike(ctx, playlistName, trackTitle); err != nil {
+			log.Warn(ctx, "Unable to update sync playlist for dislike", "deviceID", deviceID, "playlistName", playlistName, "trackTitle", trackTitle, "err", err)
+		}
+
 		notifications := conf.Server.RetailPlayer.Notifications
 		notified := false
 
@@ -3101,7 +3107,22 @@ func sendRetailPlayerDislikeNotification(ctx context.Context, clientIP, trackTit
 		playlistLabel = "unknown playlist"
 	}
 
-	body := fmt.Sprintf("%s disliked %s from %s", ipLabel, trackLabel, playlistLabel)
+	locationLabel := ""
+	if ipLabel != "" && ipLabel != "unknown IP" {
+		if info, err := fetchIPInfo(ctx, ipLabel); err == nil {
+			locationLabel = strings.TrimSpace(strings.Join([]string{
+				strings.TrimSpace(info.City),
+				strings.TrimSpace(info.Country),
+			}, ", "))
+			locationLabel = strings.Trim(locationLabel, ", ")
+		}
+	}
+
+	bodyLines := []string{fmt.Sprintf("%s disliked %s from %s", ipLabel, trackLabel, playlistLabel)}
+	if locationLabel != "" {
+		bodyLines = append(bodyLines, fmt.Sprintf("Location: %s", locationLabel))
+	}
+	body := strings.Join(bodyLines, "\n")
 	message := fmt.Sprintf("Subject: %s\n\n%s", subject, body)
 
 	args := []string{
@@ -3123,6 +3144,176 @@ func sendRetailPlayerDislikeNotification(ctx context.Context, clientIP, trackTit
 	}
 
 	return nil
+}
+
+type ipInfo struct {
+	City    string `json:"city"`
+	Country string `json:"country"`
+}
+
+func fetchIPInfo(ctx context.Context, clientIP string) (ipInfo, error) {
+	if strings.TrimSpace(clientIP) == "" {
+		return ipInfo{}, errors.New("client IP is empty")
+	}
+
+	cmd := exec.CommandContext(ctx, "curl", "-s", fmt.Sprintf("https://ipinfo.io/%s/json", clientIP))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return ipInfo{}, fmt.Errorf("ipinfo curl failed: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+
+	var info ipInfo
+	if err := json.Unmarshal(output, &info); err != nil {
+		return ipInfo{}, fmt.Errorf("unable to decode ipinfo response: %w", err)
+	}
+
+	return info, nil
+}
+
+func updateSyncPlaylistForDislike(ctx context.Context, playlistName, trackTitle string) error {
+	if strings.TrimSpace(conf.Server.SyncFolder) == "" {
+		return nil
+	}
+
+	normalizedPlaylistName := strings.TrimSpace(playlistName)
+	normalizedTrackTitle := strings.TrimSpace(trackTitle)
+	if normalizedPlaylistName == "" || normalizedTrackTitle == "" {
+		return nil
+	}
+
+	if filepath.Ext(normalizedPlaylistName) == "" {
+		normalizedPlaylistName += ".m3u"
+	}
+
+	playlistPath, rootPath, err := findPlaylistFile(conf.Server.PlaylistsPath, normalizedPlaylistName)
+	if err != nil {
+		return err
+	}
+	if playlistPath == "" {
+		return fmt.Errorf("playlist not found: %s", normalizedPlaylistName)
+	}
+
+	data, err := os.ReadFile(playlistPath)
+	if err != nil {
+		return fmt.Errorf("unable to read playlist: %w", err)
+	}
+
+	updated, removed := removeTrackFromM3U(data, normalizedTrackTitle)
+	if !removed {
+		return nil
+	}
+
+	syncPath := buildSyncPlaylistPath(conf.Server.SyncFolder, rootPath, playlistPath)
+	if err := os.MkdirAll(filepath.Dir(syncPath), 0o755); err != nil {
+		return fmt.Errorf("unable to create sync playlist dir: %w", err)
+	}
+	if err := os.WriteFile(syncPath, updated, 0o644); err != nil {
+		return fmt.Errorf("unable to write sync playlist: %w", err)
+	}
+
+	log.Info(ctx, "Synced playlist updated after dislike", "playlist", normalizedPlaylistName, "syncPath", syncPath, "trackTitle", normalizedTrackTitle)
+	return nil
+}
+
+func findPlaylistFile(playlistsPath, playlistFile string) (string, string, error) {
+	if strings.TrimSpace(playlistsPath) == "" {
+		return "", "", errors.New("playlists path not configured")
+	}
+
+	paths := strings.Split(playlistsPath, string(filepath.ListSeparator))
+	sentinel := errors.New("playlist found")
+	var foundPath string
+	var foundRoot string
+
+	for _, root := range paths {
+		root = strings.TrimSuffix(root, "**")
+		root = strings.TrimSuffix(root, string(os.PathSeparator))
+		if root == "" {
+			continue
+		}
+		if absRoot, err := filepath.Abs(root); err == nil {
+			root = absRoot
+		}
+
+		candidate := filepath.Join(root, playlistFile)
+		if stat, err := os.Stat(candidate); err == nil && !stat.IsDir() {
+			return candidate, root, nil
+		}
+
+		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if d.Name() == playlistFile {
+				foundPath = path
+				foundRoot = root
+				return sentinel
+			}
+			return nil
+		})
+		if err != nil && !errors.Is(err, sentinel) {
+			return "", "", err
+		}
+		if foundPath != "" {
+			break
+		}
+	}
+
+	return foundPath, foundRoot, nil
+}
+
+func buildSyncPlaylistPath(syncFolder, rootPath, playlistPath string) string {
+	if syncFolder == "" {
+		return ""
+	}
+	if rootPath != "" {
+		if rel, err := filepath.Rel(rootPath, playlistPath); err == nil && !strings.HasPrefix(rel, "..") {
+			return filepath.Join(syncFolder, rel)
+		}
+	}
+	return filepath.Join(syncFolder, filepath.Base(playlistPath))
+}
+
+func removeTrackFromM3U(data []byte, trackTitle string) ([]byte, bool) {
+	if len(data) == 0 {
+		return data, false
+	}
+	normalized := strings.ToLower(strings.TrimSpace(trackTitle))
+	if normalized == "" {
+		return data, false
+	}
+
+	content := strings.ReplaceAll(string(data), "\r\n", "\n")
+	lines := strings.Split(content, "\n")
+	kept := make([]string, 0, len(lines))
+	removed := false
+
+	for i := 0; i < len(lines); i++ {
+		line := strings.TrimSuffix(lines[i], "\r")
+		lowerLine := strings.ToLower(line)
+		if strings.HasPrefix(lowerLine, "#extinf") && strings.Contains(lowerLine, normalized) {
+			removed = true
+			if i+1 < len(lines) {
+				i++
+			}
+			continue
+		}
+		if line != "" && !strings.HasPrefix(line, "#") && strings.Contains(lowerLine, normalized) {
+			removed = true
+			continue
+		}
+		kept = append(kept, line)
+	}
+
+	output := strings.Join(kept, "\n")
+	if strings.HasSuffix(content, "\n") {
+		output += "\n"
+	}
+
+	return []byte(output), removed
 }
 
 func (n *Router) syncRetailPlayerQR(ctx context.Context) ([]retailPlayerQRSyncResult, error) {

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -912,6 +912,9 @@ const RetailPlayerDashboard = () => {
   const lastTrackSignatureRef = useRef('')
   const dislikeTimeoutRef = useRef(null)
   const dislikeRequestControllerRef = useRef(null)
+  const dislikeRetryTimeoutRef = useRef(null)
+  const latestNowPlayingRef = useRef(null)
+  const latestScheduleLabelRef = useRef('')
   const channelRequestControllerRef = useRef(null)
   const [showDislikeMessage, setShowDislikeMessage] = useState(false)
   const [previousNowPlaying, setPreviousNowPlaying] = useState(null)
@@ -1358,57 +1361,108 @@ const RetailPlayerDashboard = () => {
 
   const rootClassName = classes.root
 
+  useEffect(() => {
+    latestNowPlayingRef.current = device?.nowPlaying
+  }, [device?.nowPlaying])
+
+  useEffect(() => {
+    latestScheduleLabelRef.current = activeSchedule?.label || ''
+  }, [activeSchedule?.label])
+
+  const resolveDislikePayload = useCallback((nowPlaying, scheduleLabel) => {
+    const nowPlayingData = nowPlaying && typeof nowPlaying === 'object' ? nowPlaying : {}
+    const metadata =
+      nowPlayingData?.metadata && typeof nowPlayingData.metadata === 'object'
+        ? nowPlayingData.metadata
+        : {}
+
+    const titleCandidates = [
+      typeof nowPlayingData?.title === 'string' ? nowPlayingData.title.trim() : '',
+      typeof metadata?.title === 'string' ? metadata.title.trim() : '',
+    ]
+    const trackTitle = titleCandidates.find((value) => value) || ''
+
+    const playlistName = typeof scheduleLabel === 'string' ? scheduleLabel.trim() : ''
+
+    if (!trackTitle && !playlistName) {
+      return null
+    }
+
+    return { trackTitle, playlistName }
+  }, [])
+
+  const sendDislikeRequest = useCallback(
+    (payload) => {
+      if (!payload) {
+        return
+      }
+
+      if (dislikeRequestControllerRef.current) {
+        dislikeRequestControllerRef.current.abort()
+      }
+
+      const abortController = new AbortController()
+      dislikeRequestControllerRef.current = abortController
+
+      const headers = new Headers({ 'Content-Type': 'application/json' })
+
+      httpClient(`/api/retailplayer/devices/${encodeURIComponent(deviceApiId)}/dislike`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+        signal: abortController.signal,
+      })
+        .catch((err) => {
+          if (err?.name !== 'AbortError') {
+            // eslint-disable-next-line no-console
+            console.error('Failed to send dislike notification', err)
+          }
+        })
+        .finally(() => {
+          if (dislikeRequestControllerRef.current === abortController) {
+            dislikeRequestControllerRef.current = null
+          }
+        })
+    },
+    [deviceApiId],
+  )
+
   const sendDislikeNotification = useCallback(() => {
     if (!isApiEnabled || !deviceApiId) {
       return
     }
 
-    const nowPlaying = device?.nowPlaying && typeof device.nowPlaying === 'object' ? device.nowPlaying : {}
-    const metadata =
-      nowPlaying?.metadata && typeof nowPlaying.metadata === 'object'
-        ? nowPlaying.metadata
-        : {}
-
-    const titleCandidates = [
-      typeof nowPlaying?.title === 'string' ? nowPlaying.title.trim() : '',
-      typeof metadata?.title === 'string' ? metadata.title.trim() : '',
-    ]
-    const trackTitle = titleCandidates.find((value) => value) || ''
-
-    const playlistName =
-      typeof activeSchedule?.label === 'string' ? activeSchedule.label.trim() : ''
-
-    if (!trackTitle && !playlistName) {
+    const payload = resolveDislikePayload(device?.nowPlaying, activeSchedule?.label)
+    if (!payload) {
       return
     }
 
-    if (dislikeRequestControllerRef.current) {
-      dislikeRequestControllerRef.current.abort()
+    if (payload.trackTitle.toLowerCase() === 'loading') {
+      if (dislikeRetryTimeoutRef.current) {
+        window.clearTimeout(dislikeRetryTimeoutRef.current)
+      }
+      dislikeRetryTimeoutRef.current = window.setTimeout(() => {
+        const retryPayload = resolveDislikePayload(
+          latestNowPlayingRef.current,
+          latestScheduleLabelRef.current,
+        )
+        if (retryPayload && retryPayload.trackTitle.toLowerCase() !== 'loading') {
+          sendDislikeRequest(retryPayload)
+        }
+        dislikeRetryTimeoutRef.current = null
+      }, 3000)
+      return
     }
 
-    const abortController = new AbortController()
-    dislikeRequestControllerRef.current = abortController
-
-    const headers = new Headers({ 'Content-Type': 'application/json' })
-
-    httpClient(`/api/retailplayer/devices/${encodeURIComponent(deviceApiId)}/dislike`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({ trackTitle, playlistName }),
-      signal: abortController.signal,
-    })
-      .catch((err) => {
-        if (err?.name !== 'AbortError') {
-          // eslint-disable-next-line no-console
-          console.error('Failed to send dislike notification', err)
-        }
-      })
-      .finally(() => {
-        if (dislikeRequestControllerRef.current === abortController) {
-          dislikeRequestControllerRef.current = null
-        }
-      })
-  }, [activeSchedule?.label, device?.nowPlaying, deviceApiId, isApiEnabled])
+    sendDislikeRequest(payload)
+  }, [
+    activeSchedule?.label,
+    device?.nowPlaying,
+    deviceApiId,
+    isApiEnabled,
+    resolveDislikePayload,
+    sendDislikeRequest,
+  ])
 
   const dropdownLabel = activeSchedule ? activeSchedule.label : 'No playlists available'
 
@@ -2089,6 +2143,10 @@ const RetailPlayerDashboard = () => {
     clearVolumeTimeout()
     if (dislikeTimeoutRef.current) {
       window.clearTimeout(dislikeTimeoutRef.current)
+    }
+    if (dislikeRetryTimeoutRef.current) {
+      window.clearTimeout(dislikeRetryTimeoutRef.current)
+      dislikeRetryTimeoutRef.current = null
     }
     if (dislikeRequestControllerRef.current) {
       dislikeRequestControllerRef.current.abort()


### PR DESCRIPTION
### Motivation
- Ensure dislikes operate on the actual playlist file on disk by removing the disliked track from the synced `.m3u` file and writing the updated playlist to the sync folder.  
- Avoid sending a dislike for a transient `Loading` placeholder by retrying a short time later so the correct track is targeted.  
- Enrich notification emails with geolocation (city and country) inferred from the client IP to give more useful context.  

### Description
- Server: added `updateSyncPlaylistForDislike`, `findPlaylistFile`, `buildSyncPlaylistPath`, and `removeTrackFromM3U` to find the referenced `.m3u` playlist, remove the matching track entry, and write the updated file into the configured `SyncFolder` while preserving path layout.  
- Server: added `fetchIPInfo` (uses `curl` to `https://ipinfo.io/<ip>/json`) and updated `sendRetailPlayerDislikeNotification` to include `City, Country` location info in the email body when available.  
- Server: the dislike handler now invokes the sync update via `updateSyncPlaylistForDislike` and logs warnings on failure.  
- UI: replaced the inline dislike request with `resolveDislikePayload` and `sendDislikeRequest`, added refs to track latest now-playing and schedule label, and implemented a 3s retry when the resolved `trackTitle` equals `Loading`, while preserving abort/cleanup logic.  

### Testing
- Ran `gofmt` on the modified Go source files to ensure formatting consistency and it completed successfully.  
- No automated unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695784a4e9608322a3e9e2e0bedffa69)