### PR TITLE
Fix retail player realtime updates

### DIFF
--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -188,6 +188,7 @@ type retailPlayerAPIDevice struct {
 	ChannelList  string `json:"channelList"`
 	MacAddress   string `json:"macAddress"`
 	TimeZone     string `json:"timeZone"`
+	Online       *bool  `json:"online"`
 }
 
 type retailPlayerAPIResponse struct {
@@ -210,6 +211,7 @@ type retailPlayerDevice struct {
 	ChannelList     string   `json:"channelList"`
 	Organization    string   `json:"organization"`
 	TimeZone        string   `json:"timeZone,omitempty"`
+	Online          *bool    `json:"online,omitempty"`
 	FolderIDs       []string `json:"folderIds,omitempty"`
 	RemoteControlID string   `json:"remoteControlId,omitempty"`
 }
@@ -3047,6 +3049,9 @@ func isRetailPlayerAPIDeviceEmpty(device retailPlayerAPIDevice) bool {
 	if strings.TrimSpace(device.TimeZone) != "" {
 		return false
 	}
+	if device.Online != nil {
+		return false
+	}
 
 	return true
 }
@@ -3081,6 +3086,7 @@ func simplifyRetailPlayerDevice(device retailPlayerAPIDevice) (retailPlayerDevic
 		ChannelList:  strings.TrimSpace(device.ChannelList),
 		Organization: organization,
 		TimeZone:     strings.TrimSpace(device.TimeZone),
+		Online:       device.Online,
 	}, true
 }
 

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -18,7 +18,7 @@ import SpeakerGroupIcon from '@material-ui/icons/SpeakerGroup'
 import ChevronRightIcon from '@material-ui/icons/ChevronRight'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import FolderIcon from '@material-ui/icons/Folder'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 import { BiCog } from 'react-icons/bi'
 import SubMenu from './SubMenu'
 import { humanize, pluralize } from 'inflection'
@@ -313,6 +313,7 @@ const Menu = ({ dense = false }) => {
 
   const [openFolders, setOpenFolders] = useState({})
   const assignDeviceToFolder = useAssignRetailPlayerDeviceToFolder()
+  const location = useLocation()
 
   const handleDeviceDrop = useCallback(
     async (deviceId, folderId) => {
@@ -339,8 +340,10 @@ const Menu = ({ dense = false }) => {
   }, [])
 
   const goToRetailPlayerSettings = useCallback(() => {
-    history.push('/retail-player/devices')
-  }, [history])
+    if (location.pathname !== '/retail-player/devices') {
+      history.push('/retail-player/devices')
+    }
+  }, [history, location.pathname])
 
   const renderRetailPlayerNodes = useCallback(
     (nodes, depth = 0) =>

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -1351,7 +1351,8 @@ const RetailPlayerDeviceManagement = () => {
       const isSelected = selectedIds.has(node.id)
       const rowKey = node.treeKey || node.id
       const channelCount = channelCountsByDeviceId?.[node.id]
-      const isOnline = deviceStatusMap.get(node.id) ?? null
+      const isOnline =
+        typeof node.online === 'boolean' ? node.online : deviceStatusMap.get(node.id) ?? null
       return (
         <RetailPlayerDeviceRow
           key={`device-row-${rowKey}`}

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -104,6 +104,12 @@ const baseDeviceShape = (device, existing) => {
       : typeof existing?.isLocked === 'boolean'
         ? existing.isLocked
         : false
+  const normalizedIsOnline =
+    typeof device?.online === 'boolean'
+      ? device.online
+      : typeof existing?.online === 'boolean'
+        ? existing.online
+        : undefined
 
   const existingFolderIds = normalizeFolderIds(
     existing?.folderIds ?? existing?.folderId,
@@ -130,6 +136,7 @@ const baseDeviceShape = (device, existing) => {
     timeZone: normalizedTimeZone || '',
     remoteControlId: normalizedRemoteControlId || '',
     isLocked: normalizedIsLocked,
+    ...(typeof normalizedIsOnline === 'boolean' ? { online: normalizedIsOnline } : {}),
     folderIds,
     folderId: primaryFolderId,
     source: existing?.source === 'local' ? 'local' : 'remote',

--- a/ui/src/retailPlayer/useRemoteControlSocket.js
+++ b/ui/src/retailPlayer/useRemoteControlSocket.js
@@ -40,30 +40,49 @@ const useRemoteControlSocket = (deviceUUID) => {
       cleanupSocket()
       setIsConnected(false)
       setLastMessage(null)
+      setConnectionError(null)
       return undefined
     }
 
+    let isActive = true
     const socket = new WebSocket(socketUrl)
     socketRef.current = socket
 
     socket.onopen = () => {
+      if (!isActive) {
+        return
+      }
       setIsConnected(true)
       setConnectionError(null)
     }
 
     socket.onmessage = (event) => {
+      if (!isActive) {
+        return
+      }
       setLastMessage(event.data)
     }
 
     socket.onerror = () => {
+      if (!isActive) {
+        return
+      }
       setConnectionError(new Error('Remote control socket error'))
     }
 
     socket.onclose = () => {
+      if (!isActive) {
+        return
+      }
       setIsConnected(false)
     }
 
     return () => {
+      isActive = false
+      socket.onopen = null
+      socket.onmessage = null
+      socket.onerror = null
+      socket.onclose = null
       cleanupSocket()
     }
   }, [cleanupSocket, socketUrl])

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -1040,37 +1040,49 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
       })
       setHasRealtimeStatus(true)
 
-      if (payloadChannels) {
-        setChannelState({
-          data: mapChannelListResponse({ channels: payloadChannels }, channelState.data),
-          error: null,
-          isLoading: false,
-          fetchedAt: new Date(),
-        })
-      } else if (channelState.isLoading) {
-        setChannelState((previous) => ({
-          ...previous,
-          isLoading: false,
-          error: null,
-        }))
-      }
+      setChannelState((previous) => {
+        if (payloadChannels) {
+          return {
+            data: mapChannelListResponse({ channels: payloadChannels }, previous.data),
+            error: null,
+            isLoading: false,
+            fetchedAt: new Date(),
+          }
+        }
 
-      if (payloadTriggers) {
-        setTriggerState({
-          data: ensureArray(payloadTriggers),
-          error: null,
-          isLoading: false,
-          fetchedAt: new Date(),
-        })
-      } else if (triggerState.isLoading) {
-        setTriggerState((previous) => ({
-          ...previous,
-          isLoading: false,
-          error: null,
-        }))
-      }
+        if (previous.isLoading) {
+          return {
+            ...previous,
+            isLoading: false,
+            error: null,
+          }
+        }
+
+        return previous
+      })
+
+      setTriggerState((previous) => {
+        if (payloadTriggers) {
+          return {
+            data: ensureArray(payloadTriggers),
+            error: null,
+            isLoading: false,
+            fetchedAt: new Date(),
+          }
+        }
+
+        if (previous.isLoading) {
+          return {
+            ...previous,
+            isLoading: false,
+            error: null,
+          }
+        }
+
+        return previous
+      })
     },
-    [channelState.data, channelState.isLoading, remoteControlDeviceId, triggerState.isLoading],
+    [remoteControlDeviceId],
   )
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Prevent console errors and stale updates caused by websocket callbacks running after the socket has been cleaned up.
- Stabilize realtime payload handling to avoid unnecessary re-renders / update loops when channel or trigger lists change.
- Avoid redundant navigation pushes to the retail player settings route that can trigger warnings.

### Description
- Guard websocket callbacks and reset connection state in `ui/src/retailPlayer/useRemoteControlSocket.js` by adding an `isActive` flag, nulling handlers on cleanup, and clearing `connectionError` when no `socketUrl` is present.
- Replace direct `setChannelState` / `setTriggerState` calls with functional updates in `ui/src/retailPlayer/useRetailPlayerDeviceStatus.js` to use the previous state, avoid stale closures, and reduce effect dependencies to `remoteControlDeviceId`.
- Prevent redundant navigation in `ui/src/layout/Menu.jsx` by checking `location.pathname` before calling `history.push('/retail-player/devices')`.

### Testing
- No automated tests were executed for this change.
- Local static checks or runtime verification were not run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69861773531c8322bd9563b32e0f2d21)