### PR TITLE
Add CoverArt page and /api/coverart-songs with MusicBrainz enrichment

### DIFF
--- a/server/nativeapi/coverart_songs.go
+++ b/server/nativeapi/coverart_songs.go
@@ -1,0 +1,310 @@
+package nativeapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+)
+
+const (
+	coverArtBatchSize    = 50
+	coverArtPlaceholder  = "/musicmatters.png"
+	musicBrainzUserAgent = "Navidrome-MusicMatters/1.0 (https://github.com/navidrome/navidrome)"
+)
+
+type coverArtSong struct {
+	ID          string  `json:"id"`
+	Title       string  `json:"title"`
+	Artist      string  `json:"artist"`
+	Album       string  `json:"album"`
+	Genre       string  `json:"genre"`
+	Year        int     `json:"year"`
+	Duration    float32 `json:"duration"`
+	CoverArtURL string  `json:"coverArtUrl"`
+}
+
+type mbRecordingResponse struct {
+	Recordings []struct {
+		Length           int     `json:"length"`
+		FirstReleaseDate string  `json:"first-release-date"`
+		Tags             []mbTag `json:"tags"`
+		Releases         []mbRel `json:"releases"`
+	} `json:"recordings"`
+}
+
+type mbTag struct {
+	Name string `json:"name"`
+}
+
+type mbRel struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+}
+
+type musicBrainzClient struct {
+	httpClient  *http.Client
+	mu          sync.Mutex
+	lastRequest time.Time
+}
+
+func newMusicBrainzClient() *musicBrainzClient {
+	return &musicBrainzClient{
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (c *musicBrainzClient) throttle() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	wait := time.Second - time.Since(c.lastRequest)
+	if wait > 0 {
+		time.Sleep(wait)
+	}
+	c.lastRequest = time.Now()
+}
+
+func (c *musicBrainzClient) do(req *http.Request) (*http.Response, error) {
+	c.throttle()
+	req.Header.Set("User-Agent", musicBrainzUserAgent)
+	req.Header.Set("Accept", "application/json")
+	return c.httpClient.Do(req)
+}
+
+func (c *musicBrainzClient) searchRecording(ctx context.Context, title, artist string) (*mbRecordingResponse, error) {
+	query := fmt.Sprintf(`recording:"%s" AND artist:"%s"`, title, artist)
+	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json&limit=1"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("musicbrainz search failed: %s", resp.Status)
+	}
+	var data mbRecordingResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, err
+	}
+	return &data, nil
+}
+
+func (c *musicBrainzClient) coverArtExists(ctx context.Context, releaseID string) bool {
+	if releaseID == "" {
+		return false
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, "https://coverartarchive.org/release/"+releaseID+"/front", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+func (n *Router) addCoverArtSongsRoute(r chi.Router) {
+	r.Get("/coverart-songs", n.handleCoverArtSongs)
+}
+
+var (
+	coverArtUpdaterMu sync.Mutex
+	coverArtUpdater   = newMusicBrainzClient()
+)
+
+func (n *Router) handleCoverArtSongs(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	start, end := parseRange(r)
+	limit := end - start
+	if limit <= 0 || limit > coverArtBatchSize {
+		limit = coverArtBatchSize
+	}
+	search := strings.TrimSpace(r.URL.Query().Get("q"))
+	refreshMissingOnly := strings.EqualFold(r.URL.Query().Get("refreshMissingCoverArt"), "true")
+
+	filters := squirrel.And{squirrel.Eq{"missing": false}}
+	if search != "" {
+		like := "%" + strings.ToLower(search) + "%"
+		filters = append(filters, squirrel.Or{
+			squirrel.Expr("lower(title) like ?", like),
+			squirrel.Expr("lower(artist) like ?", like),
+			squirrel.Expr("lower(album) like ?", like),
+		})
+	}
+
+	repo := n.ds.MediaFile(ctx)
+	total, err := repo.CountAll(model.QueryOptions{Filters: filters})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	songs, err := repo.GetAll(model.QueryOptions{
+		Sort:    "title",
+		Order:   "ASC",
+		Offset:  start,
+		Max:     limit,
+		Filters: filters,
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resp := make([]coverArtSong, 0, len(songs))
+	toUpdate := make([]model.MediaFile, 0, coverArtBatchSize)
+	for i := range songs {
+		song := songs[i]
+		n.populateSongArtwork(r, &song)
+		coverURL := song.ArtworkURL
+		if coverURL == "" && song.MbzAlbumID != "" {
+			coverURL = "https://coverartarchive.org/release/" + song.MbzAlbumID + "/front"
+		}
+		if coverURL == "" {
+			coverURL = coverArtPlaceholder
+		}
+		resp = append(resp, coverArtSong{
+			ID:          song.ID,
+			Title:       song.Title,
+			Artist:      song.Artist,
+			Album:       song.Album,
+			Genre:       song.Genre,
+			Year:        song.Year,
+			Duration:    song.Duration,
+			CoverArtURL: coverURL,
+		})
+		if len(toUpdate) < coverArtBatchSize && needsMetadataUpdate(song, refreshMissingOnly) {
+			toUpdate = append(toUpdate, song)
+		}
+	}
+
+	if len(toUpdate) > 0 {
+		go n.updateSongsFromMusicBrainz(request.AddValues(context.Background(), ctx), toUpdate, refreshMissingOnly)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Total-Count", strconv.FormatInt(total, 10))
+	w.Header().Set("Access-Control-Expose-Headers", "X-Total-Count")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func parseRange(r *http.Request) (int, int) {
+	q := r.URL.Query()
+	start, _ := strconv.Atoi(q.Get("_start"))
+	end, _ := strconv.Atoi(q.Get("_end"))
+	if end <= start {
+		end = start + coverArtBatchSize
+	}
+	if start < 0 {
+		start = 0
+	}
+	return start, end
+}
+
+func needsMetadataUpdate(song model.MediaFile, refreshMissingOnly bool) bool {
+	if refreshMissingOnly {
+		return !song.HasCoverArt
+	}
+	return song.Album == "" || song.Genre == "" || song.Year == 0 || song.Duration == 0 || (!song.HasCoverArt && song.MbzAlbumID == "")
+}
+
+func (n *Router) updateSongsFromMusicBrainz(ctx context.Context, songs []model.MediaFile, refreshMissingOnly bool) {
+	coverArtUpdaterMu.Lock()
+	defer coverArtUpdaterMu.Unlock()
+
+	for _, song := range songs {
+		updated := song
+		changed := false
+
+		if (!refreshMissingOnly && (updated.Album == "" || updated.Genre == "" || updated.Year == 0 || updated.Duration == 0 || updated.MbzAlbumID == "")) || (refreshMissingOnly && updated.MbzAlbumID == "") {
+			mbData, err := coverArtUpdater.searchRecording(ctx, updated.Title, updated.Artist)
+			if err != nil {
+				log.Debug(ctx, "MusicBrainz lookup failed", "songId", updated.ID, "err", err)
+				continue
+			}
+			if len(mbData.Recordings) > 0 {
+				rec := mbData.Recordings[0]
+				if !refreshMissingOnly && updated.Album == "" && len(rec.Releases) > 0 && rec.Releases[0].Title != "" {
+					updated.Album = rec.Releases[0].Title
+					changed = true
+				}
+				if !refreshMissingOnly && updated.Year == 0 && len(rec.FirstReleaseDate) >= 4 {
+					if y, err := strconv.Atoi(rec.FirstReleaseDate[:4]); err == nil {
+						updated.Year = y
+						changed = true
+					}
+				}
+				if !refreshMissingOnly && updated.Genre == "" && len(rec.Tags) > 0 {
+					updated.Genre = rec.Tags[0].Name
+					changed = true
+				}
+				if !refreshMissingOnly && updated.Duration == 0 && rec.Length > 0 {
+					updated.Duration = float32(rec.Length) / 1000
+					changed = true
+				}
+				if updated.MbzAlbumID == "" && len(rec.Releases) > 0 && rec.Releases[0].ID != "" {
+					updated.MbzAlbumID = rec.Releases[0].ID
+					changed = true
+				}
+			}
+		}
+
+		if !updated.HasCoverArt && updated.MbzAlbumID != "" {
+			if coverArtUpdater.coverArtExists(ctx, updated.MbzAlbumID) {
+				changed = true
+			}
+		}
+
+		if !changed {
+			continue
+		}
+
+		err := n.ds.WithTx(func(tx model.DataStore) error {
+			repo := tx.MediaFile(ctx)
+			stored, err := repo.Get(updated.ID)
+			if err != nil {
+				return err
+			}
+			if stored.Title != updated.Title || stored.Artist != updated.Artist {
+				updated.Title = stored.Title
+				updated.Artist = stored.Artist
+			}
+			if stored.Album != "" {
+				updated.Album = stored.Album
+			}
+			if stored.Genre != "" {
+				updated.Genre = stored.Genre
+			}
+			if stored.Year != 0 {
+				updated.Year = stored.Year
+			}
+			if stored.Duration != 0 {
+				updated.Duration = stored.Duration
+			}
+			if stored.MbzAlbumID != "" {
+				updated.MbzAlbumID = stored.MbzAlbumID
+			}
+			return repo.Put(&updated)
+		})
+		if err != nil {
+			log.Debug(ctx, "Could not persist MusicBrainz data", "songId", updated.ID, "err", err)
+		}
+	}
+}

--- a/server/nativeapi/coverart_songs.go
+++ b/server/nativeapi/coverart_songs.go
@@ -35,6 +35,18 @@ type coverArtSong struct {
 	CoverArtURL string  `json:"coverArtUrl"`
 }
 
+type coverArtStatus struct {
+	Running              bool   `json:"running"`
+	Total                int    `json:"total"`
+	Completed            int    `json:"completed"`
+	Remaining            int    `json:"remaining"`
+	Updated              int    `json:"updated"`
+	NotFound             int    `json:"notFound"`
+	MissingCoverSongs    int64  `json:"missingCoverSongs"`
+	MissingMetadataSongs int64  `json:"missingMetadataSongs"`
+	Message              string `json:"message,omitempty"`
+}
+
 type mbRecordingResponse struct {
 	Recordings []struct {
 		Length           int     `json:"length"`
@@ -59,10 +71,17 @@ type musicBrainzClient struct {
 	lastRequest time.Time
 }
 
+type coverArtRefreshTracker struct {
+	mu     sync.Mutex
+	status coverArtStatus
+}
+
 func newMusicBrainzClient() *musicBrainzClient {
-	return &musicBrainzClient{
-		httpClient: &http.Client{Timeout: 10 * time.Second},
-	}
+	return &musicBrainzClient{httpClient: &http.Client{Timeout: 10 * time.Second}}
+}
+
+func newCoverArtRefreshTracker() *coverArtRefreshTracker {
+	return &coverArtRefreshTracker{status: coverArtStatus{}}
 }
 
 func (c *musicBrainzClient) throttle() {
@@ -121,13 +140,60 @@ func (c *musicBrainzClient) coverArtExists(ctx context.Context, releaseID string
 }
 
 func (n *Router) addCoverArtSongsRoute(r chi.Router) {
-	r.Get("/coverart-songs", n.handleCoverArtSongs)
+	r.Route("/coverart-songs", func(r chi.Router) {
+		r.Get("/", n.handleCoverArtSongs)
+		r.Get("/status", n.handleCoverArtStatus)
+		r.Post("/refresh", n.handleCoverArtRefresh)
+	})
 }
 
 var (
 	coverArtUpdaterMu sync.Mutex
 	coverArtUpdater   = newMusicBrainzClient()
+	coverArtTracker   = newCoverArtRefreshTracker()
 )
+
+func (t *coverArtRefreshTracker) snapshot() coverArtStatus {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	s := t.status
+	s.Remaining = max(0, s.Total-s.Completed)
+	return s
+}
+
+func (t *coverArtRefreshTracker) setStart(total int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.status = coverArtStatus{
+		Running:   true,
+		Total:     total,
+		Completed: 0,
+		Updated:   0,
+		NotFound:  0,
+		Message:   "Refresh started",
+	}
+}
+
+func (t *coverArtRefreshTracker) setComplete(msg string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.status.Running = false
+	t.status.Message = msg
+	t.status.Remaining = max(0, t.status.Total-t.status.Completed)
+}
+
+func (t *coverArtRefreshTracker) markSong(updated bool, found bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.status.Completed++
+	if updated {
+		t.status.Updated++
+	}
+	if !found {
+		t.status.NotFound++
+	}
+	t.status.Remaining = max(0, t.status.Total-t.status.Completed)
+}
 
 func (n *Router) handleCoverArtSongs(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -136,18 +202,10 @@ func (n *Router) handleCoverArtSongs(w http.ResponseWriter, r *http.Request) {
 	if limit <= 0 || limit > coverArtBatchSize {
 		limit = coverArtBatchSize
 	}
+
 	search := strings.TrimSpace(r.URL.Query().Get("q"))
 	refreshMissingOnly := strings.EqualFold(r.URL.Query().Get("refreshMissingCoverArt"), "true")
-
-	filters := squirrel.And{squirrel.Eq{"missing": false}}
-	if search != "" {
-		like := "%" + strings.ToLower(search) + "%"
-		filters = append(filters, squirrel.Or{
-			squirrel.Expr("lower(title) like ?", like),
-			squirrel.Expr("lower(artist) like ?", like),
-			squirrel.Expr("lower(album) like ?", like),
-		})
-	}
+	filters := listFilters(search)
 
 	repo := n.ds.MediaFile(ctx)
 	total, err := repo.CountAll(model.QueryOptions{Filters: filters})
@@ -190,19 +248,108 @@ func (n *Router) handleCoverArtSongs(w http.ResponseWriter, r *http.Request) {
 			Duration:    song.Duration,
 			CoverArtURL: coverURL,
 		})
+
 		if len(toUpdate) < coverArtBatchSize && needsMetadataUpdate(song, refreshMissingOnly) {
 			toUpdate = append(toUpdate, song)
 		}
 	}
 
 	if len(toUpdate) > 0 {
-		go n.updateSongsFromMusicBrainz(request.AddValues(context.Background(), ctx), toUpdate, refreshMissingOnly)
+		go n.updateSongsFromMusicBrainz(request.AddValues(context.Background(), ctx), toUpdate, refreshMissingOnly, nil)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Total-Count", strconv.FormatInt(total, 10))
 	w.Header().Set("Access-Control-Expose-Headers", "X-Total-Count")
 	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (n *Router) handleCoverArtRefresh(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	status := coverArtTracker.snapshot()
+	if status.Running {
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(status)
+		return
+	}
+
+	songs, err := n.ds.MediaFile(ctx).GetAll(model.QueryOptions{
+		Sort:  "title",
+		Order: "ASC",
+		Max:   coverArtBatchSize,
+		Filters: squirrel.And{
+			squirrel.Eq{"missing": false},
+			squirrel.Eq{"has_cover_art": false},
+		},
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	coverArtTracker.setStart(len(songs))
+	go func(items []model.MediaFile) {
+		if len(items) == 0 {
+			coverArtTracker.setComplete("No songs with missing cover art in current batch")
+			return
+		}
+		n.updateSongsFromMusicBrainz(request.AddValues(context.Background(), ctx), items, true, coverArtTracker)
+		coverArtTracker.setComplete("Refresh finished")
+	}(songs)
+
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(coverArtTracker.snapshot())
+}
+
+func (n *Router) handleCoverArtStatus(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	status := coverArtTracker.snapshot()
+	status.MissingCoverSongs = n.countMissingCoverSongs(ctx)
+	status.MissingMetadataSongs = n.countMissingMetadataSongs(ctx)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(status)
+}
+
+func (n *Router) countMissingCoverSongs(ctx context.Context) int64 {
+	count, err := n.ds.MediaFile(ctx).CountAll(model.QueryOptions{Filters: squirrel.And{
+		squirrel.Eq{"missing": false},
+		squirrel.Eq{"has_cover_art": false},
+	}})
+	if err != nil {
+		log.Debug(ctx, "Could not count missing cover songs", "err", err)
+		return 0
+	}
+	return count
+}
+
+func (n *Router) countMissingMetadataSongs(ctx context.Context) int64 {
+	count, err := n.ds.MediaFile(ctx).CountAll(model.QueryOptions{Filters: squirrel.And{
+		squirrel.Eq{"missing": false},
+		squirrel.Or{
+			squirrel.Eq{"album": ""},
+			squirrel.Eq{"genre": ""},
+			squirrel.Eq{"year": 0},
+			squirrel.Eq{"duration": 0},
+		},
+	}})
+	if err != nil {
+		log.Debug(ctx, "Could not count missing metadata songs", "err", err)
+		return 0
+	}
+	return count
+}
+
+func listFilters(search string) squirrel.And {
+	filters := squirrel.And{squirrel.Eq{"missing": false}}
+	if search == "" {
+		return filters
+	}
+	like := "%" + strings.ToLower(search) + "%"
+	return append(filters, squirrel.Or{
+		squirrel.Expr("lower(title) like ?", like),
+		squirrel.Expr("lower(artist) like ?", like),
+		squirrel.Expr("lower(album) like ?", like),
+	})
 }
 
 func parseRange(r *http.Request) (int, int) {
@@ -222,89 +369,106 @@ func needsMetadataUpdate(song model.MediaFile, refreshMissingOnly bool) bool {
 	if refreshMissingOnly {
 		return !song.HasCoverArt
 	}
-	return song.Album == "" || song.Genre == "" || song.Year == 0 || song.Duration == 0 || (!song.HasCoverArt && song.MbzAlbumID == "")
+	return song.Album == "" || song.Genre == "" || song.Year == 0 || song.Duration == 0 || !song.HasCoverArt
 }
 
-func (n *Router) updateSongsFromMusicBrainz(ctx context.Context, songs []model.MediaFile, refreshMissingOnly bool) {
+func (n *Router) updateSongsFromMusicBrainz(
+	ctx context.Context,
+	songs []model.MediaFile,
+	refreshMissingOnly bool,
+	tracker *coverArtRefreshTracker,
+) {
 	coverArtUpdaterMu.Lock()
 	defer coverArtUpdaterMu.Unlock()
 
 	for _, song := range songs {
-		updated := song
-		changed := false
-
-		if (!refreshMissingOnly && (updated.Album == "" || updated.Genre == "" || updated.Year == 0 || updated.Duration == 0 || updated.MbzAlbumID == "")) || (refreshMissingOnly && updated.MbzAlbumID == "") {
-			mbData, err := coverArtUpdater.searchRecording(ctx, updated.Title, updated.Artist)
-			if err != nil {
-				log.Debug(ctx, "MusicBrainz lookup failed", "songId", updated.ID, "err", err)
-				continue
-			}
-			if len(mbData.Recordings) > 0 {
-				rec := mbData.Recordings[0]
-				if !refreshMissingOnly && updated.Album == "" && len(rec.Releases) > 0 && rec.Releases[0].Title != "" {
-					updated.Album = rec.Releases[0].Title
-					changed = true
-				}
-				if !refreshMissingOnly && updated.Year == 0 && len(rec.FirstReleaseDate) >= 4 {
-					if y, err := strconv.Atoi(rec.FirstReleaseDate[:4]); err == nil {
-						updated.Year = y
-						changed = true
-					}
-				}
-				if !refreshMissingOnly && updated.Genre == "" && len(rec.Tags) > 0 {
-					updated.Genre = rec.Tags[0].Name
-					changed = true
-				}
-				if !refreshMissingOnly && updated.Duration == 0 && rec.Length > 0 {
-					updated.Duration = float32(rec.Length) / 1000
-					changed = true
-				}
-				if updated.MbzAlbumID == "" && len(rec.Releases) > 0 && rec.Releases[0].ID != "" {
-					updated.MbzAlbumID = rec.Releases[0].ID
-					changed = true
-				}
-			}
+		updated, found := n.updateSingleSong(ctx, song, refreshMissingOnly)
+		if tracker != nil {
+			tracker.markSong(updated, found)
 		}
+	}
+}
 
-		if !updated.HasCoverArt && updated.MbzAlbumID != "" {
-			if coverArtUpdater.coverArtExists(ctx, updated.MbzAlbumID) {
+func (n *Router) updateSingleSong(ctx context.Context, song model.MediaFile, refreshMissingOnly bool) (bool, bool) {
+	updated := song
+	changed := false
+	found := false
+
+	if (!refreshMissingOnly && (updated.Album == "" || updated.Genre == "" || updated.Year == 0 || updated.Duration == 0 || updated.MbzAlbumID == "")) || (refreshMissingOnly && updated.MbzAlbumID == "") {
+		mbData, err := coverArtUpdater.searchRecording(ctx, updated.Title, updated.Artist)
+		if err != nil {
+			log.Debug(ctx, "MusicBrainz lookup failed", "songId", updated.ID, "err", err)
+			return false, false
+		}
+		if len(mbData.Recordings) > 0 {
+			found = true
+			rec := mbData.Recordings[0]
+			if !refreshMissingOnly && updated.Album == "" && len(rec.Releases) > 0 && rec.Releases[0].Title != "" {
+				updated.Album = rec.Releases[0].Title
+				changed = true
+			}
+			if !refreshMissingOnly && updated.Year == 0 && len(rec.FirstReleaseDate) >= 4 {
+				if y, err := strconv.Atoi(rec.FirstReleaseDate[:4]); err == nil {
+					updated.Year = y
+					changed = true
+				}
+			}
+			if !refreshMissingOnly && updated.Genre == "" && len(rec.Tags) > 0 {
+				updated.Genre = rec.Tags[0].Name
+				changed = true
+			}
+			if !refreshMissingOnly && updated.Duration == 0 && rec.Length > 0 {
+				updated.Duration = float32(rec.Length) / 1000
+				changed = true
+			}
+			if updated.MbzAlbumID == "" && len(rec.Releases) > 0 && rec.Releases[0].ID != "" {
+				updated.MbzAlbumID = rec.Releases[0].ID
 				changed = true
 			}
 		}
+	}
 
-		if !changed {
-			continue
-		}
-
-		err := n.ds.WithTx(func(tx model.DataStore) error {
-			repo := tx.MediaFile(ctx)
-			stored, err := repo.Get(updated.ID)
-			if err != nil {
-				return err
-			}
-			if stored.Title != updated.Title || stored.Artist != updated.Artist {
-				updated.Title = stored.Title
-				updated.Artist = stored.Artist
-			}
-			if stored.Album != "" {
-				updated.Album = stored.Album
-			}
-			if stored.Genre != "" {
-				updated.Genre = stored.Genre
-			}
-			if stored.Year != 0 {
-				updated.Year = stored.Year
-			}
-			if stored.Duration != 0 {
-				updated.Duration = stored.Duration
-			}
-			if stored.MbzAlbumID != "" {
-				updated.MbzAlbumID = stored.MbzAlbumID
-			}
-			return repo.Put(&updated)
-		})
-		if err != nil {
-			log.Debug(ctx, "Could not persist MusicBrainz data", "songId", updated.ID, "err", err)
+	if !updated.HasCoverArt && updated.MbzAlbumID != "" {
+		if coverArtUpdater.coverArtExists(ctx, updated.MbzAlbumID) {
+			found = true
+			changed = true
 		}
 	}
+
+	if !changed {
+		return false, found
+	}
+
+	err := n.ds.WithTx(func(tx model.DataStore) error {
+		repo := tx.MediaFile(ctx)
+		stored, err := repo.Get(updated.ID)
+		if err != nil {
+			return err
+		}
+		// Never overwrite title/artist
+		updated.Title = stored.Title
+		updated.Artist = stored.Artist
+
+		if stored.Album != "" {
+			updated.Album = stored.Album
+		}
+		if stored.Genre != "" {
+			updated.Genre = stored.Genre
+		}
+		if stored.Year != 0 {
+			updated.Year = stored.Year
+		}
+		if stored.Duration != 0 {
+			updated.Duration = stored.Duration
+		}
+		if stored.MbzAlbumID != "" {
+			updated.MbzAlbumID = stored.MbzAlbumID
+		}
+		return repo.Put(&updated)
+	})
+	if err != nil {
+		log.Debug(ctx, "Could not persist MusicBrainz data", "songId", updated.ID, "err", err)
+		return false, found
+	}
+	return true, true
 }

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -125,6 +125,7 @@ func (n *Router) routes() http.Handler {
 		n.addDiscoveryRoute(r)
 		n.addSongPlaylistsRoute(r)
 		n.addSongDiscoveriesRoute(r)
+		n.addCoverArtSongsRoute(r)
 		n.addSongCommentRoute(r)
 		n.addQueueRoute(r)
 		n.addMissingFilesRoute(r)

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -10,6 +10,7 @@ import transcoding from './transcoding'
 import player from './player'
 import user from './user'
 import song from './song'
+import coverart from './coverart'
 import album from './album'
 import artist from './artist'
 import playlist from './playlist'
@@ -109,6 +110,7 @@ const Admin = (props) => {
         <Resource name="album" {...album} options={{ subMenu: 'albumList' }} />,
         <Resource name="artist" {...artist} />,
         <Resource name="song" {...song} />,
+        <Resource name="coverart" {...coverart} />,
         <Resource
           name="radio"
           {...(permissions === 'admin' ? radio.admin : radio.all)}

--- a/ui/src/coverart/CoverArtPage.jsx
+++ b/ui/src/coverart/CoverArtPage.jsx
@@ -8,10 +8,10 @@ import {
   TopToolbar,
   sanitizeListRestProps,
   useDataProvider,
-  useListContext,
   useNotify,
   useRefresh,
 } from 'react-admin'
+import { Box, Chip } from '@material-ui/core'
 import Button from '@material-ui/core/Button'
 import RefreshIcon from '@material-ui/icons/Refresh'
 import { makeStyles } from '@material-ui/core/styles'
@@ -25,6 +25,13 @@ const useStyles = makeStyles(() => ({
     borderRadius: 4,
     backgroundColor: '#f4f4f4',
   },
+  statusRow: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 8,
+    alignItems: 'center',
+    marginLeft: 8,
+  },
 }))
 
 const CoverArtFilter = (props) => (
@@ -33,46 +40,78 @@ const CoverArtFilter = (props) => (
   </Filter>
 )
 
-const RefreshMissingCoverArtButton = () => {
+const defaultStatus = {
+  running: false,
+  total: 0,
+  completed: 0,
+  remaining: 0,
+  updated: 0,
+  notFound: 0,
+  missingCoverSongs: 0,
+  missingMetadataSongs: 0,
+}
+
+const CoverArtActions = ({ className, filters, resource, showFilter, displayedFilters, filterValues, ...rest }) => {
+  const classes = useStyles()
   const dataProvider = useDataProvider()
   const notify = useNotify()
   const refresh = useRefresh()
-  const { filterValues = {} } = useListContext()
+  const [status, setStatus] = React.useState(defaultStatus)
 
-  const handleClick = async () => {
+  const loadStatus = React.useCallback(async () => {
     try {
-      await dataProvider.getList('coverart', {
-        pagination: { page: 1, perPage: 50 },
-        sort: { field: 'title', order: 'ASC' },
-        filter: { ...filterValues, refreshMissingCoverArt: true },
+      const response = await dataProvider.getCoverArtStatus()
+      setStatus({ ...defaultStatus, ...(response?.data || {}) })
+    } catch (_error) {
+      // ignore polling failures
+    }
+  }, [dataProvider])
+
+  React.useEffect(() => {
+    loadStatus()
+    const interval = setInterval(loadStatus, 2000)
+    return () => clearInterval(interval)
+  }, [loadStatus])
+
+  const handleRefresh = async () => {
+    try {
+      const response = await dataProvider.refreshCoverArtMissing({
+        filter: { ...filterValues },
       })
-      notify('Refreshing missing cover art in background', { type: 'info' })
+      setStatus({ ...defaultStatus, ...(response?.data || {}) })
+      notify('Sequential refresh started (up to 50 songs)', { type: 'info' })
       refresh()
-    } catch (error) {
-      notify('Failed to refresh missing cover art', { type: 'warning' })
+      loadStatus()
+    } catch (_error) {
+      notify('Failed to start refresh', { type: 'warning' })
     }
   }
 
   return (
-    <Button onClick={handleClick} startIcon={<RefreshIcon />}>
-      Refresh Missing Cover Art
-    </Button>
+    <TopToolbar className={className} {...sanitizeListRestProps(rest)}>
+      {filters &&
+        React.cloneElement(filters, {
+          resource,
+          showFilter,
+          displayedFilters,
+          filterValues,
+          context: 'button',
+        })}
+      <Button onClick={handleRefresh} startIcon={<RefreshIcon />}>
+        Refresh Missing Cover Art
+      </Button>
+      <Box className={classes.statusRow}>
+        <Chip label={`Done: ${status.completed}/${status.total}`} size="small" />
+        <Chip label={`Left: ${status.remaining}`} size="small" />
+        <Chip label={`Not Found: ${status.notFound}`} size="small" />
+        <Chip label={`Updated: ${status.updated}`} size="small" />
+        <Chip label={`Missing Covers: ${status.missingCoverSongs}`} size="small" />
+        <Chip label={`Missing Metadata: ${status.missingMetadataSongs}`} size="small" />
+        {status.running && <Chip label="Refreshing..." color="secondary" size="small" />}
+      </Box>
+    </TopToolbar>
   )
 }
-
-const CoverArtActions = ({ className, filters, resource, showFilter, displayedFilters, filterValues, ...rest }) => (
-  <TopToolbar className={className} {...sanitizeListRestProps(rest)}>
-    {filters &&
-      React.cloneElement(filters, {
-        resource,
-        showFilter,
-        displayedFilters,
-        filterValues,
-        context: 'button',
-      })}
-    <RefreshMissingCoverArtButton />
-  </TopToolbar>
-)
 
 const CoverArtImageField = ({ record }) => {
   const classes = useStyles()
@@ -95,32 +134,30 @@ const CoverArtImageField = ({ record }) => {
   )
 }
 
-const CoverArtPage = (props) => {
-  return (
-    <List
-      {...props}
-      sort={{ field: 'title', order: 'ASC' }}
-      filters={<CoverArtFilter />}
-      actions={<CoverArtActions />}
-      perPage={50}
-      exporter={false}
-    >
-      <Datagrid rowClick={false}>
-        <FunctionField
-          label="Cover Art"
-          source="coverArtUrl"
-          render={(record) => <CoverArtImageField record={record} />}
-          sortable={false}
-        />
-        <TextField source="title" label="Title" />
-        <TextField source="artist" label="Artist Name" />
-        <TextField source="album" label="Album" />
-        <TextField source="genre" label="Genre" />
-        <TextField source="year" label="Year of Release" />
-        <DurationField source="duration" label="Duration" />
-      </Datagrid>
-    </List>
-  )
-}
+const CoverArtPage = (props) => (
+  <List
+    {...props}
+    sort={{ field: 'title', order: 'ASC' }}
+    filters={<CoverArtFilter />}
+    actions={<CoverArtActions />}
+    perPage={50}
+    exporter={false}
+  >
+    <Datagrid rowClick={false}>
+      <FunctionField
+        label="Cover Art"
+        source="coverArtUrl"
+        render={(record) => <CoverArtImageField record={record} />}
+        sortable={false}
+      />
+      <TextField source="title" label="Title" />
+      <TextField source="artist" label="Artist Name" />
+      <TextField source="album" label="Album" />
+      <TextField source="genre" label="Genre" />
+      <TextField source="year" label="Year of Release" />
+      <DurationField source="duration" label="Duration" />
+    </Datagrid>
+  </List>
+)
 
 export default CoverArtPage

--- a/ui/src/coverart/CoverArtPage.jsx
+++ b/ui/src/coverart/CoverArtPage.jsx
@@ -1,0 +1,126 @@
+import React from 'react'
+import {
+  Datagrid,
+  Filter,
+  FunctionField,
+  SearchInput,
+  TextField,
+  TopToolbar,
+  sanitizeListRestProps,
+  useDataProvider,
+  useListContext,
+  useNotify,
+  useRefresh,
+} from 'react-admin'
+import Button from '@material-ui/core/Button'
+import RefreshIcon from '@material-ui/icons/Refresh'
+import { makeStyles } from '@material-ui/core/styles'
+import { DurationField, List } from '../common'
+
+const useStyles = makeStyles(() => ({
+  cover: {
+    width: 80,
+    height: 80,
+    objectFit: 'cover',
+    borderRadius: 4,
+    backgroundColor: '#f4f4f4',
+  },
+}))
+
+const CoverArtFilter = (props) => (
+  <Filter {...props} variant={'outlined'}>
+    <SearchInput source="q" alwaysOn />
+  </Filter>
+)
+
+const RefreshMissingCoverArtButton = () => {
+  const dataProvider = useDataProvider()
+  const notify = useNotify()
+  const refresh = useRefresh()
+  const { filterValues = {} } = useListContext()
+
+  const handleClick = async () => {
+    try {
+      await dataProvider.getList('coverart', {
+        pagination: { page: 1, perPage: 50 },
+        sort: { field: 'title', order: 'ASC' },
+        filter: { ...filterValues, refreshMissingCoverArt: true },
+      })
+      notify('Refreshing missing cover art in background', { type: 'info' })
+      refresh()
+    } catch (error) {
+      notify('Failed to refresh missing cover art', { type: 'warning' })
+    }
+  }
+
+  return (
+    <Button onClick={handleClick} startIcon={<RefreshIcon />}>
+      Refresh Missing Cover Art
+    </Button>
+  )
+}
+
+const CoverArtActions = ({ className, filters, resource, showFilter, displayedFilters, filterValues, ...rest }) => (
+  <TopToolbar className={className} {...sanitizeListRestProps(rest)}>
+    {filters &&
+      React.cloneElement(filters, {
+        resource,
+        showFilter,
+        displayedFilters,
+        filterValues,
+        context: 'button',
+      })}
+    <RefreshMissingCoverArtButton />
+  </TopToolbar>
+)
+
+const CoverArtImageField = ({ record }) => {
+  const classes = useStyles()
+  const [src, setSrc] = React.useState(record?.coverArtUrl || '/musicmatters.png')
+
+  React.useEffect(() => {
+    setSrc(record?.coverArtUrl || '/musicmatters.png')
+  }, [record?.coverArtUrl])
+
+  return (
+    <img
+      src={src}
+      alt={record?.title || 'cover'}
+      width={80}
+      height={80}
+      loading="lazy"
+      className={classes.cover}
+      onError={() => setSrc('/musicmatters.png')}
+    />
+  )
+}
+
+const CoverArtPage = (props) => {
+  return (
+    <List
+      {...props}
+      sort={{ field: 'title', order: 'ASC' }}
+      filters={<CoverArtFilter />}
+      actions={<CoverArtActions />}
+      perPage={50}
+      exporter={false}
+    >
+      <Datagrid rowClick={false}>
+        <FunctionField
+          label="Cover Art"
+          source="coverArtUrl"
+          render={(record) => <CoverArtImageField record={record} />}
+          sortable={false}
+        />
+        <TextField source="title" label="Title" />
+        <TextField source="artist" label="Artist Name" />
+        <TextField source="album" label="Album" />
+        <TextField source="genre" label="Genre" />
+        <TextField source="year" label="Year of Release" />
+        <DurationField source="duration" label="Duration" />
+      </Datagrid>
+    </List>
+  )
+}
+
+export default CoverArtPage

--- a/ui/src/coverart/index.jsx
+++ b/ui/src/coverart/index.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import ImageOutlinedIcon from '@material-ui/icons/ImageOutlined'
+import ImageIcon from '@material-ui/icons/Image'
+import DynamicMenuIcon from '../layout/DynamicMenuIcon'
+import CoverArtPage from './CoverArtPage'
+
+export default {
+  list: CoverArtPage,
+  icon: (
+    <DynamicMenuIcon
+      path={'coverart'}
+      icon={ImageOutlinedIcon}
+      activeIcon={ImageIcon}
+    />
+  ),
+}

--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -197,8 +197,23 @@ const getCoverArtSongs = async (params = {}) => {
   }
 }
 
+
+const getCoverArtStatus = async () => {
+  const response = await httpClient(`${REST_URL}/coverart-songs/status`)
+  return { data: response.json || {} }
+}
+
+const refreshCoverArtMissing = async () => {
+  const response = await httpClient(`${REST_URL}/coverart-songs/refresh`, {
+    method: 'POST',
+  })
+  return { data: response.json || {} }
+}
+
 const wrapperDataProvider = {
   ...dataProvider,
+  getCoverArtStatus: () => getCoverArtStatus(),
+  refreshCoverArtMissing: () => refreshCoverArtMissing(),
   getList: (resource, params) => {
     if (resource === 'coverart') {
       return getCoverArtSongs(params)

--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -169,9 +169,40 @@ const emitFoldersChanged = (detail) => {
   }
 }
 
+
+const getCoverArtSongs = async (params = {}) => {
+  const page = params?.pagination?.page || 1
+  const perPage = params?.pagination?.perPage || 50
+  const start = (page - 1) * perPage
+  const end = start + perPage
+  const q = params?.filter?.q || ''
+  const refreshMissingCoverArt = params?.filter?.refreshMissingCoverArt
+
+  const query = new URLSearchParams({
+    _start: String(start),
+    _end: String(end),
+  })
+
+  if (q) {
+    query.set('q', q)
+  }
+  if (refreshMissingCoverArt) {
+    query.set('refreshMissingCoverArt', 'true')
+  }
+
+  const response = await httpClient(`${REST_URL}/coverart-songs?${query.toString()}`)
+  return {
+    data: response.json || [],
+    total: Number(response.headers.get('x-total-count') || 0),
+  }
+}
+
 const wrapperDataProvider = {
   ...dataProvider,
   getList: (resource, params) => {
+    if (resource === 'coverart') {
+      return getCoverArtSongs(params)
+    }
     const [r, p] = mapResource(resource, params)
     return dataProvider.getList(r, p)
   },

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -56,6 +56,18 @@
         }
       }
     },
+    "coverart": {
+      "name": "CoverArt",
+      "fields": {
+        "title": "Title",
+        "artist": "Artist Name",
+        "album": "Album",
+        "genre": "Genre",
+        "year": "Year of Release",
+        "duration": "Duration",
+        "coverArt": "Cover Art"
+      }
+    },
     "album": {
       "name": "Album |||| Albums",
       "fields": {


### PR DESCRIPTION
### Motivation
- Provide a dedicated UI for inspecting and filling missing cover art and related metadata for songs using MusicBrainz as the first metadata source.
- Avoid changing existing `song` behavior while enabling safe background metadata enrichment and cover-art population.
- Expose a lightweight paginated endpoint tailored to the CoverArt UI so the app can request and process songs in controlled batches.

### Description
- Added a new React Admin resource `coverart` and registered it in the admin resources immediately after `song`, exposing the UI at `#/coverart` and the route path `/coverart` (UI changes in `ui/src/coverart/*` and `ui/src/App.jsx`).
- Implemented `CoverArtPage` which reuses existing list/pagination/layout patterns and shows columns in the requested order: Cover Art (80x80 lazy thumbnail), Title, Artist Name, Album, Genre, Year of Release, Duration, plus a search box and a `Refresh Missing Cover Art` button (`ui/src/coverart/CoverArtPage.jsx`).
- Added custom data-provider support for the `coverart` resource so `getList` calls `GET /api/coverart-songs` and parses `_start/_end`, `q`, and `refreshMissingCoverArt` query parameters (`ui/src/dataProvider/wrapperDataProvider.js`).
- Added backend endpoint `GET /coverart-songs` which returns paginated rows with the JSON schema: `{ id, title, artist, album, genre, year, duration, coverArtUrl }`, exposes `X-Total-Count`, and uses the same list pagination logic as other endpoints (`server/nativeapi/coverart_songs.go` and router registration in `server/nativeapi/native_api.go`).
- Implemented MusicBrainz-only enrichment flow and Cover Art Archive checks with a simple client that throttles to ~1 request/sec, processes updates in batches (max 50), runs updates asynchronously (non-blocking list responses), and follows safe update rules that never overwrite `title` or `artist` and only fill missing `album`, `genre`, `year`, `duration`, and `mbz` release id; cover-art URL is built from MB release ID or a placeholder when not found.

### Testing
- Ran `npx eslint` on the new UI files (`ui/src/coverart/CoverArtPage.jsx`, `ui/src/coverart/index.jsx`, `ui/src/App.jsx`, `ui/src/dataProvider/wrapperDataProvider.js`) and it passed for those files.
- Ran `gofmt`/`gofmt -w` on the new backend file and ensured it is formatted successfully.
- Attempted Go test suite (`go test ./server/nativeapi`) but full test execution in this environment failed due to a missing system `taglib` pkg-config dependency, so unit tests could not be fully validated here.
- Attempted `npm --prefix ui run build` and `npm --prefix ui run start`; the dev server started and a screenshot of `#/coverart` was captured, but the build/dev run reported an unresolved existing dependency (`@dnd-kit/core`) in this environment (pre-existing in the project), which prevented a full production build here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699188dcb8048322b703fd9733620d99)