### PR TITLE
Add Channel Name column for Retail Player Devices (backend + UI)

### DIFF
--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -3,6 +3,7 @@ package nativeapi
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -208,6 +209,7 @@ type retailPlayerDevice struct {
 	OrganizationID  string   `json:"organizationId,omitempty"`
 	OrganisationID  string   `json:"organisationid,omitempty"`
 	Channel         string   `json:"channel"`
+	ChannelName     string   `json:"channelName,omitempty"`
 	ChannelList     string   `json:"channelList"`
 	Organization    string   `json:"organization"`
 	TimeZone        string   `json:"timeZone,omitempty"`
@@ -509,6 +511,8 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 			}
 		}
 
+		populateRetailPlayerChannelNames(ctx, response.Data)
+
 		response.Folders = make([]retailPlayerFolder, 0, len(folders))
 		for _, folder := range folders {
 			response.Folders = append(response.Folders, mapModelRetailPlayerFolder(folder))
@@ -646,6 +650,8 @@ func (n *Router) handleRetailPlayerDeviceByName() http.HandlerFunc {
 				}
 			}
 		}
+
+		populateRetailPlayerChannelNames(ctx, filtered.Data)
 
 		filtered.Folders = make([]retailPlayerFolder, 0, len(folders))
 		for _, folder := range folders {
@@ -1427,6 +1433,63 @@ func mapRetailPlayerMappingToDevice(mapping model.RetailPlayerDeviceMapping) ret
 		Organization:    strings.TrimSpace(mapping.Organization),
 		TimeZone:        strings.TrimSpace(mapping.TimeZone),
 		RemoteControlID: strings.TrimSpace(mapping.RemoteCtrlID),
+	}
+}
+
+func populateRetailPlayerChannelNames(ctx context.Context, devices []retailPlayerDevice) {
+	if len(devices) == 0 || conf.Server.DataFolder == "" {
+		return
+	}
+
+	dbFile := filepath.Join(conf.Server.DataFolder, "rpp_devices.db")
+	if _, err := os.Stat(dbFile); err != nil {
+		return
+	}
+
+	dsn := fmt.Sprintf("file:%s?_busy_timeout=5000&_journal_mode=WAL", filepath.ToSlash(dbFile))
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		log.Warn(ctx, "Unable to open retail player devices database", "path", dbFile, "err", err)
+		return
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`PRAGMA journal_mode=WAL`); err != nil {
+		log.Debug(ctx, "Unable to enable WAL for retail player devices database", "path", dbFile, "err", err)
+	}
+
+	stmt, err := db.PrepareContext(ctx, `SELECT channel_name FROM devices WHERE device_id = ? OR device_name = ? LIMIT 1`)
+	if err != nil {
+		if strings.Contains(err.Error(), "no such table") {
+			return
+		}
+		log.Warn(ctx, "Unable to prepare retail player channel name lookup", "path", dbFile, "err", err)
+		return
+	}
+	defer stmt.Close()
+
+	for index := range devices {
+		deviceID := strings.TrimSpace(devices[index].ID)
+		deviceName := strings.TrimSpace(devices[index].Name)
+		if deviceID == "" && deviceName == "" {
+			continue
+		}
+
+		var channelName sql.NullString
+		err = stmt.QueryRowContext(ctx, deviceID, deviceName).Scan(&channelName)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
+			if strings.Contains(err.Error(), "no such table") {
+				return
+			}
+			log.Warn(ctx, "Unable to lookup retail player channel name", "deviceID", deviceID, "deviceName", deviceName, "err", err)
+			continue
+		}
+		if channelName.Valid {
+			devices[index].ChannelName = strings.TrimSpace(channelName.String)
+		}
 	}
 }
 

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -1437,12 +1437,12 @@ func mapRetailPlayerMappingToDevice(mapping model.RetailPlayerDeviceMapping) ret
 }
 
 func populateRetailPlayerChannelNames(ctx context.Context, devices []retailPlayerDevice) {
-	if len(devices) == 0 || conf.Server.DataFolder == "" {
+	if len(devices) == 0 {
 		return
 	}
 
-	dbFile := filepath.Join(conf.Server.DataFolder, "rpp_devices.db")
-	if _, err := os.Stat(dbFile); err != nil {
+	dbFile := locateRetailPlayerDevicesDB()
+	if dbFile == "" {
 		return
 	}
 
@@ -1458,7 +1458,7 @@ func populateRetailPlayerChannelNames(ctx context.Context, devices []retailPlaye
 		log.Debug(ctx, "Unable to enable WAL for retail player devices database", "path", dbFile, "err", err)
 	}
 
-	stmt, err := db.PrepareContext(ctx, `SELECT channel_name FROM devices WHERE device_id = ? OR device_name = ? LIMIT 1`)
+	stmt, err := db.PrepareContext(ctx, `SELECT channel_name FROM devices WHERE device_id = ? COLLATE NOCASE OR device_name = ? COLLATE NOCASE LIMIT 1`)
 	if err != nil {
 		if strings.Contains(err.Error(), "no such table") {
 			return
@@ -1491,6 +1491,36 @@ func populateRetailPlayerChannelNames(ctx context.Context, devices []retailPlaye
 			devices[index].ChannelName = strings.TrimSpace(channelName.String)
 		}
 	}
+}
+
+func locateRetailPlayerDevicesDB() string {
+	candidates := make([]string, 0, 3)
+
+	if conf.Server.DataFolder != "" {
+		candidates = append(candidates, filepath.Join(conf.Server.DataFolder, "rpp_devices.db"))
+	}
+
+	if conf.Server.DbPath != "" {
+		candidates = append(candidates, filepath.Join(filepath.Dir(conf.Server.DbPath), "rpp_devices.db"))
+	}
+
+	candidates = append(candidates, "rpp_devices.db")
+
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+
+	return ""
 }
 
 func (n *Router) handleRetailPlayerChannelListChannels() http.HandlerFunc {

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -166,7 +166,7 @@ const useStyles = makeStyles((theme) => {
   listHeader: {
     display: 'grid',
     gridTemplateColumns:
-      '64px minmax(220px, 2fr) minmax(140px, 1fr) minmax(140px, 1fr) minmax(200px, 1.2fr) minmax(96px, 0.8fr)',
+      '64px minmax(220px, 2fr) minmax(140px, 1fr) minmax(140px, 1fr) minmax(200px, 1.2fr) minmax(200px, 1.2fr) minmax(96px, 0.8fr)',
     paddingTop: theme.spacing(0),
     paddingBottom: theme.spacing(0),
     paddingLeft: theme.spacing(1.7),
@@ -181,7 +181,7 @@ const useStyles = makeStyles((theme) => {
     gap: theme.spacing(1),
     [theme.breakpoints.down('sm')]: {
       gridTemplateColumns:
-        '56px minmax(180px, 2fr) minmax(120px, 1fr) minmax(120px, 1fr) minmax(180px, 1.1fr) 72px',
+        '56px minmax(180px, 2fr) minmax(120px, 1fr) minmax(120px, 1fr) minmax(160px, 1.1fr) minmax(160px, 1.1fr) 72px',
       fontSize: theme.typography.pxToRem(11),
       letterSpacing: 0.6,
     },
@@ -201,7 +201,7 @@ const useStyles = makeStyles((theme) => {
   row: {
     display: 'grid',
     gridTemplateColumns:
-      '64px minmax(220px, 2fr) minmax(140px, 1fr) minmax(140px, 1fr) minmax(200px, 1.2fr) minmax(96px, 0.8fr)',
+      '64px minmax(220px, 2fr) minmax(140px, 1fr) minmax(140px, 1fr) minmax(200px, 1.2fr) minmax(200px, 1.2fr) minmax(96px, 0.8fr)',
     alignItems: 'center',
     padding: '1px 2px',
     borderTop: `1px solid ${theme.palette.divider}`,
@@ -218,7 +218,7 @@ const useStyles = makeStyles((theme) => {
     },
     [theme.breakpoints.down('sm')]: {
       gridTemplateColumns:
-        '56px minmax(180px, 2fr) minmax(120px, 1fr) minmax(120px, 1fr) minmax(180px, 1.1fr) 72px',
+        '56px minmax(180px, 2fr) minmax(120px, 1fr) minmax(120px, 1fr) minmax(160px, 1.1fr) minmax(160px, 1.1fr) 72px',
     },
   },
 
@@ -279,6 +279,13 @@ const useStyles = makeStyles((theme) => {
     fontSize: theme.typography.pxToRem(14),
     color: theme.palette.text.secondary,
     textAlign: 'center',
+  },
+  channelNameCell: {
+    fontSize: theme.typography.pxToRem(14),
+    color: theme.palette.text.secondary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
   },
   remoteControlCell: {
     fontSize: theme.typography.pxToRem(14),
@@ -560,6 +567,7 @@ const RetailPlayerFolderRow = memo(
         </div>
         <div className={classes.typeCell}>Folder</div>
         <div className={classes.countCell}>{deviceCount}</div>
+        <div className={classes.channelNameCell}>—</div>
         <div className={classes.remoteControlCell}>—</div>
         <div className={classes.actionsCell}>
           <Tooltip title="Edit folder">
@@ -660,6 +668,9 @@ const RetailPlayerDeviceRow = memo(
         <div className={classes.countCell}>
           {typeof channelCount === 'number' ? channelCount : '—'}
         </div>
+        <div className={classes.channelNameCell}>
+          {node.channelName ? node.channelName : '—'}
+        </div>
         <div className={classes.remoteControlCell}>
           {node.remoteControlId ? node.remoteControlId : '—'}
         </div>
@@ -702,6 +713,7 @@ RetailPlayerDeviceRow.propTypes = {
   node: PropTypes.shape({
     id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
+    channelName: PropTypes.string,
   }).isRequired,
   isSelected: PropTypes.bool.isRequired,
   classes: PropTypes.object.isRequired,
@@ -1498,6 +1510,7 @@ const RetailPlayerDeviceManagement = () => {
           <span>Name</span>
           <span>Type</span>
           <span>Devices / Channels</span>
+          <span>Channel Name</span>
           <span>QR ID</span>
           <span className={classes.headerActions}>Edit</span>
         </div>

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -89,6 +89,7 @@ const mapRetailPlayerDevice = (device) => {
     slug,
     slugKey: deviceSlugKey(slug),
     channel: normalizeValue(device.channel),
+    channelName: normalizeValue(device.channelName || device.channel_name),
     channelList: normalizeValue(device.channelList),
     organization:
       normalizeValue(device.organization) ||


### PR DESCRIPTION
### Motivation
- Surface a human-readable Channel Name in the Retail Player Devices list by reading the local `rpp_devices.db` `devices.channel_name` field and exposing it to the frontend.

### Description
- Backend: added `ChannelName` to `retailPlayerDevice` and implemented `populateRetailPlayerChannelNames` which opens `rpp_devices.db` and queries `SELECT channel_name FROM devices WHERE device_id = ? OR device_name = ? LIMIT 1`, populating `ChannelName` for list and by-name responses (`handleRetailPlayerDevices` and `handleRetailPlayerDeviceByName`).
- Frontend model: extended `mapRetailPlayerDevice` in `deviceUtils.js` to map `channelName` from the API (`device.channelName` or `device.channel_name`).
- Frontend UI: updated `RetailPlayerDeviceManagement.jsx` to add a new "Channel Name" column, adjusted grid template columns and styles, and bound `node.channelName` into device rows; added PropTypes for the new field.
- Kept existing functionality unchanged: remote-control/lock/folder behaviour and payload shapes remain intact aside from the added `channelName` field.

### Testing
- `gofmt` was run on the modified Go file and completed successfully.
- No automated unit/integration tests were executed for these changes in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a27a28e048322a194efc94ffb2e7b)