### PR TITLE
Improve MusicBrainz metadata matching for cover art fetch

### DIFF
--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -283,7 +283,7 @@ func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, ye
 	up := Update(r.tableName).Where(Eq{"id": id})
 
 	if album != nil {
-		up = up.Set("album", Expr("case when trim(ifnull(album, '')) = '' then ? else album end", *album))
+		up = up.Set("album", Expr("case when trim(ifnull(album, '')) = '' or lower(trim(ifnull(album, ''))) in ('unknown album', '[unknown album]') then ? else album end", *album))
 	}
 	if year != nil {
 		up = up.Set("year", Expr("case when ifnull(year, 0) = 0 then ? else year end", *year))

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -459,4 +459,22 @@ var _ = Describe("MediaRepository", func() {
 			})
 		})
 	})
+	Context("UpdateMissingMetadata", func() {
+		It("updates album when current value is [Unknown Album]", func() {
+			mf := model.MediaFile{ID: id.NewRandom(), LibraryID: 1, Title: "Song", Album: "[Unknown Album]", Year: 0, Genre: ""}
+			Expect(mr.Put(&mf)).To(Succeed())
+
+			album := "Real Album"
+			year := 2014
+			genre := "Rock"
+			Expect(mr.UpdateMissingMetadata(mf.ID, &album, &year, &genre)).To(Succeed())
+
+			updated, err := mr.Get(mf.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated.Album).To(Equal("Real Album"))
+			Expect(updated.Year).To(Equal(2014))
+			Expect(updated.Genre).To(Equal("Rock"))
+		})
+	})
+
 })

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/navidrome/navidrome/log"
@@ -96,6 +99,18 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
+	missingAlbums := 0
+	fetched := 0
+	updated := 0
+	skipped := 0
+	failed := 0
+
+	for _, c := range candidates {
+		if c.flags.album {
+			missingAlbums++
+		}
+	}
+
 	for i, c := range candidates {
 		if i > 0 {
 			<-ticker.C
@@ -104,8 +119,13 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 
 		album, year, genre, fetchErr := j.fetchMetadata(c.mf.Title, c.mf.Artist)
 		if fetchErr != nil {
+			failed++
 			log.Warn(ctx, "Could not fetch metadata from MusicBrainz", "songId", c.mf.ID, "title", c.mf.Title, "artist", c.mf.Artist, fetchErr)
+			j.finishFetch(c.flags, false, false, false)
+			continue
 		}
+
+		fetched++
 
 		var setAlbum *string
 		var setYear *int
@@ -123,14 +143,26 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 
 		if setAlbum != nil || setYear != nil || setGenre != nil {
 			if err := ds.MediaFile(ctx).UpdateMissingMetadata(c.mf.ID, setAlbum, setYear, setGenre); err != nil {
+				failed++
 				log.Error(ctx, "Could not update fetched MusicBrainz metadata", "songId", c.mf.ID, err)
 			} else {
+				updated++
 				j.setUpdated(setAlbum != nil, setYear != nil, setGenre != nil)
 			}
+		} else {
+			skipped++
 		}
 
 		j.finishFetch(c.flags, album != "", year > 0, genre != "")
 	}
+
+	log.Info(ctx, "MusicBrainz metadata fetch completed",
+		"missingAlbums", missingAlbums,
+		"fetched", fetched,
+		"updated", updated,
+		"skipped", skipped,
+		"failed", failed,
+	)
 }
 
 func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model.DataStore) ([]mbMetadataCandidate, error) {
@@ -149,7 +181,7 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 		}
 
 		flags := missingFlags{
-			album: strings.TrimSpace(mf.Album) == "",
+			album: isMissingAlbum(mf.Album),
 			year:  mf.Year == 0,
 			genre: strings.TrimSpace(mf.Genre) == "",
 		}
@@ -161,6 +193,11 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 		j.incrementMissing(flags)
 	}
 	return res, nil
+}
+
+func isMissingAlbum(album string) bool {
+	album = normalizeMBString(album)
+	return album == "" || album == "unknown album"
 }
 
 func (j *musicBrainzMetadataJob) incrementMissing(flags missingFlags) {
@@ -242,22 +279,35 @@ func (j *musicBrainzMetadataJob) setError(err error) {
 
 type mbSearchResponse struct {
 	Recordings []struct {
+		Score            string `json:"score"`
 		FirstReleaseDate string `json:"first-release-date"`
-		Releases         []struct {
-			Title string `json:"title"`
-			Date  string `json:"date"`
+		ArtistCredit     []struct {
+			Name string `json:"name"`
+		} `json:"artist-credit"`
+		Releases []struct {
+			Title        string   `json:"title"`
+			Date         string   `json:"date"`
+			Status       string   `json:"status"`
+			ReleaseGroup mbGroup  `json:"release-group"`
+			Tags         []mbName `json:"tags"`
+			Genres       []mbName `json:"genres"`
 		} `json:"releases"`
-		Tags []struct {
-			Name string `json:"name"`
-		} `json:"tags"`
-		Genres []struct {
-			Name string `json:"name"`
-		} `json:"genres"`
+		Tags   []mbName `json:"tags"`
+		Genres []mbName `json:"genres"`
 	} `json:"recordings"`
 }
 
+type mbName struct {
+	Name string `json:"name"`
+}
+
+type mbGroup struct {
+	PrimaryType   string   `json:"primary-type"`
+	SecondaryType []string `json:"secondary-types"`
+}
+
 func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (string, int, string, error) {
-	query := fmt.Sprintf("recording:\"%s\" AND artist:\"%s\"", title, artist)
+	query := fmt.Sprintf("artist:%s AND recording:%s", artist, title)
 	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json"
 	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
@@ -281,33 +331,315 @@ func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (string, in
 	if len(payload.Recordings) == 0 {
 		return "", 0, "", nil
 	}
-	rec := payload.Recordings[0]
 
-	album := ""
-	if len(rec.Releases) > 0 {
-		album = strings.TrimSpace(rec.Releases[0].Title)
+	bestRecording := selectBestRecording(payload.Recordings, artist)
+	if bestRecording == nil {
+		return "", 0, "", nil
 	}
-	year := yearFromDate(rec.FirstReleaseDate)
-	if year == 0 && len(rec.Releases) > 0 {
-		year = yearFromDate(rec.Releases[0].Date)
+
+	bestRelease := selectBestRelease(bestRecording.Releases)
+	if bestRelease == nil {
+		return "", 0, collectRecordingGenre(*bestRecording), nil
 	}
-	genre := collectGenre(rec)
+
+	album := strings.TrimSpace(bestRelease.Title)
+	year := yearFromDate(bestRelease.Date)
+	if year == 0 {
+		year = yearFromDate(bestRecording.FirstReleaseDate)
+	}
+	genre := collectGenre(*bestRecording, *bestRelease)
 	return album, year, genre, nil
 }
 
-func collectGenre(rec struct {
+func selectBestRecording(recordings []struct {
+	Score            string `json:"score"`
 	FirstReleaseDate string `json:"first-release-date"`
-	Releases         []struct {
-		Title string `json:"title"`
-		Date  string `json:"date"`
+	ArtistCredit     []struct {
+		Name string `json:"name"`
+	} `json:"artist-credit"`
+	Releases []struct {
+		Title        string   `json:"title"`
+		Date         string   `json:"date"`
+		Status       string   `json:"status"`
+		ReleaseGroup mbGroup  `json:"release-group"`
+		Tags         []mbName `json:"tags"`
+		Genres       []mbName `json:"genres"`
 	} `json:"releases"`
-	Tags []struct {
+	Tags   []mbName `json:"tags"`
+	Genres []mbName `json:"genres"`
+}, artist string) *struct {
+	Score            string `json:"score"`
+	FirstReleaseDate string `json:"first-release-date"`
+	ArtistCredit     []struct {
 		Name string `json:"name"`
-	} `json:"tags"`
-	Genres []struct {
+	} `json:"artist-credit"`
+	Releases []struct {
+		Title        string   `json:"title"`
+		Date         string   `json:"date"`
+		Status       string   `json:"status"`
+		ReleaseGroup mbGroup  `json:"release-group"`
+		Tags         []mbName `json:"tags"`
+		Genres       []mbName `json:"genres"`
+	} `json:"releases"`
+	Tags   []mbName `json:"tags"`
+	Genres []mbName `json:"genres"`
+} {
+	normalizedArtist := normalizeMBString(artist)
+
+	type recCandidate struct {
+		rec *struct {
+			Score            string `json:"score"`
+			FirstReleaseDate string `json:"first-release-date"`
+			ArtistCredit     []struct {
+				Name string `json:"name"`
+			} `json:"artist-credit"`
+			Releases []struct {
+				Title        string   `json:"title"`
+				Date         string   `json:"date"`
+				Status       string   `json:"status"`
+				ReleaseGroup mbGroup  `json:"release-group"`
+				Tags         []mbName `json:"tags"`
+				Genres       []mbName `json:"genres"`
+			} `json:"releases"`
+			Tags   []mbName `json:"tags"`
+			Genres []mbName `json:"genres"`
+		}
+		score    int
+		releases int
+		hasAlbum bool
+		earliest int
+	}
+
+	candidates := make([]recCandidate, 0, len(recordings))
+	for i := range recordings {
+		rec := &recordings[i]
+		score, err := strconv.Atoi(rec.Score)
+		if err != nil || score < 80 {
+			continue
+		}
+		if !artistCreditMatches(rec.ArtistCredit, normalizedArtist) {
+			continue
+		}
+
+		hasAlbum := false
+		earliest := 9999
+		for _, rel := range rec.Releases {
+			if !isValidRelease(rel) {
+				continue
+			}
+			if isAlbumRelease(rel) {
+				hasAlbum = true
+			}
+			if y := yearFromDate(rel.Date); y > 0 && y < earliest {
+				earliest = y
+			}
+		}
+		candidates = append(candidates, recCandidate{rec: rec, score: score, releases: len(rec.Releases), hasAlbum: hasAlbum, earliest: earliest})
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	slices.SortFunc(candidates, func(a, b recCandidate) int {
+		if a.releases > 0 && b.releases == 0 {
+			return -1
+		}
+		if a.releases == 0 && b.releases > 0 {
+			return 1
+		}
+		if a.score != b.score {
+			return b.score - a.score
+		}
+		if a.hasAlbum && !b.hasAlbum {
+			return -1
+		}
+		if !a.hasAlbum && b.hasAlbum {
+			return 1
+		}
+		if a.earliest != b.earliest {
+			return a.earliest - b.earliest
+		}
+		return 0
+	})
+
+	return candidates[0].rec
+}
+
+func artistCreditMatches(credits []struct {
+	Name string `json:"name"`
+}, normalizedArtist string) bool {
+	if normalizedArtist == "" {
+		return false
+	}
+	for _, credit := range credits {
+		if normalizeMBString(credit.Name) == normalizedArtist {
+			return true
+		}
+	}
+	return false
+}
+
+func selectBestRelease(releases []struct {
+	Title        string   `json:"title"`
+	Date         string   `json:"date"`
+	Status       string   `json:"status"`
+	ReleaseGroup mbGroup  `json:"release-group"`
+	Tags         []mbName `json:"tags"`
+	Genres       []mbName `json:"genres"`
+}) *struct {
+	Title        string   `json:"title"`
+	Date         string   `json:"date"`
+	Status       string   `json:"status"`
+	ReleaseGroup mbGroup  `json:"release-group"`
+	Tags         []mbName `json:"tags"`
+	Genres       []mbName `json:"genres"`
+} {
+	type relCandidate struct {
+		release *struct {
+			Title        string   `json:"title"`
+			Date         string   `json:"date"`
+			Status       string   `json:"status"`
+			ReleaseGroup mbGroup  `json:"release-group"`
+			Tags         []mbName `json:"tags"`
+			Genres       []mbName `json:"genres"`
+		}
+		official bool
+		album    bool
+		year     int
+	}
+
+	candidates := make([]relCandidate, 0, len(releases))
+	for i := range releases {
+		release := &releases[i]
+		if !isValidRelease(*release) {
+			continue
+		}
+		candidates = append(candidates, relCandidate{
+			release:  release,
+			official: strings.EqualFold(strings.TrimSpace(release.Status), "Official"),
+			album:    isAlbumRelease(*release),
+			year:     yearFromDate(release.Date),
+		})
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	slices.SortFunc(candidates, func(a, b relCandidate) int {
+		if a.official && !b.official {
+			return -1
+		}
+		if !a.official && b.official {
+			return 1
+		}
+		if a.album && !b.album {
+			return -1
+		}
+		if !a.album && b.album {
+			return 1
+		}
+		if a.year == 0 && b.year > 0 {
+			return 1
+		}
+		if b.year == 0 && a.year > 0 {
+			return -1
+		}
+		if a.year != b.year {
+			return a.year - b.year
+		}
+		return 0
+	})
+
+	return candidates[0].release
+}
+
+func isValidRelease(release struct {
+	Title        string   `json:"title"`
+	Date         string   `json:"date"`
+	Status       string   `json:"status"`
+	ReleaseGroup mbGroup  `json:"release-group"`
+	Tags         []mbName `json:"tags"`
+	Genres       []mbName `json:"genres"`
+}) bool {
+	if strings.TrimSpace(release.Title) == "" {
+		return false
+	}
+	types := make([]string, 0, len(release.ReleaseGroup.SecondaryType)+1)
+	types = append(types, release.ReleaseGroup.PrimaryType)
+	types = append(types, release.ReleaseGroup.SecondaryType...)
+	for _, t := range types {
+		n := normalizeMBString(t)
+		if n == "compilation" || n == "live" || n == "unofficial" || n == "promo" {
+			return false
+		}
+	}
+	return true
+}
+
+func isAlbumRelease(release struct {
+	Title        string   `json:"title"`
+	Date         string   `json:"date"`
+	Status       string   `json:"status"`
+	ReleaseGroup mbGroup  `json:"release-group"`
+	Tags         []mbName `json:"tags"`
+	Genres       []mbName `json:"genres"`
+}) bool {
+	primaryType := normalizeMBString(release.ReleaseGroup.PrimaryType)
+	return primaryType == "album"
+}
+
+func collectRecordingGenre(rec struct {
+	Score            string `json:"score"`
+	FirstReleaseDate string `json:"first-release-date"`
+	ArtistCredit     []struct {
 		Name string `json:"name"`
-	} `json:"genres"`
+	} `json:"artist-credit"`
+	Releases []struct {
+		Title        string   `json:"title"`
+		Date         string   `json:"date"`
+		Status       string   `json:"status"`
+		ReleaseGroup mbGroup  `json:"release-group"`
+		Tags         []mbName `json:"tags"`
+		Genres       []mbName `json:"genres"`
+	} `json:"releases"`
+	Tags   []mbName `json:"tags"`
+	Genres []mbName `json:"genres"`
 }) string {
+	return collectGenres(rec.Genres, rec.Tags)
+}
+
+func collectGenre(rec struct {
+	Score            string `json:"score"`
+	FirstReleaseDate string `json:"first-release-date"`
+	ArtistCredit     []struct {
+		Name string `json:"name"`
+	} `json:"artist-credit"`
+	Releases []struct {
+		Title        string   `json:"title"`
+		Date         string   `json:"date"`
+		Status       string   `json:"status"`
+		ReleaseGroup mbGroup  `json:"release-group"`
+		Tags         []mbName `json:"tags"`
+		Genres       []mbName `json:"genres"`
+	} `json:"releases"`
+	Tags   []mbName `json:"tags"`
+	Genres []mbName `json:"genres"`
+}, release struct {
+	Title        string   `json:"title"`
+	Date         string   `json:"date"`
+	Status       string   `json:"status"`
+	ReleaseGroup mbGroup  `json:"release-group"`
+	Tags         []mbName `json:"tags"`
+	Genres       []mbName `json:"genres"`
+}) string {
+	genre := collectGenres(release.Genres, release.Tags)
+	if genre != "" {
+		return genre
+	}
+	return collectRecordingGenre(rec)
+}
+
+func collectGenres(genres, tags []mbName) string {
 	unique := map[string]bool{}
 	ordered := make([]string, 0, 4)
 	appendName := func(v string) {
@@ -323,10 +655,10 @@ func collectGenre(rec struct {
 		ordered = append(ordered, v)
 	}
 
-	for _, g := range rec.Genres {
+	for _, g := range genres {
 		appendName(g.Name)
 	}
-	for _, t := range rec.Tags {
+	for _, t := range tags {
 		appendName(t.Name)
 	}
 	if len(ordered) == 0 {
@@ -336,6 +668,20 @@ func collectGenre(rec struct {
 		ordered = ordered[:5]
 	}
 	return strings.Join(ordered, ", ")
+}
+
+var punctuationRegex = regexp.MustCompile(`[\p{P}\p{S}]`)
+
+func normalizeMBString(v string) string {
+	v = strings.ToLower(strings.TrimSpace(v))
+	v = punctuationRegex.ReplaceAllString(v, " ")
+	v = strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return ' '
+		}
+		return r
+	}, v)
+	return strings.Join(strings.Fields(v), " ")
 }
 
 func yearFromDate(date string) int {

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -279,8 +279,8 @@ func (j *musicBrainzMetadataJob) setError(err error) {
 
 type mbSearchResponse struct {
 	Recordings []struct {
-		Score            string `json:"score"`
-		FirstReleaseDate string `json:"first-release-date"`
+		Score            mbScore `json:"score"`
+		FirstReleaseDate string  `json:"first-release-date"`
 		ArtistCredit     []struct {
 			Name string `json:"name"`
 		} `json:"artist-credit"`
@@ -295,6 +295,31 @@ type mbSearchResponse struct {
 		Tags   []mbName `json:"tags"`
 		Genres []mbName `json:"genres"`
 	} `json:"recordings"`
+}
+
+type mbScore string
+
+func (s *mbScore) UnmarshalJSON(data []byte) error {
+	v := strings.TrimSpace(string(data))
+	if v == "" || v == "null" {
+		*s = ""
+		return nil
+	}
+	if len(v) >= 2 && v[0] == '"' && v[len(v)-1] == '"' {
+		*s = mbScore(strings.TrimSpace(v[1 : len(v)-1]))
+		return nil
+	}
+	*s = mbScore(v)
+	return nil
+}
+
+func (s mbScore) Int() int {
+	v := strings.TrimSpace(string(s))
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		return 0
+	}
+	return i
 }
 
 type mbName struct {
@@ -352,8 +377,8 @@ func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (string, in
 }
 
 func selectBestRecording(recordings []struct {
-	Score            string `json:"score"`
-	FirstReleaseDate string `json:"first-release-date"`
+	Score            mbScore `json:"score"`
+	FirstReleaseDate string  `json:"first-release-date"`
 	ArtistCredit     []struct {
 		Name string `json:"name"`
 	} `json:"artist-credit"`
@@ -368,8 +393,8 @@ func selectBestRecording(recordings []struct {
 	Tags   []mbName `json:"tags"`
 	Genres []mbName `json:"genres"`
 }, artist string) *struct {
-	Score            string `json:"score"`
-	FirstReleaseDate string `json:"first-release-date"`
+	Score            mbScore `json:"score"`
+	FirstReleaseDate string  `json:"first-release-date"`
 	ArtistCredit     []struct {
 		Name string `json:"name"`
 	} `json:"artist-credit"`
@@ -388,8 +413,8 @@ func selectBestRecording(recordings []struct {
 
 	type recCandidate struct {
 		rec *struct {
-			Score            string `json:"score"`
-			FirstReleaseDate string `json:"first-release-date"`
+			Score            mbScore `json:"score"`
+			FirstReleaseDate string  `json:"first-release-date"`
 			ArtistCredit     []struct {
 				Name string `json:"name"`
 			} `json:"artist-credit"`
@@ -413,8 +438,8 @@ func selectBestRecording(recordings []struct {
 	candidates := make([]recCandidate, 0, len(recordings))
 	for i := range recordings {
 		rec := &recordings[i]
-		score, err := strconv.Atoi(rec.Score)
-		if err != nil || score < 80 {
+		score := rec.Score.Int()
+		if score < 80 {
 			continue
 		}
 		if !artistCreditMatches(rec.ArtistCredit, normalizedArtist) {
@@ -589,8 +614,8 @@ func isAlbumRelease(release struct {
 }
 
 func collectRecordingGenre(rec struct {
-	Score            string `json:"score"`
-	FirstReleaseDate string `json:"first-release-date"`
+	Score            mbScore `json:"score"`
+	FirstReleaseDate string  `json:"first-release-date"`
 	ArtistCredit     []struct {
 		Name string `json:"name"`
 	} `json:"artist-credit"`
@@ -609,8 +634,8 @@ func collectRecordingGenre(rec struct {
 }
 
 func collectGenre(rec struct {
-	Score            string `json:"score"`
-	FirstReleaseDate string `json:"first-release-date"`
+	Score            mbScore `json:"score"`
+	FirstReleaseDate string  `json:"first-release-date"`
 	ArtistCredit     []struct {
 		Name string `json:"name"`
 	} `json:"artist-credit"`

--- a/server/nativeapi/musicbrainz_metadata_test.go
+++ b/server/nativeapi/musicbrainz_metadata_test.go
@@ -1,0 +1,96 @@
+package nativeapi
+
+import "testing"
+
+func TestNormalizeMBString(t *testing.T) {
+	got := normalizeMBString("  AC/DC - Live!  ")
+	if got != "ac dc live" {
+		t.Fatalf("unexpected normalized value: %q", got)
+	}
+}
+
+func TestSelectBestRecording(t *testing.T) {
+	payload := mbSearchResponse{Recordings: []struct {
+		Score            string `json:"score"`
+		FirstReleaseDate string `json:"first-release-date"`
+		ArtistCredit     []struct {
+			Name string `json:"name"`
+		} `json:"artist-credit"`
+		Releases []struct {
+			Title        string   `json:"title"`
+			Date         string   `json:"date"`
+			Status       string   `json:"status"`
+			ReleaseGroup mbGroup  `json:"release-group"`
+			Tags         []mbName `json:"tags"`
+			Genres       []mbName `json:"genres"`
+		} `json:"releases"`
+		Tags   []mbName `json:"tags"`
+		Genres []mbName `json:"genres"`
+	}{
+		{
+			Score: "95",
+			ArtistCredit: []struct {
+				Name string `json:"name"`
+			}{{Name: "Wrong Artist"}},
+			Releases: []struct {
+				Title        string   `json:"title"`
+				Date         string   `json:"date"`
+				Status       string   `json:"status"`
+				ReleaseGroup mbGroup  `json:"release-group"`
+				Tags         []mbName `json:"tags"`
+				Genres       []mbName `json:"genres"`
+			}{{Title: "Wrong Album", Date: "2010-01-01", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}},
+		},
+		{
+			Score: "92",
+			ArtistCredit: []struct {
+				Name string `json:"name"`
+			}{{Name: "The Artist"}},
+			Releases: []struct {
+				Title        string   `json:"title"`
+				Date         string   `json:"date"`
+				Status       string   `json:"status"`
+				ReleaseGroup mbGroup  `json:"release-group"`
+				Tags         []mbName `json:"tags"`
+				Genres       []mbName `json:"genres"`
+			}{{Title: "Best Album", Date: "2001-01-01", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}},
+		},
+		{
+			Score: "79",
+			ArtistCredit: []struct {
+				Name string `json:"name"`
+			}{{Name: "The Artist"}},
+		},
+	}}
+
+	rec := selectBestRecording(payload.Recordings, "the artist")
+	if rec == nil {
+		t.Fatal("expected a recording")
+	}
+	if len(rec.Releases) == 0 || rec.Releases[0].Title != "Best Album" {
+		t.Fatalf("unexpected selected recording: %+v", rec)
+	}
+}
+
+func TestSelectBestRelease(t *testing.T) {
+	releases := []struct {
+		Title        string   `json:"title"`
+		Date         string   `json:"date"`
+		Status       string   `json:"status"`
+		ReleaseGroup mbGroup  `json:"release-group"`
+		Tags         []mbName `json:"tags"`
+		Genres       []mbName `json:"genres"`
+	}{
+		{Title: "Live Cut", Date: "1990", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album", SecondaryType: []string{"Live"}}},
+		{Title: "Single Cut", Date: "2003", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Single"}},
+		{Title: "Album Cut", Date: "2001", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
+	}
+
+	rel := selectBestRelease(releases)
+	if rel == nil {
+		t.Fatal("expected release")
+	}
+	if rel.Title != "Album Cut" {
+		t.Fatalf("expected Album Cut, got %q", rel.Title)
+	}
+}

--- a/server/nativeapi/musicbrainz_metadata_test.go
+++ b/server/nativeapi/musicbrainz_metadata_test.go
@@ -11,8 +11,8 @@ func TestNormalizeMBString(t *testing.T) {
 
 func TestSelectBestRecording(t *testing.T) {
 	payload := mbSearchResponse{Recordings: []struct {
-		Score            string `json:"score"`
-		FirstReleaseDate string `json:"first-release-date"`
+		Score            mbScore `json:"score"`
+		FirstReleaseDate string  `json:"first-release-date"`
 		ArtistCredit     []struct {
 			Name string `json:"name"`
 		} `json:"artist-credit"`


### PR DESCRIPTION
### Motivation

- The existing MusicBrainz integration was picking the first recording result and often returned incorrect or missing album data such as `[Unknown Album]` and occasionally wrong years.  
- The goal is to use the MusicBrainz recording search API and stronger matching rules to reliably populate missing Album/Year/Genre on the coverart page without overwriting existing values.

### Description

- Replaced naive first-result selection in `server/nativeapi/musicbrainz_metadata.go` with a selection pipeline that queries the recording search endpoint and applies score and artist-credit matching, release filtering, and ranking.  
- Added normalization utilities to compare strings case-insensitively and punctuation/spacing-insensitively via `normalizeMBString`, and treat `[Unknown Album]` as missing so it can be updated.  
- Filtered out recordings with score < 80 and removed releases marked as `compilation`, `live`, `unofficial`, or `promo`, then prefer official album releases and the earliest release date when picking a release; pull `release.title` → Album, `release.date` → Year (first 4 digits), and release `tags/genres` → Genre with recording-level fallbacks.  
- Added fetch counters and final logging for `missingAlbums`, `fetched`, `updated`, `skipped`, and `failed`, preserved 1 request/second throttling, and added unit tests for normalization, recording selection, and release selection (`server/nativeapi/musicbrainz_metadata_test.go`).

### Testing

- Ran `gofmt -w server/nativeapi/musicbrainz_metadata.go server/nativeapi/musicbrainz_metadata_test.go` successfully.  
- Added unit tests and attempted `go test ./server/nativeapi -run 'TestNormalizeMBString|TestSelectBestRecording|TestSelectBestRelease'`, but the test run could not complete in this environment because of unrelated native build dependencies (missing `taglib` / sqlite CGO symbols) which prevented package build.  
- Attempts to run tests in isolation also hit build constraints in this environment (e.g. `Router` type context and CGO-linked packages); the new unit tests are included and should pass in a standard build environment where native deps are satisfied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69930062e3e483229742de0b9068982e)