### PR TITLE
Display channel name (not ID) for retail player devices

### DIFF
--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -193,6 +193,7 @@ type retailPlayerAPIDevice struct {
 	Organization string `json:"organization"`
 	Channel      string `json:"channel"`
 	ChannelName  string `json:"channelName"`
+	ChannelName2 string `json:"channel_name"`
 	ChannelList  string `json:"channelList"`
 	MacAddress   string `json:"macAddress"`
 	TimeZone     string `json:"timeZone"`
@@ -3092,6 +3093,9 @@ func simplifyRetailPlayerDevice(device retailPlayerAPIDevice) (retailPlayerDevic
 		strings.TrimSpace(device.Location),
 	)
 	channelName := strings.TrimSpace(device.ChannelName)
+	if channelName == "" {
+		channelName = strings.TrimSpace(device.ChannelName2)
+	}
 	if channelName == "" {
 		channelName = strings.TrimSpace(device.Channel)
 	}

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -46,6 +46,57 @@ const deviceSlugKey = (value) => {
   return normalized.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
 }
 
+const resolveChannelName = (device) => {
+  if (!device || typeof device !== 'object') {
+    return ''
+  }
+
+  const direct = normalizeValue(device.channelName)
+  if (direct) {
+    return direct
+  }
+
+  const snakeCase = normalizeValue(device.channel_name)
+  if (snakeCase) {
+    return snakeCase
+  }
+
+  const channelObject =
+    device.channel && typeof device.channel === 'object'
+      ? device.channel
+      : null
+  if (channelObject) {
+    return normalizeValue(
+      channelObject.name || channelObject.label || channelObject.title,
+    )
+  }
+
+  return ''
+}
+
+const resolveChannelId = (device) => {
+  if (!device || typeof device !== 'object') {
+    return ''
+  }
+
+  if (
+    typeof device.channel === 'string' ||
+    typeof device.channel === 'number'
+  ) {
+    return normalizeValue(device.channel)
+  }
+
+  const channelObject =
+    device.channel && typeof device.channel === 'object'
+      ? device.channel
+      : null
+  if (channelObject) {
+    return normalizeValue(channelObject.id || channelObject.channelId)
+  }
+
+  return ''
+}
+
 const mapRetailPlayerDevice = (device) => {
   if (!device || typeof device !== 'object') {
     return null
@@ -63,7 +114,7 @@ const mapRetailPlayerDevice = (device) => {
 
   const slug = buildDeviceSlug(device) || fallbackId
   const macAddress = normalizeValue(device.macAddress)
-  const channelName = normalizeValue(device.channelName)
+  const channelName = resolveChannelName(device)
   const name = normalizeValue(device.name) || fallbackId
   const folderIds = Array.isArray(device.folderIds)
     ? device.folderIds
@@ -90,8 +141,8 @@ const mapRetailPlayerDevice = (device) => {
     name,
     slug,
     slugKey: deviceSlugKey(slug),
-    channel: normalizeValue(device.channel),
-    channelName: channelName || normalizeValue(device.channel),
+    channel: resolveChannelId(device),
+    channelName: channelName || resolveChannelId(device),
     channelList: normalizeValue(device.channelList),
     macAddress,
     organization:
@@ -106,4 +157,10 @@ const mapRetailPlayerDevice = (device) => {
   }
 }
 
-export { buildDeviceSlug, deviceSlugKey, mapRetailPlayerDevice, normalizeValue }
+export {
+  buildDeviceSlug,
+  deviceSlugKey,
+  mapRetailPlayerDevice,
+  normalizeValue,
+  resolveChannelName,
+}

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -9,6 +9,7 @@ import {
   deviceSlugKey,
   mapRetailPlayerDevice,
   normalizeValue,
+  resolveChannelName,
 } from './deviceUtils'
 import useRemoteControlSocket from './useRemoteControlSocket'
 import useRetailPlayerDevices from './useRetailPlayerDevices'
@@ -182,7 +183,7 @@ const mapStatusPayloadToDevice = (baseDevice, payload, channelList) => {
     (item) => item && typeof item === 'object',
   )
   const macAddress = normalizeValue(payloadDevice?.macAddress)
-  const channelName = normalizeValue(payloadDevice?.channelName)
+  const channelName = resolveChannelName(payloadDevice)
 
   const payloadArtwork =
     payload && typeof payload === 'object' ? payload.artwork || {} : {}


### PR DESCRIPTION
### Motivation
- The retail player API can provide channel information in multiple shapes (explicit `channelName`, snake_case `channel_name`, or a nested `channel` object), but the UI was only using the raw `channel` id/string leading to IDs being shown instead of human-friendly names.
- Make device mapping and status mapping prefer/normalize channel names so lists and now-playing show readable channel names instead of IDs.

### Description
- Added `resolveChannelName` and `resolveChannelId` helpers in `ui/src/retailPlayer/deviceUtils.js` to normalize channel name and id from different payload shapes (`channelName`, `channel_name`, nested `channel` object, or plain `channel` string/number).
- Updated `mapRetailPlayerDevice` to use `resolveChannelId` for the `channel` field and `resolveChannelName` for `channelName`, falling back appropriately when values are missing.
- Exported `resolveChannelName` from `deviceUtils` and reused it in `ui/src/retailPlayer/useRetailPlayerDeviceStatus.js` so status payload mapping also prefers normalized channel names.

### Testing
- Ran UI unit tests with `npm test` in `ui`; overall `300` tests were executed with `295` passing and `5` failing (test suite run: `vitest --watch=false`).
- The failing tests are unrelated to these changes and occur in `PlayerToolbar` tests (missing `save-queue-button` in some mobile layout cases).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69877761343c83229f5cebdc25ae340a)