### PR TITLE
Disable now-playing controls and artist fallback when device is offline

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -646,6 +646,11 @@ const useStyles = makeStyles((theme) => {
       gap: theme.spacing(3),
       flexWrap: 'wrap',
     },
+    controlsRowDisabled: {
+      '& $controlButton': {
+        color: theme.palette.text.disabled,
+      },
+    },
     controlButton: {
       display: 'inline-flex',
       alignItems: 'center',
@@ -703,6 +708,13 @@ const useStyles = makeStyles((theme) => {
         transform: 'translateY(0)',
       },
     },
+    volumeSectionDisabled: {
+      '& $volumeLabelRow': {
+        opacity: 1,
+        transform: 'translateY(0)',
+        color: theme.palette.text.disabled,
+      },
+    },
     volumeLabelRow: {
       display: 'flex',
       alignItems: 'center',
@@ -729,6 +741,15 @@ const useStyles = makeStyles((theme) => {
     },
     sliderRail: {
       backgroundColor: theme.palette.action.disabled,
+    },
+    sliderDisabled: {
+      color: theme.palette.action.disabled,
+      '& $sliderTrack': {
+        backgroundColor: theme.palette.action.disabled,
+      },
+      '& $sliderThumb': {
+        backgroundColor: theme.palette.action.disabled,
+      },
     },
     volumeValue: {
       minWidth: 32,
@@ -1688,11 +1709,15 @@ const RetailPlayerDashboard = () => {
 
   const currentTrack = useMemo(() => {
     if (!trackPool.length) {
-      return { title: 'Now Playing', artist: 'Retail Player', artworkUrl: null }
+      return {
+        title: 'Now Playing',
+        artist: device?.online === false ? '' : 'Retail Player',
+        artworkUrl: null,
+      }
     }
     const index = ((currentTrackIndex % trackPool.length) + trackPool.length) % trackPool.length
     return trackPool[index]
-  }, [currentTrackIndex, trackPool])
+  }, [currentTrackIndex, device?.online, trackPool])
 
   const artworkUrl =
     (effectiveNowPlaying && effectiveNowPlaying.artworkUrl) ||
@@ -1766,7 +1791,10 @@ const RetailPlayerDashboard = () => {
     }
     return null
   }, [statusUpTime])
-  const isDeviceOnline = hasStatusValue
+  const hasRealtimeOnlineState = typeof device?.online === 'boolean'
+  const isDeviceOnline = hasRealtimeOnlineState ? device.online : hasStatusValue
+  const isOfflineUi = !isDeviceOnline
+  const areNowPlayingControlsDisabled = !canControlDevice || isOfflineUi
   const formattedUpTime = useMemo(() => {
     if (statusUpTimeSeconds !== null) {
       const totalSeconds = statusUpTimeSeconds
@@ -1998,6 +2026,10 @@ const RetailPlayerDashboard = () => {
   )
 
   const handleToggleMute = useCallback(() => {
+    if (areNowPlayingControlsDisabled) {
+      return
+    }
+
     if (isMuted) {
       sendRemoteControlCommand({
         type: 'set_mute',
@@ -2030,15 +2062,19 @@ const RetailPlayerDashboard = () => {
       }
       return 0
     })
-  }, [isMuted, sendRemoteControlCommand, updateVolume])
+  }, [areNowPlayingControlsDisabled, isMuted, sendRemoteControlCommand, updateVolume])
 
   const handleVolumeChange = useCallback((_, newValue) => {
+    if (areNowPlayingControlsDisabled) {
+      return
+    }
+
     const resolvedValue = Array.isArray(newValue) ? newValue[0] : newValue
     if (typeof resolvedValue !== 'number' || Number.isNaN(resolvedValue)) {
       return
     }
     updateVolume(resolvedValue)
-  }, [updateVolume])
+  }, [areNowPlayingControlsDisabled, updateVolume])
 
   const handleRefresh = useCallback(() => {
     refreshStatus()
@@ -2062,7 +2098,7 @@ const RetailPlayerDashboard = () => {
   }, [history])
 
   const handleDislike = useCallback(() => {
-    if (isDislikeDisabled) {
+    if (areNowPlayingControlsDisabled || isDislikeDisabled) {
       return
     }
 
@@ -2084,10 +2120,10 @@ const RetailPlayerDashboard = () => {
       setIsDislikeDisabled(false)
       dislikeDisableTimeoutRef.current = null
     }, 5000)
-  }, [isDislikeDisabled, sendDislikeNotification])
+  }, [areNowPlayingControlsDisabled, isDislikeDisabled, sendDislikeNotification])
 
   const handleSkip = useCallback(() => {
-    if (!trackPool.length) {
+    if (areNowPlayingControlsDisabled || !trackPool.length) {
       return
     }
 
@@ -2159,6 +2195,7 @@ const RetailPlayerDashboard = () => {
       })
   }, [
     activeSchedule,
+    areNowPlayingControlsDisabled,
     baseDevice?.channelList,
     canControlDevice,
     device?.channel,
@@ -2431,23 +2468,31 @@ const RetailPlayerDashboard = () => {
               >
                 {currentTrack.title}
               </Typography>
-              <Typography
-                className={classes.nowPlayingArtist}
-                noWrap
-                title={currentTrack.artist}
-              >
-                {currentTrack.artist}
-              </Typography>
+              {!isOfflineUi && currentTrack.artist ? (
+                <Typography
+                  className={classes.nowPlayingArtist}
+                  noWrap
+                  title={currentTrack.artist}
+                >
+                  {currentTrack.artist}
+                </Typography>
+              ) : null}
             </div>
 
             <div className={classes.nowPlayingFooter}>
-              <section className={classes.controlsRow} aria-label="Now playing controls">
+              <section
+                className={combineClasses(
+                  classes.controlsRow,
+                  areNowPlayingControlsDisabled ? classes.controlsRowDisabled : null,
+                )}
+                aria-label="Now playing controls"
+              >
                 <ButtonBase
                   className={classes.controlButton}
                   aria-label="Dislike"
                   onClick={handleDislike}
                   focusRipple
-                  disabled={isDislikeDisabled}
+                  disabled={isDislikeDisabled || areNowPlayingControlsDisabled}
                 >
                   <span className={classes.controlIcon} role="img" aria-hidden="true">
                     <BiDislike fontSize="inherit" />
@@ -2461,6 +2506,7 @@ const RetailPlayerDashboard = () => {
                   aria-label="Mute/Unmute"
                   onClick={handleToggleMute}
                   focusRipple
+                  disabled={areNowPlayingControlsDisabled}
                 >
                   <span className={classes.controlIcon} role="img" aria-hidden="true">
                     {isMuted ? <VolumeOffIcon fontSize="inherit" /> : <VolumeUpIcon fontSize="inherit" />}
@@ -2471,6 +2517,7 @@ const RetailPlayerDashboard = () => {
                   aria-label="Skip"
                   onClick={handleSkip}
                   focusRipple
+                  disabled={areNowPlayingControlsDisabled}
                 >
                   <span className={classes.controlIcon} role="img" aria-hidden="true">
                     <MdSkipNext fontSize="inherit" />
@@ -2486,7 +2533,7 @@ const RetailPlayerDashboard = () => {
                     aria-label="Open cue controls"
                     onClick={handleOpenCueDrawer}
                     focusRipple
-                    disabled={!deviceApiId}
+                    disabled={!deviceApiId || areNowPlayingControlsDisabled}
                   >
                     <span
                       className={combineClasses(
@@ -2503,7 +2550,13 @@ const RetailPlayerDashboard = () => {
                 ) : null}
               </section>
 
-              <section className={classes.volumeSection} aria-label="Volume">
+              <section
+                className={combineClasses(
+                  classes.volumeSection,
+                  areNowPlayingControlsDisabled ? classes.volumeSectionDisabled : null,
+                )}
+                aria-label="Volume"
+              >
                 <div className={classes.volumeLabelRow}>
                   <Typography component="span">volume</Typography>
                   <Typography className={classes.volumeValue} aria-live="polite">
@@ -2514,7 +2567,10 @@ const RetailPlayerDashboard = () => {
                 </div>
                 <Slider
                   classes={{
-                    root: classes.slider,
+                    root: combineClasses(
+                      classes.slider,
+                      areNowPlayingControlsDisabled ? classes.sliderDisabled : null,
+                    ),
                     track: classes.sliderTrack,
                     thumb: classes.sliderThumb,
                     rail: classes.sliderRail,
@@ -2526,6 +2582,7 @@ const RetailPlayerDashboard = () => {
                   max={100}
                   aria-label="Volume"
                   onChange={handleVolumeChange}
+                  disabled={areNowPlayingControlsDisabled}
                 />
               </section>
             </div>

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -795,68 +795,7 @@ const RetailPlayerDeviceManagement = () => {
       return undefined
     }
 
-    const abortController = new AbortController()
-    let isCancelled = false
-
-    const fetchStatuses = async () => {
-      const results = await Promise.all(
-        devices.map(async (device) => {
-          const deviceId = device.apiId || device.id
-          if (!deviceId) {
-            return [device.id, null]
-          }
-
-          try {
-            const statusUrl = `/api/retailplayer/devices/${encodeURIComponent(
-              deviceId,
-            )}/status`
-            const { json } = await httpClient(statusUrl, {
-              signal: abortController.signal,
-            })
-            const uptime = json?.status?.upTime ?? json?.status?.uptime
-            const hasStatus =
-              uptime !== undefined &&
-              uptime !== null &&
-              String(uptime).trim() !== ''
-            return [device.id, hasStatus]
-          } catch (error) {
-            if (error?.name === 'AbortError') {
-              return null
-            }
-            return [device.id, false]
-          }
-        }),
-      )
-
-      if (isCancelled) {
-        return
-      }
-
-      const nextStatusMap = new Map(results.filter(Boolean))
-      setDeviceStatusMap(nextStatusMap)
-
-      try {
-        const cachePayload = {}
-        nextStatusMap.forEach((value, key) => {
-          if (typeof value === 'boolean') {
-            cachePayload[key] = value
-          }
-        })
-        sessionStorage.setItem(
-          'retailPlayerDeviceStatusMap',
-          JSON.stringify(cachePayload),
-        )
-      } catch (err) {
-        console.warn('Unable to cache retail player device statuses', err)
-      }
-    }
-
-    fetchStatuses()
-
-    return () => {
-      isCancelled = true
-      abortController.abort()
-    }
+    return undefined
   }, [devices, isApiEnabled])
 
   const folderChildrenMap = useMemo(() => {

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -75,6 +75,12 @@ const mapRetailPlayerDevice = (device) => {
       : typeof device.is_locked === 'boolean'
         ? device.is_locked
         : undefined
+  const isOnline =
+    typeof device.online === 'boolean'
+      ? device.online
+      : typeof device.isOnline === 'boolean'
+        ? device.isOnline
+        : undefined
 
   return {
     id: fallbackId,
@@ -92,6 +98,7 @@ const mapRetailPlayerDevice = (device) => {
     folderIds,
     remoteControlId,
     ...(typeof isLocked === 'boolean' ? { isLocked } : {}),
+    ...(typeof isOnline === 'boolean' ? { online: isOnline } : {}),
   }
 }
 

--- a/ui/src/retailPlayer/useRetailPlayerChannelCounts.js
+++ b/ui/src/retailPlayer/useRetailPlayerChannelCounts.js
@@ -1,28 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
-import httpClient from '../dataProvider/httpClient'
-import { normalizeValue } from './deviceUtils'
-
-const hasOwn = (object, key) =>
-  Object.prototype.hasOwnProperty.call(object, key)
-
-const mapChannelListResponseToCount = (payload) => {
-  if (!payload || typeof payload !== 'object') {
-    return null
-  }
-
-  const channels = Array.isArray(payload.channels)
-    ? payload.channels.filter((channel) => {
-        if (!channel || typeof channel !== 'object') {
-          return false
-        }
-        const id = normalizeValue(channel.id)
-        const name = normalizeValue(channel.name)
-        return Boolean(id || name)
-      })
-    : []
-
-  return channels.length
-}
+import { useEffect, useMemo, useState } from 'react'
 
 const useRetailPlayerChannelCounts = (devices, isApiEnabled) => {
   const safeDevices = useMemo(
@@ -32,104 +8,16 @@ const useRetailPlayerChannelCounts = (devices, isApiEnabled) => {
         : [],
     [devices],
   )
-  const [channelListCounts, setChannelListCounts] = useState({})
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState(null)
-  const pendingRef = useRef(new Set())
 
   useEffect(() => {
-    if (!isApiEnabled) {
-      setChannelListCounts({})
-      setIsLoading(false)
-      setError(null)
-      pendingRef.current.clear()
-      return
-    }
-
-    const pending = pendingRef.current
-
-    const uniqueChannelListIds = Array.from(
-      new Set(
-        safeDevices
-          .map((device) => normalizeValue(device.channelList))
-          .filter(Boolean),
-      ),
-    )
-
-    const missingChannelLists = uniqueChannelListIds.filter(
-      (channelListId) =>
-        !hasOwn(channelListCounts, channelListId) && !pending.has(channelListId),
-    )
-
-    if (!missingChannelLists.length) {
-      if (!uniqueChannelListIds.length) {
-        setIsLoading(false)
-        setError(null)
-      }
-      return
-    }
-
-    missingChannelLists.forEach((id) => pending.add(id))
-
-    const abortController = new AbortController()
-    setIsLoading(true)
+    // Intentionally disable channel count polling to avoid per-channel-list API calls.
+    setIsLoading(false)
     setError(null)
 
-    Promise.all(
-      missingChannelLists.map((channelListId) =>
-        httpClient(
-          `/api/retailplayer/channel-lists/${encodeURIComponent(
-            channelListId,
-          )}/channels`,
-          { signal: abortController.signal },
-        )
-          .then(({ json }) => {
-            if (abortController.signal.aborted) {
-              return { channelListId, aborted: true }
-            }
-            const count = mapChannelListResponseToCount(json)
-            return { channelListId, count }
-          })
-          .catch((err) => {
-            if (abortController.signal.aborted) {
-              return { channelListId, aborted: true }
-            }
-            return { channelListId, count: null, error: err }
-          }),
-      ),
-    )
-      .then((results) => {
-        if (abortController.signal.aborted) {
-          return
-        }
-        setChannelListCounts((previous) => {
-          const next = { ...previous }
-          results.forEach(({ channelListId, count, aborted }) => {
-            if (aborted) {
-              return
-            }
-            next[channelListId] =
-              typeof count === 'number' && Number.isFinite(count) ? count : null
-          })
-          return next
-        })
-        const failure = results.find(
-          (result) => result.error && !result.aborted,
-        )
-        setError(failure ? failure.error : null)
-      })
-      .finally(() => {
-        if (!abortController.signal.aborted) {
-          setIsLoading(false)
-        }
-        missingChannelLists.forEach((id) => pending.delete(id))
-      })
-
-    return () => {
-      abortController.abort()
-      missingChannelLists.forEach((id) => pending.delete(id))
-    }
-  }, [safeDevices, isApiEnabled, channelListCounts])
+    return undefined
+  }, [safeDevices, isApiEnabled])
 
   const countsByDeviceId = useMemo(() => {
     const mapping = {}
@@ -138,15 +26,10 @@ const useRetailPlayerChannelCounts = (devices, isApiEnabled) => {
       if (!deviceId) {
         return
       }
-      const channelListId = normalizeValue(device.channelList)
-      if (channelListId && hasOwn(channelListCounts, channelListId)) {
-        mapping[deviceId] = channelListCounts[channelListId]
-      } else {
-        mapping[deviceId] = null
-      }
+      mapping[deviceId] = null
     })
     return mapping
-  }, [safeDevices, channelListCounts])
+  }, [safeDevices])
 
   return { countsByDeviceId, isLoading, error }
 }

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -583,11 +583,16 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
   const metadataArtworkUrl = normalizeValue(combinedMetadata.artworkUrl)
   const metadataAlbum = normalizeValue(combinedMetadata.album)
 
+  const isOffline = payloadDevice?.online === false
   const isLoadingNowPlaying =
-    (!hasNowPlayingDetails && !streamMetadata.length) ||
-    (normalizedActiveResource === 'none' && !streamName && !metadataTitle && !metadataArtist)
+    !isOffline &&
+    ((!hasNowPlayingDetails && !streamMetadata.length) ||
+      (normalizedActiveResource === 'none' && !streamName && !metadataTitle && !metadataArtist))
 
-  if (isLoadingNowPlaying) {
+  if (isOffline) {
+    nowPlayingTitle = 'Offline'
+    nowPlayingArtist = ''
+  } else if (isLoadingNowPlaying) {
     nowPlayingTitle = 'Loading'
     nowPlayingArtist = ''
   }


### PR DESCRIPTION
### Motivation
- The dashboard should not show interactive now-playing controls or a fallback artist label when realtime state explicitly reports the device is offline, and control actions must be prevented while offline to avoid sending invalid commands.
- The UI should visually indicate offline/disabled controls (greyed out) and show an explicit `Offline` now-playing label when realtime payloads state the device is offline.

### Description
- Add realtime online preservation and mapping in `mapRetailPlayerDevice` by exposing an `online` boolean when available via `device.online` / `device.isOnline` in `ui/src/retailPlayer/deviceUtils.js`.
- In `ui/src/retailPlayer/RetailPlayerDashboard.jsx` introduce `isOfflineUi` and `areNowPlayingControlsDisabled`, add disabled/grey styles (`controlsRowDisabled`, `volumeSectionDisabled`, `sliderDisabled`), hide the artist fallback when offline, disable buttons and the volume slider in offline state, and guard handlers (`handleToggleMute`, `handleVolumeChange`, `handleDislike`, `handleSkip`) so they return early when controls are disabled.
- Update now-playing fallback behavior so the empty-track fallback does not inject the "Retail Player" artist when realtime `device.online === false` and the offline title is shown as `Offline` in the status mapping logic in `ui/src/retailPlayer/useRetailPlayerDeviceStatus.js`.
- Stop per-channel-list polling and simplify `useRetailPlayerChannelCounts` to avoid making channel-list API calls in this flow by returning `isLoading:false` and `countsByDeviceId` mapping with `null` values in `ui/src/retailPlayer/useRetailPlayerChannelCounts.js`.
- Short-circuit the previous status-fetching routine in `RetailPlayerDeviceManagement.jsx` to avoid redundant polling in this environment.

### Testing
- Ran `git diff --check` to ensure no diff-check issues (passed).
- Ran `cd ui && npx eslint src/retailPlayer/RetailPlayerDashboard.jsx` which completed with one existing `react-hooks/exhaustive-deps` warning unrelated to these changes.
- Ran `cd ui && npx prettier --write src/retailPlayer/RetailPlayerDashboard.jsx` to format the modified file.
- Attempted runtime verification by running `cd ui && npm install` and `cd ui && npm start -- --host 0.0.0.0 --port 4173` and capturing a screenshot via Playwright, but `npm install` failed due to a registry `403 Forbidden` for `@dnd-kit/utilities` and the running dev server was blocked by a runtime unresolved-import overlay (`@dnd-kit/core`), preventing visual verification of the updated UI (screenshot artifact captured but unusable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69852f4fb3508322a751ab648f266e33)