### PR TITLE
Fix retail player devices table header alignment

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -180,7 +180,6 @@ const useStyles = makeStyles((theme) => {
     letterSpacing: 0.8,
     fontWeight: theme.typography.fontWeightMedium,
     alignItems: 'center',
-    gap: theme.spacing(1.2),
     [theme.breakpoints.down('sm')]: {
       gridTemplateColumns: mobileColumns,
       fontSize: theme.typography.pxToRem(11),
@@ -190,10 +189,12 @@ const useStyles = makeStyles((theme) => {
   headerSelect: {
     display: 'flex',
     alignItems: 'center',
-    gap: theme.spacing(0.5),
+    justifyContent: 'center',
   },
   headerLabel: {
     textTransform: 'uppercase',
+    display: 'flex',
+    alignItems: 'center',
   },
   headerActions: {
     justifySelf: 'flex-end',
@@ -1608,13 +1609,13 @@ const RetailPlayerDeviceManagement = () => {
               indeterminate={someSelected}
               onChange={handleSelectAllChange}
               inputProps={{ 'aria-label': 'Select all retail player items' }}
-              style={{ transform: 'scale(0.8)' }} 
+              style={{ transform: 'scale(0.8)' }}
             />
           </div>
-          <span>Name</span>
-          <span>Channel Name</span>
-          <span>MAC Address</span>
-          <span>QR ID</span>
+          <span className={classes.headerLabel}>Name</span>
+          <span className={classes.headerLabel}>Channel Name</span>
+          <span className={classes.headerLabel}>MAC Address</span>
+          <span className={classes.headerLabel}>QR ID</span>
           <span className={classes.headerActions}>Edit</span>
         </div>
         {isLoading ? (


### PR DESCRIPTION
### Motivation
- Make the Retail Player Devices table look professional by aligning header text and the select-all checkbox with the row content so columns line up consistently.

### Description
- Center the header select-all checkbox container by updating the `headerSelect` style to `justifyContent: 'center'` so it lines up with row checkboxes.
- Apply a shared `headerLabel` style (`display: 'flex'` + `alignItems: 'center'`) to the `Name`, `Channel Name`, `MAC Address`, and `QR ID` header spans for consistent vertical alignment.
- Remove the extra grid `gap` from the header (`listHeader`) to prevent headers from being offset from the table body columns.

### Testing
- Ran `git diff --check` which reported no whitespace or merge errors.
- Ran `npm run lint` which failed to complete due to pre-existing lint violations in the workspace (notably `no-console` errors) so a clean lint pass could not be verified.
- Started the dev server and executed a Playwright script to navigate to `/#/retail-player/devices` and capture a screenshot, which completed; however the running app reported an unresolved import of `@dnd-kit/core` that limited further runtime verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991818c9dfc8322ac21d4d86c68f494)