### PR TITLE
Add minimal covertart page with song metadata columns

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -10,6 +10,7 @@ import transcoding from './transcoding'
 import player from './player'
 import user from './user'
 import song from './song'
+import covertart from './covertart'
 import album from './album'
 import artist from './artist'
 import playlist from './playlist'
@@ -109,6 +110,7 @@ const Admin = (props) => {
         <Resource name="album" {...album} options={{ subMenu: 'albumList' }} />,
         <Resource name="artist" {...artist} />,
         <Resource name="song" {...song} />,
+        <Resource name="covertart" {...covertart} />,
         <Resource
           name="radio"
           {...(permissions === 'admin' ? radio.admin : radio.all)}

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import {
+  Datagrid,
+  Filter,
+  FunctionField,
+  List,
+  SearchInput,
+  TextField,
+} from 'react-admin'
+import { DurationField } from '../common'
+import subsonic from '../subsonic'
+
+const CovertartFilter = (props) => (
+  <Filter {...props} variant={'outlined'}>
+    <SearchInput source="title" alwaysOn />
+  </Filter>
+)
+
+const CovertartList = (props) => (
+  <List
+    {...props}
+    sort={{ field: 'title', order: 'ASC' }}
+    filters={<CovertartFilter />}
+    exporter={false}
+    bulkActionButtons={false}
+    perPage={50}
+  >
+    <Datagrid rowClick={false}>
+      <FunctionField
+        label="Cover Art"
+        sortable={false}
+        render={(record) => (
+          <img
+            src={subsonic.getCoverArtUrl(record, 64, true)}
+            alt={record.title || 'cover art'}
+            width="64"
+            height="64"
+          />
+        )}
+      />
+      <TextField source="title" />
+      <TextField source="artist" label="Artist" />
+      <TextField source="album" label="Album" />
+      <TextField source="year" label="Release Year" />
+      <TextField source="genre" label="Genre" />
+      <DurationField source="duration" />
+    </Datagrid>
+  </List>
+)
+
+export default CovertartList

--- a/ui/src/covertart/index.jsx
+++ b/ui/src/covertart/index.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import ImageOutlinedIcon from '@material-ui/icons/ImageOutlined'
+import ImageIcon from '@material-ui/icons/Image'
+import DynamicMenuIcon from '../layout/DynamicMenuIcon'
+import CovertartList from './CovertartList'
+
+export default {
+  list: CovertartList,
+  icon: (
+    <DynamicMenuIcon
+      path={'covertart'}
+      icon={ImageOutlinedIcon}
+      activeIcon={ImageIcon}
+    />
+  ),
+}

--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -84,6 +84,7 @@ const mapResource = (resource, params) => {
     }
     case 'album':
     case 'song':
+    case 'covertart':
     case 'artist':
     case 'tag': {
       params.filter = params.filter || {}
@@ -91,6 +92,10 @@ const mapResource = (resource, params) => {
         params.filter.missing = false
       }
       params = applyLibraryFilter(resource, params)
+
+      if (resource === 'covertart') {
+        return ['song', params]
+      }
 
       return [resource, params]
     }


### PR DESCRIPTION
### Motivation
- Provide a simple, minimal UI page named `covertart` to view existing cover art and core song metadata (title, artist, album, release year, genre, duration) with a small search box. 
- Keep changes minimal and avoid modifying backend APIs by reusing existing song data where possible. 

### Description
- Added a new list view resource at `ui/src/covertart/CovertartList.jsx` that renders cover art using `subsonic.getCoverArtUrl` and shows `title`, `artist`, `album`, `year`, `genre`, and `duration` (via `DurationField`).
- Added a resource module and icon at `ui/src/covertart/index.jsx` so the page appears in the navigation.
- Registered the `covertart` resource in `ui/src/App.jsx` so it is available in the main Admin UI.
- Mapped `covertart` requests to the existing `song` endpoint in `ui/src/dataProvider/wrapperDataProvider.js` to avoid backend changes.

### Testing
- Ran linter: `cd ui && npx eslint src/covertart/CovertartList.jsx src/covertart/index.jsx src/App.jsx src/dataProvider/wrapperDataProvider.js`, which completed successfully.
- Attempted to run the dev server with `cd ui && npm start -- --host 0.0.0.0 --port 4173`, which started Vite but exposed a runtime unresolved dependency during the environment boot (`@dnd-kit/core`) causing the app to not fully load in this environment.
- Attempted an automated Playwright screenshot of `http://127.0.0.1:4173/#/covertart`, but Chromium crashed in this environment (SIGSEGV), so no visual artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699192d4523c8322b52e1763ffe20a51)