### PR TITLE
Normalize retail player lock state across payload formats

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -30,7 +30,7 @@ import { useHistory, useParams } from 'react-router-dom'
 import { BiDislike } from 'react-icons/bi'
 import { MdSkipNext } from 'react-icons/md'
 import useRetailPlayerDeviceStatus from './useRetailPlayerDeviceStatus'
-import { normalizeValue } from './deviceUtils'
+import { normalizeLockedValue, normalizeValue } from './deviceUtils'
 import httpClient from '../dataProvider/httpClient'
 
 const combineClasses = (...classNames) => classNames.filter(Boolean).join(' ')
@@ -2340,7 +2340,7 @@ const RetailPlayerDashboard = () => {
     )
   }
 
-  const isDeviceLocked = Boolean(device.locked)
+  const isDeviceLocked = normalizeLockedValue(device.locked)
 
   if (isDeviceLocked && !isUnlocked) {
     return (

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -10,7 +10,13 @@ import PropTypes from 'prop-types'
 import { v4 as uuidv4 } from 'uuid'
 import useRetailPlayerDevices from './useRetailPlayerDevices'
 import httpClient from '../dataProvider/httpClient'
-import { buildDeviceSlug, deviceSlugKey, normalizeValue } from './deviceUtils'
+import {
+  buildDeviceSlug,
+  deviceSlugKey,
+  normalizeLockedValue,
+  normalizeValue,
+  resolveLockedField,
+} from './deviceUtils'
 
 const RetailPlayerDeviceStoreContext = createContext(null)
 
@@ -98,11 +104,10 @@ const baseDeviceShape = (device, existing) => {
   const normalizedOrganization = normalizeValue(device?.organization)
   const normalizedTimeZone = normalizeValue(device?.timeZone)
   const normalizedRemoteControlId = normalizeValue(device?.remoteControlId)
-  const incomingLocked = typeof device?.locked === 'boolean'
-    ? device.locked
-    : existing?.locked
-  const normalizedLocked =
-    typeof incomingLocked === 'boolean' ? incomingLocked : false
+  const normalizedLocked = normalizeLockedValue(
+    resolveLockedField(device),
+    existing?.locked || false,
+  )
 
   const existingFolderIds = normalizeFolderIds(
     existing?.folderIds ?? existing?.folderId,
@@ -314,7 +319,9 @@ const reducer = (state, action) => {
               ? normalizeValue(remoteControlId)
               : device.remoteControlId,
           locked:
-            locked !== undefined ? Boolean(locked) : device.locked,
+            locked !== undefined
+              ? normalizeLockedValue(locked, device.locked)
+              : device.locked,
         }
       })
       return { ...state, devices: nextDevices, lastUpdated: Date.now() }
@@ -720,7 +727,7 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
         return null
       }
 
-      const normalizedLocked = Boolean(locked)
+      const normalizedLocked = normalizeLockedValue(locked)
       dispatch({
         type: 'UPDATE_DEVICE',
         payload: { id: normalizedId, locked: normalizedLocked },

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -46,6 +46,58 @@ const deviceSlugKey = (value) => {
   return normalized.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
 }
 
+
+const normalizeLockedValue = (value, fallback = false) => {
+  if (typeof value === 'boolean') {
+    return value
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    if (value === 1) {
+      return true
+    }
+    if (value === 0) {
+      return false
+    }
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (!normalized) {
+      return fallback
+    }
+    if (['true', '1', 'yes', 'y', 'on', 'locked'].includes(normalized)) {
+      return true
+    }
+    if (['false', '0', 'no', 'n', 'off', 'unlocked'].includes(normalized)) {
+      return false
+    }
+  }
+
+  return fallback
+}
+
+const resolveLockedField = (device) => {
+  if (!device || typeof device !== 'object') {
+    return undefined
+  }
+
+  if (Object.prototype.hasOwnProperty.call(device, 'locked')) {
+    return device.locked
+  }
+  if (Object.prototype.hasOwnProperty.call(device, 'isLocked')) {
+    return device.isLocked
+  }
+  if (Object.prototype.hasOwnProperty.call(device, 'is_locked')) {
+    return device.is_locked
+  }
+  if (Object.prototype.hasOwnProperty.call(device, 'lock')) {
+    return device.lock
+  }
+
+  return undefined
+}
+
 const mapRetailPlayerDevice = (device) => {
   if (!device || typeof device !== 'object') {
     return null
@@ -69,10 +121,7 @@ const mapRetailPlayerDevice = (device) => {
         .filter(Boolean)
     : []
   const remoteControlId = normalizeValue(device.remoteControlId)
-  const locked =
-    typeof device.locked === 'boolean'
-      ? device.locked
-      : Boolean(device.locked)
+  const locked = normalizeLockedValue(resolveLockedField(device))
 
   return {
     id: fallbackId,
@@ -93,4 +142,11 @@ const mapRetailPlayerDevice = (device) => {
   }
 }
 
-export { buildDeviceSlug, deviceSlugKey, mapRetailPlayerDevice, normalizeValue }
+export {
+  buildDeviceSlug,
+  deviceSlugKey,
+  mapRetailPlayerDevice,
+  normalizeLockedValue,
+  normalizeValue,
+  resolveLockedField,
+}


### PR DESCRIPTION
### Motivation
- Fix the auto-dismissing unlock modal and disappearing lock icon caused by unstable lock-state interpretation across renders and payload shapes.
- The underlying issue was reliance on JavaScript truthiness (`Boolean(...)`) and a single expected field name, which treats strings like `"false"` as truthy and misses alternate backend fields such as `isLocked` or `is_locked`.

### Description
- Add `normalizeLockedValue(value, fallback)` to `ui/src/retailPlayer/deviceUtils.js` to deterministically normalize lock values from booleans, numeric flags (`0/1`) and common string values (`"true"/"false"`, `"locked"/"unlocked"`, etc.).
- Add `resolveLockedField(device)` to detect lock information from multiple possible payload keys (`locked`, `isLocked`, `is_locked`, `lock`).
- Use the new helpers in `mapRetailPlayerDevice` so device mapping yields an authoritative boolean `locked` value regardless of API format.
- Replace ad-hoc `Boolean(...)` coercion with `normalizeLockedValue` in `RetailPlayerDeviceStoreContext.jsx` (base shaping, reducer `UPDATE_DEVICE` handling, and `updateDeviceLock`) to ensure store updates and API round-trips keep lock state stable.
- Replace `Boolean(device.locked)` in `RetailPlayerDashboard.jsx` with `normalizeLockedValue(device.locked)` so the dashboard lock gate and modal rely on the same authoritative state.

### Testing
- Ran lint for the changed files with `cd ui && npx eslint src/retailPlayer/deviceUtils.js src/retailPlayer/RetailPlayerDeviceStoreContext.jsx src/retailPlayer/RetailPlayerDashboard.jsx`, which completed and reported one pre-existing hook dependency warning in `RetailPlayerDashboard.jsx` (no new lint errors).
- Ran `cd ui && npm run test -- src/retailPlayer`, which exited because there are no unit tests in that folder (no test files found).
- Ran `cd ui && npx prettier --write` on the updated files to keep formatting consistent (completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69848a3ed2d88322afb8465e7342afac)