### PR TITLE
Fix retail player devices table column alignment

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -199,7 +199,8 @@ const useStyles = makeStyles((theme) => {
     textTransform: 'uppercase',
   },
   headerActions: {
-    justifySelf: 'flex-end',
+    justifySelf: 'center',
+    textAlign: 'center',
   },
 
   row: {
@@ -255,10 +256,8 @@ const useStyles = makeStyles((theme) => {
   nameCell: {
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'center',
     gap: theme.spacing(1.5),
     fontWeight: theme.typography.fontWeightMedium,
-    textAlign: 'center',
   },
   nameIcon: {
     color: theme.palette.primary.main,
@@ -270,7 +269,6 @@ const useStyles = makeStyles((theme) => {
   nameLabel: {
     display: 'flex',
     flexDirection: 'column',
-    alignItems: 'center',
     gap: theme.spacing(0.5),
   },
   searchField: {
@@ -300,7 +298,6 @@ const useStyles = makeStyles((theme) => {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
-    textAlign: 'center',
   },
   macAddressCell: {
     fontSize: theme.typography.pxToRem(14),
@@ -1627,8 +1624,8 @@ const RetailPlayerDeviceManagement = () => {
           </div>
           <span className={classes.headerCentered}>Name</span>
           <span className={classes.headerCentered}>Channel Name</span>
-          <span>MAC Address</span>
-          <span>QR ID</span>
+          <span className={classes.headerCentered}>MAC Address</span>
+          <span className={classes.headerCentered}>QR ID</span>
           <span className={classes.headerActions}>Edit</span>
         </div>
         {isLoading ? (

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -50,9 +50,9 @@ import { isDeviceLocked } from './deviceLockState'
 const useStyles = makeStyles((theme) => {
   const dndStyles = buildRetailPlayerDnDStyles(theme)
   const desktopColumns =
-    '64px minmax(260px, 2fr) minmax(220px, 1.2fr) minmax(170px, 1fr) minmax(160px, 1fr) minmax(96px, 0.8fr)'
+    '64px minmax(234px, 1.8fr) minmax(232px, 1.35fr) minmax(176px, 1.1fr) minmax(160px, 1fr) minmax(96px, 0.75fr)'
   const mobileColumns =
-    '56px minmax(220px, 2fr) minmax(200px, 1.2fr) minmax(150px, 1fr) minmax(140px, 1fr) 72px'
+    '56px minmax(198px, 1.8fr) minmax(204px, 1.3fr) minmax(152px, 1fr) minmax(140px, 1fr) 72px'
 
   return {
     root: {
@@ -190,7 +190,10 @@ const useStyles = makeStyles((theme) => {
   headerSelect: {
     display: 'flex',
     alignItems: 'center',
-    gap: theme.spacing(0.5),
+    justifyContent: 'center',
+  },
+  headerCentered: {
+    textAlign: 'center',
   },
   headerLabel: {
     textTransform: 'uppercase',
@@ -245,11 +248,17 @@ const useStyles = makeStyles((theme) => {
     alignItems: 'center',
     justifyContent: 'center',
   },
+  compactCheckbox: {
+    padding: 2,
+    margin: 0,
+  },
   nameCell: {
     display: 'flex',
     alignItems: 'center',
+    justifyContent: 'center',
     gap: theme.spacing(1.5),
     fontWeight: theme.typography.fontWeightMedium,
+    textAlign: 'center',
   },
   nameIcon: {
     color: theme.palette.primary.main,
@@ -261,6 +270,7 @@ const useStyles = makeStyles((theme) => {
   nameLabel: {
     display: 'flex',
     flexDirection: 'column',
+    alignItems: 'center',
     gap: theme.spacing(0.5),
   },
   searchField: {
@@ -290,6 +300,7 @@ const useStyles = makeStyles((theme) => {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
+    textAlign: 'center',
   },
   macAddressCell: {
     fontSize: theme.typography.pxToRem(14),
@@ -560,7 +571,8 @@ const RetailPlayerFolderRow = memo(
             }}
             onClick={(event) => event.stopPropagation()}
             inputProps={{ 'aria-label': `Select folder ${node.name}` }}
-            style={{ transform: 'scale(0.8)' }}
+            className={classes.compactCheckbox}
+            size="small"
           />
         </div>
         <div className={classes.nameCell}>
@@ -689,7 +701,8 @@ const RetailPlayerDeviceRow = memo(
             }}
             onClick={(event) => event.stopPropagation()}
             inputProps={{ 'aria-label': `Select device ${node.name}` }}
-            style={{ transform: 'scale(0.8)' }}
+            className={classes.compactCheckbox}
+            size="small"
           />
         </div>
         <div className={classes.nameCell}>
@@ -1608,11 +1621,12 @@ const RetailPlayerDeviceManagement = () => {
               indeterminate={someSelected}
               onChange={handleSelectAllChange}
               inputProps={{ 'aria-label': 'Select all retail player items' }}
-              style={{ transform: 'scale(0.8)' }} 
+              className={classes.compactCheckbox}
+              size="small"
             />
           </div>
-          <span>Name</span>
-          <span>Channel Name</span>
+          <span className={classes.headerCentered}>Name</span>
+          <span className={classes.headerCentered}>Channel Name</span>
           <span>MAC Address</span>
           <span>QR ID</span>
           <span className={classes.headerActions}>Edit</span>


### PR DESCRIPTION
### Motivation
- Correct misalignment between header and body columns in the Retail Player Devices table so headers and data cells line up precisely and the checkbox column aligns vertically and horizontally with row checkboxes.
- Reduce the `Name` column width by approximately 10% and rebalance column widths for a cleaner, proportional layout while preserving existing behavior.

### Description
- Updated grid column templates `desktopColumns` and `mobileColumns` to shrink the `Name` column and redistribute widths across adjacent columns for better balance (`ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx`).
- Replaced inline scaled checkbox styling with a reusable `compactCheckbox` class and applied `size="small"` to header and row checkboxes to ensure consistent sizing and centered alignment of the selection column.
- Added `headerCentered` utility class and applied it to the `Name` and `Channel Name` header labels, and center-aligned the `nameCell`, `nameLabel`, and `channelNameCell` to visually center content in header and body.
- Kept existing padding/spacing approach and other component logic unchanged so only layout and alignment were adjusted.

### Testing
- Ran lint via `npm --prefix ui run lint`, which failed due to pre-existing repository lint issues (including `no-console` errors) and not caused by these layout changes.
- Started the dev server with `npm --prefix ui run start` which brought the app up (Vite reported ready), but an automated Playwright screenshot attempt crashed the headless browser with a `TargetClosedError`/`SIGSEGV`, preventing an automated visual snapshot.
- No unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69917d18538c8322aa9c0e8105924b98)