### PR TITLE
Preserve retail player lock state during realtime updates

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -2363,11 +2363,7 @@ const RetailPlayerDashboard = () => {
         </DialogActions>
       </Dialog>
 
-      <div
-        className={rootClassName}
-        aria-hidden={isAccessBlockedByLock ? 'true' : undefined}
-        style={isAccessBlockedByLock ? { pointerEvents: 'none', userSelect: 'none' } : undefined}
-      >
+      <div className={rootClassName}>
         <Title title="Retail Player" />
 
         <header className={classes.headerBar}>

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -2320,13 +2320,7 @@ const RetailPlayerDashboard = () => {
   }
 
   return (
-    <div
-      className={rootClassName}
-      aria-hidden={isAccessBlockedByLock ? 'true' : undefined}
-      style={isAccessBlockedByLock ? { pointerEvents: 'none', userSelect: 'none' } : undefined}
-    >
-      <Title title="Retail Player" />
-
+    <>
       <Dialog
         open={Boolean(device && isAccessBlockedByLock)}
         disableEscapeKeyDown
@@ -2369,7 +2363,14 @@ const RetailPlayerDashboard = () => {
         </DialogActions>
       </Dialog>
 
-      <header className={classes.headerBar}>
+      <div
+        className={rootClassName}
+        aria-hidden={isAccessBlockedByLock ? 'true' : undefined}
+        style={isAccessBlockedByLock ? { pointerEvents: 'none', userSelect: 'none' } : undefined}
+      >
+        <Title title="Retail Player" />
+
+        <header className={classes.headerBar}>
         <ButtonBase
           className={classes.headerBackButton}
           onClick={handleBack}
@@ -2792,6 +2793,7 @@ const RetailPlayerDashboard = () => {
         </div>
       </Drawer>
     </div>
+    </>
   )
 }
 

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -1016,8 +1016,20 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
 
       const mappedDevice = mapRetailPlayerDevice(mergedDevice)
       if (mappedDevice) {
+        const resolvedLockState =
+          typeof mappedDevice.isLocked === 'boolean'
+            ? mappedDevice.isLocked
+            : typeof baseDevice?.isLocked === 'boolean'
+              ? baseDevice.isLocked
+              : typeof deviceState.data?.isLocked === 'boolean'
+                ? deviceState.data.isLocked
+                : undefined
+        const normalizedMappedDevice =
+          typeof resolvedLockState === 'boolean'
+            ? { ...mappedDevice, isLocked: resolvedLockState }
+            : mappedDevice
         setDeviceState({
-          data: mappedDevice,
+          data: normalizedMappedDevice,
           error: null,
           isLoading: false,
           fetchedAt: new Date(),
@@ -1070,7 +1082,14 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
         }))
       }
     },
-    [channelState.data, channelState.isLoading, remoteControlDeviceId, triggerState.isLoading],
+    [
+      baseDevice?.isLocked,
+      channelState.data,
+      channelState.isLoading,
+      deviceState.data?.isLocked,
+      remoteControlDeviceId,
+      triggerState.isLoading,
+    ],
   )
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Fix a security issue where a locked retail player would become unlocked automatically when the device came online because realtime payloads sometimes lack `isLocked` information. 
- Prevent overwriting a previously-known lock state with an undefined/absent value from realtime updates.

### Description
- Updated `ui/src/retailPlayer/useRetailPlayerDeviceStatus.js` to preserve lock state when handling realtime payloads by resolving a `resolvedLockState` from `mappedDevice.isLocked`, `baseDevice?.isLocked`, or `deviceState.data?.isLocked` and applying it when boolean. 
- Use the normalized device (`normalizedMappedDevice`) when calling `setDeviceState` so `isLocked` is not unintentionally cleared by payloads without lock info. 
- Added `baseDevice?.isLocked` and `deviceState.data?.isLocked` to the `useCallback` dependency array so the handler reacts correctly to lock-state changes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985dd158c708322b5a52774bfbf5a34)