### PR TITLE
Show MAC addresses in retail player device list

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -558,7 +558,7 @@ const RetailPlayerFolderRow = memo(
             </Typography>
           </div>
         </div>
-        <div className={classes.typeCell}>Folder</div>
+        <div className={classes.typeCell}>—</div>
         <div className={classes.countCell}>{deviceCount}</div>
         <div className={classes.remoteControlCell}>—</div>
         <div className={classes.actionsCell}>
@@ -656,7 +656,7 @@ const RetailPlayerDeviceRow = memo(
             </Typography>
           </div>
         </div>
-        <div className={classes.typeCell}>Device</div>
+        <div className={classes.typeCell}>{node.macAddress || '—'}</div>
         <div className={classes.countCell}>
           {typeof channelCount === 'number' ? channelCount : '—'}
         </div>
@@ -702,6 +702,7 @@ RetailPlayerDeviceRow.propTypes = {
   node: PropTypes.shape({
     id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
+    macAddress: PropTypes.string,
   }).isRequired,
   isSelected: PropTypes.bool.isRequired,
   classes: PropTypes.object.isRequired,
@@ -1496,7 +1497,7 @@ const RetailPlayerDeviceManagement = () => {
             />
           </div>
           <span>Name</span>
-          <span>Type</span>
+          <span>MAC Address</span>
           <span>Devices / Channels</span>
           <span>QR ID</span>
           <span className={classes.headerActions}>Edit</span>

--- a/ui/src/retailPlayer/RetailPlayerMockService.js
+++ b/ui/src/retailPlayer/RetailPlayerMockService.js
@@ -142,6 +142,7 @@ class RetailPlayerMockService {
       channel: device.channel,
       channelList: device.channelList,
       organization: device.organization,
+      macAddress: device.macAddress || '',
     }))
   }
 

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -88,6 +88,7 @@ const mapRetailPlayerDevice = (device) => {
     name,
     slug,
     slugKey: deviceSlugKey(slug),
+    macAddress: normalizeValue(device.macAddress || device.mac_address),
     channel: normalizeValue(device.channel),
     channelList: normalizeValue(device.channelList),
     organization:


### PR DESCRIPTION
### Motivation
- Surface device MAC addresses provided by the retail player API in the UI so users can identify devices by hardware address instead of a static "Type" label.
- Ensure local/mock data and mapping logic include the MAC address so UI consumers receive consistent fields.

### Description
- Added `macAddress: normalizeValue(device.macAddress || device.mac_address)` to `mapRetailPlayerDevice` so API mac values are exposed to mapped device objects (`ui/src/retailPlayer/deviceUtils.js`).
- Updated the device management list to replace the "Type" column with a "MAC Address" column and render `node.macAddress || '—'` for device rows while showing `—` for folder rows, and added `macAddress` to the device propTypes (`ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx`).
- Included `macAddress` in the mock device listing returned by `RetailPlayerMockService.listDevices()` for local/dev consistency (`ui/src/retailPlayer/RetailPlayerMockService.js`).

### Testing
- A Playwright page screenshot attempt was executed to verify the UI, but it failed with `net::ERR_EMPTY_RESPONSE` when navigating to `http://localhost:4533/#/retail-player/devices` so no visual check could be completed.
- No other automated tests (unit/integration) were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69875131e438832298b88ce16c6e2bf8)