### PR TITLE
Preserve and expose Retail Player `online` state in API mapping and UI store

### DIFF
--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -188,6 +188,7 @@ type retailPlayerAPIDevice struct {
 	ChannelList  string `json:"channelList"`
 	MacAddress   string `json:"macAddress"`
 	TimeZone     string `json:"timeZone"`
+	Online       *bool  `json:"online"`
 }
 
 type retailPlayerAPIResponse struct {
@@ -210,6 +211,7 @@ type retailPlayerDevice struct {
 	ChannelList     string   `json:"channelList"`
 	Organization    string   `json:"organization"`
 	TimeZone        string   `json:"timeZone,omitempty"`
+	Online          *bool    `json:"online,omitempty"`
 	FolderIDs       []string `json:"folderIds,omitempty"`
 	RemoteControlID string   `json:"remoteControlId,omitempty"`
 }
@@ -3047,6 +3049,9 @@ func isRetailPlayerAPIDeviceEmpty(device retailPlayerAPIDevice) bool {
 	if strings.TrimSpace(device.TimeZone) != "" {
 		return false
 	}
+	if device.Online != nil {
+		return false
+	}
 
 	return true
 }
@@ -3081,6 +3086,7 @@ func simplifyRetailPlayerDevice(device retailPlayerAPIDevice) (retailPlayerDevic
 		ChannelList:  strings.TrimSpace(device.ChannelList),
 		Organization: organization,
 		TimeZone:     strings.TrimSpace(device.TimeZone),
+		Online:       device.Online,
 	}, true
 }
 

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -1351,7 +1351,8 @@ const RetailPlayerDeviceManagement = () => {
       const isSelected = selectedIds.has(node.id)
       const rowKey = node.treeKey || node.id
       const channelCount = channelCountsByDeviceId?.[node.id]
-      const isOnline = deviceStatusMap.get(node.id) ?? null
+      const isOnline =
+        typeof node.online === 'boolean' ? node.online : deviceStatusMap.get(node.id) ?? null
       return (
         <RetailPlayerDeviceRow
           key={`device-row-${rowKey}`}

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -104,6 +104,12 @@ const baseDeviceShape = (device, existing) => {
       : typeof existing?.isLocked === 'boolean'
         ? existing.isLocked
         : false
+  const normalizedIsOnline =
+    typeof device?.online === 'boolean'
+      ? device.online
+      : typeof existing?.online === 'boolean'
+        ? existing.online
+        : undefined
 
   const existingFolderIds = normalizeFolderIds(
     existing?.folderIds ?? existing?.folderId,
@@ -130,6 +136,7 @@ const baseDeviceShape = (device, existing) => {
     timeZone: normalizedTimeZone || '',
     remoteControlId: normalizedRemoteControlId || '',
     isLocked: normalizedIsLocked,
+    ...(typeof normalizedIsOnline === 'boolean' ? { online: normalizedIsOnline } : {}),
     folderIds,
     folderId: primaryFolderId,
     source: existing?.source === 'local' ? 'local' : 'remote',


### PR DESCRIPTION
### Motivation
- Accept and preserve the `online` boolean from the Retail Player API so the server model and UI can reflect realtime device connectivity.
- Ensure the device tree nodes produced in the UI store include the `online` flag so list icons can prefer the API-provided status over cached state.

### Description
- Server: added `Online *bool` to `retailPlayerAPIDevice` and `Online *bool` to the simplified `retailPlayerDevice`, updated `isRetailPlayerAPIDeviceEmpty` to treat a non-nil `Online` as non-empty, and propagated `device.Online` in `simplifyRetailPlayerDevice` (`server/nativeapi/retail_player.go`).
- UI store: preserved the `online` value when normalizing devices in `baseDeviceShape` by computing `normalizedIsOnline` and including `online` on the returned device object when it's a boolean (`ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx`).
- UI list: prefer `node.online` when it is a boolean and otherwise fall back to the `deviceStatusMap` cached value when computing `isOnline` for rows (`ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx`).

### Testing
- Attempted a Playwright UI snapshot of `#/retailplayer/devices`, but the run failed with `net::ERR_EMPTY_RESPONSE` and no screenshot was produced.
- No other automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985fa5ee48c83228111f751a3ffc80d)