### PR TITLE
Add MAC address column to retail player devices list

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDevicesList.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDevicesList.jsx
@@ -50,13 +50,14 @@ const useStyles = makeStyles((theme) => ({
   },
   headerRow: {
     display: 'grid',
-    gridTemplateColumns: '160px 1.5fr 1fr 1fr 1fr',
+    gridTemplateColumns: '160px 1.5fr 1fr 1fr 1fr 1fr',
     padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`,
     backgroundColor: theme.palette.action.hover,
     gap: theme.spacing(2),
     [theme.breakpoints.down('sm')]: {
       gridTemplateColumns: '120px 1.2fr 1fr',
-      gridTemplateAreas: "'actions name name' 'channel channelList org'",
+      gridTemplateAreas:
+        "'actions name name' 'channel channelList org' 'mac mac mac'",
       rowGap: theme.spacing(1),
     },
   },
@@ -79,6 +80,9 @@ const useStyles = makeStyles((theme) => ({
       '&[data-area="channelList"]': {
         gridArea: 'channelList',
       },
+      '&[data-area="mac"]': {
+        gridArea: 'mac',
+      },
       '&[data-area="organization"]': {
         gridArea: 'org',
       },
@@ -99,7 +103,7 @@ const useStyles = makeStyles((theme) => ({
   },
   rowButton: {
     display: 'grid',
-    gridTemplateColumns: '160px 1.5fr 1fr 1fr 1fr',
+    gridTemplateColumns: '160px 1.5fr 1fr 1fr 1fr 1fr',
     padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`,
     textAlign: 'left',
     gap: theme.spacing(2),
@@ -110,7 +114,8 @@ const useStyles = makeStyles((theme) => ({
     }),
     [theme.breakpoints.down('sm')]: {
       gridTemplateColumns: '120px 1.2fr 1fr',
-      gridTemplateAreas: "'actions name name' 'channel channelList org'",
+      gridTemplateAreas:
+        "'actions name name' 'channel channelList org' 'mac mac mac'",
       rowGap: theme.spacing(1.5),
     },
   },
@@ -129,6 +134,9 @@ const useStyles = makeStyles((theme) => ({
       },
       '&[data-area="channelList"]': {
         gridArea: 'channelList',
+      },
+      '&[data-area="mac"]': {
+        gridArea: 'mac',
       },
       '&[data-area="organization"]': {
         gridArea: 'org',
@@ -213,6 +221,9 @@ const RetailPlayerDevicesList = () => {
           <span className={classes.headerCell} data-area="channel">
             Channel
           </span>
+          <span className={classes.headerCell} data-area="mac">
+            MAC Address
+          </span>
           <span className={classes.headerCell} data-area="channelList">
             Channel List
           </span>
@@ -247,6 +258,9 @@ const RetailPlayerDevicesList = () => {
                 </span>
                 <span className={classes.cell} data-area="channel">
                   {device.channel}
+                </span>
+                <span className={classes.cell} data-area="mac">
+                  {device.macAddress}
                 </span>
                 <span className={classes.cell} data-area="channelList">
                   {device.channelList}

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -88,6 +88,7 @@ const mapRetailPlayerDevice = (device) => {
     name,
     slug,
     slugKey: deviceSlugKey(slug),
+    macAddress: normalizeValue(device.macAddress || device.mac_address),
     channel: normalizeValue(device.channel),
     channelName: normalizeValue(device.channelName || device.channel_name),
     channelList: normalizeValue(device.channelList),


### PR DESCRIPTION
### Motivation
- Expose the already-fetched MAC address on the Retail Player devices list so users can see device MACs in the same table as the channel and name.
- Keep changes minimal and non-invasive by mapping the value and rendering it in the existing list layout.

### Description
- Add `macAddress` to the normalized device model in `ui/src/retailPlayer/deviceUtils.js` via `mapRetailPlayerDevice` so `device.macAddress` is available to the UI.
- Render a new `MAC Address` header and a corresponding cell containing `device.macAddress` in `ui/src/retailPlayer/RetailPlayerDevicesList.jsx`.
- Update the grid column template and responsive `gridTemplateAreas`/`gridArea` entries in `RetailPlayerDevicesList.jsx` to include a `mac` area so the new column behaves responsively.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a4da4bba48322a04bda9015939a2e)