### PR TITLE
Fix retail player lock state parsing for device payloads

### DIFF
--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -73,7 +73,7 @@ const normalizeBoolean = (value, fallback = false) => {
   return fallback
 }
 
-const mapRetailPlayerDevice = (device) => {
+const mapRetailPlayerDevice = (device, options = {}) => {
   if (!device || typeof device !== 'object') {
     return null
   }
@@ -96,7 +96,9 @@ const mapRetailPlayerDevice = (device) => {
         .filter(Boolean)
     : []
   const remoteControlId = normalizeValue(device.remoteControlId)
-  const locked = normalizeBoolean(device.locked, false)
+  const lockedFallback =
+    typeof options.lockedFallback === 'boolean' ? options.lockedFallback : false
+  const locked = normalizeBoolean(device.locked, lockedFallback)
 
   return {
     id: fallbackId,

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -46,6 +46,33 @@ const deviceSlugKey = (value) => {
   return normalized.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
 }
 
+const normalizeBoolean = (value, fallback = false) => {
+  if (typeof value === 'boolean') {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (normalized === 'true' || normalized === '1') {
+      return true
+    }
+    if (normalized === 'false' || normalized === '0') {
+      return false
+    }
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    if (value === 1) {
+      return true
+    }
+    if (value === 0) {
+      return false
+    }
+  }
+
+  return fallback
+}
+
 const mapRetailPlayerDevice = (device) => {
   if (!device || typeof device !== 'object') {
     return null
@@ -69,10 +96,7 @@ const mapRetailPlayerDevice = (device) => {
         .filter(Boolean)
     : []
   const remoteControlId = normalizeValue(device.remoteControlId)
-  const locked =
-    typeof device.locked === 'boolean'
-      ? device.locked
-      : Boolean(device.locked)
+  const locked = normalizeBoolean(device.locked, false)
 
   return {
     id: fallbackId,

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -747,7 +747,11 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
 
     const payloadDevice = statusState.data?.device
     if (payloadDevice) {
-      return ensureMatchingDevice(mapRetailPlayerDevice(payloadDevice))
+      return ensureMatchingDevice(
+        mapRetailPlayerDevice(payloadDevice, {
+          lockedFallback: deviceState.data?.locked ?? false,
+        }),
+      )
     }
 
     if (Array.isArray(devices)) {
@@ -1009,7 +1013,10 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
 
       realtimeDeviceRef.current = mergedDevice
 
-      const mappedDevice = mapRetailPlayerDevice(mergedDevice)
+      const mappedDevice = mapRetailPlayerDevice(mergedDevice, {
+        lockedFallback:
+          previousDevice?.locked ?? baseDevice?.locked ?? deviceState.data?.locked ?? false,
+      })
       if (mappedDevice) {
         setDeviceState({
           data: mappedDevice,
@@ -1065,7 +1072,14 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
         }))
       }
     },
-    [channelState.data, channelState.isLoading, remoteControlDeviceId, triggerState.isLoading],
+    [
+      baseDevice?.locked,
+      channelState.data,
+      channelState.isLoading,
+      deviceState.data?.locked,
+      remoteControlDeviceId,
+      triggerState.isLoading,
+    ],
   )
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- The UI treated various non-boolean `locked` payload values (e.g. the string "false") as truthy, causing lock overlays/popups to disappear or be misinterpreted on refresh.

### Description
- Add a stricter boolean normalizer `normalizeBoolean` and use it in `mapRetailPlayerDevice` inside `ui/src/retailPlayer/deviceUtils.js` so `device.locked` is parsed explicitly from booleans, strings (`"true"/"false"`, `"1"/"0"`) and numeric `1/0` values with a fallback.

### Testing
- Ran `npx eslint src/retailPlayer/deviceUtils.js` in `ui/` and it passed. 
- Ran `npm run lint -- src/retailPlayer/deviceUtils.js` in `ui/` which failed due to pre-existing unrelated lint issues in other files (warnings/errors outside the changed file).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984775b8f34832299463521942b824c)