### PR TITLE
Add folder lock support for Retail Player

### DIFF
--- a/db/migrations/20250918120000_add_retail_player_folder_lock.go
+++ b/db/migrations/20250918120000_add_retail_player_folder_lock.go
@@ -1,0 +1,28 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upAddRetailPlayerFolderLock, downAddRetailPlayerFolderLock)
+}
+
+func upAddRetailPlayerFolderLock(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+        ALTER TABLE retail_player_folder
+        ADD COLUMN is_locked BOOLEAN NOT NULL DEFAULT 0;
+    `)
+	return err
+}
+
+func downAddRetailPlayerFolderLock(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+        ALTER TABLE retail_player_folder
+        DROP COLUMN is_locked;
+    `)
+	return err
+}

--- a/model/retail_player_folder.go
+++ b/model/retail_player_folder.go
@@ -9,6 +9,7 @@ type RetailPlayerFolder struct {
 	ID        string    `db:"id" json:"id"`
 	Name      string    `db:"name" json:"name"`
 	ParentID  *string   `db:"parent_id" json:"parentId,omitempty"`
+	IsLocked  bool      `db:"is_locked" json:"isLocked"`
 	CreatedAt time.Time `db:"created_at" json:"createdAt"`
 	UpdatedAt time.Time `db:"updated_at" json:"updatedAt"`
 }
@@ -23,7 +24,9 @@ type RetailPlayerDeviceFolder struct {
 type RetailPlayerFolderRepository interface {
 	List(ctx context.Context) ([]RetailPlayerFolder, error)
 	Upsert(ctx context.Context, folder RetailPlayerFolder) (RetailPlayerFolder, error)
+	FindByID(ctx context.Context, id string) (RetailPlayerFolder, error)
 	DeleteMany(ctx context.Context, ids []string) error
 	Assignments(ctx context.Context) ([]RetailPlayerDeviceFolder, error)
 	ReplaceDeviceAssignments(ctx context.Context, deviceID string, folderIDs []string) error
+	SetLocked(ctx context.Context, folderID string, isLocked bool) error
 }

--- a/persistence/retail_player_folder_repository.go
+++ b/persistence/retail_player_folder_repository.go
@@ -25,7 +25,7 @@ func NewRetailPlayerFolderRepository(ctx context.Context, db dbx.Builder) model.
 }
 
 func (r retailPlayerFolderRepository) List(ctx context.Context) ([]model.RetailPlayerFolder, error) {
-	sel := Select("id", "name", "parent_id", "created_at", "updated_at").
+	sel := Select("id", "name", "parent_id", "is_locked", "created_at", "updated_at").
 		From(r.tableName).
 		OrderBy("lower(name) asc", "created_at asc")
 
@@ -70,9 +70,28 @@ func (r retailPlayerFolderRepository) Upsert(ctx context.Context, folder model.R
 		return model.RetailPlayerFolder{}, err
 	}
 
-	sel := Select("id", "name", "parent_id", "created_at", "updated_at").
+	sel := Select("id", "name", "parent_id", "is_locked", "created_at", "updated_at").
 		From(r.tableName).
 		Where(Eq{"id": id}).
+		Limit(1)
+
+	var stored model.RetailPlayerFolder
+	if err := r.queryOne(sel, &stored); err != nil {
+		return model.RetailPlayerFolder{}, err
+	}
+
+	return stored, nil
+}
+
+func (r retailPlayerFolderRepository) FindByID(ctx context.Context, id string) (model.RetailPlayerFolder, error) {
+	trimmedID := strings.TrimSpace(id)
+	if trimmedID == "" {
+		return model.RetailPlayerFolder{}, errors.New("retail player folder id is required")
+	}
+
+	sel := Select("id", "name", "parent_id", "is_locked", "created_at", "updated_at").
+		From(r.tableName).
+		Where(Eq{"id": trimmedID}).
 		Limit(1)
 
 	var stored model.RetailPlayerFolder
@@ -149,5 +168,21 @@ func (r retailPlayerFolderRepository) ReplaceDeviceAssignments(ctx context.Conte
         updated_at = excluded.updated_at`)
 
 	_, err := r.executeSQL(insert)
+	return err
+}
+
+func (r retailPlayerFolderRepository) SetLocked(ctx context.Context, folderID string, isLocked bool) error {
+	trimmedID := strings.TrimSpace(folderID)
+	if trimmedID == "" {
+		return errors.New("retail player folder id is required")
+	}
+
+	now := time.Now().UTC()
+	update := Update(r.tableName).
+		Set("is_locked", isLocked).
+		Set("updated_at", now).
+		Where(Eq{"id": trimmedID})
+
+	_, err := r.executeSQL(update)
 	return err
 }

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -239,6 +239,7 @@ type retailPlayerFolder struct {
 	ID        string    `json:"id"`
 	Name      string    `json:"name"`
 	ParentID  *string   `json:"parentId,omitempty"`
+	IsLocked  bool      `json:"isLocked"`
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`
 }
@@ -359,6 +360,7 @@ func (n *Router) addRetailPlayerPrivateRoutes(r chi.Router) {
 	r.Patch("/retailplayer/devices/{deviceID}/lock", n.handleUpdateRetailPlayerDeviceLock())
 	r.Post("/retailplayer/folders", n.handleCreateRetailPlayerFolder())
 	r.Patch("/retailplayer/folders/{folderID}", n.handleUpdateRetailPlayerFolder())
+	r.Patch("/retailplayer/folders/{folderID}/lock", n.handleUpdateRetailPlayerFolderLock())
 	r.Post("/retailplayer/folders/delete", n.handleDeleteRetailPlayerFolders())
 	r.Put("/retailplayer/devices/{deviceID}/folders", n.handleAssignRetailPlayerDeviceFolders())
 	r.Post("/retailplayer/qr", n.handleRetailPlayerSyncQR())
@@ -410,6 +412,54 @@ func (n *Router) handleUpdateRetailPlayerDeviceLock() http.HandlerFunc {
 		}
 
 		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{"data": mapRetailPlayerMappingToDevice(*mapping)})
+	}
+}
+
+func (n *Router) handleUpdateRetailPlayerFolderLock() http.HandlerFunc {
+	type lockUpdatePayload struct {
+		Locked bool `json:"locked"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		folderID := strings.TrimSpace(chi.URLParam(r, "folderID"))
+		if folderID == "" {
+			http.Error(w, "Retail player folder id is required", http.StatusBadRequest)
+			return
+		}
+
+		var payload lockUpdatePayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "Invalid retail player lock payload", http.StatusBadRequest)
+			return
+		}
+
+		repo := n.ds.RetailPlayerFolder(ctx)
+		if repo == nil {
+			http.Error(w, "Retail player folder repository not available", http.StatusInternalServerError)
+			return
+		}
+
+		if err := repo.SetLocked(ctx, folderID, payload.Locked); err != nil {
+			log.Error(ctx, "Unable to update retail player folder lock", "folderID", folderID, "err", err)
+			http.Error(w, "Unable to update retail player folder lock", http.StatusInternalServerError)
+			return
+		}
+
+		folder, err := repo.FindByID(ctx, folderID)
+		if err != nil {
+			log.Error(ctx, "Unable to load retail player folder after lock update", "folderID", folderID, "err", err)
+			http.Error(w, "Unable to load retail player folder", http.StatusInternalServerError)
+			return
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{"data": mapModelRetailPlayerFolder(folder)})
 	}
 }
 
@@ -1369,6 +1419,7 @@ func mapModelRetailPlayerFolder(folder model.RetailPlayerFolder) retailPlayerFol
 		ID:        strings.TrimSpace(folder.ID),
 		Name:      strings.TrimSpace(folder.Name),
 		ParentID:  parentID,
+		IsLocked:  folder.IsLocked,
 		CreatedAt: folder.CreatedAt,
 		UpdatedAt: folder.UpdatedAt,
 	}

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -39,6 +39,11 @@ import {
   isDeviceUnlockedForSession,
   markDeviceUnlockedForSession,
 } from './deviceLockState'
+import {
+  isFolderLocked,
+  isFolderUnlockedForSession,
+  markFolderUnlockedForSession,
+} from './folderLockState'
 
 const combineClasses = (...classNames) => classNames.filter(Boolean).join(' ')
 
@@ -941,6 +946,7 @@ const RetailPlayerDashboard = () => {
     refresh: refreshStatus,
     notFound,
     isApiEnabled,
+    folders,
     buttonTriggers,
     hasButtonTriggers,
     isTriggerListLoading,
@@ -1853,8 +1859,27 @@ const RetailPlayerDashboard = () => {
     [],
   )
 
+  const lockedFoldersForDevice = useMemo(() => {
+    if (!device || !Array.isArray(folders) || !folders.length) {
+      return []
+    }
+
+    const folderIds = new Set(device.folderIds || [])
+    if (!folderIds.size) {
+      return []
+    }
+
+    return folders.filter(
+      (folder) => folderIds.has(folder.id) && isFolderLocked(folder),
+    )
+  }, [device, folders])
+
   const isAccessBlockedByLock =
-    Boolean(device) && isDeviceLocked(device) && !isDeviceUnlockedForSession(device)
+    Boolean(device) &&
+    ((isDeviceLocked(device) && !isDeviceUnlockedForSession(device)) ||
+      lockedFoldersForDevice.some(
+        (folder) => !isFolderUnlockedForSession(folder),
+      ))
 
   const handleLockDialogBack = useCallback(() => {
     if (history.length > 1) {
@@ -1877,13 +1902,16 @@ const RetailPlayerDashboard = () => {
 
     if (lockPasswordInput === config.retailPlayerDeviceLockPassword) {
       markDeviceUnlockedForSession(device)
+      lockedFoldersForDevice.forEach((folder) => {
+        markFolderUnlockedForSession(folder)
+      })
       setLockPasswordInput('')
       setLockError('')
       return
     }
 
     setLockError('Incorrect password. Please try again.')
-  }, [device, isDevicePasswordConfigured, lockPasswordInput])
+  }, [device, isDevicePasswordConfigured, lockPasswordInput, lockedFoldersForDevice])
 
   useEffect(() => {
     if (!isAccessBlockedByLock) {

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -48,6 +48,7 @@ import {
 import buildRetailPlayerDnDStyles from './retailPlayerDnDStyles'
 import useRetailPlayerChannelCounts from './useRetailPlayerChannelCounts'
 import { isDeviceLocked } from './deviceLockState'
+import { isFolderLocked } from './folderLockState'
 
 const useStyles = makeStyles((theme) => {
   const dndStyles = buildRetailPlayerDnDStyles(theme)
@@ -513,6 +514,8 @@ const RetailPlayerFolderRow = memo(
     onKeyDown,
     onEdit,
     onDeviceDrop,
+    onToggleLock,
+    isLocked,
   }) => {
     const { dropRef, isOver, canDrop } = useRetailPlayerFolderDrop({
       folderId: node.id,
@@ -562,6 +565,22 @@ const RetailPlayerFolderRow = memo(
         <div className={classes.countCell}>{deviceCount}</div>
         <div className={classes.remoteControlCell}>—</div>
         <div className={classes.actionsCell}>
+          <Tooltip title={isLocked ? 'Unlock folder' : 'Lock folder'}>
+            <IconButton
+              size="small"
+              onClick={(event) => {
+                event.stopPropagation()
+                onToggleLock(node)
+              }}
+              aria-label={`${isLocked ? 'Unlock' : 'Lock'} folder ${node.name}`}
+            >
+              {isLocked ? (
+                <LockIcon style={{ fontSize: 15 }} className={classes.lockIconActive} />
+              ) : (
+                <LockOpenIcon style={{ fontSize: 15 }} />
+              )}
+            </IconButton>
+          </Tooltip>
           <Tooltip title="Edit folder">
             <IconButton
               size="small"
@@ -594,6 +613,12 @@ RetailPlayerFolderRow.propTypes = {
   onKeyDown: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
   onDeviceDrop: PropTypes.func.isRequired,
+  onToggleLock: PropTypes.func.isRequired,
+  isLocked: PropTypes.bool,
+}
+
+RetailPlayerFolderRow.defaultProps = {
+  isLocked: false,
 }
 
 RetailPlayerFolderRow.displayName = 'RetailPlayerFolderRow'
@@ -1190,6 +1215,20 @@ const RetailPlayerDeviceManagement = () => {
     }
   }, [updateDevice])
 
+  const handleToggleFolderLock = useCallback(async (folder) => {
+    if (!folder) {
+      return
+    }
+
+    try {
+      const nextLockedValue = !isFolderLocked(folder)
+      await updateFolder({ id: folder.id, isLocked: nextLockedValue })
+      setSelectedIds((previous) => new Set(previous))
+    } catch (err) {
+      console.error('Failed to update retail player folder lock state', err)
+    }
+  }, [updateFolder])
+
   const handleNavigateToDevice = useCallback(
     (device) => {
       if (!device) {
@@ -1345,6 +1384,8 @@ const RetailPlayerDeviceManagement = () => {
             onKeyDown={handleRowKeyDown}
             onEdit={handleEditFolder}
             onDeviceDrop={handleDeviceDropOnFolder}
+            onToggleLock={handleToggleFolderLock}
+            isLocked={isFolderLocked(node)}
           />
         )
       }

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -80,6 +80,12 @@ const normalizeFolderRecord = (folder, existing) => {
     folder.updatedAt,
     folder.createdAt ? folder.createdAt : existingFolder?.updatedAt || createdAt,
   )
+  const isLocked =
+    typeof folder.isLocked === 'boolean'
+      ? folder.isLocked
+      : typeof existingFolder?.isLocked === 'boolean'
+        ? existingFolder.isLocked
+        : false
 
   return {
     id,
@@ -87,6 +93,7 @@ const normalizeFolderRecord = (folder, existing) => {
     parentId,
     createdAt,
     updatedAt,
+    isLocked,
   }
 }
 
@@ -619,21 +626,45 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
         const normalizedParent = ensureFolderId(basePayload.parentId)
         requestBody.parentId = normalizedParent || null
       }
-
-      const { json } = await httpClient(
-        `/api/retailplayer/folders/${encodeURIComponent(folderId)}`,
-        {
-          method: 'PATCH',
-          body: JSON.stringify(requestBody),
-          headers: new Headers({ 'Content-Type': 'application/json' }),
-        },
+      const hasIsLocked = Object.prototype.hasOwnProperty.call(
+        basePayload,
+        'isLocked',
       )
 
-      const folder = normalizeFolderRecord(json?.data)
-      if (folder) {
-        dispatch({ type: 'UPSERT_FOLDER', payload: folder })
+      if (Object.keys(requestBody).length > 0) {
+        const { json } = await httpClient(
+          `/api/retailplayer/folders/${encodeURIComponent(folderId)}`,
+          {
+            method: 'PATCH',
+            body: JSON.stringify(requestBody),
+            headers: new Headers({ 'Content-Type': 'application/json' }),
+          },
+        )
+
+        const folder = normalizeFolderRecord(json?.data)
+        if (folder) {
+          dispatch({ type: 'UPSERT_FOLDER', payload: folder })
+        }
       }
-      return folder
+
+      if (hasIsLocked) {
+        const isLocked = Boolean(basePayload.isLocked)
+        const { json } = await httpClient(
+          `/api/retailplayer/folders/${encodeURIComponent(folderId)}/lock`,
+          {
+            method: 'PATCH',
+            body: JSON.stringify({ locked: isLocked }),
+            headers: new Headers({ 'Content-Type': 'application/json' }),
+          },
+        )
+
+        const folder = normalizeFolderRecord(json?.data)
+        if (folder) {
+          dispatch({ type: 'UPSERT_FOLDER', payload: folder })
+        }
+      }
+
+      return normalizeFolderRecord(basePayload) || null
     },
     [apiEnabled, dispatch],
   )

--- a/ui/src/retailPlayer/folderLockState.js
+++ b/ui/src/retailPlayer/folderLockState.js
@@ -1,0 +1,60 @@
+import { normalizeValue } from './deviceUtils'
+
+const UNLOCKED_STORAGE_KEY = 'retailPlayerUnlockedFolders'
+
+const readStorageMap = (key) => {
+  if (typeof window === 'undefined') {
+    return {}
+  }
+
+  try {
+    const rawValue = window.sessionStorage.getItem(key)
+    if (!rawValue) {
+      return {}
+    }
+    const parsedValue = JSON.parse(rawValue)
+    return parsedValue && typeof parsedValue === 'object' ? parsedValue : {}
+  } catch (error) {
+    return {}
+  }
+}
+
+const writeStorageMap = (key, value) => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  window.sessionStorage.setItem(key, JSON.stringify(value))
+}
+
+const getFolderIdentifiers = (folder) => {
+  const id = normalizeValue(folder?.id)
+  return id ? [id] : []
+}
+
+export const isFolderLocked = (folder) => Boolean(folder?.isLocked)
+
+export const markFolderUnlockedForSession = (folder) => {
+  const identifiers = getFolderIdentifiers(folder)
+  if (!identifiers.length) {
+    return
+  }
+
+  const unlockedMap = readStorageMap(UNLOCKED_STORAGE_KEY)
+  identifiers.forEach((identifier) => {
+    unlockedMap[identifier] = true
+  })
+  writeStorageMap(UNLOCKED_STORAGE_KEY, unlockedMap)
+}
+
+export const isFolderUnlockedForSession = (folder) => {
+  const identifiers = getFolderIdentifiers(folder)
+  if (!identifiers.length) {
+    return false
+  }
+
+  const unlockedMap = readStorageMap(UNLOCKED_STORAGE_KEY)
+  return identifiers.some((identifier) => unlockedMap[identifier] === true)
+}
+
+export const getFolderLockIdentifiers = getFolderIdentifiers

--- a/ui/src/retailPlayer/folderUtils.js
+++ b/ui/src/retailPlayer/folderUtils.js
@@ -1,0 +1,39 @@
+import { normalizeValue } from './deviceUtils'
+
+const normalizeFolderId = (value) => {
+  if (typeof value === 'string' && value.trim() !== '') {
+    return value.trim()
+  }
+  return ''
+}
+
+const mapRetailPlayerFolder = (folder) => {
+  if (!folder || typeof folder !== 'object') {
+    return null
+  }
+
+  const id = normalizeFolderId(folder.id)
+  if (!id) {
+    return null
+  }
+
+  const name = normalizeValue(folder.name) || id
+  const parentId = normalizeFolderId(folder.parentId) || null
+  const isLocked =
+    typeof folder.isLocked === 'boolean'
+      ? folder.isLocked
+      : typeof folder.is_locked === 'boolean'
+        ? folder.is_locked
+        : false
+
+  return {
+    id,
+    name,
+    parentId,
+    isLocked,
+    createdAt: folder.createdAt,
+    updatedAt: folder.updatedAt,
+  }
+}
+
+export { mapRetailPlayerFolder }

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -721,6 +721,8 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
 
   const {
     devices,
+    folders,
+    deviceFolders,
     error: deviceListError,
     isApiEnabled,
     isLoading: deviceListLoading,
@@ -1320,6 +1322,8 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
     devicesError,
     channelListError: channelState.error,
     isApiEnabled,
+    folders,
+    deviceFolders,
     notFound,
     lastUpdated: statusState.fetchedAt,
     sendRemoteControlCommand,

--- a/ui/src/retailPlayer/useRetailPlayerDevices.js
+++ b/ui/src/retailPlayer/useRetailPlayerDevices.js
@@ -3,6 +3,7 @@ import config from '../config'
 import httpClient from '../dataProvider/httpClient'
 import RetailPlayerMockService from './RetailPlayerMockService'
 import { mapRetailPlayerDevice } from './deviceUtils'
+import { mapRetailPlayerFolder } from './folderUtils'
 
 const buildDevicesUrl = (deviceName) =>
   deviceName ? '/api/retailplayer/rc' : '/api/retailplayer/devices'
@@ -44,7 +45,9 @@ const fetchRetailPlayerDevices = async (signal, deviceName) => {
   const devices = Array.isArray(payload?.data)
     ? payload.data.map(mapRetailPlayerDevice).filter(Boolean)
     : []
-  const folders = Array.isArray(payload?.folders) ? payload.folders : []
+  const folders = Array.isArray(payload?.folders)
+    ? payload.folders.map(mapRetailPlayerFolder).filter(Boolean)
+    : []
   const deviceFolders = Array.isArray(payload?.deviceFolders)
     ? payload.deviceFolders
     : []


### PR DESCRIPTION
### Motivation
- Provide the same lock functionality for Retail Player folders as exists for devices so folders can be locked/unlocked and prevent access to devices inside locked folders.

### Description
- Add a DB migration `db/migrations/20250918120000_add_retail_player_folder_lock.go` to add an `is_locked` column to `retail_player_folder` and wire it into the model `RetailPlayerFolder` (`IsLocked`).
- Extend the folder repository with `FindByID` and `SetLocked`, include `is_locked` in selects and upserts, and expose a new private API route `PATCH /retailplayer/folders/{folderID}/lock` to toggle folder lock state in `server/nativeapi/retail_player.go`.
- Update the frontend to handle folder locks by adding `ui/src/retailPlayer/folderUtils.js` (payload mapping) and `ui/src/retailPlayer/folderLockState.js` (session unlock tracking), map folders in `useRetailPlayerDevices`, surface lock state in `RetailPlayerDeviceStoreContext`, and add UI controls and handlers in `RetailPlayerDeviceManagement.jsx` to toggle folder locks.
- Enforce folder locks in the Retail Player UI by updating `RetailPlayerDashboard.jsx` to consider locked folders (in addition to device locks) and reuse the existing device lock password and session unlocking logic to unlock folders.

### Testing
- No automated tests were run as part of this change (no CI/test commands executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987440b02f88322bad48f66b4b31feb)