### PR TITLE
Add MusicBrainz metadata enrichment job and Activity UI

### DIFF
--- a/db/migrations/20260101010101_add_media_file_cover_art_url.go
+++ b/db/migrations/20260101010101_add_media_file_cover_art_url.go
@@ -1,0 +1,21 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(Up20260101010101, Down20260101010101)
+}
+
+func Up20260101010101(_ context.Context, tx *sql.Tx) error {
+	_, err := tx.Exec(`alter table media_file add column cover_art_url varchar(1024) default '' not null;`)
+	return err
+}
+
+func Down20260101010101(_ context.Context, tx *sql.Tx) error {
+	return nil
+}

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -59,6 +59,7 @@ type MediaFile struct {
 	BitDepth             int      `structs:"bit_depth" json:"bitDepth"`
 	Channels             int      `structs:"channels" json:"channels"`
 	Genre                string   `structs:"genre" json:"genre"`
+	CoverArtURL          string   `structs:"cover_art_url" json:"coverArtUrl,omitempty"`
 	Genres               Genres   `structs:"-" json:"genres,omitempty"`
 	SortTitle            string   `structs:"sort_title" json:"sortTitle,omitempty"`
 	SortAlbumName        string   `structs:"sort_album_name" json:"sortAlbumName,omitempty"`
@@ -359,7 +360,7 @@ type MediaFileRepository interface {
 	DeleteAllMissing() (int64, error)
 	FindByPaths(paths []string) (MediaFiles, error)
 	UpdateComment(ids []string, comment string) error
-	UpdateMissingMetadata(id string, album *string, year *int, genre *string) error
+	UpdateMissingMetadata(id string, album *string, year *int, genre *string, coverArtURL *string) error
 
 	// The following methods are used exclusively by the scanner:
 	MarkMissing(bool, ...*MediaFile) error

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -359,6 +359,7 @@ type MediaFileRepository interface {
 	DeleteAllMissing() (int64, error)
 	FindByPaths(paths []string) (MediaFiles, error)
 	UpdateComment(ids []string, comment string) error
+	UpdateMissingMetadata(id string, album *string, year *int, genre *string) error
 
 	// The following methods are used exclusively by the scanner:
 	MarkMissing(bool, ...*MediaFile) error

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -275,6 +275,28 @@ func (r *mediaFileRepository) UpdateComment(ids []string, comment string) error 
 	return nil
 }
 
+func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, year *int, genre *string) error {
+	if album == nil && year == nil && genre == nil {
+		return nil
+	}
+
+	up := Update(r.tableName).Where(Eq{"id": id})
+
+	if album != nil {
+		up = up.Set("album", Expr("case when trim(ifnull(album, '')) = '' then ? else album end", *album))
+	}
+	if year != nil {
+		up = up.Set("year", Expr("case when ifnull(year, 0) = 0 then ? else year end", *year))
+	}
+	if genre != nil {
+		up = up.Set("genre", Expr("case when trim(ifnull(genre, '')) = '' then ? else genre end", *genre))
+	}
+
+	up = up.Set("updated_at", time.Now())
+	_, err := r.executeSQL(up)
+	return err
+}
+
 func (r *mediaFileRepository) MarkMissing(missing bool, mfs ...*model.MediaFile) error {
 	ids := slice.SeqFunc(mfs, func(m *model.MediaFile) string { return m.ID })
 	for chunk := range slice.CollectChunks(ids, 200) {

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -275,8 +275,8 @@ func (r *mediaFileRepository) UpdateComment(ids []string, comment string) error 
 	return nil
 }
 
-func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, year *int, genre *string) error {
-	if album == nil && year == nil && genre == nil {
+func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, year *int, genre *string, coverArtURL *string) error {
+	if album == nil && year == nil && genre == nil && coverArtURL == nil {
 		return nil
 	}
 
@@ -290,6 +290,10 @@ func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, ye
 	}
 	if genre != nil {
 		up = up.Set("genre", Expr("case when trim(ifnull(genre, '')) = '' then ? else genre end", *genre))
+	}
+	if coverArtURL != nil {
+		up = up.Set("cover_art_url", Expr("case when trim(ifnull(cover_art_url, '')) = '' then ? else cover_art_url end", *coverArtURL))
+		up = up.Set("has_cover_art", Expr("case when ifnull(has_cover_art, 0) = 0 then 1 else has_cover_art end"))
 	}
 
 	up = up.Set("updated_at", time.Now())

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -17,11 +17,12 @@ import (
 )
 
 type metadataFieldProgress struct {
-	Missing  int `json:"missing"`
-	Fetching int `json:"fetching"`
-	Fetched  int `json:"fetched"`
-	Updated  int `json:"updated"`
-	Left     int `json:"left"`
+	Missing             int `json:"missing"`
+	Fetching            int `json:"fetching"`
+	Fetched             int `json:"fetched"`
+	Updated             int `json:"updated"`
+	Left                int `json:"left"`
+	MissingAfterUpdates int `json:"missingAfterUpdates"`
 }
 
 type musicBrainzMetadataStatus struct {
@@ -32,17 +33,19 @@ type musicBrainzMetadataStatus struct {
 	Album      metadataFieldProgress `json:"album"`
 	Year       metadataFieldProgress `json:"year"`
 	Genre      metadataFieldProgress `json:"genre"`
+	CoverArt   metadataFieldProgress `json:"coverArt"`
 }
 
 type musicBrainzMetadataJob struct {
-	mu     sync.RWMutex
-	status musicBrainzMetadataStatus
-	client *http.Client
+	mu       sync.RWMutex
+	status   musicBrainzMetadataStatus
+	client   *http.Client
+	mbTicker *time.Ticker
 }
 
 func newMusicBrainzMetadataJob() *musicBrainzMetadataJob {
 	return &musicBrainzMetadataJob{
-		client: &http.Client{Timeout: 15 * time.Second},
+		client: &http.Client{Timeout: 20 * time.Second},
 	}
 }
 
@@ -67,9 +70,10 @@ func (j *musicBrainzMetadataJob) start(ds model.DataStore) bool {
 }
 
 type missingFlags struct {
-	album bool
-	year  bool
-	genre bool
+	album    bool
+	year     bool
+	genre    bool
+	coverArt bool
 }
 
 type mbMetadataCandidate struct {
@@ -79,6 +83,9 @@ type mbMetadataCandidate struct {
 
 func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 	ctx := context.Background()
+	j.mbTicker = time.NewTicker(time.Second)
+	defer j.mbTicker.Stop()
+
 	defer func() {
 		j.mu.Lock()
 		j.status.Running = false
@@ -93,23 +100,23 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 		return
 	}
 
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-
-	for i, c := range candidates {
-		if i > 0 {
-			<-ticker.C
-		}
+	for _, c := range candidates {
 		j.setFetching(c.flags, 1)
 
-		album, year, genre, fetchErr := j.fetchMetadata(c.mf.Title, c.mf.Artist)
+		album, year, genre, releaseMBID, fetchErr := j.fetchMetadata(c.mf.Title, c.mf.Artist)
 		if fetchErr != nil {
 			log.Warn(ctx, "Could not fetch metadata from MusicBrainz", "songId", c.mf.ID, "title", c.mf.Title, "artist", c.mf.Artist, fetchErr)
+		}
+
+		coverURL := ""
+		if c.flags.coverArt && releaseMBID != "" {
+			coverURL, _ = j.fetchCoverArtURL(releaseMBID)
 		}
 
 		var setAlbum *string
 		var setYear *int
 		var setGenre *string
+		var setCoverArtURL *string
 
 		if c.flags.album && album != "" {
 			setAlbum = &album
@@ -120,16 +127,22 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 		if c.flags.genre && genre != "" {
 			setGenre = &genre
 		}
+		if c.flags.coverArt && coverURL != "" {
+			setCoverArtURL = &coverURL
+		}
 
-		if setAlbum != nil || setYear != nil || setGenre != nil {
-			if err := ds.MediaFile(ctx).UpdateMissingMetadata(c.mf.ID, setAlbum, setYear, setGenre); err != nil {
-				log.Error(ctx, "Could not update fetched MusicBrainz metadata", "songId", c.mf.ID, err)
+		updated := missingFlags{}
+		if setAlbum != nil || setYear != nil || setGenre != nil || setCoverArtURL != nil {
+			if err := ds.MediaFile(ctx).UpdateMissingMetadata(c.mf.ID, setAlbum, setYear, setGenre, setCoverArtURL); err != nil {
+				log.Error(ctx, "Could not update fetched metadata", "songId", c.mf.ID, err)
 			} else {
-				j.setUpdated(setAlbum != nil, setYear != nil, setGenre != nil)
+				updated = missingFlags{album: setAlbum != nil, year: setYear != nil, genre: setGenre != nil, coverArt: setCoverArtURL != nil}
+				j.setUpdated(updated)
 			}
 		}
 
-		j.finishFetch(c.flags, album != "", year > 0, genre != "")
+		fetched := missingFlags{album: album != "", year: year > 0, genre: genre != "", coverArt: coverURL != ""}
+		j.finishFetch(c.flags, fetched, updated)
 	}
 }
 
@@ -149,11 +162,12 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 		}
 
 		flags := missingFlags{
-			album: strings.TrimSpace(mf.Album) == "",
-			year:  mf.Year == 0,
-			genre: strings.TrimSpace(mf.Genre) == "",
+			album:    strings.TrimSpace(mf.Album) == "",
+			year:     mf.Year == 0,
+			genre:    strings.TrimSpace(mf.Genre) == "",
+			coverArt: !mf.HasCoverArt && strings.TrimSpace(mf.CoverArtURL) == "",
 		}
-		if !flags.album && !flags.year && !flags.genre {
+		if !flags.album && !flags.year && !flags.genre && !flags.coverArt {
 			continue
 		}
 
@@ -178,6 +192,10 @@ func (j *musicBrainzMetadataJob) incrementMissing(flags missingFlags) {
 		j.status.Genre.Missing++
 		j.status.Genre.Left++
 	}
+	if flags.coverArt {
+		j.status.CoverArt.Missing++
+		j.status.CoverArt.Left++
+	}
 }
 
 func (j *musicBrainzMetadataJob) setFetching(flags missingFlags, delta int) {
@@ -192,46 +210,48 @@ func (j *musicBrainzMetadataJob) setFetching(flags missingFlags, delta int) {
 	if flags.genre {
 		j.status.Genre.Fetching += delta
 	}
-}
-
-func (j *musicBrainzMetadataJob) setUpdated(album, year, genre bool) {
-	j.mu.Lock()
-	defer j.mu.Unlock()
-	if album {
-		j.status.Album.Updated++
-	}
-	if year {
-		j.status.Year.Updated++
-	}
-	if genre {
-		j.status.Genre.Updated++
+	if flags.coverArt {
+		j.status.CoverArt.Fetching += delta
 	}
 }
 
-func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, fetchedYear, fetchedGenre bool) {
+func (j *musicBrainzMetadataJob) setUpdated(flags missingFlags) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	if flags.album {
-		j.status.Album.Fetching--
-		j.status.Album.Left--
-		if fetchedAlbum {
-			j.status.Album.Fetched++
-		}
+		j.status.Album.Updated++
 	}
 	if flags.year {
-		j.status.Year.Fetching--
-		j.status.Year.Left--
-		if fetchedYear {
-			j.status.Year.Fetched++
-		}
+		j.status.Year.Updated++
 	}
 	if flags.genre {
-		j.status.Genre.Fetching--
-		j.status.Genre.Left--
-		if fetchedGenre {
-			j.status.Genre.Fetched++
+		j.status.Genre.Updated++
+	}
+	if flags.coverArt {
+		j.status.CoverArt.Updated++
+	}
+}
+
+func (j *musicBrainzMetadataJob) finishFetch(requested, fetched, updated missingFlags) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	finish := func(field *metadataFieldProgress, req, got, upd bool) {
+		if !req {
+			return
+		}
+		field.Fetching--
+		field.Left--
+		if got {
+			field.Fetched++
+		}
+		if !upd {
+			field.MissingAfterUpdates++
 		}
 	}
+	finish(&j.status.Album, requested.album, fetched.album, updated.album)
+	finish(&j.status.Year, requested.year, fetched.year, updated.year)
+	finish(&j.status.Genre, requested.genre, fetched.genre, updated.genre)
+	finish(&j.status.CoverArt, requested.coverArt, fetched.coverArt, updated.coverArt)
 }
 
 func (j *musicBrainzMetadataJob) setError(err error) {
@@ -244,6 +264,7 @@ type mbSearchResponse struct {
 	Recordings []struct {
 		FirstReleaseDate string `json:"first-release-date"`
 		Releases         []struct {
+			ID    string `json:"id"`
 			Title string `json:"title"`
 			Date  string `json:"date"`
 		} `json:"releases"`
@@ -256,48 +277,114 @@ type mbSearchResponse struct {
 	} `json:"recordings"`
 }
 
-func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (string, int, string, error) {
-	query := fmt.Sprintf("recording:\"%s\" AND artist:\"%s\"", title, artist)
+func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (string, int, string, string, error) {
+	<-j.mbTicker.C
+	query := fmt.Sprintf("recording:%s AND artist:%s", sanitizeQuery(title), sanitizeQuery(artist))
 	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json"
 	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
-		return "", 0, "", err
+		return "", 0, "", "", err
 	}
 	req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
 
 	resp, err := j.client.Do(req)
 	if err != nil {
-		return "", 0, "", err
+		return "", 0, "", "", err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", 0, "", fmt.Errorf("musicbrainz status %d", resp.StatusCode)
+		return "", 0, "", "", fmt.Errorf("musicbrainz status %d", resp.StatusCode)
 	}
 
 	var payload mbSearchResponse
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return "", 0, "", err
+		return "", 0, "", "", err
 	}
 	if len(payload.Recordings) == 0 {
-		return "", 0, "", nil
+		return "", 0, "", "", nil
 	}
 	rec := payload.Recordings[0]
 
 	album := ""
+	releaseMBID := ""
 	if len(rec.Releases) > 0 {
 		album = strings.TrimSpace(rec.Releases[0].Title)
+		releaseMBID = strings.TrimSpace(rec.Releases[0].ID)
 	}
 	year := yearFromDate(rec.FirstReleaseDate)
 	if year == 0 && len(rec.Releases) > 0 {
 		year = yearFromDate(rec.Releases[0].Date)
 	}
 	genre := collectGenre(rec)
-	return album, year, genre, nil
+	return album, year, genre, releaseMBID, nil
+}
+
+func sanitizeQuery(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, `"`, "")
+	return s
+}
+
+type caaResponse struct {
+	Images []struct {
+		Front      bool   `json:"front"`
+		Image      string `json:"image"`
+		Thumbnails struct {
+			Large string `json:"large"`
+		} `json:"thumbnails"`
+	} `json:"images"`
+}
+
+func (j *musicBrainzMetadataJob) fetchCoverArtURL(releaseMBID string) (string, error) {
+	u := "https://coverartarchive.org/release/" + url.PathEscape(releaseMBID)
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
+	resp, err := j.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return "", nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("coverartarchive status %d", resp.StatusCode)
+	}
+
+	var payload caaResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", err
+	}
+	if len(payload.Images) == 0 {
+		return "", nil
+	}
+	pick := func(img struct {
+		Front      bool   `json:"front"`
+		Image      string `json:"image"`
+		Thumbnails struct {
+			Large string `json:"large"`
+		} `json:"thumbnails"`
+	}) string {
+		if strings.TrimSpace(img.Thumbnails.Large) != "" {
+			return strings.TrimSpace(img.Thumbnails.Large)
+		}
+		return strings.TrimSpace(img.Image)
+	}
+	for _, img := range payload.Images {
+		if img.Front {
+			return pick(img), nil
+		}
+	}
+	return pick(payload.Images[0]), nil
 }
 
 func collectGenre(rec struct {
 	FirstReleaseDate string `json:"first-release-date"`
 	Releases         []struct {
+		ID    string `json:"id"`
 		Title string `json:"title"`
 		Date  string `json:"date"`
 	} `json:"releases"`

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/navidrome/navidrome/log"
@@ -37,15 +39,20 @@ type musicBrainzMetadataStatus struct {
 }
 
 type musicBrainzMetadataJob struct {
-	mu       sync.RWMutex
-	status   musicBrainzMetadataStatus
-	client   *http.Client
-	mbTicker *time.Ticker
+	mu                     sync.RWMutex
+	status                 musicBrainzMetadataStatus
+	client                 *http.Client
+	discogsToken           string
+	discogsReleaseIDCache  map[string]int
+	discogsReleaseURLCache map[int]string
 }
 
 func newMusicBrainzMetadataJob() *musicBrainzMetadataJob {
 	return &musicBrainzMetadataJob{
-		client: &http.Client{Timeout: 20 * time.Second},
+		client:                 &http.Client{Timeout: 20 * time.Second},
+		discogsToken:           strings.TrimSpace(os.Getenv("ND_DISCOGS_TOKEN")),
+		discogsReleaseIDCache:  map[string]int{},
+		discogsReleaseURLCache: map[int]string{},
 	}
 }
 
@@ -81,10 +88,20 @@ type mbMetadataCandidate struct {
 	flags missingFlags
 }
 
+type coverArtRunStats struct {
+	totalMissing int
+	fetching     int
+	matched      int
+	failed       int
+	skipped      int
+}
+
 func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 	ctx := context.Background()
-	j.mbTicker = time.NewTicker(time.Second)
-	defer j.mbTicker.Stop()
+	mbTicker := time.NewTicker(time.Second)
+	discogsTicker := time.NewTicker(time.Second)
+	defer mbTicker.Stop()
+	defer discogsTicker.Stop()
 
 	defer func() {
 		j.mu.Lock()
@@ -100,17 +117,34 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 		return
 	}
 
+	stats := coverArtRunStats{}
 	for _, c := range candidates {
+		if c.flags.coverArt {
+			stats.totalMissing++
+		} else {
+			stats.skipped++
+		}
 		j.setFetching(c.flags, 1)
 
-		album, year, genre, releaseMBID, fetchErr := j.fetchMetadata(c.mf.Title, c.mf.Artist)
+		album, year, genre, releaseMBID, fetchErr := j.fetchMetadata(mbTicker, c.mf.Title, c.mf.Artist)
 		if fetchErr != nil {
 			log.Warn(ctx, "Could not fetch metadata from MusicBrainz", "songId", c.mf.ID, "title", c.mf.Title, "artist", c.mf.Artist, fetchErr)
 		}
 
 		coverURL := ""
-		if c.flags.coverArt && releaseMBID != "" {
-			coverURL, _ = j.fetchCoverArtURL(releaseMBID)
+		if c.flags.coverArt {
+			stats.fetching++
+			if releaseMBID != "" {
+				coverURL, _ = j.fetchCoverArtURL(releaseMBID)
+			}
+			if coverURL == "" {
+				coverURL, _ = j.fetchCoverArtFromDiscogs(discogsTicker, c.mf)
+			}
+			if coverURL != "" {
+				stats.matched++
+			} else {
+				stats.failed++
+			}
 		}
 
 		var setAlbum *string
@@ -144,6 +178,14 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 		fetched := missingFlags{album: album != "", year: year > 0, genre: genre != "", coverArt: coverURL != ""}
 		j.finishFetch(c.flags, fetched, updated)
 	}
+
+	log.Info(ctx, "Cover art metadata run summary",
+		"total_missing", stats.totalMissing,
+		"fetching", stats.fetching,
+		"matched", stats.matched,
+		"failed", stats.failed,
+		"skipped", stats.skipped,
+	)
 }
 
 func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model.DataStore) ([]mbMetadataCandidate, error) {
@@ -277,8 +319,8 @@ type mbSearchResponse struct {
 	} `json:"recordings"`
 }
 
-func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (string, int, string, string, error) {
-	<-j.mbTicker.C
+func (j *musicBrainzMetadataJob) fetchMetadata(mbTicker *time.Ticker, title, artist string) (string, int, string, string, error) {
+	<-mbTicker.C
 	query := fmt.Sprintf("recording:%s AND artist:%s", sanitizeQuery(title), sanitizeQuery(artist))
 	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json"
 	req, err := http.NewRequest(http.MethodGet, u, nil)
@@ -361,24 +403,320 @@ func (j *musicBrainzMetadataJob) fetchCoverArtURL(releaseMBID string) (string, e
 	if len(payload.Images) == 0 {
 		return "", nil
 	}
-	pick := func(img struct {
-		Front      bool   `json:"front"`
-		Image      string `json:"image"`
-		Thumbnails struct {
-			Large string `json:"large"`
-		} `json:"thumbnails"`
-	}) string {
-		if strings.TrimSpace(img.Thumbnails.Large) != "" {
-			return strings.TrimSpace(img.Thumbnails.Large)
-		}
-		return strings.TrimSpace(img.Image)
-	}
 	for _, img := range payload.Images {
 		if img.Front {
-			return pick(img), nil
+			return pickCoverArtURL(img.Image, img.Thumbnails.Large), nil
 		}
 	}
-	return pick(payload.Images[0]), nil
+	return pickCoverArtURL(payload.Images[0].Image, payload.Images[0].Thumbnails.Large), nil
+}
+
+type discogsSearchResponse struct {
+	Results []struct {
+		ID          int      `json:"id"`
+		Title       string   `json:"title"`
+		Country     string   `json:"country"`
+		Year        int      `json:"year"`
+		Type        string   `json:"type"`
+		Format      []string `json:"format"`
+		CoverImage  string   `json:"cover_image"`
+		ResourceURL string   `json:"resource_url"`
+		Community   struct {
+			Want int `json:"want"`
+			Have int `json:"have"`
+		} `json:"community"`
+	} `json:"results"`
+}
+
+type discogsReleaseResponse struct {
+	Images []struct {
+		Type string `json:"type"`
+		URI  string `json:"uri"`
+	} `json:"images"`
+}
+
+func (j *musicBrainzMetadataJob) fetchCoverArtFromDiscogs(discogsTicker *time.Ticker, mf model.MediaFile) (string, error) {
+	if j.discogsToken == "" {
+		return "", nil
+	}
+	cacheKey := strings.ToLower(strings.TrimSpace(mf.Artist)) + "|" + strings.ToLower(strings.TrimSpace(mf.Title))
+	if releaseID, ok := j.getCachedDiscogsRelease(cacheKey); ok {
+		if u, ok := j.getCachedDiscogsReleaseURL(releaseID); ok {
+			return u, nil
+		}
+		<-discogsTicker.C
+		releaseURL := fmt.Sprintf("https://api.discogs.com/releases/%d", releaseID)
+		img, err := j.fetchDiscogsReleaseImage(releaseURL)
+		if err == nil && img != "" {
+			j.setCachedDiscogsReleaseURL(releaseID, img)
+			return img, nil
+		}
+	}
+
+	<-discogsTicker.C
+	u := fmt.Sprintf("https://api.discogs.com/database/search?q=%s&type=release&token=%s", url.QueryEscape(strings.TrimSpace(mf.Artist)+" "+strings.TrimSpace(mf.Title)), url.QueryEscape(j.discogsToken))
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
+	resp, err := j.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("discogs search status %d", resp.StatusCode)
+	}
+
+	var payload discogsSearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", err
+	}
+	if len(payload.Results) == 0 {
+		return "", nil
+	}
+
+	best := j.selectBestDiscogsResult(payload.Results, mf)
+	if best == nil {
+		return "", nil
+	}
+	j.setCachedDiscogsRelease(cacheKey, best.ID)
+
+	if strings.TrimSpace(best.CoverImage) != "" {
+		j.setCachedDiscogsReleaseURL(best.ID, strings.TrimSpace(best.CoverImage))
+		return strings.TrimSpace(best.CoverImage), nil
+	}
+	if strings.TrimSpace(best.ResourceURL) == "" {
+		return "", nil
+	}
+
+	<-discogsTicker.C
+	img, err := j.fetchDiscogsReleaseImage(best.ResourceURL)
+	if err != nil {
+		return "", err
+	}
+	if img != "" {
+		j.setCachedDiscogsReleaseURL(best.ID, img)
+	}
+	return img, nil
+}
+
+func (j *musicBrainzMetadataJob) selectBestDiscogsResult(results []struct {
+	ID          int      `json:"id"`
+	Title       string   `json:"title"`
+	Country     string   `json:"country"`
+	Year        int      `json:"year"`
+	Type        string   `json:"type"`
+	Format      []string `json:"format"`
+	CoverImage  string   `json:"cover_image"`
+	ResourceURL string   `json:"resource_url"`
+	Community   struct {
+		Want int `json:"want"`
+		Have int `json:"have"`
+	} `json:"community"`
+}, mf model.MediaFile) *struct {
+	ID          int      `json:"id"`
+	Title       string   `json:"title"`
+	Country     string   `json:"country"`
+	Year        int      `json:"year"`
+	Type        string   `json:"type"`
+	Format      []string `json:"format"`
+	CoverImage  string   `json:"cover_image"`
+	ResourceURL string   `json:"resource_url"`
+	Community   struct {
+		Want int `json:"want"`
+		Have int `json:"have"`
+	} `json:"community"`
+} {
+	artistNorm := normalizeText(mf.Artist)
+	titleNorm := normalizeText(mf.Title)
+	targetCountry := normalizeText(firstTagValue(mf.Tags, "releasecountry", "country"))
+	targetYear := mf.Year
+
+	var best *struct {
+		ID          int      `json:"id"`
+		Title       string   `json:"title"`
+		Country     string   `json:"country"`
+		Year        int      `json:"year"`
+		Type        string   `json:"type"`
+		Format      []string `json:"format"`
+		CoverImage  string   `json:"cover_image"`
+		ResourceURL string   `json:"resource_url"`
+		Community   struct {
+			Want int `json:"want"`
+			Have int `json:"have"`
+		} `json:"community"`
+	}
+	bestScore := -999.0
+	for i := range results {
+		r := &results[i]
+		if !strings.EqualFold(strings.TrimSpace(r.Type), "release") {
+			continue
+		}
+		if isUnofficialOrPromo(r.Format) {
+			continue
+		}
+
+		resArtist, resTitle := splitDiscogsTitle(r.Title)
+		score := 0.0
+		if normalizeText(resArtist) == artistNorm {
+			score += 100
+		} else if strings.Contains(normalizeText(resArtist), artistNorm) {
+			score += 70
+		}
+
+		tsim := titleSimilarity(titleNorm, normalizeText(resTitle))
+		score += tsim * 50
+
+		score += formatPriority(r.Format)
+
+		if targetCountry != "" && normalizeText(r.Country) == targetCountry {
+			score += 10
+		}
+		if targetYear > 0 && r.Year > 0 {
+			delta := absInt(targetYear - r.Year)
+			score += float64(maxInt(0, 10-delta))
+		}
+		score += float64(r.Community.Have+r.Community.Want) / 1000.0
+
+		if score > bestScore {
+			bestScore = score
+			best = r
+		}
+	}
+	return best
+}
+
+func (j *musicBrainzMetadataJob) fetchDiscogsReleaseImage(resourceURL string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, resourceURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
+	resp, err := j.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("discogs release status %d", resp.StatusCode)
+	}
+	var rel discogsReleaseResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return "", err
+	}
+	if len(rel.Images) == 0 {
+		return "", nil
+	}
+	for _, img := range rel.Images {
+		if strings.EqualFold(strings.TrimSpace(img.Type), "primary") && strings.TrimSpace(img.URI) != "" {
+			return strings.TrimSpace(img.URI), nil
+		}
+	}
+	return strings.TrimSpace(rel.Images[0].URI), nil
+}
+
+func splitDiscogsTitle(s string) (string, string) {
+	parts := strings.SplitN(strings.TrimSpace(s), " - ", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "", s
+}
+
+func titleSimilarity(a, b string) float64 {
+	if a == "" || b == "" {
+		return 0
+	}
+	if a == b {
+		return 1
+	}
+	ta := strings.Fields(a)
+	tb := strings.Fields(b)
+	if len(ta) == 0 || len(tb) == 0 {
+		return 0
+	}
+	setA := map[string]bool{}
+	for _, t := range ta {
+		setA[t] = true
+	}
+	inter := 0
+	for _, t := range tb {
+		if setA[t] {
+			inter++
+		}
+	}
+	den := len(ta) + len(tb) - inter
+	if den <= 0 {
+		return 0
+	}
+	return float64(inter) / float64(den)
+}
+
+func formatPriority(formats []string) float64 {
+	score := 0.0
+	for _, f := range formats {
+		n := normalizeText(f)
+		switch {
+		case n == "album":
+			score += 20
+		case n == "ep":
+			score += 15
+		case n == "single":
+			score += 5
+		case n == "compilation":
+			score -= 10
+		case n == "live":
+			score -= 10
+		}
+	}
+	return score
+}
+
+func isUnofficialOrPromo(formats []string) bool {
+	for _, f := range formats {
+		n := normalizeText(f)
+		if n == "unofficial release" || n == "promo" || n == "promotional" || n == "bootleg" {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeText(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	b := strings.Builder{}
+	lastSpace := false
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			b.WriteRune(r)
+			lastSpace = false
+			continue
+		}
+		if !lastSpace {
+			b.WriteByte(' ')
+			lastSpace = true
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func firstTagValue(tags model.Tags, keys ...string) string {
+	for _, k := range keys {
+		vals := tags[model.TagName(k)]
+		if len(vals) > 0 {
+			return vals[0]
+		}
+	}
+	return ""
+}
+
+func pickCoverArtURL(image, large string) string {
+	if strings.TrimSpace(large) != "" {
+		return strings.TrimSpace(large)
+	}
+	return strings.TrimSpace(image)
 }
 
 func collectGenre(rec struct {
@@ -434,6 +772,52 @@ func yearFromDate(date string) int {
 		return 0
 	}
 	return y
+}
+
+func absInt(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func (j *musicBrainzMetadataJob) getCachedDiscogsRelease(key string) (int, bool) {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+	id, ok := j.discogsReleaseIDCache[key]
+	return id, ok
+}
+
+func (j *musicBrainzMetadataJob) setCachedDiscogsRelease(key string, releaseID int) {
+	if releaseID <= 0 {
+		return
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.discogsReleaseIDCache[key] = releaseID
+}
+
+func (j *musicBrainzMetadataJob) getCachedDiscogsReleaseURL(releaseID int) (string, bool) {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+	u, ok := j.discogsReleaseURLCache[releaseID]
+	return u, ok
+}
+
+func (j *musicBrainzMetadataJob) setCachedDiscogsReleaseURL(releaseID int, coverURL string) {
+	if releaseID <= 0 || strings.TrimSpace(coverURL) == "" {
+		return
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.discogsReleaseURLCache[releaseID] = strings.TrimSpace(coverURL)
 }
 
 func (n *Router) addMusicBrainzMetadataRoute(r chi.Router) {

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -1,0 +1,367 @@
+package nativeapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+)
+
+type metadataFieldProgress struct {
+	Missing  int `json:"missing"`
+	Fetching int `json:"fetching"`
+	Fetched  int `json:"fetched"`
+	Updated  int `json:"updated"`
+	Left     int `json:"left"`
+}
+
+type musicBrainzMetadataStatus struct {
+	Running    bool                  `json:"running"`
+	StartedAt  *time.Time            `json:"startedAt,omitempty"`
+	FinishedAt *time.Time            `json:"finishedAt,omitempty"`
+	LastError  string                `json:"lastError,omitempty"`
+	Album      metadataFieldProgress `json:"album"`
+	Year       metadataFieldProgress `json:"year"`
+	Genre      metadataFieldProgress `json:"genre"`
+}
+
+type musicBrainzMetadataJob struct {
+	mu     sync.RWMutex
+	status musicBrainzMetadataStatus
+	client *http.Client
+}
+
+func newMusicBrainzMetadataJob() *musicBrainzMetadataJob {
+	return &musicBrainzMetadataJob{
+		client: &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+func (j *musicBrainzMetadataJob) getStatus() musicBrainzMetadataStatus {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+	return j.status
+}
+
+func (j *musicBrainzMetadataJob) start(ds model.DataStore) bool {
+	j.mu.Lock()
+	if j.status.Running {
+		j.mu.Unlock()
+		return false
+	}
+	now := time.Now()
+	j.status = musicBrainzMetadataStatus{Running: true, StartedAt: &now}
+	j.mu.Unlock()
+
+	go j.run(ds)
+	return true
+}
+
+type missingFlags struct {
+	album bool
+	year  bool
+	genre bool
+}
+
+type mbMetadataCandidate struct {
+	mf    model.MediaFile
+	flags missingFlags
+}
+
+func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
+	ctx := context.Background()
+	defer func() {
+		j.mu.Lock()
+		j.status.Running = false
+		now := time.Now()
+		j.status.FinishedAt = &now
+		j.mu.Unlock()
+	}()
+
+	candidates, err := j.collectCandidates(ctx, ds)
+	if err != nil {
+		j.setError(err)
+		return
+	}
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for i, c := range candidates {
+		if i > 0 {
+			<-ticker.C
+		}
+		j.setFetching(c.flags, 1)
+
+		album, year, genre, fetchErr := j.fetchMetadata(c.mf.Title, c.mf.Artist)
+		if fetchErr != nil {
+			log.Warn(ctx, "Could not fetch metadata from MusicBrainz", "songId", c.mf.ID, "title", c.mf.Title, "artist", c.mf.Artist, fetchErr)
+		}
+
+		var setAlbum *string
+		var setYear *int
+		var setGenre *string
+
+		if c.flags.album && album != "" {
+			setAlbum = &album
+		}
+		if c.flags.year && year > 0 {
+			setYear = &year
+		}
+		if c.flags.genre && genre != "" {
+			setGenre = &genre
+		}
+
+		if setAlbum != nil || setYear != nil || setGenre != nil {
+			if err := ds.MediaFile(ctx).UpdateMissingMetadata(c.mf.ID, setAlbum, setYear, setGenre); err != nil {
+				log.Error(ctx, "Could not update fetched MusicBrainz metadata", "songId", c.mf.ID, err)
+			} else {
+				j.setUpdated(setAlbum != nil, setYear != nil, setGenre != nil)
+			}
+		}
+
+		j.finishFetch(c.flags, album != "", year > 0, genre != "")
+	}
+}
+
+func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model.DataStore) ([]mbMetadataCandidate, error) {
+	cursor, err := ds.MediaFile(ctx).GetCursor()
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]mbMetadataCandidate, 0)
+	for mf, e := range cursor {
+		if e != nil {
+			return nil, e
+		}
+		if strings.TrimSpace(mf.Title) == "" || strings.TrimSpace(mf.Artist) == "" {
+			continue
+		}
+
+		flags := missingFlags{
+			album: strings.TrimSpace(mf.Album) == "",
+			year:  mf.Year == 0,
+			genre: strings.TrimSpace(mf.Genre) == "",
+		}
+		if !flags.album && !flags.year && !flags.genre {
+			continue
+		}
+
+		res = append(res, mbMetadataCandidate{mf: mf, flags: flags})
+		j.incrementMissing(flags)
+	}
+	return res, nil
+}
+
+func (j *musicBrainzMetadataJob) incrementMissing(flags missingFlags) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if flags.album {
+		j.status.Album.Missing++
+		j.status.Album.Left++
+	}
+	if flags.year {
+		j.status.Year.Missing++
+		j.status.Year.Left++
+	}
+	if flags.genre {
+		j.status.Genre.Missing++
+		j.status.Genre.Left++
+	}
+}
+
+func (j *musicBrainzMetadataJob) setFetching(flags missingFlags, delta int) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if flags.album {
+		j.status.Album.Fetching += delta
+	}
+	if flags.year {
+		j.status.Year.Fetching += delta
+	}
+	if flags.genre {
+		j.status.Genre.Fetching += delta
+	}
+}
+
+func (j *musicBrainzMetadataJob) setUpdated(album, year, genre bool) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if album {
+		j.status.Album.Updated++
+	}
+	if year {
+		j.status.Year.Updated++
+	}
+	if genre {
+		j.status.Genre.Updated++
+	}
+}
+
+func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, fetchedYear, fetchedGenre bool) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if flags.album {
+		j.status.Album.Fetching--
+		j.status.Album.Left--
+		if fetchedAlbum {
+			j.status.Album.Fetched++
+		}
+	}
+	if flags.year {
+		j.status.Year.Fetching--
+		j.status.Year.Left--
+		if fetchedYear {
+			j.status.Year.Fetched++
+		}
+	}
+	if flags.genre {
+		j.status.Genre.Fetching--
+		j.status.Genre.Left--
+		if fetchedGenre {
+			j.status.Genre.Fetched++
+		}
+	}
+}
+
+func (j *musicBrainzMetadataJob) setError(err error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.status.LastError = err.Error()
+}
+
+type mbSearchResponse struct {
+	Recordings []struct {
+		FirstReleaseDate string `json:"first-release-date"`
+		Releases         []struct {
+			Title string `json:"title"`
+			Date  string `json:"date"`
+		} `json:"releases"`
+		Tags []struct {
+			Name string `json:"name"`
+		} `json:"tags"`
+		Genres []struct {
+			Name string `json:"name"`
+		} `json:"genres"`
+	} `json:"recordings"`
+}
+
+func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (string, int, string, error) {
+	query := fmt.Sprintf("recording:\"%s\" AND artist:\"%s\"", title, artist)
+	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json"
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return "", 0, "", err
+	}
+	req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
+
+	resp, err := j.client.Do(req)
+	if err != nil {
+		return "", 0, "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", 0, "", fmt.Errorf("musicbrainz status %d", resp.StatusCode)
+	}
+
+	var payload mbSearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", 0, "", err
+	}
+	if len(payload.Recordings) == 0 {
+		return "", 0, "", nil
+	}
+	rec := payload.Recordings[0]
+
+	album := ""
+	if len(rec.Releases) > 0 {
+		album = strings.TrimSpace(rec.Releases[0].Title)
+	}
+	year := yearFromDate(rec.FirstReleaseDate)
+	if year == 0 && len(rec.Releases) > 0 {
+		year = yearFromDate(rec.Releases[0].Date)
+	}
+	genre := collectGenre(rec)
+	return album, year, genre, nil
+}
+
+func collectGenre(rec struct {
+	FirstReleaseDate string `json:"first-release-date"`
+	Releases         []struct {
+		Title string `json:"title"`
+		Date  string `json:"date"`
+	} `json:"releases"`
+	Tags []struct {
+		Name string `json:"name"`
+	} `json:"tags"`
+	Genres []struct {
+		Name string `json:"name"`
+	} `json:"genres"`
+}) string {
+	unique := map[string]bool{}
+	ordered := make([]string, 0, 4)
+	appendName := func(v string) {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			return
+		}
+		key := strings.ToLower(v)
+		if unique[key] {
+			return
+		}
+		unique[key] = true
+		ordered = append(ordered, v)
+	}
+
+	for _, g := range rec.Genres {
+		appendName(g.Name)
+	}
+	for _, t := range rec.Tags {
+		appendName(t.Name)
+	}
+	if len(ordered) == 0 {
+		return ""
+	}
+	if len(ordered) > 5 {
+		ordered = ordered[:5]
+	}
+	return strings.Join(ordered, ", ")
+}
+
+func yearFromDate(date string) int {
+	if len(date) < 4 {
+		return 0
+	}
+	y, err := strconv.Atoi(date[:4])
+	if err != nil {
+		return 0
+	}
+	return y
+}
+
+func (n *Router) addMusicBrainzMetadataRoute(r chi.Router) {
+	r.Route("/metadata/musicbrainz", func(r chi.Router) {
+		r.Get("/status", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(n.metadataJob.getStatus())
+		})
+		r.Post("/fetch", func(w http.ResponseWriter, _ *http.Request) {
+			if n.metadataJob.start(n.ds) {
+				w.WriteHeader(http.StatusAccepted)
+				_, _ = w.Write([]byte(`{"status":"started"}`))
+				return
+			}
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"status":"already_running"}`))
+		})
+	})
+}

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -321,7 +321,7 @@ type mbSearchResponse struct {
 
 func (j *musicBrainzMetadataJob) fetchMetadata(mbTicker *time.Ticker, title, artist string) (string, int, string, string, error) {
 	<-mbTicker.C
-	query := fmt.Sprintf("recording:%s AND artist:%s", sanitizeQuery(title), sanitizeQuery(artist))
+	query := fmt.Sprintf("recording:\"%s\" AND artist:\"%s\"", sanitizeQuery(title), sanitizeQuery(artist))
 	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json"
 	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -31,22 +31,24 @@ const (
 
 type Router struct {
 	http.Handler
-	ds        model.DataStore
-	share     core.Share
-	playlists core.Playlists
-	insights  metrics.Insights
-	libs      core.Library
-	devices   *retailPlayerDeviceResolver
+	ds          model.DataStore
+	share       core.Share
+	playlists   core.Playlists
+	insights    metrics.Insights
+	libs        core.Library
+	devices     *retailPlayerDeviceResolver
+	metadataJob *musicBrainzMetadataJob
 }
 
 func New(ds model.DataStore, share core.Share, playlists core.Playlists, insights metrics.Insights, libraryService core.Library) *Router {
 	r := &Router{
-		ds:        ds,
-		share:     share,
-		playlists: playlists,
-		insights:  insights,
-		libs:      libraryService,
-		devices:   newRetailPlayerDeviceResolver(),
+		ds:          ds,
+		share:       share,
+		playlists:   playlists,
+		insights:    insights,
+		libs:        libraryService,
+		devices:     newRetailPlayerDeviceResolver(),
+		metadataJob: newMusicBrainzMetadataJob(),
 	}
 	r.preloadRetailPlayerDeviceMappings()
 	r.Handler = r.routes()
@@ -138,6 +140,7 @@ func (n *Router) routes() http.Handler {
 			n.addConfigRoute(r)
 			n.addUserLibraryRoute(r)
 			n.addSyncRoute(r)
+			n.addMusicBrainzMetadataRoute(r)
 			n.RX(r, "/library", n.libs.NewRepository, true)
 		})
 	})

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import {
   Datagrid,
   Filter,
@@ -6,15 +6,155 @@ import {
   List,
   SearchInput,
   TextField,
+  TopToolbar,
+  useNotify,
+  usePermissions,
+  useTranslate,
 } from 'react-admin'
+import { Box, Button, Card, CardContent, Grid, Typography } from '@material-ui/core'
+import { BiDownload } from 'react-icons/bi'
 import { DurationField } from '../common'
 import subsonic from '../subsonic'
+import { httpClient } from '../dataProvider'
 
 const CovertartFilter = (props) => (
   <Filter {...props} variant={'outlined'}>
     <SearchInput source="title" alwaysOn />
   </Filter>
 )
+
+const emptyProgress = { missing: 0, fetching: 0, fetched: 0, updated: 0, left: 0 }
+
+const MetadataProgressCard = ({ title, progress, translate }) => (
+  <Card>
+    <CardContent>
+      <Typography variant="subtitle2">{title}</Typography>
+      <Box display="flex" justifyContent="space-between" mt={1}>
+        <span>{translate('activity.musicbrainz.missing')}</span>
+        <span>{progress.missing || 0}</span>
+      </Box>
+      <Box display="flex" justifyContent="space-between">
+        <span>{translate('activity.musicbrainz.fetching')}</span>
+        <span>{progress.fetching || 0}</span>
+      </Box>
+      <Box display="flex" justifyContent="space-between">
+        <span>{translate('activity.musicbrainz.fetched')}</span>
+        <span>{progress.fetched || 0}</span>
+      </Box>
+      <Box display="flex" justifyContent="space-between">
+        <span>{translate('activity.musicbrainz.updated')}</span>
+        <span>{progress.updated || 0}</span>
+      </Box>
+      <Box display="flex" justifyContent="space-between">
+        <span>{translate('activity.musicbrainz.left')}</span>
+        <span>{progress.left || 0}</span>
+      </Box>
+    </CardContent>
+  </Card>
+)
+
+const CovertartListActions = () => {
+  const translate = useTranslate()
+  const notify = useNotify()
+  const { permissions } = usePermissions()
+  const isAdmin = permissions === 'admin'
+  const [status, setStatus] = useState({
+    running: false,
+    album: emptyProgress,
+    year: emptyProgress,
+    genre: emptyProgress,
+  })
+
+  const loadStatus = useCallback(() => {
+    if (!isAdmin) {
+      return
+    }
+    httpClient('/api/metadata/musicbrainz/status')
+      .then(({ json }) => {
+        setStatus(
+          json || {
+            running: false,
+            album: emptyProgress,
+            year: emptyProgress,
+            genre: emptyProgress,
+          },
+        )
+      })
+      .catch(() => {})
+  }, [isAdmin])
+
+  useEffect(() => {
+    loadStatus()
+  }, [loadStatus])
+
+  useEffect(() => {
+    if (!status.running) {
+      return undefined
+    }
+    const timer = setInterval(() => loadStatus(), 2000)
+    return () => clearInterval(timer)
+  }, [status.running, loadStatus])
+
+  const startFetch = () => {
+    httpClient('/api/metadata/musicbrainz/fetch', { method: 'POST' })
+      .then(({ status: code }) => {
+        if (code === 202) {
+          notify('activity.musicbrainz.started', 'info')
+        } else {
+          notify('activity.musicbrainz.alreadyRunning', 'warning')
+        }
+        loadStatus()
+      })
+      .catch(() => notify('activity.musicbrainz.failed', 'warning'))
+  }
+
+  return (
+    <TopToolbar>
+      {isAdmin && (
+        <Button
+          color="primary"
+          variant="contained"
+          startIcon={<BiDownload />}
+          onClick={startFetch}
+          disabled={status.running}
+          data-testid="covertart-metadata-fetch-btn"
+        >
+          {translate('activity.musicbrainz.fetch')}
+        </Button>
+      )}
+      {isAdmin && (
+        <Box width="100%" mt={2}>
+          <Typography variant="subtitle1">
+            {translate('activity.musicbrainz.title')}
+          </Typography>
+          <Grid container spacing={2}>
+            <Grid item xs={12} md={4}>
+              <MetadataProgressCard
+                title={translate('activity.musicbrainz.album')}
+                progress={status.album || emptyProgress}
+                translate={translate}
+              />
+            </Grid>
+            <Grid item xs={12} md={4}>
+              <MetadataProgressCard
+                title={translate('activity.musicbrainz.year')}
+                progress={status.year || emptyProgress}
+                translate={translate}
+              />
+            </Grid>
+            <Grid item xs={12} md={4}>
+              <MetadataProgressCard
+                title={translate('activity.musicbrainz.genre')}
+                progress={status.genre || emptyProgress}
+                translate={translate}
+              />
+            </Grid>
+          </Grid>
+        </Box>
+      )}
+    </TopToolbar>
+  )
+}
 
 const CovertartList = (props) => (
   <List
@@ -24,6 +164,7 @@ const CovertartList = (props) => (
     exporter={false}
     bulkActionButtons={false}
     perPage={50}
+    actions={<CovertartListActions />}
   >
     <Datagrid rowClick={false}>
       <FunctionField

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -23,7 +23,14 @@ const CovertartFilter = (props) => (
   </Filter>
 )
 
-const emptyProgress = { missing: 0, fetching: 0, fetched: 0, updated: 0, left: 0 }
+const emptyProgress = {
+  missing: 0,
+  fetching: 0,
+  fetched: 0,
+  updated: 0,
+  left: 0,
+  missingAfterUpdates: 0,
+}
 
 const MetadataProgressCard = ({ title, progress, translate }) => (
   <Card>
@@ -49,6 +56,10 @@ const MetadataProgressCard = ({ title, progress, translate }) => (
         <span>{translate('activity.musicbrainz.left')}</span>
         <span>{progress.left || 0}</span>
       </Box>
+      <Box display="flex" justifyContent="space-between">
+        <span>{translate('activity.musicbrainz.missingAfterUpdates')}</span>
+        <span>{progress.missingAfterUpdates || 0}</span>
+      </Box>
     </CardContent>
   </Card>
 )
@@ -63,6 +74,7 @@ const CovertartListActions = () => {
     album: emptyProgress,
     year: emptyProgress,
     genre: emptyProgress,
+    coverArt: emptyProgress,
   })
 
   const loadStatus = useCallback(() => {
@@ -77,6 +89,7 @@ const CovertartListActions = () => {
             album: emptyProgress,
             year: emptyProgress,
             genre: emptyProgress,
+            coverArt: emptyProgress,
           },
         )
       })
@@ -128,24 +141,31 @@ const CovertartListActions = () => {
             {translate('activity.musicbrainz.title')}
           </Typography>
           <Grid container spacing={2}>
-            <Grid item xs={12} md={4}>
+            <Grid item xs={12} md={3}>
               <MetadataProgressCard
                 title={translate('activity.musicbrainz.album')}
                 progress={status.album || emptyProgress}
                 translate={translate}
               />
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid item xs={12} md={3}>
               <MetadataProgressCard
                 title={translate('activity.musicbrainz.year')}
                 progress={status.year || emptyProgress}
                 translate={translate}
               />
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid item xs={12} md={3}>
               <MetadataProgressCard
                 title={translate('activity.musicbrainz.genre')}
                 progress={status.genre || emptyProgress}
+                translate={translate}
+              />
+            </Grid>
+            <Grid item xs={12} md={3}>
+              <MetadataProgressCard
+                title={translate('activity.musicbrainz.coverArt')}
+                progress={status.coverArt || emptyProgress}
                 translate={translate}
               />
             </Grid>
@@ -172,7 +192,7 @@ const CovertartList = (props) => (
         sortable={false}
         render={(record) => (
           <img
-            src={subsonic.getCoverArtUrl(record, 64, true)}
+            src={record.coverArtUrl || subsonic.getCoverArtUrl(record, 64, true)}
             alt={record.title || 'cover art'}
             width="64"
             height="64"

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -694,7 +694,9 @@
       "fetching": "Fetching",
       "fetched": "Fetched",
       "updated": "Updated",
-      "left": "Left"
+      "left": "Left",
+      "coverArt": "Cover Art",
+      "missingAfterUpdates": "Missing after updates"
     }
   },
   "nowPlaying": {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -680,7 +680,22 @@
     "serverDown": "OFFLINE",
     "scanType": "Type",
     "status": "Scan Error",
-    "elapsedTime": "Elapsed Time"
+    "elapsedTime": "Elapsed Time",
+    "musicbrainz": {
+      "title": "MusicBrainz Metadata",
+      "fetch": "Fetch metadata from MusicBrainz",
+      "started": "Metadata fetch started",
+      "alreadyRunning": "Metadata fetch is already running",
+      "failed": "Metadata fetch failed",
+      "album": "Album",
+      "year": "Year",
+      "genre": "Genre",
+      "missing": "Missing",
+      "fetching": "Fetching",
+      "fetched": "Fetched",
+      "updated": "Updated",
+      "left": "Left"
+    }
   },
   "nowPlaying": {
     "title": "Now Playing",

--- a/ui/src/layout/ActivityPanel.jsx
+++ b/ui/src/layout/ActivityPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import { useNotify, useTranslate } from 'react-admin'
 import {
@@ -15,7 +15,7 @@ import {
   Typography,
 } from '@material-ui/core'
 import { FiActivity } from 'react-icons/fi'
-import { BiError, BiLink } from 'react-icons/bi'
+import { BiError, BiLink, BiDownload } from 'react-icons/bi'
 import { VscSync } from 'react-icons/vsc'
 import { GiMagnifyingGlass } from 'react-icons/gi'
 import subsonic from '../subsonic'
@@ -54,6 +54,23 @@ const useStyles = makeStyles((theme) => ({
   cardContent: {
     padding: theme.spacing(2, 3),
   },
+  metadataGrid: {
+    display: 'grid',
+    gap: theme.spacing(1),
+    gridTemplateColumns: 'repeat(3, minmax(11em, 1fr))',
+    marginTop: theme.spacing(2),
+  },
+  metadataCard: {
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
+    padding: theme.spacing(1.2),
+  },
+  metadataRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    fontSize: '0.8rem',
+    marginTop: theme.spacing(0.5),
+  },
 }))
 
 const getUptime = (serverStart) =>
@@ -66,6 +83,14 @@ const Uptime = () => {
     setUptime(getUptime(serverStart))
   }, 1000)
   return <span>{uptime}</span>
+}
+
+const emptyProgress = { missing: 0, fetching: 0, fetched: 0, updated: 0, left: 0 }
+const emptyMetadataStatus = {
+  running: false,
+  album: emptyProgress,
+  year: emptyProgress,
+  genre: emptyProgress,
 }
 
 const ActivityPanel = () => {
@@ -85,8 +110,15 @@ const ActivityPanel = () => {
   const translate = useTranslate()
   const notify = useNotify()
   const [anchorEl, setAnchorEl] = useState(null)
+  const [metadataStatus, setMetadataStatus] = useState(emptyMetadataStatus)
   const open = Boolean(anchorEl)
   useInitialScanStatus()
+
+  const fetchMetadataStatus = useCallback(() => {
+    httpClient('/api/metadata/musicbrainz/status')
+      .then(({ json }) => setMetadataStatus(json || emptyMetadataStatus))
+      .catch(() => {})
+  }, [])
 
   const handleMenuOpen = (event) => {
     if (scanStatus.error) {
@@ -106,11 +138,35 @@ const ActivityPanel = () => {
       })
       .catch(() => notify('Sync failed', 'warning'))
 
+  const triggerMetadataFetch = () =>
+    httpClient('/api/metadata/musicbrainz/fetch', { method: 'POST' })
+      .then(({ status }) => {
+        if (status === 202) {
+          notify('activity.musicbrainz.started', 'info')
+        } else {
+          notify('activity.musicbrainz.alreadyRunning', 'warning')
+        }
+        fetchMetadataStatus()
+      })
+      .catch(() => notify('activity.musicbrainz.failed', 'warning'))
+
   useEffect(() => {
     if (serverStart.version && serverStart.version !== config.version) {
       notify('ra.notification.new_version', 'info', {}, false, 604800000 * 50)
     }
   }, [serverStart, notify])
+
+  useEffect(() => {
+    if (open) {
+      fetchMetadataStatus()
+    }
+  }, [open, fetchMetadataStatus])
+
+  useInterval(() => {
+    if (open && metadataStatus.running) {
+      fetchMetadataStatus()
+    }
+  }, open && metadataStatus.running ? 2000 : null)
 
   const tooltipTitle = scanStatus.error
     ? `${translate('activity.status')}: ${scanStatus.error}`
@@ -126,6 +182,35 @@ const ActivityPanel = () => {
         return ''
     }
   })()
+
+  const renderMetadataCard = (title, key) => {
+    const progress = metadataStatus?.[key] || emptyProgress
+    return (
+      <Box className={classes.metadataCard}>
+        <Typography variant="subtitle2">{title}</Typography>
+        <Box className={classes.metadataRow}>
+          <span>{translate('activity.musicbrainz.missing')}</span>
+          <span>{progress.missing || 0}</span>
+        </Box>
+        <Box className={classes.metadataRow}>
+          <span>{translate('activity.musicbrainz.fetching')}</span>
+          <span>{progress.fetching || 0}</span>
+        </Box>
+        <Box className={classes.metadataRow}>
+          <span>{translate('activity.musicbrainz.fetched')}</span>
+          <span>{progress.fetched || 0}</span>
+        </Box>
+        <Box className={classes.metadataRow}>
+          <span>{translate('activity.musicbrainz.updated')}</span>
+          <span>{progress.updated || 0}</span>
+        </Box>
+        <Box className={classes.metadataRow}>
+          <span>{translate('activity.musicbrainz.left')}</span>
+          <span>{progress.left || 0}</span>
+        </Box>
+      </Box>
+    )
+  }
 
   return (
     <div className={classes.wrapper}>
@@ -195,6 +280,23 @@ const ActivityPanel = () => {
               </Box>
             </Box>
 
+            <Box mt={2}>
+              <Typography variant="subtitle2">
+                {translate('activity.musicbrainz.title')}
+              </Typography>
+              <Box className={classes.metadataGrid}>
+                {renderMetadataCard(
+                  translate('activity.musicbrainz.album'),
+                  'album',
+                )}
+                {renderMetadataCard(translate('activity.musicbrainz.year'), 'year')}
+                {renderMetadataCard(
+                  translate('activity.musicbrainz.genre'),
+                  'genre',
+                )}
+              </Box>
+            </Box>
+
             {scanStatus.error && (
               <Box
                 display="flex"
@@ -230,6 +332,14 @@ const ActivityPanel = () => {
                 disabled={scanStatus.scanning}
               >
                 <GiMagnifyingGlass />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title={translate('activity.musicbrainz.fetch')}>
+              <IconButton
+                onClick={triggerMetadataFetch}
+                disabled={metadataStatus.running}
+              >
+                <BiDownload />
               </IconButton>
             </Tooltip>
           </CardActions>

--- a/ui/src/layout/ActivityPanel.jsx
+++ b/ui/src/layout/ActivityPanel.jsx
@@ -57,7 +57,7 @@ const useStyles = makeStyles((theme) => ({
   metadataGrid: {
     display: 'grid',
     gap: theme.spacing(1),
-    gridTemplateColumns: 'repeat(3, minmax(11em, 1fr))',
+    gridTemplateColumns: 'repeat(4, minmax(11em, 1fr))',
     marginTop: theme.spacing(2),
   },
   metadataCard: {
@@ -85,12 +85,20 @@ const Uptime = () => {
   return <span>{uptime}</span>
 }
 
-const emptyProgress = { missing: 0, fetching: 0, fetched: 0, updated: 0, left: 0 }
+const emptyProgress = {
+  missing: 0,
+  fetching: 0,
+  fetched: 0,
+  updated: 0,
+  left: 0,
+  missingAfterUpdates: 0,
+}
 const emptyMetadataStatus = {
   running: false,
   album: emptyProgress,
   year: emptyProgress,
   genre: emptyProgress,
+  coverArt: emptyProgress,
 }
 
 const ActivityPanel = () => {
@@ -208,6 +216,10 @@ const ActivityPanel = () => {
           <span>{translate('activity.musicbrainz.left')}</span>
           <span>{progress.left || 0}</span>
         </Box>
+        <Box className={classes.metadataRow}>
+          <span>{translate('activity.musicbrainz.missingAfterUpdates')}</span>
+          <span>{progress.missingAfterUpdates || 0}</span>
+        </Box>
       </Box>
     )
   }
@@ -293,6 +305,11 @@ const ActivityPanel = () => {
                 {renderMetadataCard(
                   translate('activity.musicbrainz.genre'),
                   'genre',
+                )}
+
+                {renderMetadataCard(
+                  translate('activity.musicbrainz.coverArt'),
+                  'coverArt',
                 )}
               </Box>
             </Box>


### PR DESCRIPTION
### Motivation
- Fill missing `album`, `year`, and `genre` fields automatically for tracks by querying MusicBrainz recordings when the DB entries lack those values. 
- Provide an admin-controlled workflow with observability so operators can fetch metadata on-demand and see progress per-field.

### Description
- Added a background enrichment job `musicBrainzMetadataJob` that scans media files for missing `album`, `year`, or `genre`, queries the MusicBrainz recording search endpoint using `title` + `artist`, enforces a 1 request/second throttle (`time.Ticker`) and extracts album title, first-release year, and genre/tags, updating only missing fields. 
- Exposed admin endpoints `GET /api/metadata/musicbrainz/status` and `POST /api/metadata/musicbrainz/fetch` and wired the job into the native API router for admin access. 
- Extended the `MediaFileRepository` interface with `UpdateMissingMetadata(id string, album *string, year *int, genre *string) error` and implemented it in `persistence/mediafile_repository.go` using SQL `CASE` expressions so existing non-empty fields are not overwritten. 
- Updated Activity popover UI to add a “Fetch metadata from MusicBrainz” button and three progress cards (Album / Year / Genre) that display `missing`, `fetching`, `fetched`, `updated`, and `left` counters with polling while the job is running, and added English i18n strings for the new UI text. 

### Testing
- Ran formatting with `gofmt -w` on the changed Go files (succeeded). 
- Attempted `go test ./server/nativeapi` but automated tests could not complete in this environment due to a missing system dependency (`taglib` via `pkg-config`), so Go unit test execution was blocked. 
- Attempted the UI unit test `npm --prefix ui run test -- ActivityPanel.test.jsx` but it failed in this environment because a dev dependency (`@dnd-kit/core`) could not be resolved. 
- Attempted a UI screenshot via Playwright against the local dev URL but the UI endpoint was not reachable (`ERR_EMPTY_RESPONSE`), so visual verification could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991bbcfe7288322b948cee94045756b)