### PR TITLE
fix(retail-player): keep lock popup visible and fix realtime status update loop

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -959,7 +959,6 @@ const RetailPlayerDashboard = () => {
   const scheduleDropdownRef = useRef(null)
   const isBusy = retailLoading || statusLoading
   const combinedError = integrationError || statusError || devicesError
-  const lockSessionKey = 'retailPlayerUnlockedDevices'
   const [unlockPassword, setUnlockPassword] = useState('')
   const [unlockError, setUnlockError] = useState('')
   const [isUnlocking, setIsUnlocking] = useState(false)
@@ -990,49 +989,11 @@ const RetailPlayerDashboard = () => {
     )
   }, [device])
 
-  const readUnlockedDevices = useCallback(() => {
-    if (typeof sessionStorage === 'undefined') {
-      return new Set()
-    }
-
-    try {
-      const raw = sessionStorage.getItem(lockSessionKey)
-      if (!raw) {
-        return new Set()
-      }
-      const parsed = JSON.parse(raw)
-      if (Array.isArray(parsed)) {
-        return new Set(parsed.filter((value) => typeof value === 'string'))
-      }
-    } catch (err) {
-      return new Set()
-    }
-
-    return new Set()
-  }, [lockSessionKey])
-
-  const storeUnlockedDevices = useCallback(
-    (unlockedDevices) => {
-      if (typeof sessionStorage === 'undefined') {
-        return
-      }
-      sessionStorage.setItem(
-        lockSessionKey,
-        JSON.stringify(Array.from(unlockedDevices)),
-      )
-    },
-    [lockSessionKey],
-  )
-
   useEffect(() => {
-    if (!deviceLockId) {
-      setIsUnlocked(false)
-      return
-    }
-
-    const unlockedDevices = readUnlockedDevices()
-    setIsUnlocked(unlockedDevices.has(deviceLockId))
-  }, [deviceLockId, readUnlockedDevices])
+    setIsUnlocked(false)
+    setUnlockPassword('')
+    setUnlockError('')
+  }, [deviceLockId])
 
   useEffect(() => {
     setPreviousNowPlaying(null)
@@ -2095,9 +2056,6 @@ const RetailPlayerDashboard = () => {
           headers: new Headers({ 'Content-Type': 'application/json' }),
         },
       )
-      const unlockedDevices = readUnlockedDevices()
-      unlockedDevices.add(deviceLockId)
-      storeUnlockedDevices(unlockedDevices)
       setIsUnlocked(true)
       setUnlockPassword('')
     } catch (err) {
@@ -2112,12 +2070,7 @@ const RetailPlayerDashboard = () => {
     } finally {
       setIsUnlocking(false)
     }
-  }, [
-    deviceLockId,
-    readUnlockedDevices,
-    storeUnlockedDevices,
-    unlockPassword,
-  ])
+  }, [deviceLockId, unlockPassword])
 
   const handleDislike = useCallback(() => {
     if (isDislikeDisabled) {

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -1036,36 +1036,50 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
       setHasRealtimeStatus(true)
 
       if (payloadChannels) {
-        setChannelState({
-          data: mapChannelListResponse({ channels: payloadChannels }, channelState.data),
+        setChannelState((previous) => ({
+          ...previous,
+          data: mapChannelListResponse({ channels: payloadChannels }, previous.data),
           error: null,
           isLoading: false,
           fetchedAt: new Date(),
-        })
-      } else if (channelState.isLoading) {
-        setChannelState((previous) => ({
-          ...previous,
-          isLoading: false,
-          error: null,
         }))
+      } else {
+        setChannelState((previous) => {
+          if (!previous.isLoading) {
+            return previous
+          }
+
+          return {
+            ...previous,
+            isLoading: false,
+            error: null,
+          }
+        })
       }
 
       if (payloadTriggers) {
-        setTriggerState({
+        setTriggerState((previous) => ({
+          ...previous,
           data: ensureArray(payloadTriggers),
           error: null,
           isLoading: false,
           fetchedAt: new Date(),
-        })
-      } else if (triggerState.isLoading) {
-        setTriggerState((previous) => ({
-          ...previous,
-          isLoading: false,
-          error: null,
         }))
+      } else {
+        setTriggerState((previous) => {
+          if (!previous.isLoading) {
+            return previous
+          }
+
+          return {
+            ...previous,
+            isLoading: false,
+            error: null,
+          }
+        })
       }
     },
-    [channelState.data, channelState.isLoading, remoteControlDeviceId, triggerState.isLoading],
+    [remoteControlDeviceId],
   )
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Prevent the retail-player lock popup from flashing closed immediately due to a sessionStorage-based “remember unlocked” flow that re-marked devices unlocked right after render.  
- Prevent a React "Maximum update depth exceeded" loop in the realtime status handler by avoiding updates that depend on state they also mutate.

### Description
- Removed the `sessionStorage`-backed unlocked-device cache and its helpers from `ui/src/retailPlayer/RetailPlayerDashboard.jsx` so unlock state is no longer auto-restored from storage.  
- Added an effect keyed by `deviceLockId` that resets `isUnlocked`, `unlockPassword`, and `unlockError` whenever the viewed device changes to ensure the lock popup remains visible until an explicit unlock.  
- Simplified `handleUnlock` to set `isUnlocked` only in-memory after a successful unlock API call (removed `readUnlockedDevices`/`storeUnlockedDevices` usage).  
- Updated `ui/src/retailPlayer/useRetailPlayerDeviceStatus.js` to apply functional updates to `setChannelState` and `setTriggerState`, avoid unnecessary state mutations when there is no payload, and reduced the realtime payload handler dependencies to only `remoteControlDeviceId`.

### Testing
- Ran `npx eslint src/retailPlayer/RetailPlayerDashboard.jsx` which completed with a single pre-existing warning and no new errors.  
- Ran `npm run test -- src/layout/AppBar.test.jsx` which failed due to an unrelated module resolution issue in the test environment (existing test infra problem).  
- Ran `npx vitest run RetailPlayerDashboard` which found no matching test files for the filter (no unit tests were present for this component).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698496cf26dc832286ff187885437695)