### PR TITLE
Add per-device lock support for Retail Player devices

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -207,6 +207,7 @@ type retailPlayerOptions struct {
 	RemoteControlBaseURL      string
 	RemoteControlAPIKey       string
 	RemoteControlAPIKeyHeader string
+	DeviceLockPassword        string
 	QRLoginURL                string
 	QRBaseURL                 string
 	QRTenant                  string
@@ -632,6 +633,7 @@ func setViperDefaults() {
 	viper.SetDefault("retailplayer.orgid", "")
 	viper.SetDefault("retailplayer.apikey", "")
 	viper.SetDefault("retailplayer.apikeyheader", "x-retailplayer-apikey")
+	viper.SetDefault("retailplayer.devicelockpassword", "")
 	viper.SetDefault("retailplayer.qrloginurl", "")
 	viper.SetDefault("retailplayer.qrbaseurl", "")
 	viper.SetDefault("retailplayer.qrtenant", "")

--- a/model/retail_player_device_mapping.go
+++ b/model/retail_player_device_mapping.go
@@ -15,6 +15,7 @@ type RetailPlayerDeviceMapping struct {
 	Organization string    `db:"organization" json:"organization"`
 	TimeZone     string    `db:"time_zone" json:"timeZone"`
 	RemoteCtrlID string    `db:"remote_control_id" json:"remoteControlId"`
+	Locked       bool      `db:"is_locked" json:"locked"`
 	UpdatedAt    time.Time `db:"updated_at" json:"updatedAt"`
 }
 
@@ -23,6 +24,7 @@ type RetailPlayerDeviceMappingRepository interface {
 	PutMany(ctx context.Context, mappings []RetailPlayerDeviceMapping) error
 	FindByIdentifier(ctx context.Context, identifier string) (*RetailPlayerDeviceMapping, error)
 	All(ctx context.Context) ([]RetailPlayerDeviceMapping, error)
+	SetLockState(ctx context.Context, deviceID string, locked bool) error
 }
 
 func RetailPlayerNormalizeValue(value string) string {

--- a/persistence/retail_player_device_mapping_repository.go
+++ b/persistence/retail_player_device_mapping_repository.go
@@ -23,6 +23,7 @@ func NewRetailPlayerDeviceMappingRepository(ctx context.Context, db dbx.Builder)
 	r.tableName = "retail_player_device_mapping"
 	r.registerModel(&model.RetailPlayerDeviceMapping{}, nil)
 	r.ensureRemoteControlColumn()
+	r.ensureLockColumn()
 	return r
 }
 
@@ -41,6 +42,23 @@ ADD COLUMN remote_control_id TEXT DEFAULT '';
 	}
 
 	log.Error(r.ctx, "Unable to ensure remote control column for retail player device mappings", "err", err)
+}
+
+func (r retailPlayerDeviceMappingRepository) ensureLockColumn() {
+	_, err := r.db.NewQuery(`
+ALTER TABLE retail_player_device_mapping
+ADD COLUMN is_locked INTEGER DEFAULT 0;
+`).Execute()
+	if err == nil {
+		return
+	}
+
+	lowerErr := strings.ToLower(err.Error())
+	if strings.Contains(lowerErr, "duplicate column name") || strings.Contains(lowerErr, "already exists") {
+		return
+	}
+
+	log.Error(r.ctx, "Unable to ensure lock column for retail player device mappings", "err", err)
 }
 
 func (r retailPlayerDeviceMappingRepository) Put(ctx context.Context, mapping model.RetailPlayerDeviceMapping) error {
@@ -67,6 +85,7 @@ func (r retailPlayerDeviceMappingRepository) PutMany(ctx context.Context, mappin
 			"organization",
 			"time_zone",
 			"remote_control_id",
+			"is_locked",
 			"updated_at",
 		)
 	valuesAdded := 0
@@ -95,6 +114,7 @@ func (r retailPlayerDeviceMappingRepository) PutMany(ctx context.Context, mappin
 			strings.TrimSpace(mapping.Organization),
 			strings.TrimSpace(mapping.TimeZone),
 			strings.TrimSpace(mapping.RemoteCtrlID),
+			mapping.Locked,
 			now,
 		)
 		valuesAdded++
@@ -135,7 +155,7 @@ func (r retailPlayerDeviceMappingRepository) FindByIdentifier(ctx context.Contex
 	orClause := Or{}
 	orClause = append(orClause, conditions...)
 
-	sel := Select("device_id", "device_name", "device_slug", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "updated_at").
+	sel := Select("device_id", "device_name", "device_slug", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "is_locked", "updated_at").
 		From(r.tableName).
 		Where(orClause).
 		OrderBy("updated_at DESC").
@@ -149,7 +169,7 @@ func (r retailPlayerDeviceMappingRepository) FindByIdentifier(ctx context.Contex
 }
 
 func (r retailPlayerDeviceMappingRepository) All(ctx context.Context) ([]model.RetailPlayerDeviceMapping, error) {
-	sel := Select("device_id", "device_name", "device_slug", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "updated_at").
+	sel := Select("device_id", "device_name", "device_slug", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "is_locked", "updated_at").
 		From(r.tableName).
 		OrderBy("updated_at DESC")
 
@@ -162,4 +182,55 @@ func (r retailPlayerDeviceMappingRepository) All(ctx context.Context) ([]model.R
 		return nil, err
 	}
 	return mappings, nil
+}
+
+func (r retailPlayerDeviceMappingRepository) SetLockState(ctx context.Context, deviceID string, locked bool) error {
+	trimmed := strings.TrimSpace(deviceID)
+	if trimmed == "" {
+		return errors.New("retail player device id is required")
+	}
+
+	now := time.Now().UTC()
+	update := Update(r.tableName).
+		Set("is_locked", locked).
+		Set("updated_at", now).
+		Where(Eq{"device_id": trimmed})
+
+	rowsAffected, err := r.executeSQL(update)
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected > 0 {
+		return nil
+	}
+
+	insert := Insert(r.tableName).
+		Columns(
+			"device_id",
+			"device_name",
+			"device_slug",
+			"channel",
+			"channel_list",
+			"organization",
+			"time_zone",
+			"remote_control_id",
+			"is_locked",
+			"updated_at",
+		).
+		Values(
+			trimmed,
+			trimmed,
+			model.RetailPlayerDeviceSlug(trimmed),
+			"",
+			"",
+			"",
+			"",
+			"",
+			locked,
+			now,
+		)
+
+	_, err = r.executeSQL(insert)
+	return err
 }

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -211,6 +211,7 @@ type retailPlayerDevice struct {
 	TimeZone        string   `json:"timeZone,omitempty"`
 	FolderIDs       []string `json:"folderIds,omitempty"`
 	RemoteControlID string   `json:"remoteControlId,omitempty"`
+	Locked          bool     `json:"locked"`
 }
 
 type retailPlayerDeviceConfigResponse struct {
@@ -342,6 +343,7 @@ func (n *Router) addRetailPlayerPublicRoutes(r chi.Router) {
 		r.Get("/devices/{deviceID}/status", n.handleRetailPlayerDeviceStatus())
 		r.Get("/devices/{deviceID}/triggers", n.handleRetailPlayerDeviceTriggers())
 		r.Post("/devices/{deviceID}/triggers", n.handleRetailPlayerDeviceTriggerAction())
+		r.Post("/devices/{deviceID}/unlock", n.handleRetailPlayerDeviceUnlock())
 		r.Get("/channel-lists/{channelListID}/channels", n.handleRetailPlayerChannelListChannels())
 		r.Post("/devices/{deviceID}/volume", n.handleRetailPlayerDeviceVolume())
 		r.Post("/devices/{deviceID}/channel", n.handleRetailPlayerDeviceChannel())
@@ -359,6 +361,7 @@ func (n *Router) addRetailPlayerPrivateRoutes(r chi.Router) {
 	r.Put("/retailplayer/devices/{deviceID}/folders", n.handleAssignRetailPlayerDeviceFolders())
 	r.Post("/retailplayer/qr", n.handleRetailPlayerSyncQR())
 	r.Patch("/retailplayer/devices/{deviceID}/remote-control", n.handleUpdateRetailPlayerDeviceRemoteControl())
+	r.Patch("/retailplayer/devices/{deviceID}/lock", n.handleUpdateRetailPlayerDeviceLock())
 }
 
 var errRetailPlayerDeviceNotFound = errors.New("retail player device not found")
@@ -426,16 +429,20 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 
 			if len(mappings) > 0 {
 				remoteControlByID := make(map[string]string, len(mappings))
+				lockByID := make(map[string]bool, len(mappings))
 				for _, mapping := range mappings {
 					id := strings.TrimSpace(mapping.DeviceID)
 					remoteControlID := strings.TrimSpace(mapping.RemoteCtrlID)
-					if id == "" || remoteControlID == "" {
+					if id == "" {
 						continue
 					}
-					remoteControlByID[id] = remoteControlID
+					if remoteControlID != "" {
+						remoteControlByID[id] = remoteControlID
+					}
+					lockByID[id] = mapping.Locked
 				}
 
-				if len(remoteControlByID) > 0 {
+				if len(remoteControlByID) > 0 || len(lockByID) > 0 {
 					for index := range response.Data {
 						id := strings.TrimSpace(response.Data[index].ID)
 						if id == "" {
@@ -443,6 +450,9 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 						}
 						if remoteControlID, ok := remoteControlByID[id]; ok {
 							response.Data[index].RemoteControlID = remoteControlID
+						}
+						if locked, ok := lockByID[id]; ok {
+							response.Data[index].Locked = locked
 						}
 					}
 				}
@@ -556,16 +566,20 @@ func (n *Router) handleRetailPlayerDeviceByName() http.HandlerFunc {
 
 			if len(mappings) > 0 {
 				remoteControlByID := make(map[string]string, len(mappings))
+				lockByID := make(map[string]bool, len(mappings))
 				for _, mapping := range mappings {
 					id := strings.TrimSpace(mapping.DeviceID)
 					remoteControlID := strings.TrimSpace(mapping.RemoteCtrlID)
-					if id == "" || remoteControlID == "" {
+					if id == "" {
 						continue
 					}
-					remoteControlByID[id] = remoteControlID
+					if remoteControlID != "" {
+						remoteControlByID[id] = remoteControlID
+					}
+					lockByID[id] = mapping.Locked
 				}
 
-				if len(remoteControlByID) > 0 {
+				if len(remoteControlByID) > 0 || len(lockByID) > 0 {
 					for index := range filtered.Data {
 						id := strings.TrimSpace(filtered.Data[index].ID)
 						if id == "" {
@@ -573,6 +587,9 @@ func (n *Router) handleRetailPlayerDeviceByName() http.HandlerFunc {
 						}
 						if remoteControlID, ok := remoteControlByID[id]; ok {
 							filtered.Data[index].RemoteControlID = remoteControlID
+						}
+						if locked, ok := lockByID[id]; ok {
+							filtered.Data[index].Locked = locked
 						}
 					}
 				}
@@ -1218,6 +1235,7 @@ func (n *Router) saveRetailPlayerRemoteControlMapping(ctx context.Context, devic
 			mapping.ChannelList = existing.ChannelList
 			mapping.Organization = existing.Organization
 			mapping.TimeZone = existing.TimeZone
+			mapping.Locked = existing.Locked
 		}
 
 		if name := strings.TrimSpace(deviceName); name != "" {
@@ -1345,6 +1363,7 @@ func mapRetailPlayerDeviceToMapping(device retailPlayerDevice) (model.RetailPlay
 		Organization: strings.TrimSpace(device.Organization),
 		TimeZone:     strings.TrimSpace(device.TimeZone),
 		RemoteCtrlID: strings.TrimSpace(device.RemoteControlID),
+		Locked:       device.Locked,
 	}, true
 }
 
@@ -1357,6 +1376,120 @@ func mapRetailPlayerMappingToDevice(mapping model.RetailPlayerDeviceMapping) ret
 		Organization:    strings.TrimSpace(mapping.Organization),
 		TimeZone:        strings.TrimSpace(mapping.TimeZone),
 		RemoteControlID: strings.TrimSpace(mapping.RemoteCtrlID),
+		Locked:          mapping.Locked,
+	}
+}
+
+func (n *Router) handleUpdateRetailPlayerDeviceLock() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		deviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		if deviceID == "" {
+			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
+			return
+		}
+
+		var payload struct {
+			Locked bool `json:"locked"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "Invalid retail player device payload", http.StatusBadRequest)
+			return
+		}
+
+		repo := n.ds.RetailPlayerDeviceMapping(ctx)
+		if repo == nil {
+			http.Error(w, "Retail player device mapping repository not available", http.StatusInternalServerError)
+			return
+		}
+
+		if err := repo.SetLockState(ctx, deviceID, payload.Locked); err != nil {
+			log.Error(ctx, "Unable to update retail player device lock state", "err", err)
+			http.Error(w, "Unable to update retail player device lock state", http.StatusInternalServerError)
+			return
+		}
+
+		device, err := n.findRetailPlayerDeviceMapping(ctx, deviceID)
+		if err != nil {
+			log.Error(ctx, "Unable to load retail player device mapping", "err", err)
+			http.Error(w, "Unable to load retail player device mapping", http.StatusInternalServerError)
+			return
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{"data": device})
+	}
+}
+
+func (n *Router) handleRetailPlayerDeviceUnlock() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		deviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		if deviceID == "" {
+			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
+			return
+		}
+
+		var payload struct {
+			Password string `json:"password"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "Invalid retail player device payload", http.StatusBadRequest)
+			return
+		}
+
+		repo := n.ds.RetailPlayerDeviceMapping(ctx)
+		if repo == nil {
+			http.Error(w, "Retail player device mapping repository not available", http.StatusInternalServerError)
+			return
+		}
+
+		mapping, err := repo.FindByIdentifier(ctx, deviceID)
+		if err != nil {
+			if errors.Is(err, model.ErrNotFound) {
+				http.Error(w, "Retail player device not found", http.StatusNotFound)
+				return
+			}
+			log.Error(ctx, "Unable to load retail player device mapping", "err", err)
+			http.Error(w, "Unable to load retail player device mapping", http.StatusInternalServerError)
+			return
+		}
+
+		if !mapping.Locked {
+			writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{
+				"unlocked": true,
+				"locked":   false,
+			})
+			return
+		}
+
+		password := strings.TrimSpace(payload.Password)
+		configured := strings.TrimSpace(conf.Server.RetailPlayer.DeviceLockPassword)
+		if configured == "" {
+			http.Error(w, "Retail player device lock password is not configured", http.StatusForbidden)
+			return
+		}
+
+		if password != configured {
+			http.Error(w, "Invalid retail player device password", http.StatusUnauthorized)
+			return
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{
+			"unlocked": true,
+			"locked":   false,
+		})
 	}
 }
 

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1,12 +1,18 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { alpha, makeStyles } from '@material-ui/core/styles'
 import {
+  Button,
   ButtonBase,
   Drawer,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   List,
   ListItem,
   ListItemText,
   Slider,
+  TextField,
   Typography,
 } from '@material-ui/core'
 import Tooltip from '@material-ui/core/Tooltip'
@@ -751,6 +757,27 @@ const useStyles = makeStyles((theme) => {
       color: theme.palette.text.secondary,
       fontSize: theme.typography.pxToRem(18),
     },
+    lockedWrapper: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(2),
+      padding: theme.spacing(5),
+      maxWidth: 640,
+      width: '100%',
+      margin: '0 auto',
+      textAlign: 'center',
+      [theme.breakpoints.down('sm')]: {
+        padding: theme.spacing(3),
+      },
+    },
+    lockedTitle: {
+      fontWeight: theme.typography.fontWeightBold,
+      fontSize: theme.typography.pxToRem(32),
+    },
+    lockedMessage: {
+      color: theme.palette.text.secondary,
+      fontSize: theme.typography.pxToRem(16),
+    },
     refreshButton: {
       borderRadius: theme.shape.borderRadius * 2,
       padding: theme.spacing(0.75),
@@ -933,6 +960,11 @@ const RetailPlayerDashboard = () => {
   const scheduleDropdownRef = useRef(null)
   const isBusy = retailLoading || statusLoading
   const combinedError = integrationError || statusError || devicesError
+  const lockSessionKey = 'retailPlayerUnlockedDevices'
+  const [unlockPassword, setUnlockPassword] = useState('')
+  const [unlockError, setUnlockError] = useState('')
+  const [isUnlocking, setIsUnlocking] = useState(false)
+  const [isUnlocked, setIsUnlocked] = useState(false)
 
   const deviceTrackKey = useMemo(() => {
     if (!device) {
@@ -946,6 +978,62 @@ const RetailPlayerDashboard = () => {
       normalizeValue(device.macAddress)
     )
   }, [device])
+
+  const deviceLockId = useMemo(() => {
+    if (!device) {
+      return ''
+    }
+    return (
+      normalizeValue(device.apiId) ||
+      normalizeValue(device.id) ||
+      normalizeValue(device.slug) ||
+      normalizeValue(device.macAddress)
+    )
+  }, [device])
+
+  const readUnlockedDevices = useCallback(() => {
+    if (typeof sessionStorage === 'undefined') {
+      return new Set()
+    }
+
+    try {
+      const raw = sessionStorage.getItem(lockSessionKey)
+      if (!raw) {
+        return new Set()
+      }
+      const parsed = JSON.parse(raw)
+      if (Array.isArray(parsed)) {
+        return new Set(parsed.filter((value) => typeof value === 'string'))
+      }
+    } catch (err) {
+      return new Set()
+    }
+
+    return new Set()
+  }, [lockSessionKey])
+
+  const storeUnlockedDevices = useCallback(
+    (unlockedDevices) => {
+      if (typeof sessionStorage === 'undefined') {
+        return
+      }
+      sessionStorage.setItem(
+        lockSessionKey,
+        JSON.stringify(Array.from(unlockedDevices)),
+      )
+    },
+    [lockSessionKey],
+  )
+
+  useEffect(() => {
+    if (!deviceLockId) {
+      setIsUnlocked(false)
+      return
+    }
+
+    const unlockedDevices = readUnlockedDevices()
+    setIsUnlocked(unlockedDevices.has(deviceLockId))
+  }, [deviceLockId, readUnlockedDevices])
 
   useEffect(() => {
     setPreviousNowPlaying(null)
@@ -1993,6 +2081,45 @@ const RetailPlayerDashboard = () => {
     history.push('/retailplayer/devices')
   }, [history])
 
+  const handleUnlock = useCallback(async () => {
+    if (!deviceLockId) {
+      return
+    }
+    setIsUnlocking(true)
+    setUnlockError('')
+    try {
+      await httpClient(
+        `/api/retailplayer/devices/${encodeURIComponent(deviceLockId)}/unlock`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ password: unlockPassword }),
+          headers: new Headers({ 'Content-Type': 'application/json' }),
+        },
+      )
+      const unlockedDevices = readUnlockedDevices()
+      unlockedDevices.add(deviceLockId)
+      storeUnlockedDevices(unlockedDevices)
+      setIsUnlocked(true)
+      setUnlockPassword('')
+    } catch (err) {
+      const status = typeof err?.status === 'number' ? err.status : null
+      if (status === 401) {
+        setUnlockError('Incorrect password. Please try again.')
+      } else if (status === 403) {
+        setUnlockError('Unlocking is unavailable. Contact an administrator.')
+      } else {
+        setUnlockError('Unable to unlock this device right now.')
+      }
+    } finally {
+      setIsUnlocking(false)
+    }
+  }, [
+    deviceLockId,
+    readUnlockedDevices,
+    storeUnlockedDevices,
+    unlockPassword,
+  ])
+
   const handleDislike = useCallback(() => {
     if (isDislikeDisabled) {
       return
@@ -2210,6 +2337,64 @@ const RetailPlayerDashboard = () => {
             {combinedError.message || String(combinedError)}
           </Typography>
         ) : null}
+      </div>
+    )
+  }
+
+  const isDeviceLocked = Boolean(device.locked)
+
+  if (isDeviceLocked && !isUnlocked) {
+    return (
+      <div className={classes.lockedWrapper}>
+        <Title title="Retail Player" />
+        <Typography component="h1" className={classes.lockedTitle}>
+          Device Locked
+        </Typography>
+        <Typography className={classes.lockedMessage}>
+          Enter the device password to continue.
+        </Typography>
+        <Dialog
+          open
+          disableBackdropClick
+          disableEscapeKeyDown
+          aria-labelledby="retail-player-unlock-title"
+        >
+          <DialogTitle id="retail-player-unlock-title">
+            Unlock {device?.name || 'Retail Player'}
+          </DialogTitle>
+          <DialogContent>
+            <TextField
+              autoFocus
+              fullWidth
+              label="Password"
+              type="password"
+              variant="outlined"
+              value={unlockPassword}
+              onChange={(event) => {
+                setUnlockPassword(event.target.value)
+                if (unlockError) {
+                  setUnlockError('')
+                }
+              }}
+              error={Boolean(unlockError)}
+              helperText={unlockError || ' '}
+              inputProps={{ 'aria-label': 'Device password' }}
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleBack} color="default">
+              Back
+            </Button>
+            <Button
+              onClick={handleUnlock}
+              color="primary"
+              variant="contained"
+              disabled={!unlockPassword || isUnlocking}
+            >
+              {isUnlocking ? 'Unlocking…' : 'Unlock'}
+            </Button>
+          </DialogActions>
+        </Dialog>
       </div>
     )
   }

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -252,6 +252,9 @@ const useStyles = makeStyles((theme) => {
     color: theme.palette.primary.main,
     fontSize: theme.typography.pxToRem(16.5),
   },
+  lockedIcon: {
+    color: theme.palette.primary.main,
+  },
   onlineIcon: {
     color: theme.palette.success.main,
   },
@@ -672,7 +675,10 @@ const RetailPlayerDeviceRow = memo(
                 disabled={!canToggleLock}
               >
                 {node.locked ? (
-                  <LockIcon style={{ fontSize: 15 }} />
+                  <LockIcon
+                    style={{ fontSize: 15 }}
+                    className={classes.lockedIcon}
+                  />
                 ) : (
                   <LockOpenIcon style={{ fontSize: 15 }} />
                 )}

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -23,9 +23,11 @@ import {
 } from '@material-ui/core'
 import { makeStyles, useTheme } from '@material-ui/core/styles'
 import { fade } from '@material-ui/core/styles/colorManipulator'
-import { Title } from 'react-admin'
+import { Title, usePermissions } from 'react-admin'
 import AddIcon from '@material-ui/icons/Add'
 import EditIcon from '@material-ui/icons/Edit'
+import LockIcon from '@material-ui/icons/Lock'
+import LockOpenIcon from '@material-ui/icons/LockOpen'
 import FolderIcon from '@material-ui/icons/Folder'
 import SpeakerGroupIcon from '@material-ui/icons/SpeakerGroup'
 import SearchIcon from '@material-ui/icons/Search'
@@ -602,7 +604,9 @@ const RetailPlayerDeviceRow = memo(
     onToggleSelection,
     onKeyDown,
     onEdit,
+    onToggleLock,
     isOnline,
+    canToggleLock,
   }) => {
     const { dragRef, isDragging } = useRetailPlayerDeviceDrag({
       deviceId: node.id,
@@ -656,6 +660,25 @@ const RetailPlayerDeviceRow = memo(
           {node.remoteControlId ? node.remoteControlId : '—'}
         </div>
         <div className={classes.actionsCell}>
+          <Tooltip title={node.locked ? 'Unlock device' : 'Lock device'}>
+            <span>
+              <IconButton
+                size="small"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onToggleLock(node)
+                }}
+                aria-label={`${node.locked ? 'Unlock' : 'Lock'} device ${node.name}`}
+                disabled={!canToggleLock}
+              >
+                {node.locked ? (
+                  <LockIcon style={{ fontSize: 15 }} />
+                ) : (
+                  <LockOpenIcon style={{ fontSize: 15 }} />
+                )}
+              </IconButton>
+            </span>
+          </Tooltip>
           <Tooltip title="Edit device">
             <IconButton
               size="small"
@@ -678,6 +701,7 @@ RetailPlayerDeviceRow.propTypes = {
   node: PropTypes.shape({
     id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
+    locked: PropTypes.bool,
   }).isRequired,
   isSelected: PropTypes.bool.isRequired,
   classes: PropTypes.object.isRequired,
@@ -686,12 +710,15 @@ RetailPlayerDeviceRow.propTypes = {
   onToggleSelection: PropTypes.func.isRequired,
   onKeyDown: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
+  onToggleLock: PropTypes.func.isRequired,
   isOnline: PropTypes.bool,
+  canToggleLock: PropTypes.bool,
 }
 
 RetailPlayerDeviceRow.defaultProps = {
   channelCount: null,
   isOnline: null,
+  canToggleLock: false,
 }
 
 RetailPlayerDeviceRow.displayName = 'RetailPlayerDeviceRow'
@@ -700,9 +727,17 @@ const RetailPlayerDeviceManagement = () => {
   const classes = useStyles()
   const theme = useTheme()
   const history = useHistory()
+  const { permissions } = usePermissions()
   const {
     state: { tree, folders, devices, loading, error, isApiEnabled },
-    actions: { createFolder, updateFolder, createDevice, updateDevice, deleteNodes },
+    actions: {
+      createFolder,
+      updateFolder,
+      createDevice,
+      updateDevice,
+      updateDeviceLock,
+      deleteNodes,
+    },
   } = useRetailPlayerDeviceStore()
   const [folderDialog, setFolderDialog] = useState({
     open: false,
@@ -720,6 +755,18 @@ const RetailPlayerDeviceManagement = () => {
   const assignDeviceToFolder = useAssignRetailPlayerDeviceToFolder()
   const { countsByDeviceId: channelCountsByDeviceId } =
     useRetailPlayerChannelCounts(devices, isApiEnabled)
+
+  const canToggleLock = permissions === 'admin'
+
+  const handleToggleLock = useCallback(
+    async (device) => {
+      if (!canToggleLock || !device?.id) {
+        return
+      }
+      await updateDeviceLock(device.id, !device.locked)
+    },
+    [canToggleLock, updateDeviceLock],
+  )
 
   const folderMap = useMemo(() => {
     const map = new Map()
@@ -1383,7 +1430,9 @@ const RetailPlayerDeviceManagement = () => {
           onToggleSelection={toggleNodeSelection}
           onKeyDown={handleRowKeyDown}
           onEdit={handleEditDevice}
+          onToggleLock={handleToggleLock}
           isOnline={isOnline}
+          canToggleLock={canToggleLock}
         />
       )
     })

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -98,6 +98,11 @@ const baseDeviceShape = (device, existing) => {
   const normalizedOrganization = normalizeValue(device?.organization)
   const normalizedTimeZone = normalizeValue(device?.timeZone)
   const normalizedRemoteControlId = normalizeValue(device?.remoteControlId)
+  const incomingLocked = typeof device?.locked === 'boolean'
+    ? device.locked
+    : existing?.locked
+  const normalizedLocked =
+    typeof incomingLocked === 'boolean' ? incomingLocked : false
 
   const existingFolderIds = normalizeFolderIds(
     existing?.folderIds ?? existing?.folderId,
@@ -123,6 +128,7 @@ const baseDeviceShape = (device, existing) => {
     organization: normalizedOrganization || '',
     timeZone: normalizedTimeZone || '',
     remoteControlId: normalizedRemoteControlId || '',
+    locked: normalizedLocked,
     folderIds,
     folderId: primaryFolderId,
     source: existing?.source === 'local' ? 'local' : 'remote',
@@ -229,6 +235,7 @@ const reducer = (state, action) => {
         folderId,
         attributes,
         remoteControlId,
+        locked,
       } = action.payload || {}
       const normalizedName = normalizeValue(name) || 'New Device'
       const slug = deviceSlugKey(normalizedName) || uuidv4()
@@ -257,6 +264,7 @@ const reducer = (state, action) => {
         folderId: primaryFolderId,
         source: 'local',
         remoteControlId: normalizeValue(remoteControlId) || '',
+        locked: false,
         attributes: attributes && typeof attributes === 'object' ? { ...attributes } : {},
       }
       return {
@@ -304,6 +312,8 @@ const reducer = (state, action) => {
             remoteControlId !== undefined
               ? normalizeValue(remoteControlId)
               : device.remoteControlId,
+          locked:
+            locked !== undefined ? Boolean(locked) : device.locked,
         }
       })
       return { ...state, devices: nextDevices, lastUpdated: Date.now() }
@@ -702,6 +712,47 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
     [apiEnabled, dispatch],
   )
 
+  const updateDeviceLock = useCallback(
+    async (deviceId, locked) => {
+      const normalizedId = typeof deviceId === 'string' ? deviceId : ''
+      if (!normalizedId) {
+        return null
+      }
+
+      const normalizedLocked = Boolean(locked)
+      dispatch({
+        type: 'UPDATE_DEVICE',
+        payload: { id: normalizedId, locked: normalizedLocked },
+      })
+
+      if (!apiEnabled) {
+        return normalizedLocked
+      }
+
+      const { json } = await httpClient(
+        `/api/retailplayer/devices/${encodeURIComponent(normalizedId)}/lock`,
+        {
+          method: 'PATCH',
+          body: JSON.stringify({ locked: normalizedLocked }),
+          headers: new Headers({ 'Content-Type': 'application/json' }),
+        },
+      )
+
+      const responseLocked =
+        typeof json?.data?.locked === 'boolean'
+          ? json.data.locked
+          : normalizedLocked
+
+      dispatch({
+        type: 'UPDATE_DEVICE',
+        payload: { id: normalizedId, locked: responseLocked },
+      })
+
+      return responseLocked
+    },
+    [apiEnabled, dispatch],
+  )
+
   const assignDeviceToFolder = useCallback(
     async (payload) => {
       const basePayload = payload && typeof payload === 'object' ? payload : {}
@@ -780,6 +831,7 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
         updateFolder,
         createDevice,
         updateDevice,
+        updateDeviceLock,
         assignDeviceToFolder,
         deleteNodes,
       },
@@ -791,6 +843,7 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
       updateFolder,
       createDevice,
       updateDevice,
+      updateDeviceLock,
       assignDeviceToFolder,
       deleteNodes,
     ],

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -729,26 +729,34 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
         return normalizedLocked
       }
 
-      const { json } = await httpClient(
-        `/api/retailplayer/devices/${encodeURIComponent(normalizedId)}/lock`,
-        {
-          method: 'PATCH',
-          body: JSON.stringify({ locked: normalizedLocked }),
-          headers: new Headers({ 'Content-Type': 'application/json' }),
-        },
-      )
+      try {
+        const { json } = await httpClient(
+          `/api/retailplayer/devices/${encodeURIComponent(normalizedId)}/lock`,
+          {
+            method: 'PATCH',
+            body: JSON.stringify({ locked: normalizedLocked }),
+            headers: new Headers({ 'Content-Type': 'application/json' }),
+          },
+        )
 
-      const responseLocked =
-        typeof json?.data?.locked === 'boolean'
-          ? json.data.locked
-          : normalizedLocked
+        const responseLocked =
+          typeof json?.data?.locked === 'boolean'
+            ? json.data.locked
+            : normalizedLocked
 
-      dispatch({
-        type: 'UPDATE_DEVICE',
-        payload: { id: normalizedId, locked: responseLocked },
-      })
+        dispatch({
+          type: 'UPDATE_DEVICE',
+          payload: { id: normalizedId, locked: responseLocked },
+        })
 
-      return responseLocked
+        return responseLocked
+      } catch (err) {
+        dispatch({
+          type: 'UPDATE_DEVICE',
+          payload: { id: normalizedId, locked: !normalizedLocked },
+        })
+        return null
+      }
     },
     [apiEnabled, dispatch],
   )

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -69,6 +69,10 @@ const mapRetailPlayerDevice = (device) => {
         .filter(Boolean)
     : []
   const remoteControlId = normalizeValue(device.remoteControlId)
+  const locked =
+    typeof device.locked === 'boolean'
+      ? device.locked
+      : Boolean(device.locked)
 
   return {
     id: fallbackId,
@@ -85,6 +89,7 @@ const mapRetailPlayerDevice = (device) => {
     timeZone: normalizeValue(device.timeZone || device.time_zone),
     folderIds,
     remoteControlId,
+    locked,
   }
 }
 


### PR DESCRIPTION
### Motivation
- Provide a per-device locked/unlocked state for Retail Player devices so admins can restrict access to specific devices.
- Use a single global password configured in `conf/configuration.go` to unlock devices for the current session.

### Description
- Persist a `Locked` boolean on `model.RetailPlayerDeviceMapping` and add DB support by ensuring an `is_locked` column and a repository method `SetLockState(ctx, deviceID, locked)` in `persistence/retail_player_device_mapping_repository.go`.
- Surface lock metadata in the native API and add endpoints `PATCH /api/retailplayer/devices/{deviceID}/lock` (private) to toggle lock state and `POST /api/retailplayer/devices/{deviceID}/unlock` (public) to validate the configured password; the unlock handler checks `conf.Server.RetailPlayer.DeviceLockPassword`.
- Propagate `locked` into device mapping functions so API responses include `locked` and persistence/sync respects the flag (`server/nativeapi/retail_player.go`, `model/retail_player_device_mapping.go`).
- UI changes: add lock/unlock icon in the Retail Player management list (icons before edit) that toggles device lock for admins only, add `updateDeviceLock` action in the device store to call backend, and show a password dialog blocking the dashboard when a device is locked until the session is unlocked via successful `POST /retailplayer/devices/{id}/unlock`; unlocked state stored per-session in `sessionStorage` under `retailPlayerUnlockedDevices`.
- Add configuration option `RetailPlayer.DeviceLockPassword` and default `retailplayer.devicelockpassword` in `conf/configuration.go`.

### Testing
- No automated tests were executed as part of this change (no `go test`/JS test runner run in this rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982ca8893f88322b6941244a363b989)