### PR TITLE
Show channel catalog counts for devices

### DIFF
--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -185,18 +185,19 @@ func normalizeRetailPlayerIdentifier(value string) string {
 }
 
 type retailPlayerAPIDevice struct {
-	Ordinal      *int   `json:"ordinal"`
-	ID           string `json:"id"`
-	Name         string `json:"name"`
-	Location     string `json:"location"`
-	OrgUnit      string `json:"orgUnit"`
-	Organization string `json:"organization"`
-	Channel      string `json:"channel"`
-	ChannelName  string `json:"channelName"`
-	ChannelList  string `json:"channelList"`
-	MacAddress   string `json:"macAddress"`
-	TimeZone     string `json:"timeZone"`
-	Online       *bool  `json:"online"`
+	Ordinal      *int                        `json:"ordinal"`
+	ID           string                      `json:"id"`
+	Name         string                      `json:"name"`
+	Location     string                      `json:"location"`
+	OrgUnit      string                      `json:"orgUnit"`
+	Organization string                      `json:"organization"`
+	Channel      string                      `json:"channel"`
+	ChannelName  string                      `json:"channelName"`
+	ChannelList  string                      `json:"channelList"`
+	ChannelInfo  retailPlayerChannelSchedule `json:"channelsSchedule"`
+	MacAddress   string                      `json:"macAddress"`
+	TimeZone     string                      `json:"timeZone"`
+	Online       *bool                       `json:"online"`
 }
 
 type retailPlayerAPIResponse struct {
@@ -210,20 +211,30 @@ type retailPlayerChannelListAPIResponse struct {
 }
 
 type retailPlayerDevice struct {
-	ID              string   `json:"id"`
-	Name            string   `json:"name"`
-	IsLocked        bool     `json:"isLocked"`
-	OrganizationID  string   `json:"organizationId,omitempty"`
-	OrganisationID  string   `json:"organisationid,omitempty"`
-	Channel         string   `json:"channel"`
-	ChannelName     string   `json:"channelName,omitempty"`
-	ChannelList     string   `json:"channelList"`
-	Organization    string   `json:"organization"`
-	MacAddress      string   `json:"macAddress,omitempty"`
-	TimeZone        string   `json:"timeZone,omitempty"`
-	Online          *bool    `json:"online,omitempty"`
-	FolderIDs       []string `json:"folderIds,omitempty"`
-	RemoteControlID string   `json:"remoteControlId,omitempty"`
+	ID                  string   `json:"id"`
+	Name                string   `json:"name"`
+	IsLocked            bool     `json:"isLocked"`
+	OrganizationID      string   `json:"organizationId,omitempty"`
+	OrganisationID      string   `json:"organisationid,omitempty"`
+	Channel             string   `json:"channel"`
+	ChannelName         string   `json:"channelName,omitempty"`
+	ChannelList         string   `json:"channelList"`
+	ChannelCatalogCount *int     `json:"channelCatalogCount,omitempty"`
+	Organization        string   `json:"organization"`
+	MacAddress          string   `json:"macAddress,omitempty"`
+	TimeZone            string   `json:"timeZone,omitempty"`
+	Online              *bool    `json:"online,omitempty"`
+	FolderIDs           []string `json:"folderIds,omitempty"`
+	RemoteControlID     string   `json:"remoteControlId,omitempty"`
+}
+
+type retailPlayerChannelSchedule struct {
+	ChannelsCatalog map[string]retailPlayerChannelCatalogEntry `json:"channelsCatalog"`
+}
+
+type retailPlayerChannelCatalogEntry struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 type retailPlayerDeviceConfigResponse struct {
@@ -3059,6 +3070,9 @@ func isRetailPlayerAPIDeviceEmpty(device retailPlayerAPIDevice) bool {
 	if strings.TrimSpace(device.ChannelList) != "" {
 		return false
 	}
+	if len(device.ChannelInfo.ChannelsCatalog) > 0 {
+		return false
+	}
 	if strings.TrimSpace(device.TimeZone) != "" {
 		return false
 	}
@@ -3095,17 +3109,23 @@ func simplifyRetailPlayerDevice(device retailPlayerAPIDevice) (retailPlayerDevic
 	if channelName == "" {
 		channelName = strings.TrimSpace(device.Channel)
 	}
+	var channelCatalogCount *int
+	if len(device.ChannelInfo.ChannelsCatalog) > 0 {
+		count := len(device.ChannelInfo.ChannelsCatalog)
+		channelCatalogCount = &count
+	}
 
 	return retailPlayerDevice{
-		ID:           id,
-		Name:         name,
-		Channel:      strings.TrimSpace(device.Channel),
-		ChannelName:  channelName,
-		ChannelList:  strings.TrimSpace(device.ChannelList),
-		MacAddress:   strings.TrimSpace(device.MacAddress),
-		Organization: organization,
-		TimeZone:     strings.TrimSpace(device.TimeZone),
-		Online:       device.Online,
+		ID:                  id,
+		Name:                name,
+		Channel:             strings.TrimSpace(device.Channel),
+		ChannelName:         channelName,
+		ChannelList:         strings.TrimSpace(device.ChannelList),
+		ChannelCatalogCount: channelCatalogCount,
+		MacAddress:          strings.TrimSpace(device.MacAddress),
+		Organization:        organization,
+		TimeZone:            strings.TrimSpace(device.TimeZone),
+		Online:              device.Online,
 	}, true
 }
 

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -1900,12 +1900,101 @@ func fetchRetailPlayerDevices(ctx context.Context) (retailPlayerDevicesResponse,
 			devices = append(devices, device)
 		}
 	}
+	populateRetailPlayerChannelCounts(ctx, devices)
 
 	return retailPlayerDevicesResponse{
 		Data:  devices,
 		Page:  apiPayload.Page,
 		Total: apiPayload.Total,
 	}, nil
+}
+
+func populateRetailPlayerChannelCounts(ctx context.Context, devices []retailPlayerDevice) {
+	if len(devices) == 0 {
+		return
+	}
+
+	channelListIDs := make([]string, 0, len(devices))
+	seen := make(map[string]struct{}, len(devices))
+	for _, device := range devices {
+		if device.ChannelCatalogCount != nil {
+			continue
+		}
+		trimmed := strings.TrimSpace(device.ChannelList)
+		if trimmed == "" {
+			continue
+		}
+		if _, exists := seen[trimmed]; exists {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		channelListIDs = append(channelListIDs, trimmed)
+	}
+
+	if len(channelListIDs) == 0 {
+		return
+	}
+
+	counts := fetchRetailPlayerChannelCounts(ctx, channelListIDs)
+	if len(counts) == 0 {
+		return
+	}
+
+	for index, device := range devices {
+		if device.ChannelCatalogCount != nil {
+			continue
+		}
+		trimmed := strings.TrimSpace(device.ChannelList)
+		if trimmed == "" {
+			continue
+		}
+		if count, ok := counts[trimmed]; ok {
+			value := count
+			devices[index].ChannelCatalogCount = &value
+		}
+	}
+}
+
+func fetchRetailPlayerChannelCounts(ctx context.Context, channelListIDs []string) map[string]int {
+	counts := make(map[string]int, len(channelListIDs))
+	if len(channelListIDs) == 0 {
+		return counts
+	}
+
+	const maxConcurrent = 4
+	semaphore := make(chan struct{}, maxConcurrent)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	for _, channelListID := range channelListIDs {
+		channelListID := channelListID
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			semaphore <- struct{}{}
+			defer func() { <-semaphore }()
+
+			response, err := fetchRetailPlayerChannelListChannels(ctx, channelListID)
+			if err != nil {
+				log.Error(
+					ctx,
+					"Unable to fetch retail player channel list for counts",
+					"channelListID",
+					channelListID,
+					"err",
+					err,
+				)
+				return
+			}
+
+			mu.Lock()
+			counts[channelListID] = len(response.Channels)
+			mu.Unlock()
+		}()
+	}
+
+	wg.Wait()
+	return counts
 }
 
 func lookupRetailPlayerDevice(ctx context.Context, identifier string) (retailPlayerDevice, []retailPlayerDevice, error) {

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -96,6 +96,11 @@ const baseDeviceShape = (device, existing) => {
   const normalizedChannel = normalizeValue(device?.channel)
   const normalizedChannelList = normalizeValue(device?.channelList)
   const normalizedChannelName = normalizeValue(device?.channelName)
+  const normalizedChannelCatalogCount = Number.isFinite(device?.channelCatalogCount)
+    ? device.channelCatalogCount
+    : Number.isFinite(existing?.channelCatalogCount)
+      ? existing.channelCatalogCount
+      : null
   const normalizedMacAddress = normalizeValue(device?.macAddress)
   const normalizedOrganization = normalizeValue(device?.organization)
   const normalizedTimeZone = normalizeValue(device?.timeZone)
@@ -135,6 +140,7 @@ const baseDeviceShape = (device, existing) => {
     channel: normalizedChannel || '',
     channelList: normalizedChannelList || '',
     channelName: normalizedChannelName || normalizedChannel || '',
+    channelCatalogCount: normalizedChannelCatalogCount,
     macAddress: normalizedMacAddress || existing?.macAddress || '',
     organization: normalizedOrganization || '',
     timeZone: normalizedTimeZone || '',

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -65,6 +65,16 @@ const mapRetailPlayerDevice = (device) => {
   const macAddress = normalizeValue(device.macAddress)
   const channelName = normalizeValue(device.channelName)
   const name = normalizeValue(device.name) || fallbackId
+  const channelsCatalog =
+    device.channelsSchedule && typeof device.channelsSchedule === 'object'
+      ? device.channelsSchedule.channelsCatalog
+      : null
+  const channelCatalogCount =
+    channelsCatalog &&
+    typeof channelsCatalog === 'object' &&
+    !Array.isArray(channelsCatalog)
+      ? Object.keys(channelsCatalog).length
+      : null
   const folderIds = Array.isArray(device.folderIds)
     ? device.folderIds
         .map((value) => (typeof value === 'string' ? value.trim() : ''))
@@ -93,6 +103,7 @@ const mapRetailPlayerDevice = (device) => {
     channel: normalizeValue(device.channel),
     channelName: channelName || normalizeValue(device.channel),
     channelList: normalizeValue(device.channelList),
+    channelCatalogCount,
     macAddress,
     organization:
       normalizeValue(device.organization) ||

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -65,16 +65,20 @@ const mapRetailPlayerDevice = (device) => {
   const macAddress = normalizeValue(device.macAddress)
   const channelName = normalizeValue(device.channelName)
   const name = normalizeValue(device.name) || fallbackId
+  const providedCatalogCount = Number.isFinite(device.channelCatalogCount)
+    ? device.channelCatalogCount
+    : null
   const channelsCatalog =
     device.channelsSchedule && typeof device.channelsSchedule === 'object'
       ? device.channelsSchedule.channelsCatalog
       : null
   const channelCatalogCount =
-    channelsCatalog &&
+    providedCatalogCount ??
+    (channelsCatalog &&
     typeof channelsCatalog === 'object' &&
     !Array.isArray(channelsCatalog)
       ? Object.keys(channelsCatalog).length
-      : null
+      : null)
   const folderIds = Array.isArray(device.folderIds)
     ? device.folderIds
         .map((value) => (typeof value === 'string' ? value.trim() : ''))

--- a/ui/src/retailPlayer/useRetailPlayerChannelCounts.js
+++ b/ui/src/retailPlayer/useRetailPlayerChannelCounts.js
@@ -26,7 +26,8 @@ const useRetailPlayerChannelCounts = (devices, isApiEnabled) => {
       if (!deviceId) {
         return
       }
-      mapping[deviceId] = null
+      const rawCount = device.channelCatalogCount
+      mapping[deviceId] = Number.isFinite(rawCount) ? rawCount : null
     })
     return mapping
   }, [safeDevices])


### PR DESCRIPTION
### Motivation
- Expose per-device channel catalog sizes derived from the retail player device payload so the "Devices / Channels" column can show the number of channels in each device's channel catalog.

### Description
- Extract `channelsSchedule.channelsCatalog` in `mapRetailPlayerDevice` and compute `channelCatalogCount`, then include it on the mapped device object (`ui/src/retailPlayer/deviceUtils.js`).
- Use the mapped `channelCatalogCount` to populate the channel counts mapping in `useRetailPlayerChannelCounts`, assigning `countsByDeviceId[deviceId] = Number.isFinite(rawCount) ? rawCount : null` (`ui/src/retailPlayer/useRetailPlayerChannelCounts.js`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698777fe753c8322b7db11a3f0544770)