### PR TITLE
Show device MAC address in Retail Player list

### DIFF
--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -84,7 +84,14 @@ func (r *retailPlayerDeviceResolver) RememberDevices(devices []retailPlayerDevic
 		addKey(makeRetailPlayerNormalizedKey(trimmedID))
 		addKey(makeRetailPlayerSlugKey(trimmedID))
 
-		candidates := []string{device.Name, device.Channel, device.ChannelList, device.Organization}
+		candidates := []string{
+			device.Name,
+			device.Channel,
+			device.ChannelName,
+			device.ChannelList,
+			device.Organization,
+			device.MacAddress,
+		}
 		for _, candidate := range candidates {
 			trimmed := strings.TrimSpace(candidate)
 			if trimmed == "" {
@@ -178,17 +185,19 @@ func normalizeRetailPlayerIdentifier(value string) string {
 }
 
 type retailPlayerAPIDevice struct {
-	Ordinal      *int   `json:"ordinal"`
-	ID           string `json:"id"`
-	Name         string `json:"name"`
-	Location     string `json:"location"`
-	OrgUnit      string `json:"orgUnit"`
-	Organization string `json:"organization"`
-	Channel      string `json:"channel"`
-	ChannelList  string `json:"channelList"`
-	MacAddress   string `json:"macAddress"`
-	TimeZone     string `json:"timeZone"`
-	Online       *bool  `json:"online"`
+	Ordinal         *int   `json:"ordinal"`
+	ID              string `json:"id"`
+	Name            string `json:"name"`
+	Location        string `json:"location"`
+	OrgUnit         string `json:"orgUnit"`
+	Organization    string `json:"organization"`
+	Channel         string `json:"channel"`
+	ChannelName     string `json:"channelName"`
+	ChannelList     string `json:"channelList"`
+	ChannelListName string `json:"channelListName"`
+	MacAddress      string `json:"macAddress"`
+	TimeZone        string `json:"timeZone"`
+	Online          *bool  `json:"online"`
 }
 
 type retailPlayerAPIResponse struct {
@@ -208,8 +217,10 @@ type retailPlayerDevice struct {
 	OrganizationID  string   `json:"organizationId,omitempty"`
 	OrganisationID  string   `json:"organisationid,omitempty"`
 	Channel         string   `json:"channel"`
+	ChannelName     string   `json:"channelName,omitempty"`
 	ChannelList     string   `json:"channelList"`
 	Organization    string   `json:"organization"`
+	MacAddress      string   `json:"macAddress,omitempty"`
 	TimeZone        string   `json:"timeZone,omitempty"`
 	Online          *bool    `json:"online,omitempty"`
 	FolderIDs       []string `json:"folderIds,omitempty"`
@@ -3043,7 +3054,13 @@ func isRetailPlayerAPIDeviceEmpty(device retailPlayerAPIDevice) bool {
 	if strings.TrimSpace(device.Channel) != "" {
 		return false
 	}
+	if strings.TrimSpace(device.ChannelName) != "" {
+		return false
+	}
 	if strings.TrimSpace(device.ChannelList) != "" {
+		return false
+	}
+	if strings.TrimSpace(device.ChannelListName) != "" {
 		return false
 	}
 	if strings.TrimSpace(device.TimeZone) != "" {
@@ -3078,12 +3095,18 @@ func simplifyRetailPlayerDevice(device retailPlayerAPIDevice) (retailPlayerDevic
 		strings.TrimSpace(device.OrgUnit),
 		strings.TrimSpace(device.Location),
 	)
+	channelName := strings.TrimSpace(device.ChannelName)
+	if channelName == "" {
+		channelName = strings.TrimSpace(device.Channel)
+	}
 
 	return retailPlayerDevice{
 		ID:           id,
 		Name:         name,
 		Channel:      strings.TrimSpace(device.Channel),
+		ChannelName:  channelName,
 		ChannelList:  strings.TrimSpace(device.ChannelList),
+		MacAddress:   strings.TrimSpace(device.MacAddress),
 		Organization: organization,
 		TimeZone:     strings.TrimSpace(device.TimeZone),
 		Online:       device.Online,

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -185,19 +185,18 @@ func normalizeRetailPlayerIdentifier(value string) string {
 }
 
 type retailPlayerAPIDevice struct {
-	Ordinal         *int   `json:"ordinal"`
-	ID              string `json:"id"`
-	Name            string `json:"name"`
-	Location        string `json:"location"`
-	OrgUnit         string `json:"orgUnit"`
-	Organization    string `json:"organization"`
-	Channel         string `json:"channel"`
-	ChannelName     string `json:"channelName"`
-	ChannelList     string `json:"channelList"`
-	ChannelListName string `json:"channelListName"`
-	MacAddress      string `json:"macAddress"`
-	TimeZone        string `json:"timeZone"`
-	Online          *bool  `json:"online"`
+	Ordinal      *int   `json:"ordinal"`
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Location     string `json:"location"`
+	OrgUnit      string `json:"orgUnit"`
+	Organization string `json:"organization"`
+	Channel      string `json:"channel"`
+	ChannelName  string `json:"channelName"`
+	ChannelList  string `json:"channelList"`
+	MacAddress   string `json:"macAddress"`
+	TimeZone     string `json:"timeZone"`
+	Online       *bool  `json:"online"`
 }
 
 type retailPlayerAPIResponse struct {
@@ -3058,9 +3057,6 @@ func isRetailPlayerAPIDeviceEmpty(device retailPlayerAPIDevice) bool {
 		return false
 	}
 	if strings.TrimSpace(device.ChannelList) != "" {
-		return false
-	}
-	if strings.TrimSpace(device.ChannelListName) != "" {
 		return false
 	}
 	if strings.TrimSpace(device.TimeZone) != "" {

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -656,7 +656,7 @@ const RetailPlayerDeviceRow = memo(
             </Typography>
           </div>
         </div>
-        <div className={classes.typeCell}>Device</div>
+        <div className={classes.typeCell}>{node.macAddress || '—'}</div>
         <div className={classes.countCell}>
           {typeof channelCount === 'number' ? channelCount : '—'}
         </div>
@@ -702,6 +702,7 @@ RetailPlayerDeviceRow.propTypes = {
   node: PropTypes.shape({
     id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
+    macAddress: PropTypes.string,
   }).isRequired,
   isSelected: PropTypes.bool.isRequired,
   classes: PropTypes.object.isRequired,
@@ -1496,7 +1497,7 @@ const RetailPlayerDeviceManagement = () => {
             />
           </div>
           <span>Name</span>
-          <span>Type</span>
+          <span>Mac Address</span>
           <span>Devices / Channels</span>
           <span>QR ID</span>
           <span className={classes.headerActions}>Edit</span>

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -275,6 +275,11 @@ const useStyles = makeStyles((theme) => {
     fontSize: theme.typography.pxToRem(14),
     color: theme.palette.text.secondary,
   },
+  macAddressCell: {
+    fontSize: theme.typography.pxToRem(12),
+    color: theme.palette.text.secondary,
+    fontVariantNumeric: 'tabular-nums',
+  },
   countCell: {
     fontSize: theme.typography.pxToRem(14),
     color: theme.palette.text.secondary,
@@ -620,6 +625,9 @@ const RetailPlayerDeviceRow = memo(
     isLocked,
     isOnline,
   }) => {
+    const formattedMacAddress = node.macAddress
+      ? node.macAddress.replace(/-/g, ':').toLowerCase()
+      : '—'
     const { dragRef, isDragging } = useRetailPlayerDeviceDrag({
       deviceId: node.id,
       deviceName: node.name,
@@ -664,7 +672,7 @@ const RetailPlayerDeviceRow = memo(
             </Typography>
           </div>
         </div>
-        <div className={classes.typeCell}>{node.macAddress || '—'}</div>
+        <div className={classes.macAddressCell}>{formattedMacAddress}</div>
         <div className={classes.countCell}>
           {typeof channelCount === 'number' ? channelCount : '—'}
         </div>

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -166,7 +166,7 @@ const useStyles = makeStyles((theme) => {
   listHeader: {
     display: 'grid',
     gridTemplateColumns:
-      '64px minmax(220px, 2fr) minmax(140px, 1fr) minmax(140px, 1fr) minmax(200px, 1.2fr) minmax(96px, 0.8fr)',
+      '64px minmax(220px, 2fr) minmax(140px, 1fr) minmax(140px, 1fr) minmax(200px, 1.2fr) minmax(200px, 1.2fr) minmax(96px, 0.8fr)',
     paddingTop: theme.spacing(0),
     paddingBottom: theme.spacing(0),
     paddingLeft: theme.spacing(1.7),
@@ -181,7 +181,7 @@ const useStyles = makeStyles((theme) => {
     gap: theme.spacing(1),
     [theme.breakpoints.down('sm')]: {
       gridTemplateColumns:
-        '56px minmax(180px, 2fr) minmax(120px, 1fr) minmax(120px, 1fr) minmax(180px, 1.1fr) 72px',
+        '56px minmax(180px, 2fr) minmax(120px, 1fr) minmax(120px, 1fr) minmax(160px, 1.1fr) minmax(160px, 1.1fr) 72px',
       fontSize: theme.typography.pxToRem(11),
       letterSpacing: 0.6,
     },
@@ -201,7 +201,7 @@ const useStyles = makeStyles((theme) => {
   row: {
     display: 'grid',
     gridTemplateColumns:
-      '64px minmax(220px, 2fr) minmax(140px, 1fr) minmax(140px, 1fr) minmax(200px, 1.2fr) minmax(96px, 0.8fr)',
+      '64px minmax(220px, 2fr) minmax(140px, 1fr) minmax(140px, 1fr) minmax(200px, 1.2fr) minmax(200px, 1.2fr) minmax(96px, 0.8fr)',
     alignItems: 'center',
     padding: '1px 2px',
     borderTop: `1px solid ${theme.palette.divider}`,
@@ -218,7 +218,7 @@ const useStyles = makeStyles((theme) => {
     },
     [theme.breakpoints.down('sm')]: {
       gridTemplateColumns:
-        '56px minmax(180px, 2fr) minmax(120px, 1fr) minmax(120px, 1fr) minmax(180px, 1.1fr) 72px',
+        '56px minmax(180px, 2fr) minmax(120px, 1fr) minmax(120px, 1fr) minmax(160px, 1.1fr) minmax(160px, 1.1fr) 72px',
     },
   },
 
@@ -279,6 +279,13 @@ const useStyles = makeStyles((theme) => {
     fontSize: theme.typography.pxToRem(14),
     color: theme.palette.text.secondary,
     textAlign: 'center',
+  },
+  channelNameCell: {
+    fontSize: theme.typography.pxToRem(14),
+    color: theme.palette.text.secondary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
   },
   remoteControlCell: {
     fontSize: theme.typography.pxToRem(14),
@@ -558,8 +565,9 @@ const RetailPlayerFolderRow = memo(
             </Typography>
           </div>
         </div>
-        <div className={classes.typeCell}>Folder</div>
+        <div className={classes.typeCell}>—</div>
         <div className={classes.countCell}>{deviceCount}</div>
+        <div className={classes.channelNameCell}>—</div>
         <div className={classes.remoteControlCell}>—</div>
         <div className={classes.actionsCell}>
           <Tooltip title="Edit folder">
@@ -660,6 +668,9 @@ const RetailPlayerDeviceRow = memo(
         <div className={classes.countCell}>
           {typeof channelCount === 'number' ? channelCount : '—'}
         </div>
+        <div className={classes.channelNameCell}>
+          {node.channelName || node.channel || '—'}
+        </div>
         <div className={classes.remoteControlCell}>
           {node.remoteControlId ? node.remoteControlId : '—'}
         </div>
@@ -702,6 +713,8 @@ RetailPlayerDeviceRow.propTypes = {
   node: PropTypes.shape({
     id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
+    channelName: PropTypes.string,
+    channel: PropTypes.string,
     macAddress: PropTypes.string,
   }).isRequired,
   isSelected: PropTypes.bool.isRequired,
@@ -1499,6 +1512,7 @@ const RetailPlayerDeviceManagement = () => {
           <span>Name</span>
           <span>Mac Address</span>
           <span>Devices / Channels</span>
+          <span>Channel Name</span>
           <span>QR ID</span>
           <span className={classes.headerActions}>Edit</span>
         </div>

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -96,7 +96,12 @@ const baseDeviceShape = (device, existing) => {
   const normalizedChannel = normalizeValue(device?.channel)
   const normalizedChannelList = normalizeValue(device?.channelList)
   const normalizedMacAddress = normalizeValue(
-    device?.macAddress || device?.mac_address || device?.macaddress,
+    device?.macAddress ||
+      device?.mac_address ||
+      device?.macaddress ||
+      device?.status?.macAddress ||
+      device?.status?.mac_address ||
+      device?.status?.macaddress,
   )
   const normalizedOrganization = normalizeValue(device?.organization)
   const normalizedTimeZone = normalizeValue(device?.timeZone)

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -95,6 +95,9 @@ const baseDeviceShape = (device, existing) => {
   const normalizedSlug = normalizeValue(device?.slug)
   const normalizedChannel = normalizeValue(device?.channel)
   const normalizedChannelList = normalizeValue(device?.channelList)
+  const normalizedMacAddress = normalizeValue(
+    device?.macAddress || device?.mac_address || device?.macaddress,
+  )
   const normalizedOrganization = normalizeValue(device?.organization)
   const normalizedTimeZone = normalizeValue(device?.timeZone)
   const normalizedRemoteControlId = normalizeValue(device?.remoteControlId)
@@ -132,6 +135,7 @@ const baseDeviceShape = (device, existing) => {
     slugKey: deviceSlugKey(slug),
     channel: normalizedChannel || '',
     channelList: normalizedChannelList || '',
+    macAddress: normalizedMacAddress || existing?.macAddress || '',
     organization: normalizedOrganization || '',
     timeZone: normalizedTimeZone || '',
     remoteControlId: normalizedRemoteControlId || '',

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -95,13 +95,20 @@ const baseDeviceShape = (device, existing) => {
   const normalizedSlug = normalizeValue(device?.slug)
   const normalizedChannel = normalizeValue(device?.channel)
   const normalizedChannelList = normalizeValue(device?.channelList)
+  const normalizedChannelName = normalizeValue(
+    device?.channelName || device?.channel_name,
+  )
   const normalizedMacAddress = normalizeValue(
     device?.macAddress ||
       device?.mac_address ||
       device?.macaddress ||
+      device?.macAdress ||
+      device?.mac_adress ||
       device?.status?.macAddress ||
       device?.status?.mac_address ||
-      device?.status?.macaddress,
+      device?.status?.macaddress ||
+      device?.status?.macAdress ||
+      device?.status?.mac_adress,
   )
   const normalizedOrganization = normalizeValue(device?.organization)
   const normalizedTimeZone = normalizeValue(device?.timeZone)
@@ -140,6 +147,7 @@ const baseDeviceShape = (device, existing) => {
     slugKey: deviceSlugKey(slug),
     channel: normalizedChannel || '',
     channelList: normalizedChannelList || '',
+    channelName: normalizedChannelName || normalizedChannel || '',
     macAddress: normalizedMacAddress || existing?.macAddress || '',
     organization: normalizedOrganization || '',
     timeZone: normalizedTimeZone || '',

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -95,21 +95,8 @@ const baseDeviceShape = (device, existing) => {
   const normalizedSlug = normalizeValue(device?.slug)
   const normalizedChannel = normalizeValue(device?.channel)
   const normalizedChannelList = normalizeValue(device?.channelList)
-  const normalizedChannelName = normalizeValue(
-    device?.channelName || device?.channel_name,
-  )
-  const normalizedMacAddress = normalizeValue(
-    device?.macAddress ||
-      device?.mac_address ||
-      device?.macaddress ||
-      device?.macAdress ||
-      device?.mac_adress ||
-      device?.status?.macAddress ||
-      device?.status?.mac_address ||
-      device?.status?.macaddress ||
-      device?.status?.macAdress ||
-      device?.status?.mac_adress,
-  )
+  const normalizedChannelName = normalizeValue(device?.channelName)
+  const normalizedMacAddress = normalizeValue(device?.macAddress)
   const normalizedOrganization = normalizeValue(device?.organization)
   const normalizedTimeZone = normalizeValue(device?.timeZone)
   const normalizedRemoteControlId = normalizeValue(device?.remoteControlId)

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -23,18 +23,7 @@ const buildDeviceSlug = (device) => {
     return id
   }
 
-  const macAddress = normalizeValue(
-    device.macAddress ||
-      device.mac_address ||
-      device.macaddress ||
-      device.macAdress ||
-      device.mac_adress ||
-      device.status?.macAddress ||
-      device.status?.mac_address ||
-      device.status?.macaddress ||
-      device.status?.macAdress ||
-      device.status?.mac_adress,
-  )
+  const macAddress = normalizeValue(device.macAddress)
   if (macAddress) {
     return macAddress
   }
@@ -65,18 +54,7 @@ const mapRetailPlayerDevice = (device) => {
   const rawId = normalizeValue(device.id)
   const fallbackId =
     rawId ||
-    normalizeValue(
-      device.macAddress ||
-        device.mac_address ||
-        device.macaddress ||
-        device.macAdress ||
-        device.mac_adress ||
-        device.status?.macAddress ||
-        device.status?.mac_address ||
-        device.status?.macaddress ||
-        device.status?.macAdress ||
-        device.status?.mac_adress,
-    ) ||
+    normalizeValue(device.macAddress) ||
     normalizeValue(device.ordinal)
 
   if (!fallbackId) {
@@ -84,19 +62,8 @@ const mapRetailPlayerDevice = (device) => {
   }
 
   const slug = buildDeviceSlug(device) || fallbackId
-  const macAddress = normalizeValue(
-    device.macAddress ||
-      device.mac_address ||
-      device.macaddress ||
-      device.macAdress ||
-      device.mac_adress ||
-      device.status?.macAddress ||
-      device.status?.mac_address ||
-      device.status?.macaddress ||
-      device.status?.macAdress ||
-      device.status?.mac_adress,
-  )
-  const channelName = normalizeValue(device.channelName || device.channel_name)
+  const macAddress = normalizeValue(device.macAddress)
+  const channelName = normalizeValue(device.channelName)
   const name = normalizeValue(device.name) || fallbackId
   const folderIds = Array.isArray(device.folderIds)
     ? device.folderIds

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -23,7 +23,9 @@ const buildDeviceSlug = (device) => {
     return id
   }
 
-  const macAddress = normalizeValue(device.macAddress)
+  const macAddress = normalizeValue(
+    device.macAddress || device.mac_address || device.macaddress,
+  )
   if (macAddress) {
     return macAddress
   }
@@ -54,7 +56,7 @@ const mapRetailPlayerDevice = (device) => {
   const rawId = normalizeValue(device.id)
   const fallbackId =
     rawId ||
-    normalizeValue(device.macAddress || device.mac_address) ||
+    normalizeValue(device.macAddress || device.mac_address || device.macaddress) ||
     normalizeValue(device.ordinal)
 
   if (!fallbackId) {
@@ -62,6 +64,9 @@ const mapRetailPlayerDevice = (device) => {
   }
 
   const slug = buildDeviceSlug(device) || fallbackId
+  const macAddress = normalizeValue(
+    device.macAddress || device.mac_address || device.macaddress,
+  )
   const name = normalizeValue(device.name) || fallbackId
   const folderIds = Array.isArray(device.folderIds)
     ? device.folderIds
@@ -90,6 +95,7 @@ const mapRetailPlayerDevice = (device) => {
     slugKey: deviceSlugKey(slug),
     channel: normalizeValue(device.channel),
     channelList: normalizeValue(device.channelList),
+    macAddress,
     organization:
       normalizeValue(device.organization) ||
       normalizeValue(device.orgUnit || device.org_unit) ||

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -24,7 +24,12 @@ const buildDeviceSlug = (device) => {
   }
 
   const macAddress = normalizeValue(
-    device.macAddress || device.mac_address || device.macaddress,
+    device.macAddress ||
+      device.mac_address ||
+      device.macaddress ||
+      device.status?.macAddress ||
+      device.status?.mac_address ||
+      device.status?.macaddress,
   )
   if (macAddress) {
     return macAddress
@@ -56,7 +61,14 @@ const mapRetailPlayerDevice = (device) => {
   const rawId = normalizeValue(device.id)
   const fallbackId =
     rawId ||
-    normalizeValue(device.macAddress || device.mac_address || device.macaddress) ||
+    normalizeValue(
+      device.macAddress ||
+        device.mac_address ||
+        device.macaddress ||
+        device.status?.macAddress ||
+        device.status?.mac_address ||
+        device.status?.macaddress,
+    ) ||
     normalizeValue(device.ordinal)
 
   if (!fallbackId) {
@@ -65,7 +77,12 @@ const mapRetailPlayerDevice = (device) => {
 
   const slug = buildDeviceSlug(device) || fallbackId
   const macAddress = normalizeValue(
-    device.macAddress || device.mac_address || device.macaddress,
+    device.macAddress ||
+      device.mac_address ||
+      device.macaddress ||
+      device.status?.macAddress ||
+      device.status?.mac_address ||
+      device.status?.macaddress,
   )
   const name = normalizeValue(device.name) || fallbackId
   const folderIds = Array.isArray(device.folderIds)

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -27,9 +27,13 @@ const buildDeviceSlug = (device) => {
     device.macAddress ||
       device.mac_address ||
       device.macaddress ||
+      device.macAdress ||
+      device.mac_adress ||
       device.status?.macAddress ||
       device.status?.mac_address ||
-      device.status?.macaddress,
+      device.status?.macaddress ||
+      device.status?.macAdress ||
+      device.status?.mac_adress,
   )
   if (macAddress) {
     return macAddress
@@ -65,9 +69,13 @@ const mapRetailPlayerDevice = (device) => {
       device.macAddress ||
         device.mac_address ||
         device.macaddress ||
+        device.macAdress ||
+        device.mac_adress ||
         device.status?.macAddress ||
         device.status?.mac_address ||
-        device.status?.macaddress,
+        device.status?.macaddress ||
+        device.status?.macAdress ||
+        device.status?.mac_adress,
     ) ||
     normalizeValue(device.ordinal)
 
@@ -80,10 +88,15 @@ const mapRetailPlayerDevice = (device) => {
     device.macAddress ||
       device.mac_address ||
       device.macaddress ||
+      device.macAdress ||
+      device.mac_adress ||
       device.status?.macAddress ||
       device.status?.mac_address ||
-      device.status?.macaddress,
+      device.status?.macaddress ||
+      device.status?.macAdress ||
+      device.status?.mac_adress,
   )
+  const channelName = normalizeValue(device.channelName || device.channel_name)
   const name = normalizeValue(device.name) || fallbackId
   const folderIds = Array.isArray(device.folderIds)
     ? device.folderIds
@@ -111,6 +124,7 @@ const mapRetailPlayerDevice = (device) => {
     slug,
     slugKey: deviceSlugKey(slug),
     channel: normalizeValue(device.channel),
+    channelName: channelName || normalizeValue(device.channel),
     channelList: normalizeValue(device.channelList),
     macAddress,
     organization:

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -185,12 +185,24 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
     payloadDevice?.macAddress ||
       payloadDevice?.mac_address ||
       payloadDevice?.macaddress ||
+      payloadDevice?.macAdress ||
+      payloadDevice?.mac_adress ||
       payload?.macAddress ||
       payload?.mac_address ||
       payload?.macaddress ||
+      payload?.macAdress ||
+      payload?.mac_adress ||
       payload?.status?.macAddress ||
       payload?.status?.mac_address ||
-      payload?.status?.macaddress,
+      payload?.status?.macaddress ||
+      payload?.status?.macAdress ||
+      payload?.status?.mac_adress,
+  )
+  const channelName = normalizeValue(
+    payloadDevice?.channelName ||
+      payloadDevice?.channel_name ||
+      payload?.channelName ||
+      payload?.channel_name,
   )
 
   const payloadArtwork =
@@ -645,6 +657,7 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
   return {
     ...baseDevice,
     macAddress: macAddress || baseDevice.macAddress || '',
+    channelName: channelName || baseDevice.channelName || baseDevice.channel || '',
     isConnected,
     hasSignal,
     isMuted,

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -181,29 +181,8 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
   const streamMetadata = ensureArray(payload?.streamMetadata).filter(
     (item) => item && typeof item === 'object',
   )
-  const macAddress = normalizeValue(
-    payloadDevice?.macAddress ||
-      payloadDevice?.mac_address ||
-      payloadDevice?.macaddress ||
-      payloadDevice?.macAdress ||
-      payloadDevice?.mac_adress ||
-      payload?.macAddress ||
-      payload?.mac_address ||
-      payload?.macaddress ||
-      payload?.macAdress ||
-      payload?.mac_adress ||
-      payload?.status?.macAddress ||
-      payload?.status?.mac_address ||
-      payload?.status?.macaddress ||
-      payload?.status?.macAdress ||
-      payload?.status?.mac_adress,
-  )
-  const channelName = normalizeValue(
-    payloadDevice?.channelName ||
-      payloadDevice?.channel_name ||
-      payload?.channelName ||
-      payload?.channel_name,
-  )
+  const macAddress = normalizeValue(payloadDevice?.macAddress)
+  const channelName = normalizeValue(payloadDevice?.channelName)
 
   const payloadArtwork =
     payload && typeof payload === 'object' ? payload.artwork || {} : {}

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -184,7 +184,13 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
   const macAddress = normalizeValue(
     payloadDevice?.macAddress ||
       payloadDevice?.mac_address ||
-      payloadDevice?.macaddress,
+      payloadDevice?.macaddress ||
+      payload?.macAddress ||
+      payload?.mac_address ||
+      payload?.macaddress ||
+      payload?.status?.macAddress ||
+      payload?.status?.mac_address ||
+      payload?.status?.macaddress,
   )
 
   const payloadArtwork =

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -181,6 +181,11 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
   const streamMetadata = ensureArray(payload?.streamMetadata).filter(
     (item) => item && typeof item === 'object',
   )
+  const macAddress = normalizeValue(
+    payloadDevice?.macAddress ||
+      payloadDevice?.mac_address ||
+      payloadDevice?.macaddress,
+  )
 
   const payloadArtwork =
     payload && typeof payload === 'object' ? payload.artwork || {} : {}
@@ -633,6 +638,7 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
 
   return {
     ...baseDevice,
+    macAddress: macAddress || baseDevice.macAddress || '',
     isConnected,
     hasSignal,
     isMuted,


### PR DESCRIPTION
### Motivation
- The Retail Player API returns a `macaddress`/`mac_address`/`macAddress` field alongside other device fields and this value should be surfaced in the UI and persisted in the device state.

### Description
- Accept and normalize `macAddress`, `mac_address`, or `macaddress` in `mapRetailPlayerDevice` and `buildDeviceSlug` inside `ui/src/retailPlayer/deviceUtils.js`. 
- Add a `macAddress` property to the base device shape in `ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx` so mac addresses are stored in device state. 
- Replace the old “Type” column with a “Mac Address” column and render `node.macAddress` in rows in `ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx`, and update `PropTypes` accordingly. 

### Testing
- A Playwright screenshot attempt against `http://localhost:4533/#/retail-player/devices` was run but failed with `net::ERR_EMPTY_RESPONSE`, so UI verification was not completed. 
- No other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698743234f808322b8efbb077a9d426c)