### PR TITLE
Add per-device lock and password gating for Retail Player devices

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -221,8 +221,9 @@ type retailPlayerOptions struct {
 	OrderBy                   string
 	OrderDirection            string
 	Search                    string
-	Fields                    []string                        `json:",omitempty"`
-	AdditionalHeaders         map[string]string               `json:",omitempty"`
+	Fields                    []string          `json:",omitempty"`
+	AdditionalHeaders         map[string]string `json:",omitempty"`
+	LockPassword              string
 	Notifications             retailPlayerNotificationOptions `json:",omitempty"`
 }
 
@@ -648,6 +649,7 @@ func setViperDefaults() {
 	viper.SetDefault("retailplayer.search", "")
 	viper.SetDefault("retailplayer.fields", []string{})
 	viper.SetDefault("retailplayer.additionalheaders", map[string]string{})
+	viper.SetDefault("retailplayer.lockpassword", "")
 	viper.SetDefault("httpsecurityheaders.customframeoptionsvalue", "DENY")
 	viper.SetDefault("backup.path", "")
 	viper.SetDefault("backup.schedule", "")

--- a/db/migrations/20260205090000_add_lock_to_retail_player_device_mapping.go
+++ b/db/migrations/20260205090000_add_lock_to_retail_player_device_mapping.go
@@ -1,0 +1,28 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upAddLockToRetailPlayerDeviceMapping, downAddLockToRetailPlayerDeviceMapping)
+}
+
+func upAddLockToRetailPlayerDeviceMapping(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+		ALTER TABLE retail_player_device_mapping
+		ADD COLUMN is_locked BOOLEAN NOT NULL DEFAULT FALSE;
+	`)
+	return err
+}
+
+func downAddLockToRetailPlayerDeviceMapping(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+		ALTER TABLE retail_player_device_mapping
+		DROP COLUMN is_locked;
+	`)
+	return err
+}

--- a/model/retail_player_device_mapping.go
+++ b/model/retail_player_device_mapping.go
@@ -10,6 +10,7 @@ type RetailPlayerDeviceMapping struct {
 	DeviceID     string    `db:"device_id" json:"deviceId"`
 	DeviceName   string    `db:"device_name" json:"deviceName"`
 	DeviceSlug   string    `db:"device_slug" json:"deviceSlug"`
+	IsLocked     bool      `db:"is_locked" json:"isLocked"`
 	Channel      string    `db:"channel" json:"channel"`
 	ChannelList  string    `db:"channel_list" json:"channelList"`
 	Organization string    `db:"organization" json:"organization"`
@@ -22,6 +23,7 @@ type RetailPlayerDeviceMappingRepository interface {
 	Put(ctx context.Context, mapping RetailPlayerDeviceMapping) error
 	PutMany(ctx context.Context, mappings []RetailPlayerDeviceMapping) error
 	FindByIdentifier(ctx context.Context, identifier string) (*RetailPlayerDeviceMapping, error)
+	SetLockState(ctx context.Context, identifier string, isLocked bool) (*RetailPlayerDeviceMapping, error)
 	All(ctx context.Context) ([]RetailPlayerDeviceMapping, error)
 }
 

--- a/persistence/retail_player_device_mapping_repository.go
+++ b/persistence/retail_player_device_mapping_repository.go
@@ -127,7 +127,10 @@ func (r retailPlayerDeviceMappingRepository) PutMany(ctx context.Context, mappin
 	insert = insert.Suffix(`ON CONFLICT(device_id) DO UPDATE SET
                 device_name = excluded.device_name,
                 device_slug = excluded.device_slug,
-                is_locked = excluded.is_locked,
+                is_locked = CASE
+                        WHEN excluded.is_locked THEN TRUE
+                        ELSE retail_player_device_mapping.is_locked
+                END,
                 channel = excluded.channel,
                 channel_list = excluded.channel_list,
                 organization = excluded.organization,
@@ -175,11 +178,16 @@ func (r retailPlayerDeviceMappingRepository) SetLockState(ctx context.Context, i
 		return nil, err
 	}
 
-	mapping.IsLocked = isLocked
-	if err := r.Put(ctx, *mapping); err != nil {
+	update := Update(r.tableName).
+		Set("is_locked", isLocked).
+		Set("updated_at", time.Now().UTC()).
+		Where(Eq{"device_id": mapping.DeviceID})
+
+	if _, err := r.executeSQL(update); err != nil {
 		return nil, err
 	}
 
+	mapping.IsLocked = isLocked
 	return mapping, nil
 }
 

--- a/persistence/retail_player_device_mapping_repository.go
+++ b/persistence/retail_player_device_mapping_repository.go
@@ -23,6 +23,7 @@ func NewRetailPlayerDeviceMappingRepository(ctx context.Context, db dbx.Builder)
 	r.tableName = "retail_player_device_mapping"
 	r.registerModel(&model.RetailPlayerDeviceMapping{}, nil)
 	r.ensureRemoteControlColumn()
+	r.ensureLockColumn()
 	return r
 }
 
@@ -41,6 +42,23 @@ ADD COLUMN remote_control_id TEXT DEFAULT '';
 	}
 
 	log.Error(r.ctx, "Unable to ensure remote control column for retail player device mappings", "err", err)
+}
+
+func (r retailPlayerDeviceMappingRepository) ensureLockColumn() {
+	_, err := r.db.NewQuery(`
+ALTER TABLE retail_player_device_mapping
+ADD COLUMN is_locked BOOLEAN NOT NULL DEFAULT FALSE;
+`).Execute()
+	if err == nil {
+		return
+	}
+
+	lowerErr := strings.ToLower(err.Error())
+	if strings.Contains(lowerErr, "duplicate column name") || strings.Contains(lowerErr, "already exists") {
+		return
+	}
+
+	log.Error(r.ctx, "Unable to ensure lock column for retail player device mappings", "err", err)
 }
 
 func (r retailPlayerDeviceMappingRepository) Put(ctx context.Context, mapping model.RetailPlayerDeviceMapping) error {
@@ -62,6 +80,7 @@ func (r retailPlayerDeviceMappingRepository) PutMany(ctx context.Context, mappin
 			"device_id",
 			"device_name",
 			"device_slug",
+			"is_locked",
 			"channel",
 			"channel_list",
 			"organization",
@@ -90,6 +109,7 @@ func (r retailPlayerDeviceMappingRepository) PutMany(ctx context.Context, mappin
 			id,
 			name,
 			slug,
+			mapping.IsLocked,
 			strings.TrimSpace(mapping.Channel),
 			strings.TrimSpace(mapping.ChannelList),
 			strings.TrimSpace(mapping.Organization),
@@ -107,6 +127,7 @@ func (r retailPlayerDeviceMappingRepository) PutMany(ctx context.Context, mappin
 	insert = insert.Suffix(`ON CONFLICT(device_id) DO UPDATE SET
                 device_name = excluded.device_name,
                 device_slug = excluded.device_slug,
+                is_locked = excluded.is_locked,
                 channel = excluded.channel,
                 channel_list = excluded.channel_list,
                 organization = excluded.organization,
@@ -135,7 +156,7 @@ func (r retailPlayerDeviceMappingRepository) FindByIdentifier(ctx context.Contex
 	orClause := Or{}
 	orClause = append(orClause, conditions...)
 
-	sel := Select("device_id", "device_name", "device_slug", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "updated_at").
+	sel := Select("device_id", "device_name", "device_slug", "is_locked", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "updated_at").
 		From(r.tableName).
 		Where(orClause).
 		OrderBy("updated_at DESC").
@@ -148,8 +169,22 @@ func (r retailPlayerDeviceMappingRepository) FindByIdentifier(ctx context.Contex
 	return &mapping, nil
 }
 
+func (r retailPlayerDeviceMappingRepository) SetLockState(ctx context.Context, identifier string, isLocked bool) (*model.RetailPlayerDeviceMapping, error) {
+	mapping, err := r.FindByIdentifier(ctx, identifier)
+	if err != nil {
+		return nil, err
+	}
+
+	mapping.IsLocked = isLocked
+	if err := r.Put(ctx, *mapping); err != nil {
+		return nil, err
+	}
+
+	return mapping, nil
+}
+
 func (r retailPlayerDeviceMappingRepository) All(ctx context.Context) ([]model.RetailPlayerDeviceMapping, error) {
-	sel := Select("device_id", "device_name", "device_slug", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "updated_at").
+	sel := Select("device_id", "device_name", "device_slug", "is_locked", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "updated_at").
 		From(r.tableName).
 		OrderBy("updated_at DESC")
 

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -1253,24 +1253,9 @@ func (n *Router) persistRetailPlayerDeviceMappings(ctx context.Context, devices 
 		return
 	}
 
-	existingLocks := map[string]bool{}
-	existingMappings, err := repo.All(ctx)
-	if err == nil {
-		for _, existing := range existingMappings {
-			id := strings.TrimSpace(existing.DeviceID)
-			if id == "" {
-				continue
-			}
-			existingLocks[id] = existing.IsLocked
-		}
-	}
-
 	mappings := make([]model.RetailPlayerDeviceMapping, 0, len(devices))
 	for _, device := range devices {
 		if mapping, ok := mapRetailPlayerDeviceToMapping(device); ok {
-			if locked, found := existingLocks[mapping.DeviceID]; found {
-				mapping.IsLocked = locked
-			}
 			mappings = append(mappings, mapping)
 		}
 	}
@@ -1423,12 +1408,29 @@ func (n *Router) handleToggleRetailPlayerDeviceLock() http.HandlerFunc {
 		mapping, err := repo.SetLockState(ctx, deviceID, *payload.Locked)
 		if err != nil {
 			if errors.Is(err, model.ErrNotFound) {
-				http.Error(w, "Retail player device not found", http.StatusNotFound)
+				device, resolveErr := n.resolveRetailPlayerDevice(ctx, deviceID)
+				if resolveErr != nil {
+					http.Error(w, "Retail player device not found", http.StatusNotFound)
+					return
+				}
+
+				fallbackMapping, ok := mapRetailPlayerDeviceToMapping(device)
+				if !ok {
+					http.Error(w, "Retail player device not found", http.StatusNotFound)
+					return
+				}
+				fallbackMapping.IsLocked = *payload.Locked
+				if putErr := repo.Put(ctx, fallbackMapping); putErr != nil {
+					log.Error(ctx, "Unable to create retail player device lock mapping", "identifier", deviceID, "err", putErr)
+					http.Error(w, "Unable to update retail player device lock state", http.StatusInternalServerError)
+					return
+				}
+				mapping = &fallbackMapping
+			} else {
+				log.Error(ctx, "Unable to update retail player device lock state", "identifier", deviceID, "err", err)
+				http.Error(w, "Unable to update retail player device lock state", http.StatusInternalServerError)
 				return
 			}
-			log.Error(ctx, "Unable to update retail player device lock state", "identifier", deviceID, "err", err)
-			http.Error(w, "Unable to update retail player device lock state", http.StatusInternalServerError)
-			return
 		}
 
 		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -27,6 +27,7 @@ import (
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/server/public"
 	"github.com/navidrome/navidrome/utils"
 )
@@ -211,6 +212,7 @@ type retailPlayerDevice struct {
 	TimeZone        string   `json:"timeZone,omitempty"`
 	FolderIDs       []string `json:"folderIds,omitempty"`
 	RemoteControlID string   `json:"remoteControlId,omitempty"`
+	IsLocked        bool     `json:"isLocked"`
 }
 
 type retailPlayerDeviceConfigResponse struct {
@@ -359,6 +361,8 @@ func (n *Router) addRetailPlayerPrivateRoutes(r chi.Router) {
 	r.Put("/retailplayer/devices/{deviceID}/folders", n.handleAssignRetailPlayerDeviceFolders())
 	r.Post("/retailplayer/qr", n.handleRetailPlayerSyncQR())
 	r.Patch("/retailplayer/devices/{deviceID}/remote-control", n.handleUpdateRetailPlayerDeviceRemoteControl())
+	r.Post("/retailplayer/devices/{deviceID}/lock", n.handleToggleRetailPlayerDeviceLock())
+	r.Post("/retailplayer/devices/{deviceID}/unlock", n.handleVerifyRetailPlayerDevicePassword())
 }
 
 var errRetailPlayerDeviceNotFound = errors.New("retail player device not found")
@@ -425,24 +429,24 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 			}
 
 			if len(mappings) > 0 {
-				remoteControlByID := make(map[string]string, len(mappings))
+				remoteStateByID := make(map[string]model.RetailPlayerDeviceMapping, len(mappings))
 				for _, mapping := range mappings {
 					id := strings.TrimSpace(mapping.DeviceID)
-					remoteControlID := strings.TrimSpace(mapping.RemoteCtrlID)
-					if id == "" || remoteControlID == "" {
+					if id == "" {
 						continue
 					}
-					remoteControlByID[id] = remoteControlID
+					remoteStateByID[id] = mapping
 				}
 
-				if len(remoteControlByID) > 0 {
+				if len(remoteStateByID) > 0 {
 					for index := range response.Data {
 						id := strings.TrimSpace(response.Data[index].ID)
 						if id == "" {
 							continue
 						}
-						if remoteControlID, ok := remoteControlByID[id]; ok {
-							response.Data[index].RemoteControlID = remoteControlID
+						if mapping, ok := remoteStateByID[id]; ok {
+							response.Data[index].RemoteControlID = strings.TrimSpace(mapping.RemoteCtrlID)
+							response.Data[index].IsLocked = mapping.IsLocked
 						}
 					}
 				}
@@ -555,24 +559,24 @@ func (n *Router) handleRetailPlayerDeviceByName() http.HandlerFunc {
 			}
 
 			if len(mappings) > 0 {
-				remoteControlByID := make(map[string]string, len(mappings))
+				remoteStateByID := make(map[string]model.RetailPlayerDeviceMapping, len(mappings))
 				for _, mapping := range mappings {
 					id := strings.TrimSpace(mapping.DeviceID)
-					remoteControlID := strings.TrimSpace(mapping.RemoteCtrlID)
-					if id == "" || remoteControlID == "" {
+					if id == "" {
 						continue
 					}
-					remoteControlByID[id] = remoteControlID
+					remoteStateByID[id] = mapping
 				}
 
-				if len(remoteControlByID) > 0 {
+				if len(remoteStateByID) > 0 {
 					for index := range filtered.Data {
 						id := strings.TrimSpace(filtered.Data[index].ID)
 						if id == "" {
 							continue
 						}
-						if remoteControlID, ok := remoteControlByID[id]; ok {
-							filtered.Data[index].RemoteControlID = remoteControlID
+						if mapping, ok := remoteStateByID[id]; ok {
+							filtered.Data[index].RemoteControlID = strings.TrimSpace(mapping.RemoteCtrlID)
+							filtered.Data[index].IsLocked = mapping.IsLocked
 						}
 					}
 				}
@@ -1249,9 +1253,24 @@ func (n *Router) persistRetailPlayerDeviceMappings(ctx context.Context, devices 
 		return
 	}
 
+	existingLocks := map[string]bool{}
+	existingMappings, err := repo.All(ctx)
+	if err == nil {
+		for _, existing := range existingMappings {
+			id := strings.TrimSpace(existing.DeviceID)
+			if id == "" {
+				continue
+			}
+			existingLocks[id] = existing.IsLocked
+		}
+	}
+
 	mappings := make([]model.RetailPlayerDeviceMapping, 0, len(devices))
 	for _, device := range devices {
 		if mapping, ok := mapRetailPlayerDeviceToMapping(device); ok {
+			if locked, found := existingLocks[mapping.DeviceID]; found {
+				mapping.IsLocked = locked
+			}
 			mappings = append(mappings, mapping)
 		}
 	}
@@ -1345,6 +1364,7 @@ func mapRetailPlayerDeviceToMapping(device retailPlayerDevice) (model.RetailPlay
 		Organization: strings.TrimSpace(device.Organization),
 		TimeZone:     strings.TrimSpace(device.TimeZone),
 		RemoteCtrlID: strings.TrimSpace(device.RemoteControlID),
+		IsLocked:     device.IsLocked,
 	}, true
 }
 
@@ -1357,6 +1377,116 @@ func mapRetailPlayerMappingToDevice(mapping model.RetailPlayerDeviceMapping) ret
 		Organization:    strings.TrimSpace(mapping.Organization),
 		TimeZone:        strings.TrimSpace(mapping.TimeZone),
 		RemoteControlID: strings.TrimSpace(mapping.RemoteCtrlID),
+		IsLocked:        mapping.IsLocked,
+	}
+}
+
+func (n *Router) handleToggleRetailPlayerDeviceLock() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		user, ok := request.UserFrom(ctx)
+		if !ok || !user.IsAdmin {
+			http.Error(w, "Access denied: admin privileges required", http.StatusForbidden)
+			return
+		}
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		deviceID := normalizeRetailPlayerIdentifier(chi.URLParam(r, "deviceID"))
+		if deviceID == "" {
+			http.Error(w, "Retail player device identifier is required", http.StatusBadRequest)
+			return
+		}
+
+		var payload struct {
+			Locked *bool `json:"locked"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "Invalid retail player lock payload", http.StatusBadRequest)
+			return
+		}
+		if payload.Locked == nil {
+			http.Error(w, "Retail player lock state is required", http.StatusBadRequest)
+			return
+		}
+
+		repo := n.ds.RetailPlayerDeviceMapping(ctx)
+		if repo == nil {
+			http.Error(w, "Retail player mapping repository unavailable", http.StatusInternalServerError)
+			return
+		}
+
+		mapping, err := repo.SetLockState(ctx, deviceID, *payload.Locked)
+		if err != nil {
+			if errors.Is(err, model.ErrNotFound) {
+				http.Error(w, "Retail player device not found", http.StatusNotFound)
+				return
+			}
+			log.Error(ctx, "Unable to update retail player device lock state", "identifier", deviceID, "err", err)
+			http.Error(w, "Unable to update retail player device lock state", http.StatusInternalServerError)
+			return
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{
+			"deviceId": mapping.DeviceID,
+			"isLocked": mapping.IsLocked,
+		})
+	}
+}
+
+func (n *Router) handleVerifyRetailPlayerDevicePassword() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		deviceID := normalizeRetailPlayerIdentifier(chi.URLParam(r, "deviceID"))
+		if deviceID == "" {
+			http.Error(w, "Retail player device identifier is required", http.StatusBadRequest)
+			return
+		}
+
+		var payload struct {
+			Password string `json:"password"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "Invalid retail player unlock payload", http.StatusBadRequest)
+			return
+		}
+
+		repo := n.ds.RetailPlayerDeviceMapping(ctx)
+		if repo == nil {
+			http.Error(w, "Retail player mapping repository unavailable", http.StatusInternalServerError)
+			return
+		}
+
+		mapping, err := repo.FindByIdentifier(ctx, deviceID)
+		if err != nil {
+			if errors.Is(err, model.ErrNotFound) {
+				http.Error(w, "Retail player device not found", http.StatusNotFound)
+				return
+			}
+			log.Error(ctx, "Unable to load retail player lock state", "identifier", deviceID, "err", err)
+			http.Error(w, "Unable to verify retail player password", http.StatusInternalServerError)
+			return
+		}
+
+		isValid := !mapping.IsLocked || (conf.Server.RetailPlayer.LockPassword != "" && payload.Password == conf.Server.RetailPlayer.LockPassword)
+		status := http.StatusUnauthorized
+		if isValid {
+			status = http.StatusOK
+		}
+
+		writeRetailPlayerJSON(ctx, w, status, map[string]any{
+			"valid": isValid,
+		})
 	}
 }
 

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -2,11 +2,16 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { alpha, makeStyles } from '@material-ui/core/styles'
 import {
   ButtonBase,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   Drawer,
   List,
   ListItem,
   ListItemText,
   Slider,
+  TextField,
   Typography,
 } from '@material-ui/core'
 import Tooltip from '@material-ui/core/Tooltip'
@@ -930,6 +935,10 @@ const RetailPlayerDashboard = () => {
   const [cueError, setCueError] = useState(null)
   const [activeCueTriggerId, setActiveCueTriggerId] = useState('')
   const [activeCueTriggerOrdinal, setActiveCueTriggerOrdinal] = useState(null)
+  const [passwordModalOpen, setPasswordModalOpen] = useState(false)
+  const [lockPassword, setLockPassword] = useState('')
+  const [passwordError, setPasswordError] = useState('')
+  const [isSubmittingPassword, setSubmittingPassword] = useState(false)
   const scheduleDropdownRef = useRef(null)
   const isBusy = retailLoading || statusLoading
   const combinedError = integrationError || statusError || devicesError
@@ -956,6 +965,80 @@ const RetailPlayerDashboard = () => {
       dislikeDisableTimeoutRef.current = null
     }
   }, [deviceTrackKey])
+
+
+  const deviceLockSessionKey = useMemo(() => {
+    if (!deviceTrackKey) {
+      return null
+    }
+    return `retailPlayerUnlocked:${deviceTrackKey}`
+  }, [deviceTrackKey])
+
+  const isDeviceUnlockedForSession = useMemo(() => {
+    if (!device?.isLocked || !deviceLockSessionKey) {
+      return true
+    }
+
+    try {
+      return window.sessionStorage.getItem(deviceLockSessionKey) === 'true'
+    } catch (error) {
+      return false
+    }
+  }, [device?.isLocked, deviceLockSessionKey])
+
+  useEffect(() => {
+    if (device?.isLocked && !isDeviceUnlockedForSession) {
+      setPasswordModalOpen(true)
+      setPasswordError('')
+      setLockPassword('')
+      return
+    }
+
+    setPasswordModalOpen(false)
+    setPasswordError('')
+    setLockPassword('')
+  }, [device?.isLocked, isDeviceUnlockedForSession, deviceTrackKey])
+
+  const handleUnlockSubmit = useCallback(async () => {
+    if (!device) {
+      return
+    }
+
+    setSubmittingPassword(true)
+    setPasswordError('')
+
+    try {
+      const deviceId = device.apiId || device.id
+      const { json } = await httpClient(
+        `/api/retailplayer/devices/${encodeURIComponent(deviceId)}/unlock`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ password: lockPassword }),
+          headers: new Headers({ 'Content-Type': 'application/json' }),
+        },
+      )
+
+      const isValid = json?.valid === true
+      if (!isValid) {
+        setPasswordError('Incorrect password')
+        return
+      }
+
+      if (deviceLockSessionKey) {
+        window.sessionStorage.setItem(deviceLockSessionKey, 'true')
+      }
+      setPasswordModalOpen(false)
+    } catch (err) {
+      setPasswordError('Incorrect password')
+    } finally {
+      setSubmittingPassword(false)
+    }
+  }, [device, lockPassword, deviceLockSessionKey])
+
+  const handleClosePasswordModal = useCallback(() => {
+    setPasswordModalOpen(false)
+    history.push('/retailplayer/devices')
+  }, [history])
 
   const cueStorageKey = useMemo(() => {
     if (!deviceTrackKey) {
@@ -2210,6 +2293,49 @@ const RetailPlayerDashboard = () => {
             {combinedError.message || String(combinedError)}
           </Typography>
         ) : null}
+      </div>
+    )
+  }
+
+  if (device?.isLocked && !isDeviceUnlockedForSession) {
+    return (
+      <div className={classes.notFoundWrapper}>
+        <Title title="Retail Player" />
+        <Dialog open={passwordModalOpen} disableEscapeKeyDown aria-labelledby="retail-player-password-dialog-title">
+          <DialogTitle id="retail-player-password-dialog-title">Device Locked</DialogTitle>
+          <DialogContent>
+            <Typography gutterBottom>
+              Enter the retail player password to access {device?.name || 'this device'}.
+            </Typography>
+            <TextField
+              autoFocus
+              fullWidth
+              type="password"
+              value={lockPassword}
+              onChange={(event) => setLockPassword(event.target.value)}
+              error={Boolean(passwordError)}
+              helperText={passwordError || ' '}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault()
+                  handleUnlockSubmit()
+                }
+              }}
+            />
+          </DialogContent>
+          <DialogActions>
+            <ButtonBase onClick={handleClosePasswordModal} aria-label="Close password prompt">
+              <Typography>Close</Typography>
+            </ButtonBase>
+            <ButtonBase
+              onClick={handleUnlockSubmit}
+              aria-label="Unlock device"
+              disabled={isSubmittingPassword}
+            >
+              <Typography>{isSubmittingPassword ? 'Unlocking…' : 'Unlock'}</Typography>
+            </ButtonBase>
+          </DialogActions>
+        </Dialog>
       </div>
     )
   }

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -935,7 +935,6 @@ const RetailPlayerDashboard = () => {
   const [cueError, setCueError] = useState(null)
   const [activeCueTriggerId, setActiveCueTriggerId] = useState('')
   const [activeCueTriggerOrdinal, setActiveCueTriggerOrdinal] = useState(null)
-  const [passwordModalOpen, setPasswordModalOpen] = useState(false)
   const [lockPassword, setLockPassword] = useState('')
   const [passwordError, setPasswordError] = useState('')
   const [isSubmittingPassword, setSubmittingPassword] = useState(false)
@@ -986,19 +985,6 @@ const RetailPlayerDashboard = () => {
     }
   }, [device?.isLocked, deviceLockSessionKey])
 
-  useEffect(() => {
-    if (device?.isLocked && !isDeviceUnlockedForSession) {
-      setPasswordModalOpen(true)
-      setPasswordError('')
-      setLockPassword('')
-      return
-    }
-
-    setPasswordModalOpen(false)
-    setPasswordError('')
-    setLockPassword('')
-  }, [device?.isLocked, isDeviceUnlockedForSession, deviceTrackKey])
-
   const handleUnlockSubmit = useCallback(async () => {
     if (!device) {
       return
@@ -1027,7 +1013,8 @@ const RetailPlayerDashboard = () => {
       if (deviceLockSessionKey) {
         window.sessionStorage.setItem(deviceLockSessionKey, 'true')
       }
-      setPasswordModalOpen(false)
+      setPasswordError('')
+      setLockPassword('')
     } catch (err) {
       setPasswordError('Incorrect password')
     } finally {
@@ -1036,7 +1023,8 @@ const RetailPlayerDashboard = () => {
   }, [device, lockPassword, deviceLockSessionKey])
 
   const handleClosePasswordModal = useCallback(() => {
-    setPasswordModalOpen(false)
+    setPasswordError('')
+    setLockPassword('')
     history.push('/retailplayer/devices')
   }, [history])
 
@@ -2301,7 +2289,7 @@ const RetailPlayerDashboard = () => {
     return (
       <div className={classes.notFoundWrapper}>
         <Title title="Retail Player" />
-        <Dialog open={passwordModalOpen} disableEscapeKeyDown aria-labelledby="retail-player-password-dialog-title">
+        <Dialog open disableEscapeKeyDown aria-labelledby="retail-player-password-dialog-title">
           <DialogTitle id="retail-player-password-dialog-title">Device Locked</DialogTitle>
           <DialogContent>
             <Typography gutterBottom>

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -23,9 +23,11 @@ import {
 } from '@material-ui/core'
 import { makeStyles, useTheme } from '@material-ui/core/styles'
 import { fade } from '@material-ui/core/styles/colorManipulator'
-import { Title } from 'react-admin'
+import { Title, usePermissions } from 'react-admin'
 import AddIcon from '@material-ui/icons/Add'
 import EditIcon from '@material-ui/icons/Edit'
+import LockOpenIcon from '@material-ui/icons/LockOpen'
+import LockIcon from '@material-ui/icons/Lock'
 import FolderIcon from '@material-ui/icons/Folder'
 import SpeakerGroupIcon from '@material-ui/icons/SpeakerGroup'
 import SearchIcon from '@material-ui/icons/Search'
@@ -602,6 +604,8 @@ const RetailPlayerDeviceRow = memo(
     onToggleSelection,
     onKeyDown,
     onEdit,
+    onToggleLock,
+    canToggleLock,
     isOnline,
   }) => {
     const { dragRef, isDragging } = useRetailPlayerDeviceDrag({
@@ -656,6 +660,27 @@ const RetailPlayerDeviceRow = memo(
           {node.remoteControlId ? node.remoteControlId : '—'}
         </div>
         <div className={classes.actionsCell}>
+          <Tooltip title={node.isLocked ? 'Unlock device access' : 'Lock device access'}>
+            <span>
+              <IconButton
+                size="small"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  if (canToggleLock) {
+                    onToggleLock(node)
+                  }
+                }}
+                aria-label={`${node.isLocked ? 'Unlock' : 'Lock'} device ${node.name}`}
+                disabled={!canToggleLock}
+              >
+                {node.isLocked ? (
+                  <LockIcon style={{ fontSize: 15 }} />
+                ) : (
+                  <LockOpenIcon style={{ fontSize: 15 }} />
+                )}
+              </IconButton>
+            </span>
+          </Tooltip>
           <Tooltip title="Edit device">
             <IconButton
               size="small"
@@ -686,6 +711,8 @@ RetailPlayerDeviceRow.propTypes = {
   onToggleSelection: PropTypes.func.isRequired,
   onKeyDown: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
+  onToggleLock: PropTypes.func.isRequired,
+  canToggleLock: PropTypes.bool.isRequired,
   isOnline: PropTypes.bool,
 }
 
@@ -700,6 +727,8 @@ const RetailPlayerDeviceManagement = () => {
   const classes = useStyles()
   const theme = useTheme()
   const history = useHistory()
+  const { permissions } = usePermissions()
+  const isAdmin = permissions === 'admin'
   const {
     state: { tree, folders, devices, loading, error, isApiEnabled },
     actions: { createFolder, updateFolder, createDevice, updateDevice, deleteNodes },
@@ -1210,6 +1239,34 @@ const RetailPlayerDeviceManagement = () => {
     }
   }
 
+
+  const handleToggleDeviceLock = async (device) => {
+    if (!device || !isAdmin) {
+      return
+    }
+
+    const targetLockedState = device.isLocked !== true
+    const deviceId = device.apiId || device.id
+
+    try {
+      const { json } = await httpClient(
+        `/api/retailplayer/devices/${encodeURIComponent(deviceId)}/lock`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ locked: targetLockedState }),
+          headers: new Headers({ 'Content-Type': 'application/json' }),
+        },
+      )
+
+      await updateDevice({
+        id: device.id,
+        isLocked: json?.isLocked === true,
+      })
+    } catch (err) {
+      // Keep UI responsive if the lock update fails; state remains unchanged.
+    }
+  }
+
   const handleNavigateToDevice = useCallback(
     (device) => {
       if (!device) {
@@ -1383,6 +1440,8 @@ const RetailPlayerDeviceManagement = () => {
           onToggleSelection={toggleNodeSelection}
           onKeyDown={handleRowKeyDown}
           onEdit={handleEditDevice}
+          onToggleLock={handleToggleDeviceLock}
+          canToggleLock={isAdmin}
           isOnline={isOnline}
         />
       )
@@ -1516,7 +1575,7 @@ const RetailPlayerDeviceManagement = () => {
           <span>Type</span>
           <span>Devices / Channels</span>
           <span>QR ID</span>
-          <span className={classes.headerActions}>Edit</span>
+          <span className={classes.headerActions}>Actions</span>
         </div>
         {isLoading ? (
           <div className={classes.loaderState}>

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -98,6 +98,7 @@ const baseDeviceShape = (device, existing) => {
   const normalizedOrganization = normalizeValue(device?.organization)
   const normalizedTimeZone = normalizeValue(device?.timeZone)
   const normalizedRemoteControlId = normalizeValue(device?.remoteControlId)
+  const normalizedIsLocked = device?.isLocked === true
 
   const existingFolderIds = normalizeFolderIds(
     existing?.folderIds ?? existing?.folderId,
@@ -123,6 +124,7 @@ const baseDeviceShape = (device, existing) => {
     organization: normalizedOrganization || '',
     timeZone: normalizedTimeZone || '',
     remoteControlId: normalizedRemoteControlId || '',
+    isLocked: normalizedIsLocked || existing?.isLocked === true,
     folderIds,
     folderId: primaryFolderId,
     source: existing?.source === 'local' ? 'local' : 'remote',
@@ -229,6 +231,7 @@ const reducer = (state, action) => {
         folderId,
         attributes,
         remoteControlId,
+        isLocked,
       } = action.payload || {}
       const normalizedName = normalizeValue(name) || 'New Device'
       const slug = deviceSlugKey(normalizedName) || uuidv4()
@@ -275,6 +278,7 @@ const reducer = (state, action) => {
         folderIds,
         folderId,
         remoteControlId,
+        isLocked,
       } = action.payload || {}
       if (!id) {
         return state
@@ -304,6 +308,7 @@ const reducer = (state, action) => {
             remoteControlId !== undefined
               ? normalizeValue(remoteControlId)
               : device.remoteControlId,
+          isLocked: isLocked === true ? true : isLocked === false ? false : device.isLocked === true,
         }
       })
       return { ...state, devices: nextDevices, lastUpdated: Date.now() }

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -69,6 +69,7 @@ const mapRetailPlayerDevice = (device) => {
         .filter(Boolean)
     : []
   const remoteControlId = normalizeValue(device.remoteControlId)
+  const isLocked = device.isLocked === true
 
   return {
     id: fallbackId,
@@ -85,6 +86,7 @@ const mapRetailPlayerDevice = (device) => {
     timeZone: normalizeValue(device.timeZone || device.time_zone),
     folderIds,
     remoteControlId,
+    isLocked,
   }
 }
 


### PR DESCRIPTION
### Motivation
- Provide a per-device lock feature for Retail Player devices with a single global password stored in configuration and per-session unlock behavior. 
- Ensure lock state is persistent across refreshes and independent per device (no global unlocked flags and no reliance on JS truthiness). 

### Description
- Add persistent `is_locked` boolean column to `retail_player_device_mapping` with a DB migration and repository support, including a new `SetLockState` method in the repository. 
- Add `retailplayer.lockpassword` configuration option in `conf/configuration.go` and a default viper key `retailplayer.lockpassword`. 
- Extend the native API to return device lock state with device payloads, preserve lock state when refreshing mappings, and add two endpoints: `POST /api/retailplayer/devices/{deviceID}/lock` (admin-only toggle) and `POST /api/retailplayer/devices/{deviceID}/unlock` (password verification). 
- Update UI: include `isLocked` on device objects, show a lock/unlock icon before the edit icon in the Device Management list (admin-only toggle wired to the lock endpoint), and block access to locked devices in the Retail Player Dashboard with a non-auto-dismiss password modal that requires the configured password and stores unlock status per-device in session storage using an explicit per-device key. 

### Testing
- Ran `go test ./server/nativeapi ./persistence ./model` which could not complete in this environment due to an external system dependency (`taglib` pkg-config) unrelated to the changes. 
- Ran `cd ui && npx eslint` for the modified JS files; linting caught existing `no-console` violations in `RetailPlayerDeviceManagement.jsx` that were present prior to this change and are not introduced by the new behavior. 
- Attempted a local UI browser screenshot to validate the modal, but the UI server was not reachable (`ERR_EMPTY_RESPONSE`) in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69848e6b18ac8322933e4f66a4ce6ac6)