### PR TITLE
Fix retail player lock state fallback mapping

### DIFF
--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -74,6 +74,8 @@ const mapRetailPlayerDevice = (device) => {
       ? device.isLocked
       : typeof device.is_locked === 'boolean'
         ? device.is_locked
+        : typeof device.locked === 'boolean'
+          ? device.locked
         : undefined
 
   return {


### PR DESCRIPTION
### Motivation
- Ensure the dashboard correctly recognizes device lock state when the API payload uses an alternative `locked` field name so the unlock dialog does not unexpectedly disappear.

### Description
- Add a fallback in `mapRetailPlayerDevice` to read `device.locked` when `device.isLocked` / `device.is_locked` are not present, and continue to only expose `isLocked` when the resolved value is a boolean (`ui/src/retailPlayer/deviceUtils.js`).

### Testing
- Ran lint to sanity-check the change with `cd ui && npm run lint -- src/retailPlayer/deviceUtils.js`, which executed but overall linting failed due to unrelated pre-existing `no-console` and hook dependency issues in other files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69854ea325d08322941eb852f9000083)