### PR TITLE
Return channel name for retail player devices and display it in UI

### DIFF
--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -3194,9 +3194,12 @@ func simplifyRetailPlayerDevice(device retailPlayerAPIDevice) (retailPlayerDevic
 		strings.TrimSpace(device.OrgUnit),
 		strings.TrimSpace(device.Location),
 	)
-	channelName := strings.TrimSpace(device.ChannelName)
-	if channelName == "" {
-		channelName = strings.TrimSpace(device.Channel)
+	channelID := strings.TrimSpace(device.Channel)
+	channelName := ""
+	if channelID != "" {
+		if entry, ok := device.ChannelInfo.ChannelsCatalog[channelID]; ok {
+			channelName = strings.TrimSpace(entry.Name)
+		}
 	}
 	var channelCatalogCount *int
 	if len(device.ChannelInfo.ChannelsCatalog) > 0 {
@@ -3207,7 +3210,7 @@ func simplifyRetailPlayerDevice(device retailPlayerAPIDevice) (retailPlayerDevic
 	return retailPlayerDevice{
 		ID:                  id,
 		Name:                name,
-		Channel:             strings.TrimSpace(device.Channel),
+		Channel:             channelID,
 		ChannelName:         channelName,
 		ChannelList:         strings.TrimSpace(device.ChannelList),
 		ChannelCatalogCount: channelCatalogCount,

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -677,7 +677,7 @@ const RetailPlayerDeviceRow = memo(
           {typeof channelCount === 'number' ? channelCount : '—'}
         </div>
         <div className={classes.channelNameCell}>
-          {node.channelName || node.channel || '—'}
+          {node.channelName || '—'}
         </div>
         <div className={classes.remoteControlCell}>
           {node.remoteControlId ? node.remoteControlId : '—'}

--- a/ui/src/retailPlayer/RetailPlayerDevicesList.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDevicesList.jsx
@@ -246,7 +246,7 @@ const RetailPlayerDevicesList = () => {
                   {device.name}
                 </span>
                 <span className={classes.cell} data-area="channel">
-                  {device.channel}
+                  {device.channelName}
                 </span>
                 <span className={classes.cell} data-area="channelList">
                   {device.channelList}

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -105,7 +105,7 @@ const mapRetailPlayerDevice = (device) => {
     slug,
     slugKey: deviceSlugKey(slug),
     channel: normalizeValue(device.channel),
-    channelName: channelName || normalizeValue(device.channel),
+    channelName,
     channelList: normalizeValue(device.channelList),
     channelCatalogCount,
     macAddress,


### PR DESCRIPTION
### Motivation
- Devices list must show the human-readable channel name (e.g. `1230_Honkytonk_Late`) instead of the channel UUID while preserving existing backend channel ID logic. 
- Channel name should be sourced from the channel schedule catalog `channelsSchedule.channelsCatalog` and resolved in the native API so the frontend only displays API output. 
- Existing channel count and other device fields must remain unchanged and no DB migration is required.

### Description
- Map channel IDs to their names in the native API by looking up `device.Channel` in `device.ChannelInfo.ChannelsCatalog` and populate `ChannelName` with the resolved name or `""` if not found (`server/nativeapi/retail_player.go`).
- Keep the `Channel` field as the trimmed channel ID so backend logic that relies on the ID remains intact (`server/nativeapi/retail_player.go`).
- Stop frontend fallback to channel IDs and display the API-provided `channelName` in the devices list (`ui/src/retailPlayer/RetailPlayerDevicesList.jsx`).
- Ensure client-side mapping uses the `channelName` from the API response instead of synthesizing it locally (`ui/src/retailPlayer/deviceUtils.js`).

### Testing
- No automated tests were executed as part of this change (no test run requested or invoked).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987a7b5bfb08322a6a119897248bd19)