### PR TITLE
Preserve retail player channel names in device store and show in UI

### DIFF
--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -201,6 +201,10 @@ type retailPlayerChannelListAPIResponse struct {
 	Channels []retailPlayerAPIChannel `json:"channels"`
 }
 
+type retailPlayerChannelsAPIResponse struct {
+	Data []retailPlayerAPIChannel `json:"data"`
+}
+
 type retailPlayerDevice struct {
 	ID              string   `json:"id"`
 	Name            string   `json:"name"`
@@ -208,6 +212,7 @@ type retailPlayerDevice struct {
 	OrganizationID  string   `json:"organizationId,omitempty"`
 	OrganisationID  string   `json:"organisationid,omitempty"`
 	Channel         string   `json:"channel"`
+	ChannelName     string   `json:"channelName,omitempty"`
 	ChannelList     string   `json:"channelList"`
 	Organization    string   `json:"organization"`
 	TimeZone        string   `json:"timeZone,omitempty"`
@@ -434,6 +439,12 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 
 		log.Info(ctx, "Retail player devices fetched", "count", len(response.Data))
 
+		if len(response.Data) > 0 {
+			if err := n.applyRetailPlayerChannelNames(ctx, response.Data); err != nil {
+				log.Warn(ctx, "Unable to fetch retail player channels", "err", err)
+			}
+		}
+
 		n.devices.RememberDevices(response.Data)
 		n.persistRetailPlayerDeviceMappings(ctx, response.Data)
 
@@ -557,6 +568,12 @@ func (n *Router) handleRetailPlayerDeviceByName() http.HandlerFunc {
 			return
 		}
 
+		if len(response.Data) > 0 {
+			if err := n.applyRetailPlayerChannelNames(ctx, response.Data); err != nil {
+				log.Warn(ctx, "Unable to fetch retail player channels", "err", err)
+			}
+		}
+
 		filtered := retailPlayerDevicesResponse{
 			Data: make([]retailPlayerDevice, 0, 1),
 		}
@@ -667,6 +684,63 @@ func (n *Router) handleRetailPlayerDeviceByName() http.HandlerFunc {
 			log.Error(ctx, "Unable to encode retail player device response", "err", err)
 		}
 	}
+}
+
+func (n *Router) applyRetailPlayerChannelNames(ctx context.Context, devices []retailPlayerDevice) error {
+	if len(devices) == 0 {
+		return nil
+	}
+
+	response, err := fetchRetailPlayerChannels(ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(response.Channels) == 0 {
+		return nil
+	}
+
+	channelNameByID := make(map[string]string, len(response.Channels))
+	channelNameByName := make(map[string]string, len(response.Channels))
+
+	normalizeKey := func(value string) string {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			return ""
+		}
+		return strings.ToLower(trimmed)
+	}
+
+	for _, channel := range response.Channels {
+		name := strings.TrimSpace(channel.Name)
+		if name == "" {
+			continue
+		}
+		if key := normalizeKey(channel.ID); key != "" {
+			channelNameByID[key] = name
+		}
+		if key := normalizeKey(name); key != "" {
+			channelNameByName[key] = name
+		}
+	}
+
+	for index := range devices {
+		channelName := ""
+		if key := normalizeKey(devices[index].Channel); key != "" {
+			channelName = channelNameByID[key]
+		}
+		if channelName == "" {
+			if key := normalizeKey(devices[index].Channel); key != "" {
+				channelName = channelNameByName[key]
+			}
+		}
+
+		if channelName != "" {
+			devices[index].ChannelName = channelName
+		}
+	}
+
+	return nil
 }
 
 func (n *Router) handleCreateRetailPlayerFolder() http.HandlerFunc {
@@ -2386,6 +2460,67 @@ func fetchRetailPlayerDependents(ctx context.Context, orgID string) (retailPlaye
 	return payload, nil
 }
 
+func fetchRetailPlayerChannels(ctx context.Context) (retailPlayerChannelsResponse, error) {
+	cfg := conf.Server.RetailPlayer
+	if cfg.BaseURL == "" || cfg.OrgID == "" {
+		return retailPlayerChannelsResponse{}, errors.New("retail player API not configured")
+	}
+
+	requestConfig := retailPlayerConfig{
+		BaseURL:           cfg.BaseURL,
+		OrgID:             cfg.OrgID,
+		APIKey:            cfg.APIKey,
+		APIKeyHeader:      cfg.APIKeyHeader,
+		AdditionalHeaders: cfg.AdditionalHeaders,
+	}
+
+	req, err := buildRetailPlayerOrgRequest(ctx, requestConfig, "channels")
+	if err != nil {
+		return retailPlayerChannelsResponse{}, err
+	}
+
+	resp, err := retailPlayerHTTPClient.Do(req)
+	if err != nil {
+		return retailPlayerChannelsResponse{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return retailPlayerChannelsResponse{}, fmt.Errorf("retail player API request failed with status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return retailPlayerChannelsResponse{}, err
+	}
+
+	var channels []retailPlayerAPIChannel
+	var payload retailPlayerChannelsAPIResponse
+	if err := json.Unmarshal(body, &payload); err == nil && len(payload.Data) > 0 {
+		channels = payload.Data
+	} else {
+		var listPayload retailPlayerChannelListAPIResponse
+		if err := json.Unmarshal(body, &listPayload); err == nil && len(listPayload.Channels) > 0 {
+			channels = listPayload.Channels
+		} else {
+			var rawChannels []retailPlayerAPIChannel
+			if unmarshalErr := json.Unmarshal(body, &rawChannels); unmarshalErr != nil {
+				return retailPlayerChannelsResponse{}, err
+			}
+			channels = rawChannels
+		}
+	}
+
+	normalizedChannels := make([]retailPlayerChannel, 0, len(channels))
+	for _, item := range channels {
+		if channel, ok := simplifyRetailPlayerChannel(item); ok {
+			normalizedChannels = append(normalizedChannels, channel)
+		}
+	}
+
+	return retailPlayerChannelsResponse{Channels: normalizedChannels}, nil
+}
+
 func fetchRetailPlayerChannelListChannels(ctx context.Context, channelListID string) (retailPlayerChannelsResponse, error) {
 	cfg := conf.Server.RetailPlayer
 	if cfg.BaseURL == "" || cfg.OrgID == "" {
@@ -2820,6 +2955,31 @@ func buildRetailPlayerRequest(ctx context.Context, cfg retailPlayerConfig, pathP
 			}
 		}
 		req.URL.RawQuery = query.Encode()
+	}
+
+	applyRetailPlayerHeaders(req, cfg)
+
+	return req, nil
+}
+
+func buildRetailPlayerOrgRequest(ctx context.Context, cfg retailPlayerConfig, pathParts ...string) (*http.Request, error) {
+	baseURL := strings.TrimRight(cfg.BaseURL, "/")
+	if baseURL == "" {
+		return nil, errors.New("retail player base URL is empty")
+	}
+
+	endpoint := fmt.Sprintf("%s/orgs/%s", baseURL, url.PathEscape(cfg.OrgID))
+	for _, part := range pathParts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		endpoint = fmt.Sprintf("%s/%s", endpoint, url.PathEscape(trimmed))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
 	}
 
 	applyRetailPlayerHeaders(req, cfg)

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -166,7 +166,7 @@ const useStyles = makeStyles((theme) => {
   listHeader: {
     display: 'grid',
     gridTemplateColumns:
-      '64px minmax(220px, 2fr) minmax(140px, 1fr) minmax(140px, 1fr) minmax(180px, 1.2fr) minmax(160px, 1fr) minmax(96px, 0.8fr)',
+      '64px minmax(220px, 2fr) minmax(140px, 1fr) minmax(140px, 1fr) minmax(180px, 1.2fr) minmax(160px, 1fr) minmax(160px, 1fr) minmax(96px, 0.8fr)',
     paddingTop: theme.spacing(0),
     paddingBottom: theme.spacing(0),
     paddingLeft: theme.spacing(1.7),
@@ -181,7 +181,7 @@ const useStyles = makeStyles((theme) => {
     gap: theme.spacing(1),
     [theme.breakpoints.down('sm')]: {
       gridTemplateColumns:
-        '56px minmax(180px, 2fr) minmax(120px, 1fr) minmax(120px, 1fr) minmax(160px, 1.1fr) minmax(140px, 1fr) 72px',
+        '56px minmax(180px, 2fr) minmax(120px, 1fr) minmax(120px, 1fr) minmax(160px, 1.1fr) minmax(140px, 1fr) minmax(140px, 1fr) 72px',
       fontSize: theme.typography.pxToRem(11),
       letterSpacing: 0.6,
     },
@@ -201,7 +201,7 @@ const useStyles = makeStyles((theme) => {
   row: {
     display: 'grid',
     gridTemplateColumns:
-      '64px minmax(220px, 2fr) minmax(140px, 1fr) minmax(140px, 1fr) minmax(180px, 1.2fr) minmax(160px, 1fr) minmax(96px, 0.8fr)',
+      '64px minmax(220px, 2fr) minmax(140px, 1fr) minmax(140px, 1fr) minmax(180px, 1.2fr) minmax(160px, 1fr) minmax(160px, 1fr) minmax(96px, 0.8fr)',
     alignItems: 'center',
     padding: '1px 2px',
     borderTop: `1px solid ${theme.palette.divider}`,
@@ -218,7 +218,7 @@ const useStyles = makeStyles((theme) => {
     },
     [theme.breakpoints.down('sm')]: {
       gridTemplateColumns:
-        '56px minmax(180px, 2fr) minmax(120px, 1fr) minmax(120px, 1fr) minmax(160px, 1.1fr) minmax(140px, 1fr) 72px',
+        '56px minmax(180px, 2fr) minmax(120px, 1fr) minmax(120px, 1fr) minmax(160px, 1.1fr) minmax(140px, 1fr) minmax(140px, 1fr) 72px',
     },
   },
 
@@ -288,6 +288,13 @@ const useStyles = makeStyles((theme) => {
     whiteSpace: 'nowrap',
   },
   channelNameCell: {
+    fontSize: theme.typography.pxToRem(14),
+    color: theme.palette.text.secondary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  macAddressCell: {
     fontSize: theme.typography.pxToRem(14),
     color: theme.palette.text.secondary,
     overflow: 'hidden',
@@ -568,6 +575,7 @@ const RetailPlayerFolderRow = memo(
         <div className={classes.typeCell}>Folder</div>
         <div className={classes.countCell}>{deviceCount}</div>
         <div className={classes.channelNameCell}>—</div>
+        <div className={classes.macAddressCell}>—</div>
         <div className={classes.remoteControlCell}>—</div>
         <div className={classes.actionsCell}>
           <Tooltip title="Edit folder">
@@ -671,6 +679,9 @@ const RetailPlayerDeviceRow = memo(
         <div className={classes.channelNameCell}>
           {node.channelName ? node.channelName : '—'}
         </div>
+        <div className={classes.macAddressCell}>
+          {node.macAddress ? node.macAddress : '—'}
+        </div>
         <div className={classes.remoteControlCell}>
           {node.remoteControlId ? node.remoteControlId : '—'}
         </div>
@@ -714,6 +725,7 @@ RetailPlayerDeviceRow.propTypes = {
     id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
     channelName: PropTypes.string,
+    macAddress: PropTypes.string,
   }).isRequired,
   isSelected: PropTypes.bool.isRequired,
   classes: PropTypes.object.isRequired,
@@ -1511,6 +1523,7 @@ const RetailPlayerDeviceManagement = () => {
           <span>Type</span>
           <span>Devices / Channels</span>
           <span>Channel Name</span>
+          <span>Mac Address</span>
           <span>QR ID</span>
           <span className={classes.headerActions}>Edit</span>
         </div>

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -166,7 +166,7 @@ const useStyles = makeStyles((theme) => {
   listHeader: {
     display: 'grid',
     gridTemplateColumns:
-      '64px minmax(220px, 2fr) minmax(140px, 1fr) minmax(140px, 1fr) minmax(200px, 1.2fr) minmax(96px, 0.8fr)',
+      '64px minmax(220px, 2fr) minmax(140px, 1fr) minmax(140px, 1fr) minmax(180px, 1.2fr) minmax(160px, 1fr) minmax(96px, 0.8fr)',
     paddingTop: theme.spacing(0),
     paddingBottom: theme.spacing(0),
     paddingLeft: theme.spacing(1.7),
@@ -181,7 +181,7 @@ const useStyles = makeStyles((theme) => {
     gap: theme.spacing(1),
     [theme.breakpoints.down('sm')]: {
       gridTemplateColumns:
-        '56px minmax(180px, 2fr) minmax(120px, 1fr) minmax(120px, 1fr) minmax(180px, 1.1fr) 72px',
+        '56px minmax(180px, 2fr) minmax(120px, 1fr) minmax(120px, 1fr) minmax(160px, 1.1fr) minmax(140px, 1fr) 72px',
       fontSize: theme.typography.pxToRem(11),
       letterSpacing: 0.6,
     },
@@ -201,7 +201,7 @@ const useStyles = makeStyles((theme) => {
   row: {
     display: 'grid',
     gridTemplateColumns:
-      '64px minmax(220px, 2fr) minmax(140px, 1fr) minmax(140px, 1fr) minmax(200px, 1.2fr) minmax(96px, 0.8fr)',
+      '64px minmax(220px, 2fr) minmax(140px, 1fr) minmax(140px, 1fr) minmax(180px, 1.2fr) minmax(160px, 1fr) minmax(96px, 0.8fr)',
     alignItems: 'center',
     padding: '1px 2px',
     borderTop: `1px solid ${theme.palette.divider}`,
@@ -218,7 +218,7 @@ const useStyles = makeStyles((theme) => {
     },
     [theme.breakpoints.down('sm')]: {
       gridTemplateColumns:
-        '56px minmax(180px, 2fr) minmax(120px, 1fr) minmax(120px, 1fr) minmax(180px, 1.1fr) 72px',
+        '56px minmax(180px, 2fr) minmax(120px, 1fr) minmax(120px, 1fr) minmax(160px, 1.1fr) minmax(140px, 1fr) 72px',
     },
   },
 
@@ -281,6 +281,13 @@ const useStyles = makeStyles((theme) => {
     textAlign: 'center',
   },
   remoteControlCell: {
+    fontSize: theme.typography.pxToRem(14),
+    color: theme.palette.text.secondary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  channelNameCell: {
     fontSize: theme.typography.pxToRem(14),
     color: theme.palette.text.secondary,
     overflow: 'hidden',
@@ -560,6 +567,7 @@ const RetailPlayerFolderRow = memo(
         </div>
         <div className={classes.typeCell}>Folder</div>
         <div className={classes.countCell}>{deviceCount}</div>
+        <div className={classes.channelNameCell}>—</div>
         <div className={classes.remoteControlCell}>—</div>
         <div className={classes.actionsCell}>
           <Tooltip title="Edit folder">
@@ -660,6 +668,9 @@ const RetailPlayerDeviceRow = memo(
         <div className={classes.countCell}>
           {typeof channelCount === 'number' ? channelCount : '—'}
         </div>
+        <div className={classes.channelNameCell}>
+          {node.channelName ? node.channelName : '—'}
+        </div>
         <div className={classes.remoteControlCell}>
           {node.remoteControlId ? node.remoteControlId : '—'}
         </div>
@@ -702,6 +713,7 @@ RetailPlayerDeviceRow.propTypes = {
   node: PropTypes.shape({
     id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
+    channelName: PropTypes.string,
   }).isRequired,
   isSelected: PropTypes.bool.isRequired,
   classes: PropTypes.object.isRequired,
@@ -1498,6 +1510,7 @@ const RetailPlayerDeviceManagement = () => {
           <span>Name</span>
           <span>Type</span>
           <span>Devices / Channels</span>
+          <span>Channel Name</span>
           <span>QR ID</span>
           <span className={classes.headerActions}>Edit</span>
         </div>

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -10,7 +10,12 @@ import PropTypes from 'prop-types'
 import { v4 as uuidv4 } from 'uuid'
 import useRetailPlayerDevices from './useRetailPlayerDevices'
 import httpClient from '../dataProvider/httpClient'
-import { buildDeviceSlug, deviceSlugKey, normalizeValue } from './deviceUtils'
+import {
+  buildDeviceSlug,
+  deviceSlugKey,
+  formatMacAddress,
+  normalizeValue,
+} from './deviceUtils'
 
 const RetailPlayerDeviceStoreContext = createContext(null)
 
@@ -96,6 +101,9 @@ const baseDeviceShape = (device, existing) => {
   const normalizedChannel = normalizeValue(device?.channel)
   const normalizedChannelName = normalizeValue(device?.channelName)
   const normalizedChannelList = normalizeValue(device?.channelList)
+  const normalizedMacAddress = formatMacAddress(
+    device?.macAddress || device?.mac_address,
+  )
   const normalizedOrganization = normalizeValue(device?.organization)
   const normalizedTimeZone = normalizeValue(device?.timeZone)
   const normalizedRemoteControlId = normalizeValue(device?.remoteControlId)
@@ -134,6 +142,7 @@ const baseDeviceShape = (device, existing) => {
     channel: normalizedChannel || '',
     channelName: normalizedChannelName || existing?.channelName || '',
     channelList: normalizedChannelList || '',
+    macAddress: normalizedMacAddress || existing?.macAddress || '',
     organization: normalizedOrganization || '',
     timeZone: normalizedTimeZone || '',
     remoteControlId: normalizedRemoteControlId || '',
@@ -288,6 +297,7 @@ const reducer = (state, action) => {
         channel,
         channelName,
         channelList,
+        macAddress,
         organization,
         folderIds,
         folderId,
@@ -315,6 +325,7 @@ const reducer = (state, action) => {
           channel: normalizeValue(channel) || device.channel,
           channelName: normalizeValue(channelName) || device.channelName,
           channelList: normalizeValue(channelList) || device.channelList,
+          macAddress: formatMacAddress(macAddress) || device.macAddress,
           organization:
             normalizeValue(organization) || device.organization,
           folderIds: nextFolderIds,

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -94,6 +94,7 @@ const baseDeviceShape = (device, existing) => {
   const normalizedName = normalizeValue(device?.name)
   const normalizedSlug = normalizeValue(device?.slug)
   const normalizedChannel = normalizeValue(device?.channel)
+  const normalizedChannelName = normalizeValue(device?.channelName)
   const normalizedChannelList = normalizeValue(device?.channelList)
   const normalizedOrganization = normalizeValue(device?.organization)
   const normalizedTimeZone = normalizeValue(device?.timeZone)
@@ -131,6 +132,7 @@ const baseDeviceShape = (device, existing) => {
     slug,
     slugKey: deviceSlugKey(slug),
     channel: normalizedChannel || '',
+    channelName: normalizedChannelName || existing?.channelName || '',
     channelList: normalizedChannelList || '',
     organization: normalizedOrganization || '',
     timeZone: normalizedTimeZone || '',
@@ -284,6 +286,7 @@ const reducer = (state, action) => {
         id,
         name,
         channel,
+        channelName,
         channelList,
         organization,
         folderIds,
@@ -310,6 +313,7 @@ const reducer = (state, action) => {
           ...device,
           name: isLocal ? normalizeValue(name) || device.name : device.name,
           channel: normalizeValue(channel) || device.channel,
+          channelName: normalizeValue(channelName) || device.channelName,
           channelList: normalizeValue(channelList) || device.channelList,
           organization:
             normalizeValue(organization) || device.organization,

--- a/ui/src/retailPlayer/RetailPlayerMockService.js
+++ b/ui/src/retailPlayer/RetailPlayerMockService.js
@@ -140,6 +140,7 @@ class RetailPlayerMockService {
       slug: buildDeviceSlug(device) || device.name || device.id,
       slugKey: deviceSlugKey(device.name || device.id),
       channel: device.channel,
+      channelName: device.channelName || device.channel,
       channelList: device.channelList,
       organization: device.organization,
     }))

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -89,6 +89,7 @@ const mapRetailPlayerDevice = (device) => {
     slug,
     slugKey: deviceSlugKey(slug),
     channel: normalizeValue(device.channel),
+    channelName: normalizeValue(device.channelName || device.channel_name),
     channelList: normalizeValue(device.channelList),
     organization:
       normalizeValue(device.organization) ||

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -8,6 +8,18 @@ const normalizeValue = (value) => {
   return ''
 }
 
+const formatMacAddress = (value) => {
+  const normalized = normalizeValue(value).toLowerCase()
+  if (!normalized) {
+    return ''
+  }
+  const parts = normalized.split(/[^a-z0-9]+/).filter(Boolean)
+  if (!parts.length) {
+    return ''
+  }
+  return parts.join(':')
+}
+
 const buildDeviceSlug = (device) => {
   if (!device || typeof device !== 'object') {
     return ''
@@ -91,6 +103,7 @@ const mapRetailPlayerDevice = (device) => {
     channel: normalizeValue(device.channel),
     channelName: normalizeValue(device.channelName || device.channel_name),
     channelList: normalizeValue(device.channelList),
+    macAddress: formatMacAddress(device.macAddress || device.mac_address),
     organization:
       normalizeValue(device.organization) ||
       normalizeValue(device.orgUnit || device.org_unit) ||
@@ -103,4 +116,10 @@ const mapRetailPlayerDevice = (device) => {
   }
 }
 
-export { buildDeviceSlug, deviceSlugKey, mapRetailPlayerDevice, normalizeValue }
+export {
+  buildDeviceSlug,
+  deviceSlugKey,
+  formatMacAddress,
+  mapRetailPlayerDevice,
+  normalizeValue,
+}


### PR DESCRIPTION
### Motivation
- Devices returned from the Retail Player API include a human-friendly channel name but the UI column remained blank because the store normalization and update logic did not preserve `channelName`.
- Ensure the server-side channel lookup is applied to API device records and surface that name in the device list so the Channel Name column displays reliably.

### Description
- Added server-side support to fetch and normalize channels with `fetchRetailPlayerChannels`, a helper `buildRetailPlayerOrgRequest`, and a new `applyRetailPlayerChannelNames` function that resolves channel IDs/names and populates `ChannelName` on `retailPlayerDevice` before storing or returning devices.
- Hooked `applyRetailPlayerChannelNames` into `handleRetailPlayerDevices` and `handleRetailPlayerDeviceByName` so fetched device lists include resolved channel names.
- Preserved `channelName` in the UI device store by adding `channelName` to `baseDeviceShape` and retaining it in the `UPDATE_DEVICE` reducer in `ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx`.
- Mapped `channelName` from incoming API records in `mapRetailPlayerDevice` (`ui/src/retailPlayer/deviceUtils.js`), exposed it in the mock provider (`RetailPlayerMockService.js`), and added the `Channel Name` column, cell, styles, and `channelName` PropType to `RetailPlayerDeviceManagement.jsx` so the UI renders the value.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a2ebf3ce88322a7a8f3d14edbf857)