### PR TITLE
Preserve playlist sort order in playback queue

### DIFF
--- a/adapters/taglib/taglib_wrapper.cpp
+++ b/adapters/taglib/taglib_wrapper.cpp
@@ -1,5 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
+#include <fstream>
+#include <vector>
 
 #define TAGLIB_STATIC
 #include <apeproperties.h>
@@ -10,6 +12,7 @@
 #include <fileref.h>
 #include <flacfile.h>
 #include <id3v2tag.h>
+#include <attachedpictureframe.h>
 #include <unsynchronizedlyricsframe.h>
 #include <synchronizedlyricsframe.h>
 #include <mp4file.h>
@@ -24,6 +27,53 @@
 #include "taglib_wrapper.h"
 
 char has_cover(const TagLib::FileRef f);
+
+static void put_property(TagLib::PropertyMap &properties, const char *key, const char *value) {
+  if (value == nullptr) {
+    return;
+  }
+  TagLib::String v(value, TagLib::String::UTF8);
+  if (v.isEmpty()) {
+    return;
+  }
+  TagLib::StringList list;
+  list.append(v);
+  properties.replace(key, list);
+}
+
+static bool attach_cover_mp3(TagLib::MPEG::File *mp3File, const char *coverPath) {
+  if (mp3File == nullptr || coverPath == nullptr || *coverPath == '\0') {
+    return false;
+  }
+
+  std::ifstream image(coverPath, std::ios::binary);
+  if (!image) {
+    return false;
+  }
+
+  std::vector<char> data((std::istreambuf_iterator<char>(image)), std::istreambuf_iterator<char>());
+  if (data.empty()) {
+    return false;
+  }
+
+  auto *tag = mp3File->ID3v2Tag(true);
+  if (tag == nullptr) {
+    return false;
+  }
+
+  auto existing = tag->frameListMap()["APIC"];
+  for (auto *frame : existing) {
+    tag->removeFrame(frame, true);
+  }
+
+  auto *picture = new TagLib::ID3v2::AttachedPictureFrame;
+  picture->setType(TagLib::ID3v2::AttachedPictureFrame::FrontCover);
+  picture->setMimeType("image/jpeg");
+  picture->setDescription("Front cover");
+  picture->setPicture(TagLib::ByteVector(data.data(), (unsigned int)data.size()));
+  tag->addFrame(picture);
+  return true;
+}
 
 int taglib_write_comment(const FILENAME_CHAR_T *filename, const char *comment) {
   TagLib::FileRef f(filename, false, TagLib::AudioProperties::Fast);
@@ -50,6 +100,43 @@ int taglib_write_comment(const FILENAME_CHAR_T *filename, const char *comment) {
     properties.replace("comment", list);
   }
   f.file()->setProperties(properties);
+
+  if (!f.file()->save()) {
+    return TAGLIB_ERR_SAVE;
+  }
+
+  return 0;
+}
+
+int taglib_write_fetched_metadata(const FILENAME_CHAR_T *filename, const char *album, const char *year, const char *genre, const char *recording_mbid, const char *release_mbid, const char *cover_path) {
+  TagLib::FileRef f(filename, false, TagLib::AudioProperties::Fast);
+  if (f.isNull() || f.file() == nullptr) {
+    return TAGLIB_ERR_PARSE;
+  }
+
+  if (f.tag() != nullptr) {
+    if (album != nullptr && *album != '\0') {
+      f.tag()->setAlbum(TagLib::String(album, TagLib::String::UTF8));
+    }
+    if (genre != nullptr && *genre != '\0') {
+      f.tag()->setGenre(TagLib::String(genre, TagLib::String::UTF8));
+    }
+    if (year != nullptr && *year != '\0') {
+      f.tag()->setYear((unsigned int)atoi(year));
+    }
+  }
+
+  TagLib::PropertyMap properties = f.file()->properties();
+  put_property(properties, "ALBUM", album);
+  put_property(properties, "DATE", year);
+  put_property(properties, "YEAR", year);
+  put_property(properties, "GENRE", genre);
+  put_property(properties, "MUSICBRAINZ_RECORDINGID", recording_mbid);
+  put_property(properties, "MUSICBRAINZ_RELEASEID", release_mbid);
+  f.file()->setProperties(properties);
+
+  TagLib::MPEG::File *mp3File = dynamic_cast<TagLib::MPEG::File *>(f.file());
+  attach_cover_mp3(mp3File, cover_path);
 
   if (!f.file()->save()) {
     return TAGLIB_ERR_SAVE;

--- a/adapters/taglib/taglib_wrapper.go
+++ b/adapters/taglib/taglib_wrapper.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -100,6 +101,66 @@ func WriteComment(filename, comment string) (err error) {
 		return fmt.Errorf("cannot save media file after writing comment")
 	default:
 		return fmt.Errorf("unknown error writing comment: %d", int(res))
+	}
+}
+
+type FetchedMetadata struct {
+	Album         string
+	Year          int
+	Genre         string
+	RecordingMBID string
+	ReleaseMBID   string
+	CoverPath     string
+}
+
+func WriteFetchedMetadata(filename string, md FetchedMetadata) (err error) {
+	debug.SetPanicOnFault(true)
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("extractor: recovered from panic when writing fetched metadata", "file", filename, "error", r)
+			err = fmt.Errorf("extractor: recovered from panic: %s", r)
+		}
+	}()
+
+	fp := getFilename(filename)
+	defer C.free(unsafe.Pointer(fp))
+
+	cAlbum := C.CString(strings.TrimSpace(md.Album))
+	defer C.free(unsafe.Pointer(cAlbum))
+
+	year := ""
+	if md.Year > 0 {
+		year = strconv.Itoa(md.Year)
+	}
+	cYear := C.CString(year)
+	defer C.free(unsafe.Pointer(cYear))
+
+	cGenre := C.CString(strings.TrimSpace(md.Genre))
+	defer C.free(unsafe.Pointer(cGenre))
+
+	cRecordingMBID := C.CString(strings.TrimSpace(md.RecordingMBID))
+	defer C.free(unsafe.Pointer(cRecordingMBID))
+
+	cReleaseMBID := C.CString(strings.TrimSpace(md.ReleaseMBID))
+	defer C.free(unsafe.Pointer(cReleaseMBID))
+
+	coverPath := strings.TrimSpace(md.CoverPath)
+	if coverPath != "" {
+		coverPath = filepath.Clean(coverPath)
+	}
+	cCoverPath := C.CString(coverPath)
+	defer C.free(unsafe.Pointer(cCoverPath))
+
+	res := C.taglib_write_fetched_metadata(fp, cAlbum, cYear, cGenre, cRecordingMBID, cReleaseMBID, cCoverPath)
+	switch res {
+	case 0:
+		return nil
+	case C.TAGLIB_ERR_PARSE:
+		return fmt.Errorf("cannot open media file for writing metadata")
+	case C.TAGLIB_ERR_SAVE:
+		return fmt.Errorf("cannot save media file after writing metadata")
+	default:
+		return fmt.Errorf("unknown error writing metadata: %d", int(res))
 	}
 }
 

--- a/adapters/taglib/taglib_wrapper.h
+++ b/adapters/taglib/taglib_wrapper.h
@@ -20,6 +20,7 @@ extern void goPutLyricLine(unsigned long id, char *lang, char *text, int time);
 int taglib_read(const FILENAME_CHAR_T *filename, unsigned long id);
 char* taglib_version();
 int taglib_write_comment(const FILENAME_CHAR_T *filename, const char *comment);
+int taglib_write_fetched_metadata(const FILENAME_CHAR_T *filename, const char *album, const char *year, const char *genre, const char *recording_mbid, const char *release_mbid, const char *cover_path);
 
 #ifdef __cplusplus
 }

--- a/core/artwork/reader_album.go
+++ b/core/artwork/reader_album.go
@@ -20,12 +20,14 @@ import (
 
 type albumArtworkReader struct {
 	cacheKey
-	a          *artwork
-	provider   external.Provider
-	album      model.Album
-	updatedAt  *time.Time
-	imgFiles   []string
-	rootFolder string
+	a             *artwork
+	provider      external.Provider
+	album         model.Album
+	updatedAt     *time.Time
+	imgFiles      []string
+	rootFolder    string
+	mbCoverPath   string
+	mbCoverUpdate time.Time
 }
 
 func newAlbumArtworkReader(ctx context.Context, artwork *artwork, artID model.ArtworkID, provider external.Provider) (*albumArtworkReader, error) {
@@ -37,19 +39,28 @@ func newAlbumArtworkReader(ctx context.Context, artwork *artwork, artID model.Ar
 	if err != nil {
 		return nil, err
 	}
+	mbCoverPath, mbCoverUpdate, err := loadAlbumMetadataCover(ctx, artwork.ds, al.ID)
+	if err != nil {
+		return nil, err
+	}
 	a := &albumArtworkReader{
-		a:          artwork,
-		provider:   provider,
-		album:      *al,
-		updatedAt:  imagesUpdateAt,
-		imgFiles:   imgFiles,
-		rootFolder: core.AbsolutePath(ctx, artwork.ds, al.LibraryID, ""),
+		a:             artwork,
+		provider:      provider,
+		album:         *al,
+		updatedAt:     imagesUpdateAt,
+		imgFiles:      imgFiles,
+		rootFolder:    core.AbsolutePath(ctx, artwork.ds, al.LibraryID, ""),
+		mbCoverPath:   mbCoverPath,
+		mbCoverUpdate: mbCoverUpdate,
 	}
 	a.cacheKey.artID = artID
 	if a.updatedAt != nil && a.updatedAt.After(al.UpdatedAt) {
 		a.cacheKey.lastUpdate = *a.updatedAt
 	} else {
 		a.cacheKey.lastUpdate = al.UpdatedAt
+	}
+	if a.mbCoverUpdate.After(a.cacheKey.lastUpdate) {
+		a.cacheKey.lastUpdate = a.mbCoverUpdate
 	}
 	return a, nil
 }
@@ -71,7 +82,11 @@ func (a *albumArtworkReader) LastUpdated() time.Time {
 }
 
 func (a *albumArtworkReader) Reader(ctx context.Context) (io.ReadCloser, string, error) {
-	var ff = a.fromCoverArtPriority(ctx, a.a.ffmpeg, conf.Server.CoverArtPriority)
+	var ff []sourceFunc
+	if strings.TrimSpace(a.mbCoverPath) != "" {
+		ff = append(ff, fromLocalFile(a.mbCoverPath))
+	}
+	ff = append(ff, a.fromCoverArtPriority(ctx, a.a.ffmpeg, conf.Server.CoverArtPriority)...)
 	return selectImageReader(ctx, a.artID, ff...)
 }
 
@@ -90,6 +105,30 @@ func (a *albumArtworkReader) fromCoverArtPriority(ctx context.Context, ffmpeg ff
 		}
 	}
 	return ff
+}
+
+func loadAlbumMetadataCover(ctx context.Context, ds model.DataStore, albumID string) (string, time.Time, error) {
+	mediaFiles, err := ds.MediaFile(ctx).GetAll(model.QueryOptions{Filters: squirrel.Eq{"album_id": albumID}})
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	var coverPath string
+	var updatedAt time.Time
+	for _, mf := range mediaFiles {
+		candidate := strings.TrimSpace(mf.CoverPath)
+		if candidate == "" {
+			continue
+		}
+		if !filepath.IsAbs(candidate) {
+			candidate = filepath.Join(conf.Server.DataFolder, candidate)
+		}
+		if coverPath == "" || candidate < coverPath {
+			coverPath = candidate
+			updatedAt = mf.UpdatedAt
+		}
+	}
+	return coverPath, updatedAt, nil
 }
 
 func loadAlbumFoldersPaths(ctx context.Context, ds model.DataStore, albums ...model.Album) ([]string, []string, *time.Time, error) {

--- a/core/artwork/reader_mediafile.go
+++ b/core/artwork/reader_mediafile.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/navidrome/navidrome/conf"
@@ -52,14 +54,23 @@ func (a *mediafileArtworkReader) LastUpdated() time.Time {
 }
 
 func (a *mediafileArtworkReader) Reader(ctx context.Context) (io.ReadCloser, string, error) {
-	var ff []sourceFunc
+	ff := make([]sourceFunc, 0, 4)
+
+	if coverPath := strings.TrimSpace(a.mediafile.CoverPath); coverPath != "" {
+		if !filepath.IsAbs(coverPath) {
+			coverPath = filepath.Join(conf.Server.DataFolder, coverPath)
+		}
+		ff = append(ff, fromLocalFile(coverPath))
+	}
+
 	if a.mediafile.CoverArtID().Kind == model.KindMediaFileArtwork {
 		path := a.mediafile.AbsolutePath()
-		ff = []sourceFunc{
+		ff = append(ff,
 			fromTag(ctx, path),
 			fromFFmpegTag(ctx, a.a.ffmpeg, path),
-		}
+		)
 	}
+
 	ff = append(ff, fromAlbum(ctx, a.a, a.mediafile.AlbumCoverArtID()))
 	return selectImageReader(ctx, a.artID, ff...)
 }

--- a/core/artwork/sources.go
+++ b/core/artwork/sources.go
@@ -77,6 +77,19 @@ func fromExternalFile(ctx context.Context, files []string, pattern string) sourc
 	}
 }
 
+func fromLocalFile(path string) sourceFunc {
+	return func() (io.ReadCloser, string, error) {
+		if strings.TrimSpace(path) == "" {
+			return nil, "", nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, "", err
+		}
+		return f, path, nil
+	}
+}
+
 // These regexes are used to match the picture type in the file, in the order they are listed.
 var picTypeRegexes = []*regexp.Regexp{
 	regexp.MustCompile(`(?i).*cover.*front.*|.*front.*cover.*`),

--- a/db/migrations/20260221010101_add_musicbrainz_release_id.go
+++ b/db/migrations/20260221010101_add_musicbrainz_release_id.go
@@ -1,0 +1,47 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upAddMusicbrainzReleaseID, downAddMusicbrainzReleaseID)
+}
+
+func upAddMusicbrainzReleaseID(_ context.Context, tx *sql.Tx) error {
+	rows, err := tx.Query(`pragma table_info(media_file)`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			cid       int
+			name      string
+			ctype     string
+			notnull   int
+			dfltValue sql.NullString
+			pk        int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dfltValue, &pk); err != nil {
+			return err
+		}
+		if name == "mbz_release_id" {
+			return nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	_, err = tx.Exec(`alter table media_file add mbz_release_id text not null default ''`)
+	return err
+}
+
+func downAddMusicbrainzReleaseID(_ context.Context, _ *sql.Tx) error {
+	return nil
+}

--- a/db/migrations/20260222010101_add_cover_path_to_media_file.go
+++ b/db/migrations/20260222010101_add_cover_path_to_media_file.go
@@ -1,0 +1,47 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upAddCoverPathToMediaFile, downAddCoverPathToMediaFile)
+}
+
+func upAddCoverPathToMediaFile(_ context.Context, tx *sql.Tx) error {
+	rows, err := tx.Query(`pragma table_info(media_file)`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			cid       int
+			name      string
+			ctype     string
+			notnull   int
+			dfltValue sql.NullString
+			pk        int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dfltValue, &pk); err != nil {
+			return err
+		}
+		if name == "cover_path" {
+			return nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	_, err = tx.Exec(`alter table media_file add cover_path text not null default ''`)
+	return err
+}
+
+func downAddCoverPathToMediaFile(_ context.Context, _ *sql.Tx) error {
+	return nil
+}

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -75,6 +75,7 @@ type MediaFile struct {
 	ExplicitStatus       string   `structs:"explicit_status" json:"explicitStatus"`
 	CatalogNum           string   `structs:"catalog_num" json:"catalogNum,omitempty"`
 	MbzRecordingID       string   `structs:"mbz_recording_id" json:"mbzRecordingID,omitempty"`
+	MbzReleaseID         string   `structs:"mbz_release_id" json:"mbzReleaseId,omitempty"`
 	MbzReleaseTrackID    string   `structs:"mbz_release_track_id" json:"mbzReleaseTrackId,omitempty"`
 	MbzAlbumID           string   `structs:"mbz_album_id" json:"mbzAlbumId,omitempty"`
 	MbzReleaseGroupID    string   `structs:"mbz_release_group_id" json:"mbzReleaseGroupId,omitempty"`
@@ -359,7 +360,7 @@ type MediaFileRepository interface {
 	DeleteAllMissing() (int64, error)
 	FindByPaths(paths []string) (MediaFiles, error)
 	UpdateComment(ids []string, comment string) error
-	UpdateMissingMetadata(id string, album *string, year *int, genre *string) error
+	UpdateMissingMetadata(id string, album *string, year *int, genre *string, mbzRecordingID *string, mbzReleaseID *string) error
 
 	// The following methods are used exclusively by the scanner:
 	MarkMissing(bool, ...*MediaFile) error

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -43,6 +43,7 @@ type MediaFile struct {
 	ArtworkID            string   `structs:"-" json:"artworkId,omitempty"`
 	ArtworkURL           string   `structs:"-" json:"artworkUrl,omitempty"`
 	CoverArtURL          string   `structs:"-" json:"cover_art_url,omitempty"`
+	CoverPath            string   `structs:"cover_path" json:"coverPath,omitempty"`
 	TrackNumber          int      `structs:"track_number" json:"trackNumber"`
 	DiscNumber           int      `structs:"disc_number" json:"discNumber"`
 	DiscSubtitle         string   `structs:"disc_subtitle" json:"discSubtitle,omitempty"`
@@ -362,6 +363,7 @@ type MediaFileRepository interface {
 	FindByPaths(paths []string) (MediaFiles, error)
 	UpdateComment(ids []string, comment string) error
 	UpdateMissingMetadata(id string, album *string, year *int, genre *string, mbzRecordingID *string, mbzReleaseID *string) error
+	UpdateCoverPath(id string, coverPath string) error
 
 	// The following methods are used exclusively by the scanner:
 	MarkMissing(bool, ...*MediaFile) error

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -359,6 +359,7 @@ type MediaFileRepository interface {
 	DeleteAllMissing() (int64, error)
 	FindByPaths(paths []string) (MediaFiles, error)
 	UpdateComment(ids []string, comment string) error
+	UpdateMissingMetadata(id string, album *string, year *int, genre *string) error
 
 	// The following methods are used exclusively by the scanner:
 	MarkMissing(bool, ...*MediaFile) error

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -42,6 +42,7 @@ type MediaFile struct {
 	HasCoverArt          bool     `structs:"has_cover_art" json:"hasCoverArt"`
 	ArtworkID            string   `structs:"-" json:"artworkId,omitempty"`
 	ArtworkURL           string   `structs:"-" json:"artworkUrl,omitempty"`
+	CoverArtURL          string   `structs:"-" json:"cover_art_url,omitempty"`
 	TrackNumber          int      `structs:"track_number" json:"trackNumber"`
 	DiscNumber           int      `structs:"disc_number" json:"discNumber"`
 	DiscSubtitle         string   `structs:"disc_subtitle" json:"discSubtitle,omitempty"`

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -96,14 +96,15 @@ func NewMediaFileRepository(ctx context.Context, db dbx.Builder) model.MediaFile
 
 var mediaFileFilter = sync.OnceValue(func() map[string]filterFunc {
 	filters := map[string]filterFunc{
-		"id":         idFilter("media_file"),
-		"title":      fullTextFilter("media_file", "mbz_recording_id", "mbz_release_track_id"),
-		"starred":    booleanFilter,
-		"genre_id":   tagIDFilter,
-		"missing":    booleanFilter,
-		"artists_id": artistFilter,
-		"path":       containsFilter("media_file.path"),
-		"library_id": libraryIdFilter,
+		"id":          idFilter("media_file"),
+		"title":       fullTextFilter("media_file", "mbz_recording_id", "mbz_release_track_id"),
+		"starred":     booleanFilter,
+		"genre_id":    tagIDFilter,
+		"missing":     booleanFilter,
+		"hascoverart": func(_ string, value any) Sqlizer { return booleanFilter("media_file.has_cover_art", value) },
+		"artists_id":  artistFilter,
+		"path":        containsFilter("media_file.path"),
+		"library_id":  libraryIdFilter,
 	}
 	// Add all album tags as filters
 	for tag := range model.TagMappings() {

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -283,7 +283,7 @@ func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, ye
 	up := Update(r.tableName).Where(Eq{"id": id})
 
 	if album != nil {
-		up = up.Set("album", Expr("case when trim(ifnull(album, '')) = '' then ? else album end", *album))
+		up = up.Set("album", Expr("case when trim(ifnull(album, '')) = '' or lower(trim(ifnull(album, ''))) in ('unknown album', '[unknown album]') then ? else album end", *album))
 	}
 	if year != nil {
 		up = up.Set("year", Expr("case when ifnull(year, 0) = 0 then ? else year end", *year))

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -275,6 +275,28 @@ func (r *mediaFileRepository) UpdateComment(ids []string, comment string) error 
 	return nil
 }
 
+func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, year *int, genre *string) error {
+	if album == nil && year == nil && genre == nil {
+		return nil
+	}
+
+	up := Update(r.tableName).Where(Eq{"id": id})
+
+	if album != nil {
+		up = up.Set("album", Expr("case when trim(ifnull(album, '')) = '' then ? else album end", *album))
+	}
+	if year != nil {
+		up = up.Set("year", Expr("case when ifnull(year, 0) = 0 then ? else year end", *year))
+	}
+	if genre != nil {
+		up = up.Set("genre", Expr("case when trim(ifnull(genre, '')) = '' then ? else genre end", *genre))
+	}
+
+	up = up.Set("updated_at", time.Now())
+	_, err := r.executeSQL(up)
+	return err
+}
+
 func (r *mediaFileRepository) MarkMissing(missing bool, mfs ...*model.MediaFile) error {
 	ids := slice.SeqFunc(mfs, func(m *model.MediaFile) string { return m.ID })
 	for chunk := range slice.CollectChunks(ids, 200) {

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -275,8 +275,8 @@ func (r *mediaFileRepository) UpdateComment(ids []string, comment string) error 
 	return nil
 }
 
-func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, year *int, genre *string) error {
-	if album == nil && year == nil && genre == nil {
+func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, year *int, genre *string, mbzRecordingID *string, mbzReleaseID *string) error {
+	if album == nil && year == nil && genre == nil && mbzRecordingID == nil && mbzReleaseID == nil {
 		return nil
 	}
 
@@ -290,6 +290,12 @@ func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, ye
 	}
 	if genre != nil {
 		up = up.Set("genre", Expr("case when trim(ifnull(genre, '')) = '' then ? else genre end", *genre))
+	}
+	if mbzRecordingID != nil {
+		up = up.Set("mbz_recording_id", Expr("case when trim(ifnull(mbz_recording_id, '')) = '' then ? else mbz_recording_id end", *mbzRecordingID))
+	}
+	if mbzReleaseID != nil {
+		up = up.Set("mbz_release_id", Expr("case when trim(ifnull(mbz_release_id, '')) = '' then ? else mbz_release_id end", *mbzReleaseID))
 	}
 
 	up = up.Set("updated_at", time.Now())

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -299,6 +300,20 @@ func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, ye
 	}
 
 	up = up.Set("updated_at", time.Now())
+	_, err := r.executeSQL(up)
+	return err
+}
+
+func (r *mediaFileRepository) UpdateCoverPath(id string, coverPath string) error {
+	coverPath = strings.TrimSpace(coverPath)
+	if id == "" || coverPath == "" {
+		return nil
+	}
+
+	up := Update(r.tableName).
+		Set("cover_path", Expr("case when trim(ifnull(cover_path, '')) = '' then ? else cover_path end", coverPath)).
+		Set("updated_at", time.Now()).
+		Where(Eq{"id": id})
 	_, err := r.executeSQL(up)
 	return err
 }

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -84,6 +84,7 @@ func NewMediaFileRepository(ctx context.Context, db dbx.Builder) model.MediaFile
 		"artist":         "order_artist_name, order_album_name, release_date, disc_number, track_number",
 		"album_artist":   "order_album_artist_name, order_album_name, release_date, disc_number, track_number",
 		"album":          "order_album_name, album_id, disc_number, track_number, order_artist_name, title",
+		"fetched":        "(media_file.has_cover_art or media_file.cover_path <> '')",
 		"random":         "random",
 		"created_at":     "media_file.created_at",
 		"recently_added": mediaFileRecentlyAddedSort(),
@@ -102,9 +103,15 @@ var mediaFileFilter = sync.OnceValue(func() map[string]filterFunc {
 		"genre_id":    tagIDFilter,
 		"missing":     booleanFilter,
 		"hascoverart": func(_ string, value any) Sqlizer { return booleanFilter("media_file.has_cover_art", value) },
-		"artists_id":  artistFilter,
-		"path":        containsFilter("media_file.path"),
-		"library_id":  libraryIdFilter,
+		"fetched": func(_ string, value any) Sqlizer {
+			if isTrue(value) {
+				return Or{Eq{"media_file.has_cover_art": true}, NotEq{"media_file.cover_path": ""}}
+			}
+			return And{Eq{"media_file.has_cover_art": false}, Eq{"media_file.cover_path": ""}}
+		},
+		"artists_id": artistFilter,
+		"path":       containsFilter("media_file.path"),
+		"library_id": libraryIdFilter,
 	}
 	// Add all album tags as filters
 	for tag := range model.TagMappings() {

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -459,4 +459,22 @@ var _ = Describe("MediaRepository", func() {
 			})
 		})
 	})
+	Context("UpdateMissingMetadata", func() {
+		It("updates album when current value is [Unknown Album]", func() {
+			mf := model.MediaFile{ID: id.NewRandom(), LibraryID: 1, Title: "Song", Album: "[Unknown Album]", Year: 0, Genre: ""}
+			Expect(mr.Put(&mf)).To(Succeed())
+
+			album := "Real Album"
+			year := 2014
+			genre := "Rock"
+			Expect(mr.UpdateMissingMetadata(mf.ID, &album, &year, &genre)).To(Succeed())
+
+			updated, err := mr.Get(mf.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated.Album).To(Equal("Real Album"))
+			Expect(updated.Year).To(Equal(2014))
+			Expect(updated.Genre).To(Equal("Rock"))
+		})
+	})
+
 })

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -76,6 +76,47 @@ var _ = Describe("MediaRepository", func() {
 		Expect(ids).ToNot(ContainElement(withCover.ID))
 	})
 
+	It("filters media files by fetched status in REST query options", func() {
+		withEmbeddedCover := model.MediaFile{ID: id.NewRandom(), LibraryID: 1, Path: "embedded-cover.mp3", HasCoverArt: true}
+		withFetchedCover := model.MediaFile{ID: id.NewRandom(), LibraryID: 1, Path: "fetched-cover.mp3", CoverPath: "covers/fetched-cover.jpg"}
+		withoutFetchedCover := model.MediaFile{ID: id.NewRandom(), LibraryID: 1, Path: "missing-cover.mp3", HasCoverArt: false, CoverPath: ""}
+		Expect(adminRepo.Put(&withEmbeddedCover)).To(Succeed())
+		Expect(adminRepo.Put(&withFetchedCover)).To(Succeed())
+		Expect(adminRepo.Put(&withoutFetchedCover)).To(Succeed())
+		DeferCleanup(func() {
+			_ = adminRepo.Delete(withEmbeddedCover.ID)
+			_ = adminRepo.Delete(withFetchedCover.ID)
+			_ = adminRepo.Delete(withoutFetchedCover.ID)
+		})
+
+		resourceRepo, ok := adminRepo.(model.ResourceRepository)
+		Expect(ok).To(BeTrue())
+
+		fetchedResult, err := resourceRepo.ReadAll(rest.QueryOptions{Filters: map[string]any{"fetched": "true"}})
+		Expect(err).ToNot(HaveOccurred())
+		fetchedFiles, ok := fetchedResult.(model.MediaFiles)
+		Expect(ok).To(BeTrue())
+		fetchedIDs := make([]string, 0, len(fetchedFiles))
+		for _, file := range fetchedFiles {
+			fetchedIDs = append(fetchedIDs, file.ID)
+		}
+		Expect(fetchedIDs).To(ContainElement(withEmbeddedCover.ID))
+		Expect(fetchedIDs).To(ContainElement(withFetchedCover.ID))
+		Expect(fetchedIDs).ToNot(ContainElement(withoutFetchedCover.ID))
+
+		notFetchedResult, err := resourceRepo.ReadAll(rest.QueryOptions{Filters: map[string]any{"fetched": "false"}})
+		Expect(err).ToNot(HaveOccurred())
+		notFetchedFiles, ok := notFetchedResult.(model.MediaFiles)
+		Expect(ok).To(BeTrue())
+		notFetchedIDs := make([]string, 0, len(notFetchedFiles))
+		for _, file := range notFetchedFiles {
+			notFetchedIDs = append(notFetchedIDs, file.ID)
+		}
+		Expect(notFetchedIDs).To(ContainElement(withoutFetchedCover.ID))
+		Expect(notFetchedIDs).ToNot(ContainElement(withEmbeddedCover.ID))
+		Expect(notFetchedIDs).ToNot(ContainElement(withFetchedCover.ID))
+	})
+
 	It("returns songs ordered by lyrics with a specific title/artist", func() {
 		// attempt to mimic filters.SongsByArtistTitleWithLyricsFirst, except we want all items
 		results, err := mr.GetAll(model.QueryOptions{

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -467,7 +467,7 @@ var _ = Describe("MediaRepository", func() {
 			album := "Real Album"
 			year := 2014
 			genre := "Rock"
-			Expect(mr.UpdateMissingMetadata(mf.ID, &album, &year, &genre)).To(Succeed())
+			Expect(mr.UpdateMissingMetadata(mf.ID, &album, &year, &genre, nil, nil)).To(Succeed())
 
 			updated, err := mr.Get(mf.ID)
 			Expect(err).ToNot(HaveOccurred())

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -50,6 +50,32 @@ var _ = Describe("MediaRepository", func() {
 		Expect(mr.CountAll()).To(Equal(int64(6)))
 	})
 
+	It("filters media files by hascoverart in REST query options", func() {
+		withCover := model.MediaFile{ID: id.NewRandom(), LibraryID: 1, Path: "with-cover.mp3", HasCoverArt: true}
+		withoutCover := model.MediaFile{ID: id.NewRandom(), LibraryID: 1, Path: "without-cover.mp3", HasCoverArt: false}
+		Expect(adminRepo.Put(&withCover)).To(Succeed())
+		Expect(adminRepo.Put(&withoutCover)).To(Succeed())
+		DeferCleanup(func() {
+			_ = adminRepo.Delete(withCover.ID)
+			_ = adminRepo.Delete(withoutCover.ID)
+		})
+
+		resourceRepo, ok := adminRepo.(model.ResourceRepository)
+		Expect(ok).To(BeTrue())
+
+		result, err := resourceRepo.ReadAll(rest.QueryOptions{Filters: map[string]any{"hascoverart": "false"}})
+		Expect(err).ToNot(HaveOccurred())
+
+		files, ok := result.(model.MediaFiles)
+		Expect(ok).To(BeTrue())
+		ids := make([]string, 0, len(files))
+		for _, file := range files {
+			ids = append(ids, file.ID)
+		}
+		Expect(ids).To(ContainElement(withoutCover.ID))
+		Expect(ids).ToNot(ContainElement(withCover.ID))
+	})
+
 	It("returns songs ordered by lyrics with a specific title/artist", func() {
 		// attempt to mimic filters.SongsByArtistTitleWithLyricsFirst, except we want all items
 		results, err := mr.GetAll(model.QueryOptions{

--- a/persistence/sql_restful.go
+++ b/persistence/sql_restful.go
@@ -97,15 +97,19 @@ func containsFilter(field string) func(string, any) Sqlizer {
 }
 
 func booleanFilter(field string, value any) Sqlizer {
+	return Eq{field: isTrue(value)}
+}
+
+func isTrue(value any) bool {
 	switch v := value.(type) {
 	case bool:
-		return Eq{field: v}
+		return v
 	case string:
 		v = strings.ToLower(v)
-		return Eq{field: v == "true"}
+		return v == "true"
 	default:
 		vStr := strings.ToLower(fmt.Sprintf("%v", v))
-		return Eq{field: vStr == "true"}
+		return vStr == "true"
 	}
 }
 

--- a/persistence/sql_restful.go
+++ b/persistence/sql_restful.go
@@ -97,8 +97,16 @@ func containsFilter(field string) func(string, any) Sqlizer {
 }
 
 func booleanFilter(field string, value any) Sqlizer {
-	v := strings.ToLower(value.(string))
-	return Eq{field: v == "true"}
+	switch v := value.(type) {
+	case bool:
+		return Eq{field: v}
+	case string:
+		v = strings.ToLower(v)
+		return Eq{field: v == "true"}
+	default:
+		vStr := strings.ToLower(fmt.Sprintf("%v", v))
+		return Eq{field: vStr == "true"}
+	}
 }
 
 func fullTextFilter(tableName string, mbidFields ...string) func(string, any) Sqlizer {

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -532,29 +532,65 @@ func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (metadataRe
 		return metadataResult{}, nil
 	}
 
-	bestRecording := selectBestRecording(payload.Recordings, artist)
-	if bestRecording == nil {
+	bestCandidates := collectReleaseCandidates(payload.Recordings, artist)
+	if len(bestCandidates) == 0 {
 		return metadataResult{}, nil
 	}
 
-	bestRelease := selectBestRelease(bestRecording.Releases)
-	if bestRelease == nil {
-		return metadataResult{Genre: collectRecordingGenre(*bestRecording), RecordingMBID: strings.TrimSpace(bestRecording.ID)}, nil
+	coverCache := make(map[string]bool, len(bestCandidates))
+	best := selectBestReleaseCandidate(bestCandidates, func(releaseID string) bool {
+		return j.releaseHasCover(releaseID, coverCache)
+	})
+	if best == nil {
+		return metadataResult{}, nil
 	}
 
-	album := strings.TrimSpace(bestRelease.Title)
-	year := yearFromDate(bestRelease.Date)
+	album := strings.TrimSpace(best.release.Title)
+	year := yearFromDate(best.release.Date)
 	if year == 0 {
-		year = yearFromDate(bestRecording.FirstReleaseDate)
+		year = yearFromDate(best.recording.FirstReleaseDate)
 	}
-	genre := collectGenre(*bestRecording, *bestRelease)
+	genre := collectGenre(*best.recording, *best.release)
 	return metadataResult{
 		Album:         album,
 		Year:          year,
 		Genre:         genre,
-		RecordingMBID: strings.TrimSpace(bestRecording.ID),
-		ReleaseMBID:   strings.TrimSpace(bestRelease.ID),
+		RecordingMBID: strings.TrimSpace(best.recording.ID),
+		ReleaseMBID:   strings.TrimSpace(best.release.ID),
 	}, nil
+}
+
+func (j *musicBrainzMetadataJob) releaseHasCover(releaseID string, cache map[string]bool) bool {
+	releaseID = strings.TrimSpace(releaseID)
+	if releaseID == "" {
+		return false
+	}
+	if cached, ok := cache[releaseID]; ok {
+		return cached
+	}
+
+	u := "https://coverartarchive.org/release/" + url.PathEscape(releaseID)
+	req, err := http.NewRequest(http.MethodHead, u, nil)
+	if err != nil {
+		cache[releaseID] = false
+		return false
+	}
+	req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	resp, err := j.client.Do(req)
+	if err != nil {
+		cache[releaseID] = false
+		return false
+	}
+	defer resp.Body.Close()
+
+	hasCover := resp.StatusCode == http.StatusOK
+	cache[releaseID] = hasCover
+	return hasCover
 }
 
 func selectBestRecording(recordings []mbRecording, artist string) *mbRecording {
@@ -637,52 +673,69 @@ func artistCreditMatches(credits []struct {
 	return false
 }
 
-func selectBestRelease(releases []mbRelease) *mbRelease {
-	type relCandidate struct {
-		release               *mbRelease
-		official              bool
-		album                 bool
-		hasDiscouragedSubtype bool
-		usCountry             bool
-		year                  int
-	}
+type releaseCandidate struct {
+	recording *mbRecording
+	release   *mbRelease
+}
 
-	candidates := make([]relCandidate, 0, len(releases))
-	for i := range releases {
-		release := &releases[i]
-		if !isValidRelease(*release) {
-			continue
-		}
-		candidates = append(candidates, relCandidate{
-			release:               release,
-			official:              strings.EqualFold(strings.TrimSpace(release.Status), "Official"),
-			album:                 isAlbumRelease(*release),
-			hasDiscouragedSubtype: hasDiscouragedSecondaryType(*release),
-			usCountry:             strings.EqualFold(strings.TrimSpace(release.Country), "US"),
-			year:                  yearFromDate(release.Date),
-		})
-	}
-	if len(candidates) == 0 {
+func collectReleaseCandidates(recordings []mbRecording, artist string) []releaseCandidate {
+	bestRecording := selectBestRecording(recordings, artist)
+	if bestRecording == nil {
 		return nil
 	}
 
-	slices.SortFunc(candidates, func(a, b relCandidate) int {
-		if a.official && !b.official {
+	matches := make([]releaseCandidate, 0, len(bestRecording.Releases))
+	fallback := make([]releaseCandidate, 0, len(bestRecording.Releases))
+	for i := range bestRecording.Releases {
+		release := &bestRecording.Releases[i]
+		if !isValidRelease(*release) {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(release.Status), "Official") {
+			continue
+		}
+
+		candidate := releaseCandidate{recording: bestRecording, release: release}
+		fallback = append(fallback, candidate)
+		if isAlbumRelease(*release) && !hasDiscouragedSecondaryType(*release) {
+			matches = append(matches, candidate)
+		}
+	}
+
+	if len(matches) > 0 {
+		return matches
+	}
+	return fallback
+}
+
+func selectBestReleaseCandidate(candidates []releaseCandidate, hasCover func(releaseID string) bool) *releaseCandidate {
+	type relCandidate struct {
+		candidate *releaseCandidate
+		hasCover  bool
+		usCountry bool
+		year      int
+	}
+
+	sortedCandidates := make([]relCandidate, 0, len(candidates))
+	for i := range candidates {
+		candidate := &candidates[i]
+		releaseID := strings.TrimSpace(candidate.release.ID)
+		sortedCandidates = append(sortedCandidates, relCandidate{
+			candidate: candidate,
+			hasCover:  hasCover(releaseID),
+			usCountry: strings.EqualFold(strings.TrimSpace(candidate.release.Country), "US"),
+			year:      yearFromDate(candidate.release.Date),
+		})
+	}
+	if len(sortedCandidates) == 0 {
+		return nil
+	}
+
+	slices.SortFunc(sortedCandidates, func(a, b relCandidate) int {
+		if a.hasCover && !b.hasCover {
 			return -1
 		}
-		if !a.official && b.official {
-			return 1
-		}
-		if a.album && !b.album {
-			return -1
-		}
-		if !a.album && b.album {
-			return 1
-		}
-		if !a.hasDiscouragedSubtype && b.hasDiscouragedSubtype {
-			return -1
-		}
-		if a.hasDiscouragedSubtype && !b.hasDiscouragedSubtype {
+		if !a.hasCover && b.hasCover {
 			return 1
 		}
 		if a.year == 0 && b.year > 0 {
@@ -703,7 +756,7 @@ func selectBestRelease(releases []mbRelease) *mbRelease {
 		return 0
 	})
 
-	return candidates[0].release
+	return sortedCandidates[0].candidate
 }
 
 func isValidRelease(release mbRelease) bool {

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -907,5 +907,16 @@ func (n *Router) addMusicBrainzMetadataRoute(r chi.Router) {
 			w.WriteHeader(http.StatusConflict)
 			_, _ = w.Write([]byte(`{"status":"already_running"}`))
 		})
+		r.Post("/save", func(w http.ResponseWriter, _ *http.Request) {
+			status := n.metadataJob.getStatus()
+			if status.Running {
+				w.WriteHeader(http.StatusConflict)
+				_, _ = w.Write([]byte(`{"status":"still_running"}`))
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"saved"}`))
+		})
 	})
 }

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -24,12 +24,13 @@ import (
 )
 
 type metadataFieldProgress struct {
-	Existing int `json:"existing"`
-	Missing  int `json:"missing"`
-	Fetching int `json:"fetching"`
-	Fetched  int `json:"fetched"`
-	Updated  int `json:"updated"`
-	Left     int `json:"left"`
+	Existing     int `json:"existing"`
+	Missing      int `json:"missing"`
+	Fetching     int `json:"fetching"`
+	Fetched      int `json:"fetched"`
+	Updated      int `json:"updated"`
+	Left         int `json:"left"`
+	CouldntFetch int `json:"couldntFetch"`
 }
 
 type musicBrainzMetadataStatus struct {
@@ -353,6 +354,8 @@ func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, f
 		j.status.Album.Left--
 		if fetchedAlbum {
 			j.status.Album.Fetched++
+		} else {
+			j.status.Album.CouldntFetch++
 		}
 	}
 	if flags.year {
@@ -360,6 +363,8 @@ func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, f
 		j.status.Year.Left--
 		if fetchedYear {
 			j.status.Year.Fetched++
+		} else {
+			j.status.Year.CouldntFetch++
 		}
 	}
 	if flags.genre {
@@ -367,6 +372,8 @@ func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, f
 		j.status.Genre.Left--
 		if fetchedGenre {
 			j.status.Genre.Fetched++
+		} else {
+			j.status.Genre.CouldntFetch++
 		}
 	}
 	if flags.recordingMBID {
@@ -374,6 +381,8 @@ func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, f
 		j.status.RecordingMBID.Left--
 		if fetchedRecordingMBID {
 			j.status.RecordingMBID.Fetched++
+		} else {
+			j.status.RecordingMBID.CouldntFetch++
 		}
 	}
 	if flags.releaseMBID {
@@ -381,6 +390,8 @@ func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, f
 		j.status.ReleaseMBID.Left--
 		if fetchedReleaseMBID {
 			j.status.ReleaseMBID.Fetched++
+		} else {
+			j.status.ReleaseMBID.CouldntFetch++
 		}
 	}
 	if flags.coverArt {
@@ -388,6 +399,8 @@ func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, f
 		j.status.CoverArt.Left--
 		if fetchedCoverArt {
 			j.status.CoverArt.Fetched++
+		} else {
+			j.status.CoverArt.CouldntFetch++
 		}
 	}
 }

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/navidrome/navidrome/log"
@@ -96,6 +99,18 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
+	missingAlbums := 0
+	fetched := 0
+	updated := 0
+	skipped := 0
+	failed := 0
+
+	for _, c := range candidates {
+		if c.flags.album {
+			missingAlbums++
+		}
+	}
+
 	for i, c := range candidates {
 		if i > 0 {
 			<-ticker.C
@@ -104,8 +119,13 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 
 		album, year, genre, fetchErr := j.fetchMetadata(c.mf.Title, c.mf.Artist)
 		if fetchErr != nil {
+			failed++
 			log.Warn(ctx, "Could not fetch metadata from MusicBrainz", "songId", c.mf.ID, "title", c.mf.Title, "artist", c.mf.Artist, fetchErr)
+			j.finishFetch(c.flags, false, false, false)
+			continue
 		}
+
+		fetched++
 
 		var setAlbum *string
 		var setYear *int
@@ -123,14 +143,26 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 
 		if setAlbum != nil || setYear != nil || setGenre != nil {
 			if err := ds.MediaFile(ctx).UpdateMissingMetadata(c.mf.ID, setAlbum, setYear, setGenre); err != nil {
+				failed++
 				log.Error(ctx, "Could not update fetched MusicBrainz metadata", "songId", c.mf.ID, err)
 			} else {
+				updated++
 				j.setUpdated(setAlbum != nil, setYear != nil, setGenre != nil)
 			}
+		} else {
+			skipped++
 		}
 
 		j.finishFetch(c.flags, album != "", year > 0, genre != "")
 	}
+
+	log.Info(ctx, "MusicBrainz metadata fetch completed",
+		"missingAlbums", missingAlbums,
+		"fetched", fetched,
+		"updated", updated,
+		"skipped", skipped,
+		"failed", failed,
+	)
 }
 
 func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model.DataStore) ([]mbMetadataCandidate, error) {
@@ -149,7 +181,7 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 		}
 
 		flags := missingFlags{
-			album: strings.TrimSpace(mf.Album) == "",
+			album: isMissingAlbum(mf.Album),
 			year:  mf.Year == 0,
 			genre: strings.TrimSpace(mf.Genre) == "",
 		}
@@ -161,6 +193,11 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 		j.incrementMissing(flags)
 	}
 	return res, nil
+}
+
+func isMissingAlbum(album string) bool {
+	album = normalizeMBString(album)
+	return album == "" || album == "unknown album"
 }
 
 func (j *musicBrainzMetadataJob) incrementMissing(flags missingFlags) {
@@ -242,22 +279,35 @@ func (j *musicBrainzMetadataJob) setError(err error) {
 
 type mbSearchResponse struct {
 	Recordings []struct {
+		Score            string `json:"score"`
 		FirstReleaseDate string `json:"first-release-date"`
-		Releases         []struct {
-			Title string `json:"title"`
-			Date  string `json:"date"`
+		ArtistCredit     []struct {
+			Name string `json:"name"`
+		} `json:"artist-credit"`
+		Releases []struct {
+			Title        string   `json:"title"`
+			Date         string   `json:"date"`
+			Status       string   `json:"status"`
+			ReleaseGroup mbGroup  `json:"release-group"`
+			Tags         []mbName `json:"tags"`
+			Genres       []mbName `json:"genres"`
 		} `json:"releases"`
-		Tags []struct {
-			Name string `json:"name"`
-		} `json:"tags"`
-		Genres []struct {
-			Name string `json:"name"`
-		} `json:"genres"`
+		Tags   []mbName `json:"tags"`
+		Genres []mbName `json:"genres"`
 	} `json:"recordings"`
 }
 
+type mbName struct {
+	Name string `json:"name"`
+}
+
+type mbGroup struct {
+	PrimaryType   string   `json:"primary-type"`
+	SecondaryType []string `json:"secondary-types"`
+}
+
 func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (string, int, string, error) {
-	query := fmt.Sprintf("recording:\"%s\" AND artist:\"%s\"", title, artist)
+	query := fmt.Sprintf("artist:%s AND recording:%s", artist, title)
 	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json"
 	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
@@ -281,33 +331,315 @@ func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (string, in
 	if len(payload.Recordings) == 0 {
 		return "", 0, "", nil
 	}
-	rec := payload.Recordings[0]
 
-	album := ""
-	if len(rec.Releases) > 0 {
-		album = strings.TrimSpace(rec.Releases[0].Title)
+	bestRecording := selectBestRecording(payload.Recordings, artist)
+	if bestRecording == nil {
+		return "", 0, "", nil
 	}
-	year := yearFromDate(rec.FirstReleaseDate)
-	if year == 0 && len(rec.Releases) > 0 {
-		year = yearFromDate(rec.Releases[0].Date)
+
+	bestRelease := selectBestRelease(bestRecording.Releases)
+	if bestRelease == nil {
+		return "", 0, collectRecordingGenre(*bestRecording), nil
 	}
-	genre := collectGenre(rec)
+
+	album := strings.TrimSpace(bestRelease.Title)
+	year := yearFromDate(bestRelease.Date)
+	if year == 0 {
+		year = yearFromDate(bestRecording.FirstReleaseDate)
+	}
+	genre := collectGenre(*bestRecording, *bestRelease)
 	return album, year, genre, nil
 }
 
-func collectGenre(rec struct {
+func selectBestRecording(recordings []struct {
+	Score            string `json:"score"`
 	FirstReleaseDate string `json:"first-release-date"`
-	Releases         []struct {
-		Title string `json:"title"`
-		Date  string `json:"date"`
+	ArtistCredit     []struct {
+		Name string `json:"name"`
+	} `json:"artist-credit"`
+	Releases []struct {
+		Title        string   `json:"title"`
+		Date         string   `json:"date"`
+		Status       string   `json:"status"`
+		ReleaseGroup mbGroup  `json:"release-group"`
+		Tags         []mbName `json:"tags"`
+		Genres       []mbName `json:"genres"`
 	} `json:"releases"`
-	Tags []struct {
+	Tags   []mbName `json:"tags"`
+	Genres []mbName `json:"genres"`
+}, artist string) *struct {
+	Score            string `json:"score"`
+	FirstReleaseDate string `json:"first-release-date"`
+	ArtistCredit     []struct {
 		Name string `json:"name"`
-	} `json:"tags"`
-	Genres []struct {
+	} `json:"artist-credit"`
+	Releases []struct {
+		Title        string   `json:"title"`
+		Date         string   `json:"date"`
+		Status       string   `json:"status"`
+		ReleaseGroup mbGroup  `json:"release-group"`
+		Tags         []mbName `json:"tags"`
+		Genres       []mbName `json:"genres"`
+	} `json:"releases"`
+	Tags   []mbName `json:"tags"`
+	Genres []mbName `json:"genres"`
+} {
+	normalizedArtist := normalizeMBString(artist)
+
+	type recCandidate struct {
+		rec *struct {
+			Score            string `json:"score"`
+			FirstReleaseDate string `json:"first-release-date"`
+			ArtistCredit     []struct {
+				Name string `json:"name"`
+			} `json:"artist-credit"`
+			Releases []struct {
+				Title        string   `json:"title"`
+				Date         string   `json:"date"`
+				Status       string   `json:"status"`
+				ReleaseGroup mbGroup  `json:"release-group"`
+				Tags         []mbName `json:"tags"`
+				Genres       []mbName `json:"genres"`
+			} `json:"releases"`
+			Tags   []mbName `json:"tags"`
+			Genres []mbName `json:"genres"`
+		}
+		score    int
+		releases int
+		hasAlbum bool
+		earliest int
+	}
+
+	candidates := make([]recCandidate, 0, len(recordings))
+	for i := range recordings {
+		rec := &recordings[i]
+		score, err := strconv.Atoi(rec.Score)
+		if err != nil || score < 80 {
+			continue
+		}
+		if !artistCreditMatches(rec.ArtistCredit, normalizedArtist) {
+			continue
+		}
+
+		hasAlbum := false
+		earliest := 9999
+		for _, rel := range rec.Releases {
+			if !isValidRelease(rel) {
+				continue
+			}
+			if isAlbumRelease(rel) {
+				hasAlbum = true
+			}
+			if y := yearFromDate(rel.Date); y > 0 && y < earliest {
+				earliest = y
+			}
+		}
+		candidates = append(candidates, recCandidate{rec: rec, score: score, releases: len(rec.Releases), hasAlbum: hasAlbum, earliest: earliest})
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	slices.SortFunc(candidates, func(a, b recCandidate) int {
+		if a.releases > 0 && b.releases == 0 {
+			return -1
+		}
+		if a.releases == 0 && b.releases > 0 {
+			return 1
+		}
+		if a.score != b.score {
+			return b.score - a.score
+		}
+		if a.hasAlbum && !b.hasAlbum {
+			return -1
+		}
+		if !a.hasAlbum && b.hasAlbum {
+			return 1
+		}
+		if a.earliest != b.earliest {
+			return a.earliest - b.earliest
+		}
+		return 0
+	})
+
+	return candidates[0].rec
+}
+
+func artistCreditMatches(credits []struct {
+	Name string `json:"name"`
+}, normalizedArtist string) bool {
+	if normalizedArtist == "" {
+		return false
+	}
+	for _, credit := range credits {
+		if normalizeMBString(credit.Name) == normalizedArtist {
+			return true
+		}
+	}
+	return false
+}
+
+func selectBestRelease(releases []struct {
+	Title        string   `json:"title"`
+	Date         string   `json:"date"`
+	Status       string   `json:"status"`
+	ReleaseGroup mbGroup  `json:"release-group"`
+	Tags         []mbName `json:"tags"`
+	Genres       []mbName `json:"genres"`
+}) *struct {
+	Title        string   `json:"title"`
+	Date         string   `json:"date"`
+	Status       string   `json:"status"`
+	ReleaseGroup mbGroup  `json:"release-group"`
+	Tags         []mbName `json:"tags"`
+	Genres       []mbName `json:"genres"`
+} {
+	type relCandidate struct {
+		release *struct {
+			Title        string   `json:"title"`
+			Date         string   `json:"date"`
+			Status       string   `json:"status"`
+			ReleaseGroup mbGroup  `json:"release-group"`
+			Tags         []mbName `json:"tags"`
+			Genres       []mbName `json:"genres"`
+		}
+		official bool
+		album    bool
+		year     int
+	}
+
+	candidates := make([]relCandidate, 0, len(releases))
+	for i := range releases {
+		release := &releases[i]
+		if !isValidRelease(*release) {
+			continue
+		}
+		candidates = append(candidates, relCandidate{
+			release:  release,
+			official: strings.EqualFold(strings.TrimSpace(release.Status), "Official"),
+			album:    isAlbumRelease(*release),
+			year:     yearFromDate(release.Date),
+		})
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	slices.SortFunc(candidates, func(a, b relCandidate) int {
+		if a.official && !b.official {
+			return -1
+		}
+		if !a.official && b.official {
+			return 1
+		}
+		if a.album && !b.album {
+			return -1
+		}
+		if !a.album && b.album {
+			return 1
+		}
+		if a.year == 0 && b.year > 0 {
+			return 1
+		}
+		if b.year == 0 && a.year > 0 {
+			return -1
+		}
+		if a.year != b.year {
+			return a.year - b.year
+		}
+		return 0
+	})
+
+	return candidates[0].release
+}
+
+func isValidRelease(release struct {
+	Title        string   `json:"title"`
+	Date         string   `json:"date"`
+	Status       string   `json:"status"`
+	ReleaseGroup mbGroup  `json:"release-group"`
+	Tags         []mbName `json:"tags"`
+	Genres       []mbName `json:"genres"`
+}) bool {
+	if strings.TrimSpace(release.Title) == "" {
+		return false
+	}
+	types := make([]string, 0, len(release.ReleaseGroup.SecondaryType)+1)
+	types = append(types, release.ReleaseGroup.PrimaryType)
+	types = append(types, release.ReleaseGroup.SecondaryType...)
+	for _, t := range types {
+		n := normalizeMBString(t)
+		if n == "compilation" || n == "live" || n == "unofficial" || n == "promo" {
+			return false
+		}
+	}
+	return true
+}
+
+func isAlbumRelease(release struct {
+	Title        string   `json:"title"`
+	Date         string   `json:"date"`
+	Status       string   `json:"status"`
+	ReleaseGroup mbGroup  `json:"release-group"`
+	Tags         []mbName `json:"tags"`
+	Genres       []mbName `json:"genres"`
+}) bool {
+	primaryType := normalizeMBString(release.ReleaseGroup.PrimaryType)
+	return primaryType == "album"
+}
+
+func collectRecordingGenre(rec struct {
+	Score            string `json:"score"`
+	FirstReleaseDate string `json:"first-release-date"`
+	ArtistCredit     []struct {
 		Name string `json:"name"`
-	} `json:"genres"`
+	} `json:"artist-credit"`
+	Releases []struct {
+		Title        string   `json:"title"`
+		Date         string   `json:"date"`
+		Status       string   `json:"status"`
+		ReleaseGroup mbGroup  `json:"release-group"`
+		Tags         []mbName `json:"tags"`
+		Genres       []mbName `json:"genres"`
+	} `json:"releases"`
+	Tags   []mbName `json:"tags"`
+	Genres []mbName `json:"genres"`
 }) string {
+	return collectGenres(rec.Genres, rec.Tags)
+}
+
+func collectGenre(rec struct {
+	Score            string `json:"score"`
+	FirstReleaseDate string `json:"first-release-date"`
+	ArtistCredit     []struct {
+		Name string `json:"name"`
+	} `json:"artist-credit"`
+	Releases []struct {
+		Title        string   `json:"title"`
+		Date         string   `json:"date"`
+		Status       string   `json:"status"`
+		ReleaseGroup mbGroup  `json:"release-group"`
+		Tags         []mbName `json:"tags"`
+		Genres       []mbName `json:"genres"`
+	} `json:"releases"`
+	Tags   []mbName `json:"tags"`
+	Genres []mbName `json:"genres"`
+}, release struct {
+	Title        string   `json:"title"`
+	Date         string   `json:"date"`
+	Status       string   `json:"status"`
+	ReleaseGroup mbGroup  `json:"release-group"`
+	Tags         []mbName `json:"tags"`
+	Genres       []mbName `json:"genres"`
+}) string {
+	genre := collectGenres(release.Genres, release.Tags)
+	if genre != "" {
+		return genre
+	}
+	return collectRecordingGenre(rec)
+}
+
+func collectGenres(genres, tags []mbName) string {
 	unique := map[string]bool{}
 	ordered := make([]string, 0, 4)
 	appendName := func(v string) {
@@ -323,10 +655,10 @@ func collectGenre(rec struct {
 		ordered = append(ordered, v)
 	}
 
-	for _, g := range rec.Genres {
+	for _, g := range genres {
 		appendName(g.Name)
 	}
-	for _, t := range rec.Tags {
+	for _, t := range tags {
 		appendName(t.Name)
 	}
 	if len(ordered) == 0 {
@@ -336,6 +668,20 @@ func collectGenre(rec struct {
 		ordered = ordered[:5]
 	}
 	return strings.Join(ordered, ", ")
+}
+
+var punctuationRegex = regexp.MustCompile(`[\p{P}\p{S}]`)
+
+func normalizeMBString(v string) string {
+	v = strings.ToLower(strings.TrimSpace(v))
+	v = punctuationRegex.ReplaceAllString(v, " ")
+	v = strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return ' '
+		}
+		return r
+	}, v)
+	return strings.Join(strings.Fields(v), " ")
 }
 
 func yearFromDate(date string) int {

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -18,6 +18,7 @@ import (
 	"unicode"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/adapters/taglib"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -915,8 +916,55 @@ func (n *Router) addMusicBrainzMetadataRoute(r chi.Router) {
 				return
 			}
 
+			if err := n.saveFetchedMetadataToSongs(); err != nil {
+				log.Warn("Could not persist fetched metadata to song files", "err", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"status":"save_failed"}`))
+				return
+			}
+
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"status":"saved"}`))
 		})
 	})
+}
+
+func (n *Router) saveFetchedMetadataToSongs() error {
+	ctx := context.Background()
+	cursor, err := n.ds.MediaFile(ctx).GetCursor()
+	if err != nil {
+		return err
+	}
+
+	for mf, e := range cursor {
+		if e != nil {
+			return e
+		}
+
+		if strings.TrimSpace(mf.Path) == "" || strings.TrimSpace(mf.LibraryPath) == "" {
+			continue
+		}
+
+		coverFile := ""
+		if strings.HasPrefix(strings.TrimSpace(mf.CoverPath), coverCacheDirName+"/") {
+			coverFile = filepath.Join(conf.Server.DataFolder, filepath.FromSlash(mf.CoverPath))
+		}
+
+		if strings.TrimSpace(mf.Album) == "" && mf.Year == 0 && strings.TrimSpace(mf.Genre) == "" && strings.TrimSpace(mf.MbzRecordingID) == "" && strings.TrimSpace(mf.MbzReleaseID) == "" && coverFile == "" {
+			continue
+		}
+
+		if err := taglib.WriteFetchedMetadata(mf.AbsolutePath(), taglib.FetchedMetadata{
+			Album:         mf.Album,
+			Year:          mf.Year,
+			Genre:         mf.Genre,
+			RecordingMBID: mf.MbzRecordingID,
+			ReleaseMBID:   mf.MbzReleaseID,
+			CoverPath:     coverFile,
+		}); err != nil {
+			log.Warn(ctx, "Could not write fetched metadata to song", "songId", mf.ID, "path", mf.Path, "err", err)
+		}
+	}
+
+	return nil
 }

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -80,6 +80,14 @@ type mbMetadataCandidate struct {
 	flags missingFlags
 }
 
+type metadataResult struct {
+	Album         string
+	Year          int
+	Genre         string
+	RecordingMBID string
+	ReleaseMBID   string
+}
+
 func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 	ctx := context.Background()
 	defer func() {
@@ -117,7 +125,7 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 		}
 		j.setFetching(c.flags, 1)
 
-		album, year, genre, fetchErr := j.fetchMetadata(c.mf.Title, c.mf.Artist)
+		metadata, fetchErr := j.fetchMetadata(c.mf.Title, c.mf.Artist)
 		if fetchErr != nil {
 			failed++
 			log.Warn(ctx, "Could not fetch metadata from MusicBrainz", "songId", c.mf.ID, "title", c.mf.Title, "artist", c.mf.Artist, fetchErr)
@@ -131,18 +139,18 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 		var setYear *int
 		var setGenre *string
 
-		if c.flags.album && album != "" {
-			setAlbum = &album
+		if c.flags.album && metadata.Album != "" {
+			setAlbum = &metadata.Album
 		}
-		if c.flags.year && year > 0 {
-			setYear = &year
+		if c.flags.year && metadata.Year > 0 {
+			setYear = &metadata.Year
 		}
-		if c.flags.genre && genre != "" {
-			setGenre = &genre
+		if c.flags.genre && metadata.Genre != "" {
+			setGenre = &metadata.Genre
 		}
 
-		if setAlbum != nil || setYear != nil || setGenre != nil {
-			if err := ds.MediaFile(ctx).UpdateMissingMetadata(c.mf.ID, setAlbum, setYear, setGenre); err != nil {
+		if setAlbum != nil || setYear != nil || setGenre != nil || metadata.RecordingMBID != "" || metadata.ReleaseMBID != "" {
+			if err := ds.MediaFile(ctx).UpdateMissingMetadata(c.mf.ID, setAlbum, setYear, setGenre, valueOrNil(metadata.RecordingMBID), valueOrNil(metadata.ReleaseMBID)); err != nil {
 				failed++
 				log.Error(ctx, "Could not update fetched MusicBrainz metadata", "songId", c.mf.ID, err)
 			} else {
@@ -153,7 +161,7 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 			skipped++
 		}
 
-		j.finishFetch(c.flags, album != "", year > 0, genre != "")
+		j.finishFetch(c.flags, metadata.Album != "", metadata.Year > 0, metadata.Genre != "")
 	}
 
 	log.Info(ctx, "MusicBrainz metadata fetch completed",
@@ -278,23 +286,30 @@ func (j *musicBrainzMetadataJob) setError(err error) {
 }
 
 type mbSearchResponse struct {
-	Recordings []struct {
-		Score            mbScore `json:"score"`
-		FirstReleaseDate string  `json:"first-release-date"`
-		ArtistCredit     []struct {
-			Name string `json:"name"`
-		} `json:"artist-credit"`
-		Releases []struct {
-			Title        string   `json:"title"`
-			Date         string   `json:"date"`
-			Status       string   `json:"status"`
-			ReleaseGroup mbGroup  `json:"release-group"`
-			Tags         []mbName `json:"tags"`
-			Genres       []mbName `json:"genres"`
-		} `json:"releases"`
-		Tags   []mbName `json:"tags"`
-		Genres []mbName `json:"genres"`
-	} `json:"recordings"`
+	Recordings []mbRecording `json:"recordings"`
+}
+
+type mbRecording struct {
+	ID               string  `json:"id"`
+	Score            mbScore `json:"score"`
+	FirstReleaseDate string  `json:"first-release-date"`
+	ArtistCredit     []struct {
+		Name string `json:"name"`
+	} `json:"artist-credit"`
+	Releases []mbRelease `json:"releases"`
+	Tags     []mbName    `json:"tags"`
+	Genres   []mbName    `json:"genres"`
+}
+
+type mbRelease struct {
+	ID           string   `json:"id"`
+	Title        string   `json:"title"`
+	Date         string   `json:"date"`
+	Status       string   `json:"status"`
+	Country      string   `json:"country"`
+	ReleaseGroup mbGroup  `json:"release-group"`
+	Tags         []mbName `json:"tags"`
+	Genres       []mbName `json:"genres"`
 }
 
 type mbScore string
@@ -331,40 +346,48 @@ type mbGroup struct {
 	SecondaryType []string `json:"secondary-types"`
 }
 
-func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (string, int, string, error) {
+func valueOrNil(v string) *string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return nil
+	}
+	return &v
+}
+
+func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (metadataResult, error) {
 	query := fmt.Sprintf("artist:%s AND recording:%s", artist, title)
-	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json"
+	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json&inc=releases+release-groups"
 	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
-		return "", 0, "", err
+		return metadataResult{}, err
 	}
 	req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
 
 	resp, err := j.client.Do(req)
 	if err != nil {
-		return "", 0, "", err
+		return metadataResult{}, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", 0, "", fmt.Errorf("musicbrainz status %d", resp.StatusCode)
+		return metadataResult{}, fmt.Errorf("musicbrainz status %d", resp.StatusCode)
 	}
 
 	var payload mbSearchResponse
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return "", 0, "", err
+		return metadataResult{}, err
 	}
 	if len(payload.Recordings) == 0 {
-		return "", 0, "", nil
+		return metadataResult{}, nil
 	}
 
 	bestRecording := selectBestRecording(payload.Recordings, artist)
 	if bestRecording == nil {
-		return "", 0, "", nil
+		return metadataResult{}, nil
 	}
 
 	bestRelease := selectBestRelease(bestRecording.Releases)
 	if bestRelease == nil {
-		return "", 0, collectRecordingGenre(*bestRecording), nil
+		return metadataResult{Genre: collectRecordingGenre(*bestRecording), RecordingMBID: strings.TrimSpace(bestRecording.ID)}, nil
 	}
 
 	album := strings.TrimSpace(bestRelease.Title)
@@ -373,62 +396,20 @@ func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (string, in
 		year = yearFromDate(bestRecording.FirstReleaseDate)
 	}
 	genre := collectGenre(*bestRecording, *bestRelease)
-	return album, year, genre, nil
+	return metadataResult{
+		Album:         album,
+		Year:          year,
+		Genre:         genre,
+		RecordingMBID: strings.TrimSpace(bestRecording.ID),
+		ReleaseMBID:   strings.TrimSpace(bestRelease.ID),
+	}, nil
 }
 
-func selectBestRecording(recordings []struct {
-	Score            mbScore `json:"score"`
-	FirstReleaseDate string  `json:"first-release-date"`
-	ArtistCredit     []struct {
-		Name string `json:"name"`
-	} `json:"artist-credit"`
-	Releases []struct {
-		Title        string   `json:"title"`
-		Date         string   `json:"date"`
-		Status       string   `json:"status"`
-		ReleaseGroup mbGroup  `json:"release-group"`
-		Tags         []mbName `json:"tags"`
-		Genres       []mbName `json:"genres"`
-	} `json:"releases"`
-	Tags   []mbName `json:"tags"`
-	Genres []mbName `json:"genres"`
-}, artist string) *struct {
-	Score            mbScore `json:"score"`
-	FirstReleaseDate string  `json:"first-release-date"`
-	ArtistCredit     []struct {
-		Name string `json:"name"`
-	} `json:"artist-credit"`
-	Releases []struct {
-		Title        string   `json:"title"`
-		Date         string   `json:"date"`
-		Status       string   `json:"status"`
-		ReleaseGroup mbGroup  `json:"release-group"`
-		Tags         []mbName `json:"tags"`
-		Genres       []mbName `json:"genres"`
-	} `json:"releases"`
-	Tags   []mbName `json:"tags"`
-	Genres []mbName `json:"genres"`
-} {
+func selectBestRecording(recordings []mbRecording, artist string) *mbRecording {
 	normalizedArtist := normalizeMBString(artist)
 
 	type recCandidate struct {
-		rec *struct {
-			Score            mbScore `json:"score"`
-			FirstReleaseDate string  `json:"first-release-date"`
-			ArtistCredit     []struct {
-				Name string `json:"name"`
-			} `json:"artist-credit"`
-			Releases []struct {
-				Title        string   `json:"title"`
-				Date         string   `json:"date"`
-				Status       string   `json:"status"`
-				ReleaseGroup mbGroup  `json:"release-group"`
-				Tags         []mbName `json:"tags"`
-				Genres       []mbName `json:"genres"`
-			} `json:"releases"`
-			Tags   []mbName `json:"tags"`
-			Genres []mbName `json:"genres"`
-		}
+		rec      *mbRecording
 		score    int
 		releases int
 		hasAlbum bool
@@ -504,33 +485,14 @@ func artistCreditMatches(credits []struct {
 	return false
 }
 
-func selectBestRelease(releases []struct {
-	Title        string   `json:"title"`
-	Date         string   `json:"date"`
-	Status       string   `json:"status"`
-	ReleaseGroup mbGroup  `json:"release-group"`
-	Tags         []mbName `json:"tags"`
-	Genres       []mbName `json:"genres"`
-}) *struct {
-	Title        string   `json:"title"`
-	Date         string   `json:"date"`
-	Status       string   `json:"status"`
-	ReleaseGroup mbGroup  `json:"release-group"`
-	Tags         []mbName `json:"tags"`
-	Genres       []mbName `json:"genres"`
-} {
+func selectBestRelease(releases []mbRelease) *mbRelease {
 	type relCandidate struct {
-		release *struct {
-			Title        string   `json:"title"`
-			Date         string   `json:"date"`
-			Status       string   `json:"status"`
-			ReleaseGroup mbGroup  `json:"release-group"`
-			Tags         []mbName `json:"tags"`
-			Genres       []mbName `json:"genres"`
-		}
-		official bool
-		album    bool
-		year     int
+		release               *mbRelease
+		official              bool
+		album                 bool
+		hasDiscouragedSubtype bool
+		usCountry             bool
+		year                  int
 	}
 
 	candidates := make([]relCandidate, 0, len(releases))
@@ -540,10 +502,12 @@ func selectBestRelease(releases []struct {
 			continue
 		}
 		candidates = append(candidates, relCandidate{
-			release:  release,
-			official: strings.EqualFold(strings.TrimSpace(release.Status), "Official"),
-			album:    isAlbumRelease(*release),
-			year:     yearFromDate(release.Date),
+			release:               release,
+			official:              strings.EqualFold(strings.TrimSpace(release.Status), "Official"),
+			album:                 isAlbumRelease(*release),
+			hasDiscouragedSubtype: hasDiscouragedSecondaryType(*release),
+			usCountry:             strings.EqualFold(strings.TrimSpace(release.Country), "US"),
+			year:                  yearFromDate(release.Date),
 		})
 	}
 	if len(candidates) == 0 {
@@ -563,6 +527,12 @@ func selectBestRelease(releases []struct {
 		if !a.album && b.album {
 			return 1
 		}
+		if !a.hasDiscouragedSubtype && b.hasDiscouragedSubtype {
+			return -1
+		}
+		if a.hasDiscouragedSubtype && !b.hasDiscouragedSubtype {
+			return 1
+		}
 		if a.year == 0 && b.year > 0 {
 			return 1
 		}
@@ -572,91 +542,51 @@ func selectBestRelease(releases []struct {
 		if a.year != b.year {
 			return a.year - b.year
 		}
+		if a.usCountry && !b.usCountry {
+			return -1
+		}
+		if !a.usCountry && b.usCountry {
+			return 1
+		}
 		return 0
 	})
 
 	return candidates[0].release
 }
 
-func isValidRelease(release struct {
-	Title        string   `json:"title"`
-	Date         string   `json:"date"`
-	Status       string   `json:"status"`
-	ReleaseGroup mbGroup  `json:"release-group"`
-	Tags         []mbName `json:"tags"`
-	Genres       []mbName `json:"genres"`
-}) bool {
+func isValidRelease(release mbRelease) bool {
 	if strings.TrimSpace(release.Title) == "" {
 		return false
 	}
-	types := make([]string, 0, len(release.ReleaseGroup.SecondaryType)+1)
-	types = append(types, release.ReleaseGroup.PrimaryType)
-	types = append(types, release.ReleaseGroup.SecondaryType...)
-	for _, t := range types {
+	for _, t := range release.ReleaseGroup.SecondaryType {
 		n := normalizeMBString(t)
-		if n == "compilation" || n == "live" || n == "unofficial" || n == "promo" {
+		if n == "unofficial" || n == "promo" {
 			return false
 		}
 	}
 	return true
 }
 
-func isAlbumRelease(release struct {
-	Title        string   `json:"title"`
-	Date         string   `json:"date"`
-	Status       string   `json:"status"`
-	ReleaseGroup mbGroup  `json:"release-group"`
-	Tags         []mbName `json:"tags"`
-	Genres       []mbName `json:"genres"`
-}) bool {
+func hasDiscouragedSecondaryType(release mbRelease) bool {
+	for _, t := range release.ReleaseGroup.SecondaryType {
+		n := normalizeMBString(t)
+		if n == "compilation" || n == "live" {
+			return true
+		}
+	}
+	return false
+}
+
+func isAlbumRelease(release mbRelease) bool {
 	primaryType := normalizeMBString(release.ReleaseGroup.PrimaryType)
 	return primaryType == "album"
 }
 
-func collectRecordingGenre(rec struct {
-	Score            mbScore `json:"score"`
-	FirstReleaseDate string  `json:"first-release-date"`
-	ArtistCredit     []struct {
-		Name string `json:"name"`
-	} `json:"artist-credit"`
-	Releases []struct {
-		Title        string   `json:"title"`
-		Date         string   `json:"date"`
-		Status       string   `json:"status"`
-		ReleaseGroup mbGroup  `json:"release-group"`
-		Tags         []mbName `json:"tags"`
-		Genres       []mbName `json:"genres"`
-	} `json:"releases"`
-	Tags   []mbName `json:"tags"`
-	Genres []mbName `json:"genres"`
-}) string {
+func collectRecordingGenre(rec mbRecording) string {
 	return collectGenres(rec.Genres, rec.Tags)
 }
 
-func collectGenre(rec struct {
-	Score            mbScore `json:"score"`
-	FirstReleaseDate string  `json:"first-release-date"`
-	ArtistCredit     []struct {
-		Name string `json:"name"`
-	} `json:"artist-credit"`
-	Releases []struct {
-		Title        string   `json:"title"`
-		Date         string   `json:"date"`
-		Status       string   `json:"status"`
-		ReleaseGroup mbGroup  `json:"release-group"`
-		Tags         []mbName `json:"tags"`
-		Genres       []mbName `json:"genres"`
-	} `json:"releases"`
-	Tags   []mbName `json:"tags"`
-	Genres []mbName `json:"genres"`
-}, release struct {
-	Title        string   `json:"title"`
-	Date         string   `json:"date"`
-	Status       string   `json:"status"`
-	ReleaseGroup mbGroup  `json:"release-group"`
-	Tags         []mbName `json:"tags"`
-	Genres       []mbName `json:"genres"`
-}) string {
+func collectGenre(rec mbRecording, release mbRelease) string {
 	genre := collectGenres(release.Genres, release.Tags)
 	if genre != "" {
 		return genre

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -279,8 +279,8 @@ func (j *musicBrainzMetadataJob) setError(err error) {
 
 type mbSearchResponse struct {
 	Recordings []struct {
-		Score            string `json:"score"`
-		FirstReleaseDate string `json:"first-release-date"`
+		Score            mbScore `json:"score"`
+		FirstReleaseDate string  `json:"first-release-date"`
 		ArtistCredit     []struct {
 			Name string `json:"name"`
 		} `json:"artist-credit"`
@@ -295,6 +295,31 @@ type mbSearchResponse struct {
 		Tags   []mbName `json:"tags"`
 		Genres []mbName `json:"genres"`
 	} `json:"recordings"`
+}
+
+type mbScore string
+
+func (s *mbScore) UnmarshalJSON(data []byte) error {
+	v := strings.TrimSpace(string(data))
+	if v == "" || v == "null" {
+		*s = ""
+		return nil
+	}
+	if len(v) >= 2 && v[0] == '"' && v[len(v)-1] == '"' {
+		*s = mbScore(strings.TrimSpace(v[1 : len(v)-1]))
+		return nil
+	}
+	*s = mbScore(v)
+	return nil
+}
+
+func (s mbScore) Int() int {
+	v := strings.TrimSpace(string(s))
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		return 0
+	}
+	return i
 }
 
 type mbName struct {
@@ -352,8 +377,8 @@ func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (string, in
 }
 
 func selectBestRecording(recordings []struct {
-	Score            string `json:"score"`
-	FirstReleaseDate string `json:"first-release-date"`
+	Score            mbScore `json:"score"`
+	FirstReleaseDate string  `json:"first-release-date"`
 	ArtistCredit     []struct {
 		Name string `json:"name"`
 	} `json:"artist-credit"`
@@ -368,8 +393,8 @@ func selectBestRecording(recordings []struct {
 	Tags   []mbName `json:"tags"`
 	Genres []mbName `json:"genres"`
 }, artist string) *struct {
-	Score            string `json:"score"`
-	FirstReleaseDate string `json:"first-release-date"`
+	Score            mbScore `json:"score"`
+	FirstReleaseDate string  `json:"first-release-date"`
 	ArtistCredit     []struct {
 		Name string `json:"name"`
 	} `json:"artist-credit"`
@@ -388,8 +413,8 @@ func selectBestRecording(recordings []struct {
 
 	type recCandidate struct {
 		rec *struct {
-			Score            string `json:"score"`
-			FirstReleaseDate string `json:"first-release-date"`
+			Score            mbScore `json:"score"`
+			FirstReleaseDate string  `json:"first-release-date"`
 			ArtistCredit     []struct {
 				Name string `json:"name"`
 			} `json:"artist-credit"`
@@ -413,8 +438,8 @@ func selectBestRecording(recordings []struct {
 	candidates := make([]recCandidate, 0, len(recordings))
 	for i := range recordings {
 		rec := &recordings[i]
-		score, err := strconv.Atoi(rec.Score)
-		if err != nil || score < 80 {
+		score := rec.Score.Int()
+		if score < 80 {
 			continue
 		}
 		if !artistCreditMatches(rec.ArtistCredit, normalizedArtist) {
@@ -589,8 +614,8 @@ func isAlbumRelease(release struct {
 }
 
 func collectRecordingGenre(rec struct {
-	Score            string `json:"score"`
-	FirstReleaseDate string `json:"first-release-date"`
+	Score            mbScore `json:"score"`
+	FirstReleaseDate string  `json:"first-release-date"`
 	ArtistCredit     []struct {
 		Name string `json:"name"`
 	} `json:"artist-credit"`
@@ -609,8 +634,8 @@ func collectRecordingGenre(rec struct {
 }
 
 func collectGenre(rec struct {
-	Score            string `json:"score"`
-	FirstReleaseDate string `json:"first-release-date"`
+	Score            mbScore `json:"score"`
+	FirstReleaseDate string  `json:"first-release-date"`
 	ArtistCredit     []struct {
 		Name string `json:"name"`
 	} `json:"artist-credit"`

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -950,7 +950,8 @@ func (n *Router) saveFetchedMetadataToSongs() error {
 			coverFile = filepath.Join(conf.Server.DataFolder, filepath.FromSlash(mf.CoverPath))
 		}
 
-		if strings.TrimSpace(mf.Album) == "" && mf.Year == 0 && strings.TrimSpace(mf.Genre) == "" && strings.TrimSpace(mf.MbzRecordingID) == "" && strings.TrimSpace(mf.MbzReleaseID) == "" && coverFile == "" {
+		hasFetchedIDs := strings.TrimSpace(mf.MbzRecordingID) != "" || strings.TrimSpace(mf.MbzReleaseID) != ""
+		if !hasFetchedIDs && coverFile == "" {
 			continue
 		}
 

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strconv"
@@ -15,6 +18,7 @@ import (
 	"unicode"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 )
@@ -37,12 +41,14 @@ type musicBrainzMetadataStatus struct {
 	Genre         metadataFieldProgress `json:"genre"`
 	RecordingMBID metadataFieldProgress `json:"recordingMbid"`
 	ReleaseMBID   metadataFieldProgress `json:"releaseMbid"`
+	CoverArt      metadataFieldProgress `json:"coverArt"`
 }
 
 type musicBrainzMetadataJob struct {
-	mu     sync.RWMutex
-	status musicBrainzMetadataStatus
-	client *http.Client
+	mu          sync.RWMutex
+	status      musicBrainzMetadataStatus
+	client      *http.Client
+	coverMisses sync.Map
 }
 
 func newMusicBrainzMetadataJob() *musicBrainzMetadataJob {
@@ -77,6 +83,7 @@ type missingFlags struct {
 	genre         bool
 	recordingMBID bool
 	releaseMBID   bool
+	coverArt      bool
 }
 
 type mbMetadataCandidate struct {
@@ -133,7 +140,7 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 		if fetchErr != nil {
 			failed++
 			log.Warn(ctx, "Could not fetch metadata from MusicBrainz", "songId", c.mf.ID, "title", c.mf.Title, "artist", c.mf.Artist, fetchErr)
-			j.finishFetch(c.flags, false, false, false, false, false)
+			j.finishFetch(c.flags, false, false, false, false, false, false)
 			continue
 		}
 
@@ -159,13 +166,36 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 				log.Error(ctx, "Could not update fetched MusicBrainz metadata", "songId", c.mf.ID, err)
 			} else {
 				updated++
-				j.setUpdated(setAlbum != nil, setYear != nil, setGenre != nil, c.flags.recordingMBID && metadata.RecordingMBID != "", c.flags.releaseMBID && metadata.ReleaseMBID != "")
+				j.setUpdated(setAlbum != nil, setYear != nil, setGenre != nil, c.flags.recordingMBID && metadata.RecordingMBID != "", c.flags.releaseMBID && metadata.ReleaseMBID != "", false)
 			}
 		} else {
 			skipped++
 		}
 
-		j.finishFetch(c.flags, metadata.Album != "", metadata.Year > 0, metadata.Genre != "", metadata.RecordingMBID != "", metadata.ReleaseMBID != "")
+		coverFetched := false
+		coverUpdated := false
+		if c.flags.coverArt && !c.mf.HasCoverArt && strings.TrimSpace(c.mf.CoverPath) == "" {
+			releaseMBID := strings.TrimSpace(c.mf.MbzReleaseID)
+			if releaseMBID == "" {
+				releaseMBID = strings.TrimSpace(metadata.ReleaseMBID)
+			}
+			if releaseMBID != "" && releaseMBIDRegex.MatchString(releaseMBID) {
+				relPath, ok := j.ensureReleaseCover(ctx, releaseMBID)
+				if ok {
+					coverFetched = true
+					if err := ds.MediaFile(ctx).UpdateCoverPath(c.mf.ID, relPath); err != nil {
+						log.Warn(ctx, "Could not update cover path", "songId", c.mf.ID, "releaseMBID", releaseMBID, "err", err)
+					} else {
+						coverUpdated = true
+					}
+				}
+			}
+		}
+
+		if coverUpdated {
+			j.setUpdated(false, false, false, false, false, true)
+		}
+		j.finishFetch(c.flags, metadata.Album != "", metadata.Year > 0, metadata.Genre != "", metadata.RecordingMBID != "", metadata.ReleaseMBID != "", coverFetched)
 	}
 
 	log.Info(ctx, "MusicBrainz metadata fetch completed",
@@ -198,8 +228,9 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 			genre:         strings.TrimSpace(mf.Genre) == "",
 			recordingMBID: strings.TrimSpace(mf.MbzRecordingID) == "",
 			releaseMBID:   strings.TrimSpace(mf.MbzReleaseID) == "",
+			coverArt:      !mf.HasCoverArt && strings.TrimSpace(mf.CoverPath) == "",
 		}
-		if !flags.album && !flags.year && !flags.genre && !flags.recordingMBID && !flags.releaseMBID {
+		if !flags.album && !flags.year && !flags.genre && !flags.recordingMBID && !flags.releaseMBID && !flags.coverArt {
 			continue
 		}
 
@@ -237,6 +268,10 @@ func (j *musicBrainzMetadataJob) incrementMissing(flags missingFlags) {
 		j.status.ReleaseMBID.Missing++
 		j.status.ReleaseMBID.Left++
 	}
+	if flags.coverArt {
+		j.status.CoverArt.Missing++
+		j.status.CoverArt.Left++
+	}
 }
 
 func (j *musicBrainzMetadataJob) setFetching(flags missingFlags, delta int) {
@@ -257,9 +292,12 @@ func (j *musicBrainzMetadataJob) setFetching(flags missingFlags, delta int) {
 	if flags.releaseMBID {
 		j.status.ReleaseMBID.Fetching += delta
 	}
+	if flags.coverArt {
+		j.status.CoverArt.Fetching += delta
+	}
 }
 
-func (j *musicBrainzMetadataJob) setUpdated(album, year, genre, recordingMBID, releaseMBID bool) {
+func (j *musicBrainzMetadataJob) setUpdated(album, year, genre, recordingMBID, releaseMBID, coverArt bool) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	if album {
@@ -277,9 +315,12 @@ func (j *musicBrainzMetadataJob) setUpdated(album, year, genre, recordingMBID, r
 	if releaseMBID {
 		j.status.ReleaseMBID.Updated++
 	}
+	if coverArt {
+		j.status.CoverArt.Updated++
+	}
 }
 
-func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, fetchedYear, fetchedGenre, fetchedRecordingMBID, fetchedReleaseMBID bool) {
+func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, fetchedYear, fetchedGenre, fetchedRecordingMBID, fetchedReleaseMBID, fetchedCoverArt bool) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	if flags.album {
@@ -317,12 +358,83 @@ func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, f
 			j.status.ReleaseMBID.Fetched++
 		}
 	}
+	if flags.coverArt {
+		j.status.CoverArt.Fetching--
+		j.status.CoverArt.Left--
+		if fetchedCoverArt {
+			j.status.CoverArt.Fetched++
+		}
+	}
 }
 
 func (j *musicBrainzMetadataJob) setError(err error) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	j.status.LastError = err.Error()
+}
+
+func (j *musicBrainzMetadataJob) ensureReleaseCover(ctx context.Context, releaseMBID string) (string, bool) {
+	if _, err := os.Stat(filepath.Join(conf.Server.DataFolder, coverCacheDirName)); err != nil {
+		if err := os.MkdirAll(filepath.Join(conf.Server.DataFolder, coverCacheDirName), 0o755); err != nil {
+			log.Warn(ctx, "Could not create cover cache directory", "err", err)
+			return "", false
+		}
+	}
+
+	coverPath := filepath.Join(conf.Server.DataFolder, coverCacheDirName, releaseMBID+".jpg")
+	if _, err := os.Stat(coverPath); err == nil {
+		return filepath.ToSlash(filepath.Join(coverCacheDirName, releaseMBID+".jpg")), true
+	}
+	if _, missed := j.coverMisses.Load(releaseMBID); missed {
+		return "", false
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://coverartarchive.org/release/"+releaseMBID+"/front-500", nil)
+	if err != nil {
+		log.Warn(ctx, "Could not build cover request", "releaseMBID", releaseMBID, "err", err)
+		return "", false
+	}
+	req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
+
+	resp, err := j.client.Do(req)
+	if err != nil {
+		log.Warn(ctx, "Could not fetch cover art", "releaseMBID", releaseMBID, "err", err)
+		return "", false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		j.coverMisses.Store(releaseMBID, true)
+		return "", false
+	}
+	if resp.StatusCode != http.StatusOK {
+		log.Warn(ctx, "Unexpected cover status", "releaseMBID", releaseMBID, "status", resp.StatusCode)
+		return "", false
+	}
+
+	tmpPath := coverPath + ".tmp"
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		log.Warn(ctx, "Could not create cover file", "path", tmpPath, "err", err)
+		return "", false
+	}
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		log.Warn(ctx, "Could not save cover file", "path", tmpPath, "err", err)
+		return "", false
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", false
+	}
+	if err := os.Rename(tmpPath, coverPath); err != nil {
+		_ = os.Remove(tmpPath)
+		log.Warn(ctx, "Could not store cover file", "path", coverPath, "err", err)
+		return "", false
+	}
+
+	return filepath.ToSlash(filepath.Join(coverCacheDirName, releaseMBID+".jpg")), true
 }
 
 type mbSearchResponse struct {

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -1,0 +1,367 @@
+package nativeapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+)
+
+type metadataFieldProgress struct {
+	Missing  int `json:"missing"`
+	Fetching int `json:"fetching"`
+	Fetched  int `json:"fetched"`
+	Updated  int `json:"updated"`
+	Left     int `json:"left"`
+}
+
+type musicBrainzMetadataStatus struct {
+	Running    bool                  `json:"running"`
+	StartedAt  *time.Time            `json:"startedAt,omitempty"`
+	FinishedAt *time.Time            `json:"finishedAt,omitempty"`
+	LastError  string                `json:"lastError,omitempty"`
+	Album      metadataFieldProgress `json:"album"`
+	Year       metadataFieldProgress `json:"year"`
+	Genre      metadataFieldProgress `json:"genre"`
+}
+
+type musicBrainzMetadataJob struct {
+	mu     sync.RWMutex
+	status musicBrainzMetadataStatus
+	client *http.Client
+}
+
+func newMusicBrainzMetadataJob() *musicBrainzMetadataJob {
+	return &musicBrainzMetadataJob{
+		client: &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+func (j *musicBrainzMetadataJob) getStatus() musicBrainzMetadataStatus {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+	return j.status
+}
+
+func (j *musicBrainzMetadataJob) start(ds model.DataStore) bool {
+	j.mu.Lock()
+	if j.status.Running {
+		j.mu.Unlock()
+		return false
+	}
+	now := time.Now()
+	j.status = musicBrainzMetadataStatus{Running: true, StartedAt: &now}
+	j.mu.Unlock()
+
+	go j.run(ds)
+	return true
+}
+
+type missingFlags struct {
+	album bool
+	year  bool
+	genre bool
+}
+
+type mbMetadataCandidate struct {
+	mf    model.MediaFile
+	flags missingFlags
+}
+
+func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
+	ctx := context.Background()
+	defer func() {
+		j.mu.Lock()
+		j.status.Running = false
+		now := time.Now()
+		j.status.FinishedAt = &now
+		j.mu.Unlock()
+	}()
+
+	candidates, err := j.collectCandidates(ctx, ds)
+	if err != nil {
+		j.setError(err)
+		return
+	}
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for i, c := range candidates {
+		if i > 0 {
+			<-ticker.C
+		}
+		j.setFetching(c.flags, 1)
+
+		album, year, genre, fetchErr := j.fetchMetadata(c.mf.Title, c.mf.Artist)
+		if fetchErr != nil {
+			log.Warn(ctx, "Could not fetch metadata from MusicBrainz", "songId", c.mf.ID, "title", c.mf.Title, "artist", c.mf.Artist, fetchErr)
+		}
+
+		var setAlbum *string
+		var setYear *int
+		var setGenre *string
+
+		if c.flags.album && album != "" {
+			setAlbum = &album
+		}
+		if c.flags.year && year > 0 {
+			setYear = &year
+		}
+		if c.flags.genre && genre != "" {
+			setGenre = &genre
+		}
+
+		if setAlbum != nil || setYear != nil || setGenre != nil {
+			if err := ds.MediaFile(ctx).UpdateMissingMetadata(c.mf.ID, setAlbum, setYear, setGenre); err != nil {
+				log.Error(ctx, "Could not update fetched MusicBrainz metadata", "songId", c.mf.ID, err)
+			} else {
+				j.setUpdated(setAlbum != nil, setYear != nil, setGenre != nil)
+			}
+		}
+
+		j.finishFetch(c.flags, album != "", year > 0, genre != "")
+	}
+}
+
+func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model.DataStore) ([]mbMetadataCandidate, error) {
+	cursor, err := ds.MediaFile(ctx).GetCursor()
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]mbMetadataCandidate, 0)
+	for mf, e := range cursor {
+		if e != nil {
+			return nil, e
+		}
+		if strings.TrimSpace(mf.Title) == "" || strings.TrimSpace(mf.Artist) == "" {
+			continue
+		}
+
+		flags := missingFlags{
+			album: strings.TrimSpace(mf.Album) == "",
+			year:  mf.Year == 0,
+			genre: strings.TrimSpace(mf.Genre) == "",
+		}
+		if !flags.album && !flags.year && !flags.genre {
+			continue
+		}
+
+		res = append(res, mbMetadataCandidate{mf: mf, flags: flags})
+		j.incrementMissing(flags)
+	}
+	return res, nil
+}
+
+func (j *musicBrainzMetadataJob) incrementMissing(flags missingFlags) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if flags.album {
+		j.status.Album.Missing++
+		j.status.Album.Left++
+	}
+	if flags.year {
+		j.status.Year.Missing++
+		j.status.Year.Left++
+	}
+	if flags.genre {
+		j.status.Genre.Missing++
+		j.status.Genre.Left++
+	}
+}
+
+func (j *musicBrainzMetadataJob) setFetching(flags missingFlags, delta int) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if flags.album {
+		j.status.Album.Fetching += delta
+	}
+	if flags.year {
+		j.status.Year.Fetching += delta
+	}
+	if flags.genre {
+		j.status.Genre.Fetching += delta
+	}
+}
+
+func (j *musicBrainzMetadataJob) setUpdated(album, year, genre bool) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if album {
+		j.status.Album.Updated++
+	}
+	if year {
+		j.status.Year.Updated++
+	}
+	if genre {
+		j.status.Genre.Updated++
+	}
+}
+
+func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, fetchedYear, fetchedGenre bool) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if flags.album {
+		j.status.Album.Fetching--
+		j.status.Album.Left--
+		if fetchedAlbum {
+			j.status.Album.Fetched++
+		}
+	}
+	if flags.year {
+		j.status.Year.Fetching--
+		j.status.Year.Left--
+		if fetchedYear {
+			j.status.Year.Fetched++
+		}
+	}
+	if flags.genre {
+		j.status.Genre.Fetching--
+		j.status.Genre.Left--
+		if fetchedGenre {
+			j.status.Genre.Fetched++
+		}
+	}
+}
+
+func (j *musicBrainzMetadataJob) setError(err error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.status.LastError = err.Error()
+}
+
+type mbSearchResponse struct {
+	Recordings []struct {
+		FirstReleaseDate string `json:"first-release-date"`
+		Releases         []struct {
+			Title string `json:"title"`
+			Date  string `json:"date"`
+		} `json:"releases"`
+		Tags []struct {
+			Name string `json:"name"`
+		} `json:"tags"`
+		Genres []struct {
+			Name string `json:"name"`
+		} `json:"genres"`
+	} `json:"recordings"`
+}
+
+func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (string, int, string, error) {
+	query := fmt.Sprintf("recording:\"%s\" AND artist:\"%s\"", title, artist)
+	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json"
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return "", 0, "", err
+	}
+	req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
+
+	resp, err := j.client.Do(req)
+	if err != nil {
+		return "", 0, "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", 0, "", fmt.Errorf("musicbrainz status %d", resp.StatusCode)
+	}
+
+	var payload mbSearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", 0, "", err
+	}
+	if len(payload.Recordings) == 0 {
+		return "", 0, "", nil
+	}
+	rec := payload.Recordings[0]
+
+	album := ""
+	if len(rec.Releases) > 0 {
+		album = strings.TrimSpace(rec.Releases[0].Title)
+	}
+	year := yearFromDate(rec.FirstReleaseDate)
+	if year == 0 && len(rec.Releases) > 0 {
+		year = yearFromDate(rec.Releases[0].Date)
+	}
+	genre := collectGenre(rec)
+	return album, year, genre, nil
+}
+
+func collectGenre(rec struct {
+	FirstReleaseDate string `json:"first-release-date"`
+	Releases         []struct {
+		Title string `json:"title"`
+		Date  string `json:"date"`
+	} `json:"releases"`
+	Tags []struct {
+		Name string `json:"name"`
+	} `json:"tags"`
+	Genres []struct {
+		Name string `json:"name"`
+	} `json:"genres"`
+}) string {
+	unique := map[string]bool{}
+	ordered := make([]string, 0, 4)
+	appendName := func(v string) {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			return
+		}
+		key := strings.ToLower(v)
+		if unique[key] {
+			return
+		}
+		unique[key] = true
+		ordered = append(ordered, v)
+	}
+
+	for _, g := range rec.Genres {
+		appendName(g.Name)
+	}
+	for _, t := range rec.Tags {
+		appendName(t.Name)
+	}
+	if len(ordered) == 0 {
+		return ""
+	}
+	if len(ordered) > 5 {
+		ordered = ordered[:5]
+	}
+	return strings.Join(ordered, ", ")
+}
+
+func yearFromDate(date string) int {
+	if len(date) < 4 {
+		return 0
+	}
+	y, err := strconv.Atoi(date[:4])
+	if err != nil {
+		return 0
+	}
+	return y
+}
+
+func (n *Router) addMusicBrainzMetadataRoute(r chi.Router) {
+	r.Route("/metadata/musicbrainz", func(r chi.Router) {
+		r.Get("/status", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(n.metadataJob.getStatus())
+		})
+		r.Post("/fetch", func(w http.ResponseWriter, _ *http.Request) {
+			if n.metadataJob.start(n.ds) {
+				w.WriteHeader(http.StatusAccepted)
+				_, _ = w.Write([]byte(`{"status":"started"}`))
+				return
+			}
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"status":"already_running"}`))
+		})
+	})
+}

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -28,13 +28,15 @@ type metadataFieldProgress struct {
 }
 
 type musicBrainzMetadataStatus struct {
-	Running    bool                  `json:"running"`
-	StartedAt  *time.Time            `json:"startedAt,omitempty"`
-	FinishedAt *time.Time            `json:"finishedAt,omitempty"`
-	LastError  string                `json:"lastError,omitempty"`
-	Album      metadataFieldProgress `json:"album"`
-	Year       metadataFieldProgress `json:"year"`
-	Genre      metadataFieldProgress `json:"genre"`
+	Running       bool                  `json:"running"`
+	StartedAt     *time.Time            `json:"startedAt,omitempty"`
+	FinishedAt    *time.Time            `json:"finishedAt,omitempty"`
+	LastError     string                `json:"lastError,omitempty"`
+	Album         metadataFieldProgress `json:"album"`
+	Year          metadataFieldProgress `json:"year"`
+	Genre         metadataFieldProgress `json:"genre"`
+	RecordingMBID metadataFieldProgress `json:"recordingMbid"`
+	ReleaseMBID   metadataFieldProgress `json:"releaseMbid"`
 }
 
 type musicBrainzMetadataJob struct {
@@ -70,9 +72,11 @@ func (j *musicBrainzMetadataJob) start(ds model.DataStore) bool {
 }
 
 type missingFlags struct {
-	album bool
-	year  bool
-	genre bool
+	album         bool
+	year          bool
+	genre         bool
+	recordingMBID bool
+	releaseMBID   bool
 }
 
 type mbMetadataCandidate struct {
@@ -129,7 +133,7 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 		if fetchErr != nil {
 			failed++
 			log.Warn(ctx, "Could not fetch metadata from MusicBrainz", "songId", c.mf.ID, "title", c.mf.Title, "artist", c.mf.Artist, fetchErr)
-			j.finishFetch(c.flags, false, false, false)
+			j.finishFetch(c.flags, false, false, false, false, false)
 			continue
 		}
 
@@ -155,13 +159,13 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 				log.Error(ctx, "Could not update fetched MusicBrainz metadata", "songId", c.mf.ID, err)
 			} else {
 				updated++
-				j.setUpdated(setAlbum != nil, setYear != nil, setGenre != nil)
+				j.setUpdated(setAlbum != nil, setYear != nil, setGenre != nil, c.flags.recordingMBID && metadata.RecordingMBID != "", c.flags.releaseMBID && metadata.ReleaseMBID != "")
 			}
 		} else {
 			skipped++
 		}
 
-		j.finishFetch(c.flags, metadata.Album != "", metadata.Year > 0, metadata.Genre != "")
+		j.finishFetch(c.flags, metadata.Album != "", metadata.Year > 0, metadata.Genre != "", metadata.RecordingMBID != "", metadata.ReleaseMBID != "")
 	}
 
 	log.Info(ctx, "MusicBrainz metadata fetch completed",
@@ -189,11 +193,13 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 		}
 
 		flags := missingFlags{
-			album: isMissingAlbum(mf.Album),
-			year:  mf.Year == 0,
-			genre: strings.TrimSpace(mf.Genre) == "",
+			album:         isMissingAlbum(mf.Album),
+			year:          mf.Year == 0,
+			genre:         strings.TrimSpace(mf.Genre) == "",
+			recordingMBID: strings.TrimSpace(mf.MbzRecordingID) == "",
+			releaseMBID:   strings.TrimSpace(mf.MbzReleaseID) == "",
 		}
-		if !flags.album && !flags.year && !flags.genre {
+		if !flags.album && !flags.year && !flags.genre && !flags.recordingMBID && !flags.releaseMBID {
 			continue
 		}
 
@@ -223,6 +229,14 @@ func (j *musicBrainzMetadataJob) incrementMissing(flags missingFlags) {
 		j.status.Genre.Missing++
 		j.status.Genre.Left++
 	}
+	if flags.recordingMBID {
+		j.status.RecordingMBID.Missing++
+		j.status.RecordingMBID.Left++
+	}
+	if flags.releaseMBID {
+		j.status.ReleaseMBID.Missing++
+		j.status.ReleaseMBID.Left++
+	}
 }
 
 func (j *musicBrainzMetadataJob) setFetching(flags missingFlags, delta int) {
@@ -237,9 +251,15 @@ func (j *musicBrainzMetadataJob) setFetching(flags missingFlags, delta int) {
 	if flags.genre {
 		j.status.Genre.Fetching += delta
 	}
+	if flags.recordingMBID {
+		j.status.RecordingMBID.Fetching += delta
+	}
+	if flags.releaseMBID {
+		j.status.ReleaseMBID.Fetching += delta
+	}
 }
 
-func (j *musicBrainzMetadataJob) setUpdated(album, year, genre bool) {
+func (j *musicBrainzMetadataJob) setUpdated(album, year, genre, recordingMBID, releaseMBID bool) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	if album {
@@ -251,9 +271,15 @@ func (j *musicBrainzMetadataJob) setUpdated(album, year, genre bool) {
 	if genre {
 		j.status.Genre.Updated++
 	}
+	if recordingMBID {
+		j.status.RecordingMBID.Updated++
+	}
+	if releaseMBID {
+		j.status.ReleaseMBID.Updated++
+	}
 }
 
-func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, fetchedYear, fetchedGenre bool) {
+func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, fetchedYear, fetchedGenre, fetchedRecordingMBID, fetchedReleaseMBID bool) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	if flags.album {
@@ -275,6 +301,20 @@ func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, f
 		j.status.Genre.Left--
 		if fetchedGenre {
 			j.status.Genre.Fetched++
+		}
+	}
+	if flags.recordingMBID {
+		j.status.RecordingMBID.Fetching--
+		j.status.RecordingMBID.Left--
+		if fetchedRecordingMBID {
+			j.status.RecordingMBID.Fetched++
+		}
+	}
+	if flags.releaseMBID {
+		j.status.ReleaseMBID.Fetching--
+		j.status.ReleaseMBID.Left--
+		if fetchedReleaseMBID {
+			j.status.ReleaseMBID.Fetched++
 		}
 	}
 }

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -24,6 +24,7 @@ import (
 )
 
 type metadataFieldProgress struct {
+	Existing int `json:"existing"`
 	Missing  int `json:"missing"`
 	Fetching int `json:"fetching"`
 	Fetched  int `json:"fetched"`
@@ -230,6 +231,7 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 			releaseMBID:   strings.TrimSpace(mf.MbzReleaseID) == "",
 			coverArt:      !mf.HasCoverArt && strings.TrimSpace(mf.CoverPath) == "",
 		}
+		j.incrementExisting(flags)
 		if !flags.album && !flags.year && !flags.genre && !flags.recordingMBID && !flags.releaseMBID && !flags.coverArt {
 			continue
 		}
@@ -238,6 +240,29 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 		j.incrementMissing(flags)
 	}
 	return res, nil
+}
+
+func (j *musicBrainzMetadataJob) incrementExisting(flags missingFlags) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if !flags.album {
+		j.status.Album.Existing++
+	}
+	if !flags.year {
+		j.status.Year.Existing++
+	}
+	if !flags.genre {
+		j.status.Genre.Existing++
+	}
+	if !flags.recordingMBID {
+		j.status.RecordingMBID.Existing++
+	}
+	if !flags.releaseMBID {
+		j.status.ReleaseMBID.Existing++
+	}
+	if !flags.coverArt {
+		j.status.CoverArt.Existing++
+	}
 }
 
 func isMissingAlbum(album string) bool {

--- a/server/nativeapi/musicbrainz_metadata_test.go
+++ b/server/nativeapi/musicbrainz_metadata_test.go
@@ -1,0 +1,96 @@
+package nativeapi
+
+import "testing"
+
+func TestNormalizeMBString(t *testing.T) {
+	got := normalizeMBString("  AC/DC - Live!  ")
+	if got != "ac dc live" {
+		t.Fatalf("unexpected normalized value: %q", got)
+	}
+}
+
+func TestSelectBestRecording(t *testing.T) {
+	payload := mbSearchResponse{Recordings: []struct {
+		Score            string `json:"score"`
+		FirstReleaseDate string `json:"first-release-date"`
+		ArtistCredit     []struct {
+			Name string `json:"name"`
+		} `json:"artist-credit"`
+		Releases []struct {
+			Title        string   `json:"title"`
+			Date         string   `json:"date"`
+			Status       string   `json:"status"`
+			ReleaseGroup mbGroup  `json:"release-group"`
+			Tags         []mbName `json:"tags"`
+			Genres       []mbName `json:"genres"`
+		} `json:"releases"`
+		Tags   []mbName `json:"tags"`
+		Genres []mbName `json:"genres"`
+	}{
+		{
+			Score: "95",
+			ArtistCredit: []struct {
+				Name string `json:"name"`
+			}{{Name: "Wrong Artist"}},
+			Releases: []struct {
+				Title        string   `json:"title"`
+				Date         string   `json:"date"`
+				Status       string   `json:"status"`
+				ReleaseGroup mbGroup  `json:"release-group"`
+				Tags         []mbName `json:"tags"`
+				Genres       []mbName `json:"genres"`
+			}{{Title: "Wrong Album", Date: "2010-01-01", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}},
+		},
+		{
+			Score: "92",
+			ArtistCredit: []struct {
+				Name string `json:"name"`
+			}{{Name: "The Artist"}},
+			Releases: []struct {
+				Title        string   `json:"title"`
+				Date         string   `json:"date"`
+				Status       string   `json:"status"`
+				ReleaseGroup mbGroup  `json:"release-group"`
+				Tags         []mbName `json:"tags"`
+				Genres       []mbName `json:"genres"`
+			}{{Title: "Best Album", Date: "2001-01-01", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}},
+		},
+		{
+			Score: "79",
+			ArtistCredit: []struct {
+				Name string `json:"name"`
+			}{{Name: "The Artist"}},
+		},
+	}}
+
+	rec := selectBestRecording(payload.Recordings, "the artist")
+	if rec == nil {
+		t.Fatal("expected a recording")
+	}
+	if len(rec.Releases) == 0 || rec.Releases[0].Title != "Best Album" {
+		t.Fatalf("unexpected selected recording: %+v", rec)
+	}
+}
+
+func TestSelectBestRelease(t *testing.T) {
+	releases := []struct {
+		Title        string   `json:"title"`
+		Date         string   `json:"date"`
+		Status       string   `json:"status"`
+		ReleaseGroup mbGroup  `json:"release-group"`
+		Tags         []mbName `json:"tags"`
+		Genres       []mbName `json:"genres"`
+	}{
+		{Title: "Live Cut", Date: "1990", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album", SecondaryType: []string{"Live"}}},
+		{Title: "Single Cut", Date: "2003", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Single"}},
+		{Title: "Album Cut", Date: "2001", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
+	}
+
+	rel := selectBestRelease(releases)
+	if rel == nil {
+		t.Fatal("expected release")
+	}
+	if rel.Title != "Album Cut" {
+		t.Fatalf("expected Album Cut, got %q", rel.Title)
+	}
+}

--- a/server/nativeapi/musicbrainz_metadata_test.go
+++ b/server/nativeapi/musicbrainz_metadata_test.go
@@ -11,8 +11,8 @@ func TestNormalizeMBString(t *testing.T) {
 
 func TestSelectBestRecording(t *testing.T) {
 	payload := mbSearchResponse{Recordings: []struct {
-		Score            string `json:"score"`
-		FirstReleaseDate string `json:"first-release-date"`
+		Score            mbScore `json:"score"`
+		FirstReleaseDate string  `json:"first-release-date"`
 		ArtistCredit     []struct {
 			Name string `json:"name"`
 		} `json:"artist-credit"`

--- a/server/nativeapi/musicbrainz_metadata_test.go
+++ b/server/nativeapi/musicbrainz_metadata_test.go
@@ -10,50 +10,20 @@ func TestNormalizeMBString(t *testing.T) {
 }
 
 func TestSelectBestRecording(t *testing.T) {
-	payload := mbSearchResponse{Recordings: []struct {
-		Score            mbScore `json:"score"`
-		FirstReleaseDate string  `json:"first-release-date"`
-		ArtistCredit     []struct {
-			Name string `json:"name"`
-		} `json:"artist-credit"`
-		Releases []struct {
-			Title        string   `json:"title"`
-			Date         string   `json:"date"`
-			Status       string   `json:"status"`
-			ReleaseGroup mbGroup  `json:"release-group"`
-			Tags         []mbName `json:"tags"`
-			Genres       []mbName `json:"genres"`
-		} `json:"releases"`
-		Tags   []mbName `json:"tags"`
-		Genres []mbName `json:"genres"`
-	}{
+	payload := mbSearchResponse{Recordings: []mbRecording{
 		{
 			Score: "95",
 			ArtistCredit: []struct {
 				Name string `json:"name"`
 			}{{Name: "Wrong Artist"}},
-			Releases: []struct {
-				Title        string   `json:"title"`
-				Date         string   `json:"date"`
-				Status       string   `json:"status"`
-				ReleaseGroup mbGroup  `json:"release-group"`
-				Tags         []mbName `json:"tags"`
-				Genres       []mbName `json:"genres"`
-			}{{Title: "Wrong Album", Date: "2010-01-01", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}},
+			Releases: []mbRelease{{Title: "Wrong Album", Date: "2010-01-01", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}},
 		},
 		{
 			Score: "92",
 			ArtistCredit: []struct {
 				Name string `json:"name"`
 			}{{Name: "The Artist"}},
-			Releases: []struct {
-				Title        string   `json:"title"`
-				Date         string   `json:"date"`
-				Status       string   `json:"status"`
-				ReleaseGroup mbGroup  `json:"release-group"`
-				Tags         []mbName `json:"tags"`
-				Genres       []mbName `json:"genres"`
-			}{{Title: "Best Album", Date: "2001-01-01", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}},
+			Releases: []mbRelease{{Title: "Best Album", Date: "2001-01-01", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}},
 		},
 		{
 			Score: "79",
@@ -73,24 +43,17 @@ func TestSelectBestRecording(t *testing.T) {
 }
 
 func TestSelectBestRelease(t *testing.T) {
-	releases := []struct {
-		Title        string   `json:"title"`
-		Date         string   `json:"date"`
-		Status       string   `json:"status"`
-		ReleaseGroup mbGroup  `json:"release-group"`
-		Tags         []mbName `json:"tags"`
-		Genres       []mbName `json:"genres"`
-	}{
+	releases := []mbRelease{
 		{Title: "Live Cut", Date: "1990", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album", SecondaryType: []string{"Live"}}},
-		{Title: "Single Cut", Date: "2003", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Single"}},
-		{Title: "Album Cut", Date: "2001", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
+		{Title: "US Album Cut", Date: "2001", Country: "US", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
+		{Title: "Album Cut", Date: "2001", Country: "GB", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
 	}
 
 	rel := selectBestRelease(releases)
 	if rel == nil {
 		t.Fatal("expected release")
 	}
-	if rel.Title != "Album Cut" {
-		t.Fatalf("expected Album Cut, got %q", rel.Title)
+	if rel.Title != "US Album Cut" {
+		t.Fatalf("expected US Album Cut, got %q", rel.Title)
 	}
 }

--- a/server/nativeapi/musicbrainz_metadata_test.go
+++ b/server/nativeapi/musicbrainz_metadata_test.go
@@ -42,18 +42,73 @@ func TestSelectBestRecording(t *testing.T) {
 	}
 }
 
-func TestSelectBestRelease(t *testing.T) {
-	releases := []mbRelease{
-		{Title: "Live Cut", Date: "1990", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album", SecondaryType: []string{"Live"}}},
-		{Title: "US Album Cut", Date: "2001", Country: "US", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
-		{Title: "Album Cut", Date: "2001", Country: "GB", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
+func TestCollectReleaseCandidates(t *testing.T) {
+	recordings := []mbRecording{{
+		Score: "95",
+		ArtistCredit: []struct {
+			Name string `json:"name"`
+		}{{Name: "The Artist"}},
+		Releases: []mbRelease{
+			{ID: "live", Title: "Live Cut", Date: "1990", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album", SecondaryType: []string{"Live"}}},
+			{ID: "comp", Title: "Compilation", Date: "1992", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album", SecondaryType: []string{"Compilation"}}},
+			{ID: "album", Title: "Studio Album", Date: "2001", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
+		},
+	}}
+
+	candidates := collectReleaseCandidates(recordings, "the artist")
+	if len(candidates) != 1 {
+		t.Fatalf("expected 1 preferred candidate, got %d", len(candidates))
+	}
+	if candidates[0].release.ID != "album" {
+		t.Fatalf("expected album candidate, got %q", candidates[0].release.ID)
+	}
+}
+
+func TestCollectReleaseCandidatesFallsBackToOfficial(t *testing.T) {
+	recordings := []mbRecording{{
+		Score: "95",
+		ArtistCredit: []struct {
+			Name string `json:"name"`
+		}{{Name: "The Artist"}},
+		Releases: []mbRelease{
+			{ID: "live", Title: "Live Cut", Date: "1990", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album", SecondaryType: []string{"Live"}}},
+			{ID: "single", Title: "Official Single", Date: "1991", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Single"}},
+		},
+	}}
+
+	candidates := collectReleaseCandidates(recordings, "the artist")
+	if len(candidates) != 2 {
+		t.Fatalf("expected official fallback candidates, got %d", len(candidates))
+	}
+}
+
+func TestSelectBestReleaseCandidatePrefersCover(t *testing.T) {
+	candidates := []releaseCandidate{
+		{release: &mbRelease{ID: "a", Title: "No Cover", Date: "1980", Country: "US"}},
+		{release: &mbRelease{ID: "b", Title: "Has Cover", Date: "2001", Country: "GB"}},
 	}
 
-	rel := selectBestRelease(releases)
+	rel := selectBestReleaseCandidate(candidates, func(releaseID string) bool { return releaseID == "b" })
 	if rel == nil {
 		t.Fatal("expected release")
 	}
-	if rel.Title != "US Album Cut" {
-		t.Fatalf("expected US Album Cut, got %q", rel.Title)
+	if rel.release.ID != "b" {
+		t.Fatalf("expected release with cover, got %q", rel.release.ID)
+	}
+}
+
+func TestSelectBestReleaseCandidatePrefersEarliestThenUS(t *testing.T) {
+	candidates := []releaseCandidate{
+		{release: &mbRelease{ID: "a", Title: "Album A", Date: "2001", Country: "GB"}},
+		{release: &mbRelease{ID: "b", Title: "Album B", Date: "2001", Country: "US"}},
+		{release: &mbRelease{ID: "c", Title: "Album C", Date: "1999", Country: "GB"}},
+	}
+
+	rel := selectBestReleaseCandidate(candidates, func(string) bool { return false })
+	if rel == nil {
+		t.Fatal("expected release")
+	}
+	if rel.release.ID != "c" {
+		t.Fatalf("expected earliest release when no cover exists, got %q", rel.release.ID)
 	}
 }

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -241,22 +241,36 @@ func (n *Router) populateSongArtwork(r *http.Request, song *model.MediaFile) {
 		return
 	}
 
-	coverArtID := song.CoverArtID().String()
-	song.ArtworkID = coverArtID
-
-	if coverArtID == "" {
+	if strings.TrimSpace(song.ArtworkID) != "" || strings.TrimSpace(song.ArtworkURL) != "" || song.HasCoverArt {
+		coverArtID := strings.TrimSpace(song.ArtworkID)
+		if coverArtID == "" {
+			coverArtID = song.CoverArtID().String()
+		}
+		song.ArtworkID = coverArtID
+		coverArtURL := strings.TrimSpace(song.ArtworkURL)
+		if coverArtURL == "" && coverArtID != "" {
+			coverArtURL = public.ImageURL(r, song.CoverArtID(), coverArtDefaultSize)
+		}
+		if coverArtURL != "" {
+			if strings.Contains(coverArtURL, "?") {
+				coverArtURL += "&square=true"
+			} else {
+				coverArtURL += "?square=true"
+			}
+		}
+		song.ArtworkURL = coverArtURL
+		song.CoverArtURL = coverArtURL
 		return
 	}
 
-	coverArtURL := public.ImageURL(r, song.CoverArtID(), coverArtDefaultSize)
-	if coverArtURL != "" {
-		if strings.Contains(coverArtURL, "?") {
-			coverArtURL += "&square=true"
-		} else {
-			coverArtURL += "?square=true"
-		}
+	if strings.TrimSpace(song.MbzReleaseID) != "" {
+		coverArtURL := "https://coverartarchive.org/release/" + strings.TrimSpace(song.MbzReleaseID) + "/front-250"
+		song.ArtworkURL = coverArtURL
+		song.CoverArtURL = coverArtURL
+		return
 	}
-	song.ArtworkURL = coverArtURL
+
+	song.CoverArtURL = ""
 }
 
 func (n *Router) addSongRoute(r chi.Router) {

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -7,8 +7,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/deluan/rest"
@@ -27,7 +31,19 @@ import (
 
 const (
 	coverArtDefaultSize = consts.UICoverArtSize
+	coverCacheDirName   = "covercache"
 )
+
+var releaseMBIDRegex = regexp.MustCompile(`^[a-fA-F0-9-]+$`)
+
+var defaultCoverPlaceholder = []byte{
+	0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+	0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+	0x08, 0x04, 0x00, 0x00, 0x00, 0xB5, 0x1C, 0x0C, 0x02, 0x00, 0x00, 0x00,
+	0x0B, 0x49, 0x44, 0x41, 0x54, 0x78, 0xDA, 0x63, 0xFC, 0xFF, 0x1F, 0x00,
+	0x03, 0x03, 0x02, 0x00, 0xEF, 0x26, 0x05, 0x9B, 0x00, 0x00, 0x00, 0x00,
+	0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+}
 
 type Router struct {
 	http.Handler
@@ -38,6 +54,8 @@ type Router struct {
 	libs        core.Library
 	devices     *retailPlayerDeviceResolver
 	metadataJob *musicBrainzMetadataJob
+	coverClient *http.Client
+	coverMisses sync.Map
 }
 
 func New(ds model.DataStore, share core.Share, playlists core.Playlists, insights metrics.Insights, libraryService core.Library) *Router {
@@ -49,7 +67,9 @@ func New(ds model.DataStore, share core.Share, playlists core.Playlists, insight
 		libs:        libraryService,
 		devices:     newRetailPlayerDeviceResolver(),
 		metadataJob: newMusicBrainzMetadataJob(),
+		coverClient: &http.Client{Timeout: 10 * time.Second},
 	}
+	r.ensureCoverCacheDir()
 	r.preloadRetailPlayerDeviceMappings()
 	r.Handler = r.routes()
 	return r
@@ -101,6 +121,7 @@ func (n *Router) routes() http.Handler {
 
 	// Public
 	n.addRetailPlayerPublicRoutes(r)
+	n.addCoverRoute(r)
 	n.addSongRoute(r)
 	n.RX(r, "/translation", newTranslationRepository, false)
 
@@ -170,6 +191,44 @@ func (n *Router) RX(r chi.Router, pathPrefix string, constructor rest.Repository
 			}
 		})
 	})
+}
+
+func (n *Router) coverCacheDir() string {
+	return filepath.Join(conf.Server.DataFolder, coverCacheDirName)
+}
+
+func (n *Router) ensureCoverCacheDir() {
+	if err := os.MkdirAll(n.coverCacheDir(), 0o755); err != nil {
+		log.Error(context.Background(), "Could not create cover cache directory", "dir", n.coverCacheDir(), "err", err)
+	}
+}
+
+func (n *Router) coverFilePath(releaseMBID string) string {
+	return filepath.Join(n.coverCacheDir(), releaseMBID+".jpg")
+}
+
+func (n *Router) addCoverRoute(r chi.Router) {
+	r.Get("/cover/{releaseMBID}", func(w http.ResponseWriter, req *http.Request) {
+		releaseMBID := strings.TrimSpace(chi.URLParam(req, "releaseMBID"))
+		if releaseMBID == "" || !releaseMBIDRegex.MatchString(releaseMBID) {
+			n.writeDefaultCover(w)
+			return
+		}
+
+		filePath := n.coverFilePath(releaseMBID)
+		if _, err := os.Stat(filePath); err == nil {
+			http.ServeFile(w, req, filePath)
+			return
+		}
+
+		n.writeDefaultCover(w)
+	})
+}
+
+func (n *Router) writeDefaultCover(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "image/png")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	_, _ = w.Write(defaultCoverPlaceholder)
 }
 
 func (n *Router) withSongArtwork(handler http.HandlerFunc) http.HandlerFunc {
@@ -264,13 +323,86 @@ func (n *Router) populateSongArtwork(r *http.Request, song *model.MediaFile) {
 	}
 
 	if strings.TrimSpace(song.MbzReleaseID) != "" {
-		coverArtURL := "https://coverartarchive.org/release/" + strings.TrimSpace(song.MbzReleaseID) + "/front-250"
-		song.ArtworkURL = coverArtURL
-		song.CoverArtURL = coverArtURL
+		releaseMBID := strings.TrimSpace(song.MbzReleaseID)
+		if releaseMBIDRegex.MatchString(releaseMBID) {
+			if strings.TrimSpace(song.CoverPath) == "" {
+				if _, err := os.Stat(n.coverFilePath(releaseMBID)); err == nil {
+					coverPath := filepath.ToSlash(filepath.Join(coverCacheDirName, releaseMBID+".jpg"))
+					song.CoverPath = coverPath
+					if err := n.ds.MediaFile(r.Context()).UpdateCoverPath(song.ID, coverPath); err != nil {
+						log.Warn(r.Context(), "Could not persist cover path", "songId", song.ID, "releaseMBID", releaseMBID, "err", err)
+					}
+				} else if _, attempted := n.coverMisses.Load(releaseMBID); !attempted {
+					downloaded, notFound := n.downloadReleaseCover(r.Context(), releaseMBID)
+					if downloaded {
+						coverPath := filepath.ToSlash(filepath.Join(coverCacheDirName, releaseMBID+".jpg"))
+						song.CoverPath = coverPath
+						if err := n.ds.MediaFile(r.Context()).UpdateCoverPath(song.ID, coverPath); err != nil {
+							log.Warn(r.Context(), "Could not persist downloaded cover path", "songId", song.ID, "releaseMBID", releaseMBID, "err", err)
+						}
+					}
+					if notFound {
+						n.coverMisses.Store(releaseMBID, true)
+					}
+				}
+			}
+			song.CoverArtURL = "/api/cover/" + releaseMBID
+			song.ArtworkURL = song.CoverArtURL
+		}
 		return
 	}
 
 	song.CoverArtURL = ""
+}
+
+func (n *Router) downloadReleaseCover(ctx context.Context, releaseMBID string) (downloaded bool, notFound bool) {
+	url := "https://coverartarchive.org/release/" + releaseMBID + "/front-500"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		log.Warn(ctx, "Could not build cover download request", "releaseMBID", releaseMBID, "err", err)
+		return false, false
+	}
+
+	resp, err := n.coverClient.Do(req)
+	if err != nil {
+		log.Warn(ctx, "Could not download release cover", "releaseMBID", releaseMBID, "err", err)
+		return false, false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return false, true
+	}
+	if resp.StatusCode != http.StatusOK {
+		log.Warn(ctx, "Unexpected cover download status", "releaseMBID", releaseMBID, "status", resp.StatusCode)
+		return false, false
+	}
+
+	coverPath := n.coverFilePath(releaseMBID)
+	tmpPath := coverPath + ".tmp"
+	file, err := os.Create(tmpPath)
+	if err != nil {
+		log.Warn(ctx, "Could not create temporary cover file", "path", tmpPath, "err", err)
+		return false, false
+	}
+	if _, err := io.Copy(file, resp.Body); err != nil {
+		_ = file.Close()
+		_ = os.Remove(tmpPath)
+		log.Warn(ctx, "Could not write cover file", "path", tmpPath, "err", err)
+		return false, false
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		log.Warn(ctx, "Could not close temporary cover file", "path", tmpPath, "err", err)
+		return false, false
+	}
+	if err := os.Rename(tmpPath, coverPath); err != nil {
+		_ = os.Remove(tmpPath)
+		log.Warn(ctx, "Could not move cover file into cache", "path", coverPath, "err", err)
+		return false, false
+	}
+
+	return true, false
 }
 
 func (n *Router) addSongRoute(r chi.Router) {

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/deluan/rest"
@@ -54,8 +53,6 @@ type Router struct {
 	libs        core.Library
 	devices     *retailPlayerDeviceResolver
 	metadataJob *musicBrainzMetadataJob
-	coverClient *http.Client
-	coverMisses sync.Map
 }
 
 func New(ds model.DataStore, share core.Share, playlists core.Playlists, insights metrics.Insights, libraryService core.Library) *Router {
@@ -67,7 +64,6 @@ func New(ds model.DataStore, share core.Share, playlists core.Playlists, insight
 		libs:        libraryService,
 		devices:     newRetailPlayerDeviceResolver(),
 		metadataJob: newMusicBrainzMetadataJob(),
-		coverClient: &http.Client{Timeout: 10 * time.Second},
 	}
 	r.ensureCoverCacheDir()
 	r.preloadRetailPlayerDeviceMappings()
@@ -322,87 +318,13 @@ func (n *Router) populateSongArtwork(r *http.Request, song *model.MediaFile) {
 		return
 	}
 
-	if strings.TrimSpace(song.MbzReleaseID) != "" {
-		releaseMBID := strings.TrimSpace(song.MbzReleaseID)
-		if releaseMBIDRegex.MatchString(releaseMBID) {
-			if strings.TrimSpace(song.CoverPath) == "" {
-				if _, err := os.Stat(n.coverFilePath(releaseMBID)); err == nil {
-					coverPath := filepath.ToSlash(filepath.Join(coverCacheDirName, releaseMBID+".jpg"))
-					song.CoverPath = coverPath
-					if err := n.ds.MediaFile(r.Context()).UpdateCoverPath(song.ID, coverPath); err != nil {
-						log.Warn(r.Context(), "Could not persist cover path", "songId", song.ID, "releaseMBID", releaseMBID, "err", err)
-					}
-				} else if _, attempted := n.coverMisses.Load(releaseMBID); !attempted {
-					downloaded, notFound := n.downloadReleaseCover(r.Context(), releaseMBID)
-					if downloaded {
-						coverPath := filepath.ToSlash(filepath.Join(coverCacheDirName, releaseMBID+".jpg"))
-						song.CoverPath = coverPath
-						if err := n.ds.MediaFile(r.Context()).UpdateCoverPath(song.ID, coverPath); err != nil {
-							log.Warn(r.Context(), "Could not persist downloaded cover path", "songId", song.ID, "releaseMBID", releaseMBID, "err", err)
-						}
-					}
-					if notFound {
-						n.coverMisses.Store(releaseMBID, true)
-					}
-				}
-			}
-			song.CoverArtURL = "/api/cover/" + releaseMBID
-			song.ArtworkURL = song.CoverArtURL
-		}
+	if releaseMBID := strings.TrimSpace(song.MbzReleaseID); releaseMBID != "" && releaseMBIDRegex.MatchString(releaseMBID) {
+		song.CoverArtURL = "/api/cover/" + releaseMBID
+		song.ArtworkURL = song.CoverArtURL
 		return
 	}
 
 	song.CoverArtURL = ""
-}
-
-func (n *Router) downloadReleaseCover(ctx context.Context, releaseMBID string) (downloaded bool, notFound bool) {
-	url := "https://coverartarchive.org/release/" + releaseMBID + "/front-500"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		log.Warn(ctx, "Could not build cover download request", "releaseMBID", releaseMBID, "err", err)
-		return false, false
-	}
-
-	resp, err := n.coverClient.Do(req)
-	if err != nil {
-		log.Warn(ctx, "Could not download release cover", "releaseMBID", releaseMBID, "err", err)
-		return false, false
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return false, true
-	}
-	if resp.StatusCode != http.StatusOK {
-		log.Warn(ctx, "Unexpected cover download status", "releaseMBID", releaseMBID, "status", resp.StatusCode)
-		return false, false
-	}
-
-	coverPath := n.coverFilePath(releaseMBID)
-	tmpPath := coverPath + ".tmp"
-	file, err := os.Create(tmpPath)
-	if err != nil {
-		log.Warn(ctx, "Could not create temporary cover file", "path", tmpPath, "err", err)
-		return false, false
-	}
-	if _, err := io.Copy(file, resp.Body); err != nil {
-		_ = file.Close()
-		_ = os.Remove(tmpPath)
-		log.Warn(ctx, "Could not write cover file", "path", tmpPath, "err", err)
-		return false, false
-	}
-	if err := file.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-		log.Warn(ctx, "Could not close temporary cover file", "path", tmpPath, "err", err)
-		return false, false
-	}
-	if err := os.Rename(tmpPath, coverPath); err != nil {
-		_ = os.Remove(tmpPath)
-		log.Warn(ctx, "Could not move cover file into cache", "path", coverPath, "err", err)
-		return false, false
-	}
-
-	return true, false
 }
 
 func (n *Router) addSongRoute(r chi.Router) {

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -212,6 +212,7 @@ func (n *Router) addCoverRoute(r chi.Router) {
 		}
 
 		filePath := n.coverFilePath(releaseMBID)
+		w.Header().Set("Cache-Control", "public, max-age=86400, stale-while-revalidate=604800")
 		if _, err := os.Stat(filePath); err == nil {
 			http.ServeFile(w, req, filePath)
 			return

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -31,22 +31,24 @@ const (
 
 type Router struct {
 	http.Handler
-	ds        model.DataStore
-	share     core.Share
-	playlists core.Playlists
-	insights  metrics.Insights
-	libs      core.Library
-	devices   *retailPlayerDeviceResolver
+	ds          model.DataStore
+	share       core.Share
+	playlists   core.Playlists
+	insights    metrics.Insights
+	libs        core.Library
+	devices     *retailPlayerDeviceResolver
+	metadataJob *musicBrainzMetadataJob
 }
 
 func New(ds model.DataStore, share core.Share, playlists core.Playlists, insights metrics.Insights, libraryService core.Library) *Router {
 	r := &Router{
-		ds:        ds,
-		share:     share,
-		playlists: playlists,
-		insights:  insights,
-		libs:      libraryService,
-		devices:   newRetailPlayerDeviceResolver(),
+		ds:          ds,
+		share:       share,
+		playlists:   playlists,
+		insights:    insights,
+		libs:        libraryService,
+		devices:     newRetailPlayerDeviceResolver(),
+		metadataJob: newMusicBrainzMetadataJob(),
 	}
 	r.preloadRetailPlayerDeviceMappings()
 	r.Handler = r.routes()
@@ -138,6 +140,7 @@ func (n *Router) routes() http.Handler {
 			n.addConfigRoute(r)
 			n.addUserLibraryRoute(r)
 			n.addSyncRoute(r)
+			n.addMusicBrainzMetadataRoute(r)
 			n.RX(r, "/library", n.libs.NewRepository, true)
 		})
 	})

--- a/tests/mock_mediafile_repo.go
+++ b/tests/mock_mediafile_repo.go
@@ -132,6 +132,18 @@ func (m *MockMediaFileRepo) UpdateComment(ids []string, comment string) error {
 	return nil
 }
 
+func (m *MockMediaFileRepo) UpdateCoverPath(id string, coverPath string) error {
+	if m.Err {
+		return errors.New("error")
+	}
+	if mf, ok := m.Data[id]; ok {
+		if mf.CoverPath == "" {
+			mf.CoverPath = coverPath
+		}
+	}
+	return nil
+}
+
 func (m *MockMediaFileRepo) IncPlayCount(id string, timestamp time.Time) error {
 	if m.Err {
 		return errors.New("error")

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -107,10 +107,10 @@ const Admin = (props) => {
       {...props}
     >
       {(permissions) => [
+        <Resource name="covertart" {...covertart} />,
         <Resource name="album" {...album} options={{ subMenu: 'albumList' }} />,
         <Resource name="artist" {...artist} />,
         <Resource name="song" {...song} />,
-        <Resource name="covertart" {...covertart} />,
         <Resource
           name="radio"
           {...(permissions === 'admin' ? radio.admin : radio.all)}

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -10,6 +10,7 @@ import transcoding from './transcoding'
 import player from './player'
 import user from './user'
 import song from './song'
+import covertart from './covertart'
 import album from './album'
 import artist from './artist'
 import playlist from './playlist'
@@ -109,6 +110,7 @@ const Admin = (props) => {
         <Resource name="album" {...album} options={{ subMenu: 'albumList' }} />,
         <Resource name="artist" {...artist} />,
         <Resource name="song" {...song} />,
+        <Resource name="covertart" {...covertart} />,
         <Resource
           name="radio"
           {...(permissions === 'admin' ? radio.admin : radio.all)}

--- a/ui/src/actions/player.js
+++ b/ui/src/actions/player.js
@@ -21,7 +21,10 @@ export const filterSongs = (data, ids) => {
     ? filteredData
     : ids.reduce((acc, id) => {
         if (filteredData[id]) {
-          return { ...acc, [id]: filteredData[id] }
+          // Prefix keys so JS preserves insertion order even for numeric-like ids.
+          // Object keys like "1", "2" are always iterated numerically, which can
+          // break the queue order when users sort playlists by another column.
+          return { ...acc, [`_${id}`]: filteredData[id] }
         }
         return acc
       }, {})

--- a/ui/src/actions/player.test.js
+++ b/ui/src/actions/player.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { filterSongs, playTracks } from './player'
+import { playerReducer } from '../reducers/playerReducer'
+
+describe('player queue ordering', () => {
+  it('preserves explicit id order for numeric-like playlist track ids', () => {
+    const songs = {
+      1: { id: 's1', title: 'Song 1' },
+      2: { id: 's2', title: 'Song 2' },
+      10: { id: 's10', title: 'Song 10' },
+    }
+
+    const ordered = filterSongs(songs, ['10', '2', '1'])
+
+    expect(Object.keys(ordered)).toEqual(['_10', '_2', '_1'])
+  })
+
+  it('keeps selected track when reducer consumes normalized queue keys', () => {
+    const songs = {
+      1: { id: 's1', title: 'Song 1' },
+      2: { id: 's2', title: 'Song 2' },
+      10: { id: 's10', title: 'Song 10' },
+    }
+
+    const action = playTracks(songs, ['10', '2', '1'], '2')
+    const nextState = playerReducer(undefined, action)
+
+    expect(nextState.playIndex).toBe(1)
+    expect(nextState.queue.map((item) => item.name)).toEqual([
+      'Song 10',
+      'Song 2',
+      'Song 1',
+    ])
+  })
+})

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -75,6 +75,7 @@ const CovertartList = (props) => {
     <List
       {...props}
       sort={{ field: 'title', order: 'ASC' }}
+      filter={{ hascoverart: false }}
       actions={<CovertartListActions />}
       filters={<CovertartFilter />}
       exporter={false}

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -1,4 +1,7 @@
 import React from 'react'
+import IconButton from '@material-ui/core/IconButton'
+import Tooltip from '@material-ui/core/Tooltip'
+import ImageOutlinedIcon from '@material-ui/icons/ImageOutlined'
 import {
   Datagrid,
   Filter,
@@ -6,9 +9,13 @@ import {
   List,
   SearchInput,
   TextField,
+  TopToolbar,
+  useListContext,
+  useTranslate,
 } from 'react-admin'
 import { makeStyles } from '@material-ui/core/styles'
 import { DurationField, Pagination } from '../common'
+import subsonic from '../subsonic'
 
 const useStyles = makeStyles({
   mbidText: {
@@ -16,6 +23,44 @@ const useStyles = makeStyles({
     fontSize: '0.75rem',
   },
 })
+
+const FetchedToggleButton = () => {
+  const translate = useTranslate()
+  const { filterValues, displayedFilters, setFilters } = useListContext()
+  const missingCoverArtOn =
+    filterValues?.fetched === false || filterValues?.fetched === 'false'
+
+  const toggleFetchedFilter = () => {
+    if (missingCoverArtOn) {
+      const { fetched, ...rest } = filterValues || {}
+      setFilters(rest, displayedFilters)
+      return
+    }
+    setFilters({ ...(filterValues || {}), fetched: false }, displayedFilters)
+  }
+
+  return (
+    <Tooltip
+      title={`${translate('resources.covertart.fields.missingCoverArt')}: ${
+        missingCoverArtOn ? 'On' : 'Off'
+      }`}
+    >
+      <IconButton
+        color={missingCoverArtOn ? 'primary' : 'default'}
+        aria-label={translate('resources.covertart.fields.missingCoverArt')}
+        onClick={toggleFetchedFilter}
+      >
+        <ImageOutlinedIcon />
+      </IconButton>
+    </Tooltip>
+  )
+}
+
+const CovertartListActions = (props) => (
+  <TopToolbar {...props}>
+    <FetchedToggleButton />
+  </TopToolbar>
+)
 
 const CovertartFilter = (props) => (
   <Filter {...props} variant={'outlined'}>
@@ -30,7 +75,7 @@ const CovertartList = (props) => {
     <List
       {...props}
       sort={{ field: 'title', order: 'ASC' }}
-      filter={{ hascoverart: false }}
+      actions={<CovertartListActions />}
       filters={<CovertartFilter />}
       exporter={false}
       bulkActionButtons={false}
@@ -42,9 +87,7 @@ const CovertartList = (props) => {
           label="Cover Art"
           sortable={false}
           render={(record) => {
-            const coverSrc = record?.mbzReleaseId
-              ? `/api/cover/${record.mbzReleaseId}`
-              : '/default-cover.png'
+            const coverSrc = subsonic.getCoverArtUrl(record, 50, true) || '/default-cover.png'
 
             return (
               <img
@@ -62,6 +105,13 @@ const CovertartList = (props) => {
         <TextField source="album" label="Album" />
         <TextField source="year" label="Release Year" />
         <TextField source="genre" label="Genre" />
+        <FunctionField
+          label="Fetched"
+          sortBy="fetched"
+          render={(record) =>
+            record?.hasCoverArt || Boolean(record?.coverPath) ? 'Yes' : 'No'
+          }
+        />
         <FunctionField
           label="Recording MBID"
           sortable={false}

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React from 'react'
 import {
   Datagrid,
   Filter,
@@ -6,16 +6,9 @@ import {
   List,
   SearchInput,
   TextField,
-  TopToolbar,
-  useNotify,
-  usePermissions,
-  useTranslate,
 } from 'react-admin'
-import { Box, Button, Card, CardContent, Grid, Typography } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core/styles'
-import { BiDownload } from 'react-icons/bi'
-import { DurationField } from '../common'
-import { httpClient } from '../dataProvider'
+import { DurationField, Pagination } from '../common'
 
 const useStyles = makeStyles({
   mbidText: {
@@ -30,166 +23,6 @@ const CovertartFilter = (props) => (
   </Filter>
 )
 
-const emptyProgress = { missing: 0, fetching: 0, fetched: 0, updated: 0, left: 0 }
-
-const MetadataProgressCard = ({ title, progress, translate }) => (
-  <Card>
-    <CardContent>
-      <Typography variant="subtitle2">{title}</Typography>
-      <Box display="flex" justifyContent="space-between" mt={1}>
-        <span>{translate('activity.musicbrainz.missing')}</span>
-        <span>{progress.missing || 0}</span>
-      </Box>
-      <Box display="flex" justifyContent="space-between">
-        <span>{translate('activity.musicbrainz.fetching')}</span>
-        <span>{progress.fetching || 0}</span>
-      </Box>
-      <Box display="flex" justifyContent="space-between">
-        <span>{translate('activity.musicbrainz.fetched')}</span>
-        <span>{progress.fetched || 0}</span>
-      </Box>
-      <Box display="flex" justifyContent="space-between">
-        <span>{translate('activity.musicbrainz.updated')}</span>
-        <span>{progress.updated || 0}</span>
-      </Box>
-      <Box display="flex" justifyContent="space-between">
-        <span>{translate('activity.musicbrainz.left')}</span>
-        <span>{progress.left || 0}</span>
-      </Box>
-    </CardContent>
-  </Card>
-)
-
-const CovertartListActions = () => {
-  const translate = useTranslate()
-  const notify = useNotify()
-  const { permissions } = usePermissions()
-  const isAdmin = permissions === 'admin'
-  const [status, setStatus] = useState({
-    running: false,
-    album: emptyProgress,
-    year: emptyProgress,
-    genre: emptyProgress,
-    recordingMbid: emptyProgress,
-    releaseMbid: emptyProgress,
-    coverArt: emptyProgress,
-  })
-
-  const loadStatus = useCallback(() => {
-    if (!isAdmin) {
-      return
-    }
-    httpClient('/api/metadata/musicbrainz/status')
-      .then(({ json }) => {
-        setStatus(
-          json || {
-            running: false,
-            album: emptyProgress,
-            year: emptyProgress,
-            genre: emptyProgress,
-            recordingMbid: emptyProgress,
-            releaseMbid: emptyProgress,
-            coverArt: emptyProgress,
-          },
-        )
-      })
-      .catch(() => {})
-  }, [isAdmin])
-
-  useEffect(() => {
-    loadStatus()
-  }, [loadStatus])
-
-  useEffect(() => {
-    if (!status.running) {
-      return undefined
-    }
-    const timer = setInterval(() => loadStatus(), 2000)
-    return () => clearInterval(timer)
-  }, [status.running, loadStatus])
-
-  const startFetch = () => {
-    httpClient('/api/metadata/musicbrainz/fetch', { method: 'POST' })
-      .then(({ status: code }) => {
-        if (code === 202) {
-          notify('activity.musicbrainz.started', 'info')
-        } else {
-          notify('activity.musicbrainz.alreadyRunning', 'warning')
-        }
-        loadStatus()
-      })
-      .catch(() => notify('activity.musicbrainz.failed', 'warning'))
-  }
-
-  return (
-    <TopToolbar>
-      {isAdmin && (
-        <Button
-          color="primary"
-          variant="contained"
-          startIcon={<BiDownload />}
-          onClick={startFetch}
-          disabled={status.running}
-          data-testid="covertart-metadata-fetch-btn"
-        >
-          {translate('activity.musicbrainz.fetch')}
-        </Button>
-      )}
-      {isAdmin && (
-        <Box width="100%" mt={2}>
-          <Typography variant="subtitle1">
-            {translate('activity.musicbrainz.title')}
-          </Typography>
-          <Grid container spacing={2}>
-            <Grid item xs={12} md={3}>
-              <MetadataProgressCard
-                title={translate('activity.musicbrainz.album')}
-                progress={status.album || emptyProgress}
-                translate={translate}
-              />
-            </Grid>
-            <Grid item xs={12} md={3}>
-              <MetadataProgressCard
-                title={translate('activity.musicbrainz.year')}
-                progress={status.year || emptyProgress}
-                translate={translate}
-              />
-            </Grid>
-            <Grid item xs={12} md={2}>
-              <MetadataProgressCard
-                title={translate('activity.musicbrainz.genre')}
-                progress={status.genre || emptyProgress}
-                translate={translate}
-              />
-            </Grid>
-            <Grid item xs={12} md={2}>
-              <MetadataProgressCard
-                title="Recording MBID"
-                progress={status.recordingMbid || emptyProgress}
-                translate={translate}
-              />
-            </Grid>
-            <Grid item xs={12} md={2}>
-              <MetadataProgressCard
-                title="Release MBID"
-                progress={status.releaseMbid || emptyProgress}
-                translate={translate}
-              />
-            </Grid>
-            <Grid item xs={12} md={2}>
-              <MetadataProgressCard
-                title="Cover Art"
-                progress={status.coverArt || emptyProgress}
-                translate={translate}
-              />
-            </Grid>
-          </Grid>
-        </Box>
-      )}
-    </TopToolbar>
-  )
-}
-
 const CovertartList = (props) => {
   const classes = useStyles()
 
@@ -201,7 +34,7 @@ const CovertartList = (props) => {
       exporter={false}
       bulkActionButtons={false}
       perPage={50}
-      actions={<CovertartListActions />}
+      pagination={<Pagination />}
     >
       <Datagrid rowClick={false}>
         <FunctionField
@@ -232,14 +65,18 @@ const CovertartList = (props) => {
           label="Recording MBID"
           sortable={false}
           render={(record) => (
-            <span className={classes.mbidText}>{record?.mbzRecordingID || ''}</span>
+            <span className={classes.mbidText}>
+              {record?.mbzRecordingID || ''}
+            </span>
           )}
         />
         <FunctionField
           label="Release MBID"
           sortable={false}
           render={(record) => (
-            <span className={classes.mbidText}>{record?.mbzReleaseId || ''}</span>
+            <span className={classes.mbidText}>
+              {record?.mbzReleaseId || ''}
+            </span>
           )}
         />
         <DurationField source="duration" />

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import {
   Datagrid,
   Filter,
@@ -6,15 +6,155 @@ import {
   List,
   SearchInput,
   TextField,
+  TopToolbar,
+  useNotify,
+  usePermissions,
+  useTranslate,
 } from 'react-admin'
+import { Box, Button, Card, CardContent, Grid, Typography } from '@material-ui/core'
+import { BiDownload } from 'react-icons/bi'
 import { DurationField } from '../common'
 import subsonic from '../subsonic'
+import { httpClient } from '../dataProvider'
 
 const CovertartFilter = (props) => (
   <Filter {...props} variant={'outlined'}>
     <SearchInput source="title" alwaysOn />
   </Filter>
 )
+
+const emptyProgress = { missing: 0, fetching: 0, fetched: 0, updated: 0, left: 0 }
+
+const MetadataProgressCard = ({ title, progress, translate }) => (
+  <Card>
+    <CardContent>
+      <Typography variant="subtitle2">{title}</Typography>
+      <Box display="flex" justifyContent="space-between" mt={1}>
+        <span>{translate('activity.musicbrainz.missing')}</span>
+        <span>{progress.missing || 0}</span>
+      </Box>
+      <Box display="flex" justifyContent="space-between">
+        <span>{translate('activity.musicbrainz.fetching')}</span>
+        <span>{progress.fetching || 0}</span>
+      </Box>
+      <Box display="flex" justifyContent="space-between">
+        <span>{translate('activity.musicbrainz.fetched')}</span>
+        <span>{progress.fetched || 0}</span>
+      </Box>
+      <Box display="flex" justifyContent="space-between">
+        <span>{translate('activity.musicbrainz.updated')}</span>
+        <span>{progress.updated || 0}</span>
+      </Box>
+      <Box display="flex" justifyContent="space-between">
+        <span>{translate('activity.musicbrainz.left')}</span>
+        <span>{progress.left || 0}</span>
+      </Box>
+    </CardContent>
+  </Card>
+)
+
+const CovertartListActions = () => {
+  const translate = useTranslate()
+  const notify = useNotify()
+  const { permissions } = usePermissions()
+  const isAdmin = permissions === 'admin'
+  const [status, setStatus] = useState({
+    running: false,
+    album: emptyProgress,
+    year: emptyProgress,
+    genre: emptyProgress,
+  })
+
+  const loadStatus = useCallback(() => {
+    if (!isAdmin) {
+      return
+    }
+    httpClient('/api/metadata/musicbrainz/status')
+      .then(({ json }) => {
+        setStatus(
+          json || {
+            running: false,
+            album: emptyProgress,
+            year: emptyProgress,
+            genre: emptyProgress,
+          },
+        )
+      })
+      .catch(() => {})
+  }, [isAdmin])
+
+  useEffect(() => {
+    loadStatus()
+  }, [loadStatus])
+
+  useEffect(() => {
+    if (!status.running) {
+      return undefined
+    }
+    const timer = setInterval(() => loadStatus(), 2000)
+    return () => clearInterval(timer)
+  }, [status.running, loadStatus])
+
+  const startFetch = () => {
+    httpClient('/api/metadata/musicbrainz/fetch', { method: 'POST' })
+      .then(({ status: code }) => {
+        if (code === 202) {
+          notify('activity.musicbrainz.started', 'info')
+        } else {
+          notify('activity.musicbrainz.alreadyRunning', 'warning')
+        }
+        loadStatus()
+      })
+      .catch(() => notify('activity.musicbrainz.failed', 'warning'))
+  }
+
+  return (
+    <TopToolbar>
+      {isAdmin && (
+        <Button
+          color="primary"
+          variant="contained"
+          startIcon={<BiDownload />}
+          onClick={startFetch}
+          disabled={status.running}
+          data-testid="covertart-metadata-fetch-btn"
+        >
+          {translate('activity.musicbrainz.fetch')}
+        </Button>
+      )}
+      {isAdmin && (
+        <Box width="100%" mt={2}>
+          <Typography variant="subtitle1">
+            {translate('activity.musicbrainz.title')}
+          </Typography>
+          <Grid container spacing={2}>
+            <Grid item xs={12} md={4}>
+              <MetadataProgressCard
+                title={translate('activity.musicbrainz.album')}
+                progress={status.album || emptyProgress}
+                translate={translate}
+              />
+            </Grid>
+            <Grid item xs={12} md={4}>
+              <MetadataProgressCard
+                title={translate('activity.musicbrainz.year')}
+                progress={status.year || emptyProgress}
+                translate={translate}
+              />
+            </Grid>
+            <Grid item xs={12} md={4}>
+              <MetadataProgressCard
+                title={translate('activity.musicbrainz.genre')}
+                progress={status.genre || emptyProgress}
+                translate={translate}
+              />
+            </Grid>
+          </Grid>
+        </Box>
+      )}
+    </TopToolbar>
+  )
+}
 
 const CovertartList = (props) => (
   <List
@@ -24,6 +164,7 @@ const CovertartList = (props) => (
     exporter={false}
     bulkActionButtons={false}
     perPage={50}
+    actions={<CovertartListActions />}
   >
     <Datagrid rowClick={false}>
       <FunctionField

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -72,6 +72,7 @@ const CovertartListActions = () => {
     genre: emptyProgress,
     recordingMbid: emptyProgress,
     releaseMbid: emptyProgress,
+    coverArt: emptyProgress,
   })
 
   const loadStatus = useCallback(() => {
@@ -88,6 +89,7 @@ const CovertartListActions = () => {
             genre: emptyProgress,
             recordingMbid: emptyProgress,
             releaseMbid: emptyProgress,
+            coverArt: emptyProgress,
           },
         )
       })
@@ -171,6 +173,13 @@ const CovertartListActions = () => {
               <MetadataProgressCard
                 title="Release MBID"
                 progress={status.releaseMbid || emptyProgress}
+                translate={translate}
+              />
+            </Grid>
+            <Grid item xs={12} md={2}>
+              <MetadataProgressCard
+                title="Cover Art"
+                progress={status.coverArt || emptyProgress}
                 translate={translate}
               />
             </Grid>

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -15,7 +15,6 @@ import { Box, Button, Card, CardContent, Grid, Typography } from '@material-ui/c
 import { makeStyles } from '@material-ui/core/styles'
 import { BiDownload } from 'react-icons/bi'
 import { DurationField } from '../common'
-import subsonic from '../subsonic'
 import { httpClient } from '../dataProvider'
 
 const useStyles = makeStyles({
@@ -201,10 +200,13 @@ const CovertartList = (props) => {
           sortable={false}
           render={(record) => (
             <img
-              src={subsonic.getCoverArtUrl(record, 64, true)}
+              src={record?.cover_art_url || '/default-cover.png'}
               alt={record.title || 'cover art'}
-              width="64"
-              height="64"
+              width="50"
+              height="50"
+              onError={(e) => {
+                e.currentTarget.src = '/default-cover.png'
+              }}
             />
           )}
         />

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -200,7 +200,7 @@ const CovertartList = (props) => {
           sortable={false}
           render={(record) => (
             <img
-              src={record?.cover_art_url || '/default-cover.png'}
+              src={record?.mbzReleaseId ? `/api/cover/${record.mbzReleaseId}` : '/default-cover.png'}
               alt={record.title || 'cover art'}
               width="50"
               height="50"

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -207,17 +207,21 @@ const CovertartList = (props) => {
         <FunctionField
           label="Cover Art"
           sortable={false}
-          render={(record) => (
-            <img
-              src={record?.mbzReleaseId ? `/api/cover/${record.mbzReleaseId}` : '/default-cover.png'}
-              alt={record.title || 'cover art'}
-              width="50"
-              height="50"
-              onError={(e) => {
-                e.currentTarget.src = '/default-cover.png'
-              }}
-            />
-          )}
+          render={(record) => {
+            const coverSrc = record?.mbzReleaseId
+              ? `/api/cover/${record.mbzReleaseId}`
+              : '/default-cover.png'
+
+            return (
+              <img
+                src={coverSrc}
+                alt={record.title || 'cover art'}
+                width="50"
+                height="50"
+                loading="lazy"
+              />
+            )
+          }}
         />
         <TextField source="title" />
         <TextField source="artist" label="Artist" />

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import {
+  Datagrid,
+  Filter,
+  FunctionField,
+  List,
+  SearchInput,
+  TextField,
+} from 'react-admin'
+import { DurationField } from '../common'
+import subsonic from '../subsonic'
+
+const CovertartFilter = (props) => (
+  <Filter {...props} variant={'outlined'}>
+    <SearchInput source="title" alwaysOn />
+  </Filter>
+)
+
+const CovertartList = (props) => (
+  <List
+    {...props}
+    sort={{ field: 'title', order: 'ASC' }}
+    filters={<CovertartFilter />}
+    exporter={false}
+    bulkActionButtons={false}
+    perPage={50}
+  >
+    <Datagrid rowClick={false}>
+      <FunctionField
+        label="Cover Art"
+        sortable={false}
+        render={(record) => (
+          <img
+            src={subsonic.getCoverArtUrl(record, 64, true)}
+            alt={record.title || 'cover art'}
+            width="64"
+            height="64"
+          />
+        )}
+      />
+      <TextField source="title" />
+      <TextField source="artist" label="Artist" />
+      <TextField source="album" label="Album" />
+      <TextField source="year" label="Release Year" />
+      <TextField source="genre" label="Genre" />
+      <DurationField source="duration" />
+    </Datagrid>
+  </List>
+)
+
+export default CovertartList

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -12,10 +12,18 @@ import {
   useTranslate,
 } from 'react-admin'
 import { Box, Button, Card, CardContent, Grid, Typography } from '@material-ui/core'
+import { makeStyles } from '@material-ui/core/styles'
 import { BiDownload } from 'react-icons/bi'
 import { DurationField } from '../common'
 import subsonic from '../subsonic'
 import { httpClient } from '../dataProvider'
+
+const useStyles = makeStyles({
+  mbidText: {
+    fontFamily: 'monospace',
+    fontSize: '0.75rem',
+  },
+})
 
 const CovertartFilter = (props) => (
   <Filter {...props} variant={'outlined'}>
@@ -63,6 +71,8 @@ const CovertartListActions = () => {
     album: emptyProgress,
     year: emptyProgress,
     genre: emptyProgress,
+    recordingMbid: emptyProgress,
+    releaseMbid: emptyProgress,
   })
 
   const loadStatus = useCallback(() => {
@@ -77,6 +87,8 @@ const CovertartListActions = () => {
             album: emptyProgress,
             year: emptyProgress,
             genre: emptyProgress,
+            recordingMbid: emptyProgress,
+            releaseMbid: emptyProgress,
           },
         )
       })
@@ -128,24 +140,38 @@ const CovertartListActions = () => {
             {translate('activity.musicbrainz.title')}
           </Typography>
           <Grid container spacing={2}>
-            <Grid item xs={12} md={4}>
+            <Grid item xs={12} md={3}>
               <MetadataProgressCard
                 title={translate('activity.musicbrainz.album')}
                 progress={status.album || emptyProgress}
                 translate={translate}
               />
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid item xs={12} md={3}>
               <MetadataProgressCard
                 title={translate('activity.musicbrainz.year')}
                 progress={status.year || emptyProgress}
                 translate={translate}
               />
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid item xs={12} md={2}>
               <MetadataProgressCard
                 title={translate('activity.musicbrainz.genre')}
                 progress={status.genre || emptyProgress}
+                translate={translate}
+              />
+            </Grid>
+            <Grid item xs={12} md={2}>
+              <MetadataProgressCard
+                title="Recording MBID"
+                progress={status.recordingMbid || emptyProgress}
+                translate={translate}
+              />
+            </Grid>
+            <Grid item xs={12} md={2}>
+              <MetadataProgressCard
+                title="Release MBID"
+                progress={status.releaseMbid || emptyProgress}
                 translate={translate}
               />
             </Grid>
@@ -156,37 +182,55 @@ const CovertartListActions = () => {
   )
 }
 
-const CovertartList = (props) => (
-  <List
-    {...props}
-    sort={{ field: 'title', order: 'ASC' }}
-    filters={<CovertartFilter />}
-    exporter={false}
-    bulkActionButtons={false}
-    perPage={50}
-    actions={<CovertartListActions />}
-  >
-    <Datagrid rowClick={false}>
-      <FunctionField
-        label="Cover Art"
-        sortable={false}
-        render={(record) => (
-          <img
-            src={subsonic.getCoverArtUrl(record, 64, true)}
-            alt={record.title || 'cover art'}
-            width="64"
-            height="64"
-          />
-        )}
-      />
-      <TextField source="title" />
-      <TextField source="artist" label="Artist" />
-      <TextField source="album" label="Album" />
-      <TextField source="year" label="Release Year" />
-      <TextField source="genre" label="Genre" />
-      <DurationField source="duration" />
-    </Datagrid>
-  </List>
-)
+const CovertartList = (props) => {
+  const classes = useStyles()
+
+  return (
+    <List
+      {...props}
+      sort={{ field: 'title', order: 'ASC' }}
+      filters={<CovertartFilter />}
+      exporter={false}
+      bulkActionButtons={false}
+      perPage={50}
+      actions={<CovertartListActions />}
+    >
+      <Datagrid rowClick={false}>
+        <FunctionField
+          label="Cover Art"
+          sortable={false}
+          render={(record) => (
+            <img
+              src={subsonic.getCoverArtUrl(record, 64, true)}
+              alt={record.title || 'cover art'}
+              width="64"
+              height="64"
+            />
+          )}
+        />
+        <TextField source="title" />
+        <TextField source="artist" label="Artist" />
+        <TextField source="album" label="Album" />
+        <TextField source="year" label="Release Year" />
+        <TextField source="genre" label="Genre" />
+        <FunctionField
+          label="Recording MBID"
+          sortable={false}
+          render={(record) => (
+            <span className={classes.mbidText}>{record?.mbzRecordingID || ''}</span>
+          )}
+        />
+        <FunctionField
+          label="Release MBID"
+          sortable={false}
+          render={(record) => (
+            <span className={classes.mbidText}>{record?.mbzReleaseId || ''}</span>
+          )}
+        />
+        <DurationField source="duration" />
+      </Datagrid>
+    </List>
+  )
+}
 
 export default CovertartList

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -30,6 +30,7 @@ const CovertartList = (props) => {
     <List
       {...props}
       sort={{ field: 'title', order: 'ASC' }}
+      filter={{ hascoverart: false }}
       filters={<CovertartFilter />}
       exporter={false}
       bulkActionButtons={false}

--- a/ui/src/covertart/index.jsx
+++ b/ui/src/covertart/index.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import ImageOutlinedIcon from '@material-ui/icons/ImageOutlined'
+import ImageIcon from '@material-ui/icons/Image'
+import DynamicMenuIcon from '../layout/DynamicMenuIcon'
+import CovertartList from './CovertartList'
+
+export default {
+  list: CovertartList,
+  icon: (
+    <DynamicMenuIcon
+      path={'covertart'}
+      icon={ImageOutlinedIcon}
+      activeIcon={ImageIcon}
+    />
+  ),
+}

--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -84,6 +84,7 @@ const mapResource = (resource, params) => {
     }
     case 'album':
     case 'song':
+    case 'covertart':
     case 'artist':
     case 'tag': {
       params.filter = params.filter || {}
@@ -91,6 +92,10 @@ const mapResource = (resource, params) => {
         params.filter.missing = false
       }
       params = applyLibraryFilter(resource, params)
+
+      if (resource === 'covertart') {
+        return ['song', params]
+      }
 
       return [resource, params]
     }

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -107,6 +107,9 @@
         "topRated": "Top Rated"
       }
     },
+    "covertart": {
+      "name": "Cover Art |||| Cover Art"
+    },
     "artist": {
       "name": "Artist |||| Artists",
       "fields": {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -680,7 +680,22 @@
     "serverDown": "OFFLINE",
     "scanType": "Type",
     "status": "Scan Error",
-    "elapsedTime": "Elapsed Time"
+    "elapsedTime": "Elapsed Time",
+    "musicbrainz": {
+      "title": "MusicBrainz Metadata",
+      "fetch": "Fetch metadata from MusicBrainz",
+      "started": "Metadata fetch started",
+      "alreadyRunning": "Metadata fetch is already running",
+      "failed": "Metadata fetch failed",
+      "album": "Album",
+      "year": "Year",
+      "genre": "Genre",
+      "missing": "Missing",
+      "fetching": "Fetching",
+      "fetched": "Fetched",
+      "updated": "Updated",
+      "left": "Left"
+    }
   },
   "nowPlaying": {
     "title": "Now Playing",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -684,9 +684,12 @@
     "musicbrainz": {
       "title": "MusicBrainz Metadata",
       "fetch": "Fetch metadata",
+      "save": "Save metadata",
       "started": "Metadata fetch started",
       "alreadyRunning": "Metadata fetch is already running",
       "failed": "Metadata fetch failed",
+      "saved": "Metadata saved to songs",
+      "saveFailed": "Metadata save failed",
       "album": "Album",
       "year": "Year",
       "genre": "Genre",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -108,7 +108,11 @@
       }
     },
     "covertart": {
-      "name": "Cover Art |||| Cover Art"
+      "name": "Cover Art |||| Cover Art",
+      "fields": {
+        "fetched": "Fetched",
+        "missingCoverArt": "Missing CoverArt"
+      }
     },
     "artist": {
       "name": "Artist |||| Artists",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -695,7 +695,8 @@
       "fetching": "Fetching",
       "fetched": "Fetched",
       "updated": "Updated",
-      "missingAfterUpdate": "Missing after updates",
+      "toBeFetch": "To be fetch",
+      "couldntFetch": "Couldn't fetched",
       "left": "Left"
     }
   },

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -683,17 +683,19 @@
     "elapsedTime": "Elapsed Time",
     "musicbrainz": {
       "title": "MusicBrainz Metadata",
-      "fetch": "Fetch metadata from MusicBrainz",
+      "fetch": "Fetch metadata",
       "started": "Metadata fetch started",
       "alreadyRunning": "Metadata fetch is already running",
       "failed": "Metadata fetch failed",
       "album": "Album",
       "year": "Year",
       "genre": "Genre",
+      "existing": "Already exist",
       "missing": "Missing",
       "fetching": "Fetching",
       "fetched": "Fetched",
       "updated": "Updated",
+      "missingAfterUpdate": "Missing after updates",
       "left": "Left"
     }
   },

--- a/ui/src/layout/ActivityPanel.jsx
+++ b/ui/src/layout/ActivityPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import { useNotify, useTranslate } from 'react-admin'
 import {
@@ -15,7 +15,7 @@ import {
   Typography,
 } from '@material-ui/core'
 import { FiActivity } from 'react-icons/fi'
-import { BiError, BiLink } from 'react-icons/bi'
+import { BiError, BiLink, BiDownload } from 'react-icons/bi'
 import { VscSync } from 'react-icons/vsc'
 import { GiMagnifyingGlass } from 'react-icons/gi'
 import subsonic from '../subsonic'
@@ -54,6 +54,23 @@ const useStyles = makeStyles((theme) => ({
   cardContent: {
     padding: theme.spacing(2, 3),
   },
+  metadataGrid: {
+    display: 'grid',
+    gap: theme.spacing(1),
+    gridTemplateColumns: 'repeat(3, minmax(11em, 1fr))',
+    marginTop: theme.spacing(2),
+  },
+  metadataCard: {
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
+    padding: theme.spacing(1.2),
+  },
+  metadataRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    fontSize: '0.8rem',
+    marginTop: theme.spacing(0.5),
+  },
 }))
 
 const getUptime = (serverStart) =>
@@ -66,6 +83,14 @@ const Uptime = () => {
     setUptime(getUptime(serverStart))
   }, 1000)
   return <span>{uptime}</span>
+}
+
+const emptyProgress = { missing: 0, fetching: 0, fetched: 0, updated: 0, left: 0 }
+const emptyMetadataStatus = {
+  running: false,
+  album: emptyProgress,
+  year: emptyProgress,
+  genre: emptyProgress,
 }
 
 const ActivityPanel = () => {
@@ -85,8 +110,15 @@ const ActivityPanel = () => {
   const translate = useTranslate()
   const notify = useNotify()
   const [anchorEl, setAnchorEl] = useState(null)
+  const [metadataStatus, setMetadataStatus] = useState(emptyMetadataStatus)
   const open = Boolean(anchorEl)
   useInitialScanStatus()
+
+  const fetchMetadataStatus = useCallback(() => {
+    httpClient('/api/metadata/musicbrainz/status')
+      .then(({ json }) => setMetadataStatus(json || emptyMetadataStatus))
+      .catch(() => {})
+  }, [])
 
   const handleMenuOpen = (event) => {
     if (scanStatus.error) {
@@ -106,11 +138,35 @@ const ActivityPanel = () => {
       })
       .catch(() => notify('Sync failed', 'warning'))
 
+  const triggerMetadataFetch = () =>
+    httpClient('/api/metadata/musicbrainz/fetch', { method: 'POST' })
+      .then(({ status }) => {
+        if (status === 202) {
+          notify('activity.musicbrainz.started', 'info')
+        } else {
+          notify('activity.musicbrainz.alreadyRunning', 'warning')
+        }
+        fetchMetadataStatus()
+      })
+      .catch(() => notify('activity.musicbrainz.failed', 'warning'))
+
   useEffect(() => {
     if (serverStart.version && serverStart.version !== config.version) {
       notify('ra.notification.new_version', 'info', {}, false, 604800000 * 50)
     }
   }, [serverStart, notify])
+
+  useEffect(() => {
+    if (open) {
+      fetchMetadataStatus()
+    }
+  }, [open, fetchMetadataStatus])
+
+  useInterval(() => {
+    if (open && metadataStatus.running) {
+      fetchMetadataStatus()
+    }
+  }, open && metadataStatus.running ? 2000 : null)
 
   const tooltipTitle = scanStatus.error
     ? `${translate('activity.status')}: ${scanStatus.error}`
@@ -126,6 +182,35 @@ const ActivityPanel = () => {
         return ''
     }
   })()
+
+  const renderMetadataCard = (title, key) => {
+    const progress = metadataStatus?.[key] || emptyProgress
+    return (
+      <Box className={classes.metadataCard}>
+        <Typography variant="subtitle2">{title}</Typography>
+        <Box className={classes.metadataRow}>
+          <span>{translate('activity.musicbrainz.missing')}</span>
+          <span>{progress.missing || 0}</span>
+        </Box>
+        <Box className={classes.metadataRow}>
+          <span>{translate('activity.musicbrainz.fetching')}</span>
+          <span>{progress.fetching || 0}</span>
+        </Box>
+        <Box className={classes.metadataRow}>
+          <span>{translate('activity.musicbrainz.fetched')}</span>
+          <span>{progress.fetched || 0}</span>
+        </Box>
+        <Box className={classes.metadataRow}>
+          <span>{translate('activity.musicbrainz.updated')}</span>
+          <span>{progress.updated || 0}</span>
+        </Box>
+        <Box className={classes.metadataRow}>
+          <span>{translate('activity.musicbrainz.left')}</span>
+          <span>{progress.left || 0}</span>
+        </Box>
+      </Box>
+    )
+  }
 
   return (
     <div className={classes.wrapper}>
@@ -195,6 +280,23 @@ const ActivityPanel = () => {
               </Box>
             </Box>
 
+            <Box mt={2}>
+              <Typography variant="subtitle2">
+                {translate('activity.musicbrainz.title')}
+              </Typography>
+              <Box className={classes.metadataGrid}>
+                {renderMetadataCard(
+                  translate('activity.musicbrainz.album'),
+                  'album',
+                )}
+                {renderMetadataCard(translate('activity.musicbrainz.year'), 'year')}
+                {renderMetadataCard(
+                  translate('activity.musicbrainz.genre'),
+                  'genre',
+                )}
+              </Box>
+            </Box>
+
             {scanStatus.error && (
               <Box
                 display="flex"
@@ -230,6 +332,14 @@ const ActivityPanel = () => {
                 disabled={scanStatus.scanning}
               >
                 <GiMagnifyingGlass />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title={translate('activity.musicbrainz.fetch')}>
+              <IconButton
+                onClick={triggerMetadataFetch}
+                disabled={metadataStatus.running}
+              >
+                <BiDownload />
               </IconButton>
             </Tooltip>
           </CardActions>

--- a/ui/src/layout/ActivityPanel.jsx
+++ b/ui/src/layout/ActivityPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { useNotify, useTranslate } from 'react-admin'
 import {
@@ -15,7 +15,7 @@ import {
   Typography,
 } from '@material-ui/core'
 import { FiActivity } from 'react-icons/fi'
-import { BiError, BiLink, BiDownload } from 'react-icons/bi'
+import { BiError, BiLink } from 'react-icons/bi'
 import { VscSync } from 'react-icons/vsc'
 import { GiMagnifyingGlass } from 'react-icons/gi'
 import subsonic from '../subsonic'
@@ -54,23 +54,6 @@ const useStyles = makeStyles((theme) => ({
   cardContent: {
     padding: theme.spacing(2, 3),
   },
-  metadataGrid: {
-    display: 'grid',
-    gap: theme.spacing(1),
-    gridTemplateColumns: 'repeat(3, minmax(11em, 1fr))',
-    marginTop: theme.spacing(2),
-  },
-  metadataCard: {
-    border: `1px solid ${theme.palette.divider}`,
-    borderRadius: theme.shape.borderRadius,
-    padding: theme.spacing(1.2),
-  },
-  metadataRow: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    fontSize: '0.8rem',
-    marginTop: theme.spacing(0.5),
-  },
 }))
 
 const getUptime = (serverStart) =>
@@ -83,14 +66,6 @@ const Uptime = () => {
     setUptime(getUptime(serverStart))
   }, 1000)
   return <span>{uptime}</span>
-}
-
-const emptyProgress = { missing: 0, fetching: 0, fetched: 0, updated: 0, left: 0 }
-const emptyMetadataStatus = {
-  running: false,
-  album: emptyProgress,
-  year: emptyProgress,
-  genre: emptyProgress,
 }
 
 const ActivityPanel = () => {
@@ -110,15 +85,8 @@ const ActivityPanel = () => {
   const translate = useTranslate()
   const notify = useNotify()
   const [anchorEl, setAnchorEl] = useState(null)
-  const [metadataStatus, setMetadataStatus] = useState(emptyMetadataStatus)
   const open = Boolean(anchorEl)
   useInitialScanStatus()
-
-  const fetchMetadataStatus = useCallback(() => {
-    httpClient('/api/metadata/musicbrainz/status')
-      .then(({ json }) => setMetadataStatus(json || emptyMetadataStatus))
-      .catch(() => {})
-  }, [])
 
   const handleMenuOpen = (event) => {
     if (scanStatus.error) {
@@ -138,35 +106,11 @@ const ActivityPanel = () => {
       })
       .catch(() => notify('Sync failed', 'warning'))
 
-  const triggerMetadataFetch = () =>
-    httpClient('/api/metadata/musicbrainz/fetch', { method: 'POST' })
-      .then(({ status }) => {
-        if (status === 202) {
-          notify('activity.musicbrainz.started', 'info')
-        } else {
-          notify('activity.musicbrainz.alreadyRunning', 'warning')
-        }
-        fetchMetadataStatus()
-      })
-      .catch(() => notify('activity.musicbrainz.failed', 'warning'))
-
   useEffect(() => {
     if (serverStart.version && serverStart.version !== config.version) {
       notify('ra.notification.new_version', 'info', {}, false, 604800000 * 50)
     }
   }, [serverStart, notify])
-
-  useEffect(() => {
-    if (open) {
-      fetchMetadataStatus()
-    }
-  }, [open, fetchMetadataStatus])
-
-  useInterval(() => {
-    if (open && metadataStatus.running) {
-      fetchMetadataStatus()
-    }
-  }, open && metadataStatus.running ? 2000 : null)
 
   const tooltipTitle = scanStatus.error
     ? `${translate('activity.status')}: ${scanStatus.error}`
@@ -182,35 +126,6 @@ const ActivityPanel = () => {
         return ''
     }
   })()
-
-  const renderMetadataCard = (title, key) => {
-    const progress = metadataStatus?.[key] || emptyProgress
-    return (
-      <Box className={classes.metadataCard}>
-        <Typography variant="subtitle2">{title}</Typography>
-        <Box className={classes.metadataRow}>
-          <span>{translate('activity.musicbrainz.missing')}</span>
-          <span>{progress.missing || 0}</span>
-        </Box>
-        <Box className={classes.metadataRow}>
-          <span>{translate('activity.musicbrainz.fetching')}</span>
-          <span>{progress.fetching || 0}</span>
-        </Box>
-        <Box className={classes.metadataRow}>
-          <span>{translate('activity.musicbrainz.fetched')}</span>
-          <span>{progress.fetched || 0}</span>
-        </Box>
-        <Box className={classes.metadataRow}>
-          <span>{translate('activity.musicbrainz.updated')}</span>
-          <span>{progress.updated || 0}</span>
-        </Box>
-        <Box className={classes.metadataRow}>
-          <span>{translate('activity.musicbrainz.left')}</span>
-          <span>{progress.left || 0}</span>
-        </Box>
-      </Box>
-    )
-  }
 
   return (
     <div className={classes.wrapper}>
@@ -280,23 +195,6 @@ const ActivityPanel = () => {
               </Box>
             </Box>
 
-            <Box mt={2}>
-              <Typography variant="subtitle2">
-                {translate('activity.musicbrainz.title')}
-              </Typography>
-              <Box className={classes.metadataGrid}>
-                {renderMetadataCard(
-                  translate('activity.musicbrainz.album'),
-                  'album',
-                )}
-                {renderMetadataCard(translate('activity.musicbrainz.year'), 'year')}
-                {renderMetadataCard(
-                  translate('activity.musicbrainz.genre'),
-                  'genre',
-                )}
-              </Box>
-            </Box>
-
             {scanStatus.error && (
               <Box
                 display="flex"
@@ -332,14 +230,6 @@ const ActivityPanel = () => {
                 disabled={scanStatus.scanning}
               >
                 <GiMagnifyingGlass />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title={translate('activity.musicbrainz.fetch')}>
-              <IconButton
-                onClick={triggerMetadataFetch}
-                disabled={metadataStatus.running}
-              >
-                <BiDownload />
               </IconButton>
             </Tooltip>
           </CardActions>

--- a/ui/src/layout/AppBar.jsx
+++ b/ui/src/layout/AppBar.jsx
@@ -14,6 +14,7 @@ import { Dialogs } from '../dialogs/Dialogs'
 import { AboutDialog } from '../dialogs'
 import PersonalMenu from './PersonalMenu'
 import ActivityPanel from './ActivityPanel'
+import CoverArtPanel from './CoverArtPanel'
 import MissingTracksPanel from './MissingTracksPanel'
 import NowPlayingPanel from './NowPlayingPanel'
 import UserMenu from './UserMenu'
@@ -128,6 +129,7 @@ const CustomUserMenu = ({ onClick, ...rest }) => {
         permissions === 'admin' &&
         config.enableNowPlaying && <NowPlayingPanel />}
       {config.devActivityPanel && permissions === 'admin' && <ActivityPanel />}
+      {config.devActivityPanel && permissions === 'admin' && <CoverArtPanel />}
       <UserMenu {...rest}>
         <PersonalMenu sidebarIsOpen={true} onClick={onClick} />
         <Divider />

--- a/ui/src/layout/AppBar.test.jsx
+++ b/ui/src/layout/AppBar.test.jsx
@@ -22,6 +22,10 @@ vi.mock('./NowPlayingPanel', () => ({
 vi.mock('./ActivityPanel', () => ({
   default: () => <div data-testid="activity-panel" />,
 }))
+
+vi.mock('./CoverArtPanel', () => ({
+  default: () => <div data-testid="coverart-panel" />,
+}))
 vi.mock('./PersonalMenu', () => ({
   default: () => <div />,
 }))
@@ -51,6 +55,7 @@ describe('<AppBar />', () => {
       </Provider>,
     )
     expect(screen.getByTestId('now-playing-panel')).toBeInTheDocument()
+    expect(screen.getByTestId('coverart-panel')).toBeInTheDocument()
   })
 
   it('hides NowPlayingPanel when disabled', () => {

--- a/ui/src/layout/CoverArtPanel.jsx
+++ b/ui/src/layout/CoverArtPanel.jsx
@@ -1,0 +1,247 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { useNotify, useTranslate } from 'react-admin'
+import {
+  Popover,
+  Button,
+  makeStyles,
+  Card,
+  CardContent,
+  Box,
+  Typography,
+  Grid,
+  IconButton,
+  Tooltip,
+} from '@material-ui/core'
+import ImageOutlinedIcon from '@material-ui/icons/ImageOutlined'
+import { BiDownload } from 'react-icons/bi'
+import { httpClient } from '../dataProvider'
+
+const emptyProgress = {
+  existing: 0,
+  missing: 0,
+  fetching: 0,
+  fetched: 0,
+  updated: 0,
+  left: 0,
+}
+
+const useStyles = makeStyles((theme) => ({
+  iconButton: {
+    marginLeft: theme.spacing(1),
+    color: 'inherit',
+    padding: theme.spacing(1),
+  },
+  card: {
+    minWidth: 680,
+    maxWidth: 920,
+    padding: theme.spacing(1),
+  },
+  title: {
+    fontWeight: 600,
+    marginBottom: theme.spacing(1.5),
+  },
+  actionBar: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: theme.spacing(2),
+    gap: theme.spacing(2),
+  },
+  progressCard: {
+    height: '100%',
+  },
+  row: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    marginTop: theme.spacing(0.5),
+  },
+}))
+
+const ProgressCard = ({ title, progress, translate, classes }) => (
+  <Card variant="outlined" className={classes.progressCard}>
+    <CardContent>
+      <Typography variant="subtitle2">{title}</Typography>
+      <Box className={classes.row}>
+        <span>{translate('activity.musicbrainz.existing')}</span>
+        <span>{progress.existing || 0}</span>
+      </Box>
+      <Box className={classes.row}>
+        <span>{translate('activity.musicbrainz.missing')}</span>
+        <span>{progress.missing || 0}</span>
+      </Box>
+      <Box className={classes.row}>
+        <span>{translate('activity.musicbrainz.fetching')}</span>
+        <span>{progress.fetching || 0}</span>
+      </Box>
+      <Box className={classes.row}>
+        <span>{translate('activity.musicbrainz.fetched')}</span>
+        <span>{progress.fetched || 0}</span>
+      </Box>
+      <Box className={classes.row}>
+        <span>{translate('activity.musicbrainz.updated')}</span>
+        <span>{progress.updated || 0}</span>
+      </Box>
+      <Box className={classes.row}>
+        <span>{translate('activity.musicbrainz.missingAfterUpdate')}</span>
+        <span>{progress.left || 0}</span>
+      </Box>
+    </CardContent>
+  </Card>
+)
+
+const CoverArtPanel = () => {
+  const classes = useStyles()
+  const translate = useTranslate()
+  const notify = useNotify()
+  const [anchorEl, setAnchorEl] = useState(null)
+  const [status, setStatus] = useState({
+    running: false,
+    album: emptyProgress,
+    year: emptyProgress,
+    genre: emptyProgress,
+    recordingMbid: emptyProgress,
+    releaseMbid: emptyProgress,
+    coverArt: emptyProgress,
+  })
+
+  const open = Boolean(anchorEl)
+
+  const loadStatus = useCallback(() => {
+    httpClient('/api/metadata/musicbrainz/status')
+      .then(({ json }) => {
+        setStatus(
+          json || {
+            running: false,
+            album: emptyProgress,
+            year: emptyProgress,
+            genre: emptyProgress,
+            recordingMbid: emptyProgress,
+            releaseMbid: emptyProgress,
+            coverArt: emptyProgress,
+          },
+        )
+      })
+      .catch(() => {})
+  }, [])
+
+  useEffect(() => {
+    if (!open) {
+      return undefined
+    }
+    loadStatus()
+    const interval = setInterval(
+      () => {
+        loadStatus()
+      },
+      status.running ? 2000 : 5000,
+    )
+    return () => clearInterval(interval)
+  }, [open, status.running, loadStatus])
+
+  const startFetch = () => {
+    httpClient('/api/metadata/musicbrainz/fetch', { method: 'POST' })
+      .then(({ status: code }) => {
+        if (code === 202) {
+          notify('activity.musicbrainz.started', 'info')
+        } else {
+          notify('activity.musicbrainz.alreadyRunning', 'warning')
+        }
+        loadStatus()
+      })
+      .catch(() => notify('activity.musicbrainz.failed', 'warning'))
+  }
+
+  return (
+    <>
+      <Tooltip title="Coverart">
+        <IconButton
+          className={classes.iconButton}
+          onClick={(event) => setAnchorEl(event.currentTarget)}
+          data-testid="coverart-panel-btn"
+        >
+          <ImageOutlinedIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+      <Popover
+        id="panel-coverart"
+        anchorEl={anchorEl}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        open={open}
+        onClose={() => setAnchorEl(null)}
+      >
+        <Card className={classes.card}>
+          <CardContent>
+            <Box className={classes.actionBar}>
+              <Typography variant="h6" className={classes.title}>
+                {translate('activity.musicbrainz.title')}
+              </Typography>
+              <Button
+                color="primary"
+                variant="contained"
+                startIcon={<BiDownload />}
+                onClick={startFetch}
+                disabled={status.running}
+                data-testid="coverart-metadata-fetch-btn"
+              >
+                {translate('activity.musicbrainz.fetch')}
+              </Button>
+            </Box>
+            <Grid container spacing={2}>
+              <Grid item xs={12} md={4}>
+                <ProgressCard
+                  title={translate('activity.musicbrainz.album')}
+                  progress={status.album || emptyProgress}
+                  translate={translate}
+                  classes={classes}
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <ProgressCard
+                  title={translate('activity.musicbrainz.year')}
+                  progress={status.year || emptyProgress}
+                  translate={translate}
+                  classes={classes}
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <ProgressCard
+                  title={translate('activity.musicbrainz.genre')}
+                  progress={status.genre || emptyProgress}
+                  translate={translate}
+                  classes={classes}
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <ProgressCard
+                  title="Recording MBID"
+                  progress={status.recordingMbid || emptyProgress}
+                  translate={translate}
+                  classes={classes}
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <ProgressCard
+                  title="Release MBID"
+                  progress={status.releaseMbid || emptyProgress}
+                  translate={translate}
+                  classes={classes}
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <ProgressCard
+                  title="Cover Art"
+                  progress={status.coverArt || emptyProgress}
+                  translate={translate}
+                  classes={classes}
+                />
+              </Grid>
+            </Grid>
+          </CardContent>
+        </Card>
+      </Popover>
+    </>
+  )
+}
+
+export default CoverArtPanel

--- a/ui/src/layout/CoverArtPanel.jsx
+++ b/ui/src/layout/CoverArtPanel.jsx
@@ -23,6 +23,7 @@ const emptyProgress = {
   fetched: 0,
   updated: 0,
   left: 0,
+  couldntFetch: 0,
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -82,8 +83,12 @@ const ProgressCard = ({ title, progress, translate, classes }) => (
         <span>{progress.updated || 0}</span>
       </Box>
       <Box className={classes.row}>
-        <span>{translate('activity.musicbrainz.missingAfterUpdate')}</span>
+        <span>{translate('activity.musicbrainz.toBeFetch')}</span>
         <span>{progress.left || 0}</span>
+      </Box>
+      <Box className={classes.row}>
+        <span>{translate('activity.musicbrainz.couldntFetch')}</span>
+        <span>{progress.couldntFetch || 0}</span>
       </Box>
     </CardContent>
   </Card>

--- a/ui/src/layout/CoverArtPanel.jsx
+++ b/ui/src/layout/CoverArtPanel.jsx
@@ -14,6 +14,7 @@ import {
 } from '@material-ui/core'
 import ImageOutlinedIcon from '@material-ui/icons/ImageOutlined'
 import { BiDownload } from 'react-icons/bi'
+import { MdSave } from 'react-icons/md'
 import { httpClient } from '../dataProvider'
 
 const emptyProgress = {
@@ -47,6 +48,11 @@ const useStyles = makeStyles((theme) => ({
     alignItems: 'center',
     marginBottom: theme.spacing(2),
     gap: theme.spacing(2),
+  },
+  actions: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
   },
   progressCard: {
     height: '100%',
@@ -156,6 +162,18 @@ const CoverArtPanel = () => {
       .catch(() => notify('activity.musicbrainz.failed', 'warning'))
   }
 
+  const saveMetadata = () => {
+    httpClient('/api/metadata/musicbrainz/save', { method: 'POST' })
+      .then(({ status: code }) => {
+        if (code === 200) {
+          notify('activity.musicbrainz.saved', 'info')
+        } else {
+          notify('activity.musicbrainz.saveFailed', 'warning')
+        }
+      })
+      .catch(() => notify('activity.musicbrainz.saveFailed', 'warning'))
+  }
+
   return (
     <>
       <Tooltip title="Coverart">
@@ -181,16 +199,28 @@ const CoverArtPanel = () => {
               <Typography variant="h6" className={classes.title}>
                 {translate('activity.musicbrainz.title')}
               </Typography>
-              <Button
-                color="primary"
-                variant="contained"
-                startIcon={<BiDownload />}
-                onClick={startFetch}
-                disabled={status.running}
-                data-testid="coverart-metadata-fetch-btn"
-              >
-                {translate('activity.musicbrainz.fetch')}
-              </Button>
+              <Box className={classes.actions}>
+                <Button
+                  color="primary"
+                  variant="contained"
+                  startIcon={<MdSave />}
+                  onClick={saveMetadata}
+                  disabled={status.running}
+                  data-testid="coverart-metadata-save-btn"
+                >
+                  {translate('activity.musicbrainz.save')}
+                </Button>
+                <Button
+                  color="primary"
+                  variant="contained"
+                  startIcon={<BiDownload />}
+                  onClick={startFetch}
+                  disabled={status.running}
+                  data-testid="coverart-metadata-fetch-btn"
+                >
+                  {translate('activity.musicbrainz.fetch')}
+                </Button>
+              </Box>
             </Box>
             <Grid container spacing={2}>
               <Grid item xs={12} md={4}>

--- a/ui/src/layout/CoverArtPanel.jsx
+++ b/ui/src/layout/CoverArtPanel.jsx
@@ -29,7 +29,6 @@ const emptyProgress = {
 
 const useStyles = makeStyles((theme) => ({
   iconButton: {
-    marginLeft: theme.spacing(1),
     color: 'inherit',
     padding: theme.spacing(1),
   },
@@ -225,6 +224,14 @@ const CoverArtPanel = () => {
             <Grid container spacing={2}>
               <Grid item xs={12} md={4}>
                 <ProgressCard
+                  title="Cover Art"
+                  progress={status.coverArt || emptyProgress}
+                  translate={translate}
+                  classes={classes}
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <ProgressCard
                   title={translate('activity.musicbrainz.album')}
                   progress={status.album || emptyProgress}
                   translate={translate}
@@ -259,14 +266,6 @@ const CoverArtPanel = () => {
                 <ProgressCard
                   title="Release MBID"
                   progress={status.releaseMbid || emptyProgress}
-                  translate={translate}
-                  classes={classes}
-                />
-              </Grid>
-              <Grid item xs={12} md={4}>
-                <ProgressCard
-                  title="Cover Art"
-                  progress={status.coverArt || emptyProgress}
                   translate={translate}
                   classes={classes}
                 />

--- a/ui/src/reducers/playerReducer.js
+++ b/ui/src/reducers/playerReducer.js
@@ -21,6 +21,9 @@ const initialState = {
   savedPlayIndex: 0,
 }
 
+const normalizeQueueKey = (value) =>
+  typeof value === 'string' ? value.replace(/^_+/, '') : value
+
 const pad = (value) => {
   const str = value.toString()
   if (str.length === 1) {
@@ -93,7 +96,7 @@ const reduceClearQueue = () => ({ ...initialState, clear: true })
 const reducePlayTracks = (state, { data, id }) => {
   let playIndex = 0
   const queue = Object.keys(data).map((key, idx) => {
-    if (key === id) {
+    if (normalizeQueueKey(key) === normalizeQueueKey(id)) {
       playIndex = idx
     }
     return mapToAudioLists(data[key])

--- a/ui/src/song/ReorderableSongList.jsx
+++ b/ui/src/song/ReorderableSongList.jsx
@@ -70,10 +70,6 @@ const useStyles = makeStyles({
     margin: 0,
     height: '24px',
   },
-  debugMbid: {
-    fontFamily: 'monospace',
-    fontSize: '0.75rem',
-  },
 })
 
 const DEFAULT_OFF_COLUMNS = [
@@ -316,16 +312,6 @@ const ReorderableSongList = (props) => {
         />
       ) : null,
       comment: <TextField source="comment" sortBy="comment" />,
-      releaseMbid: (
-        <FunctionField
-          source="mbzReleaseId"
-          sortable={false}
-          label="Release MBID"
-          render={(record) => (
-            <span className={classes.debugMbid}>{record?.mbzReleaseId || ''}</span>
-          )}
-        />
-      ),
       path: <PathField source="path" />,
       createdAt: <DateField source="createdAt" sortBy="recently_added" showTime />,
     }

--- a/ui/src/song/ReorderableSongList.jsx
+++ b/ui/src/song/ReorderableSongList.jsx
@@ -70,6 +70,10 @@ const useStyles = makeStyles({
     margin: 0,
     height: '24px',
   },
+  debugMbid: {
+    fontFamily: 'monospace',
+    fontSize: '0.75rem',
+  },
 })
 
 const DEFAULT_OFF_COLUMNS = [
@@ -312,6 +316,16 @@ const ReorderableSongList = (props) => {
         />
       ) : null,
       comment: <TextField source="comment" sortBy="comment" />,
+      releaseMbid: (
+        <FunctionField
+          source="mbzReleaseId"
+          sortable={false}
+          label="Release MBID"
+          render={(record) => (
+            <span className={classes.debugMbid}>{record?.mbzReleaseId || ''}</span>
+          )}
+        />
+      ),
       path: <PathField source="path" />,
       createdAt: <DateField source="createdAt" sortBy="recently_added" showTime />,
     }


### PR DESCRIPTION
### Motivation
- Playing a song from a playlist that is sorted by a different column produced a queue ordered by numeric track ids instead of the visible sort order due to JS object key iteration semantics for numeric-like keys. 

### Description
- Prefix explicit ids when building the ordered song map in `filterSongs` so insertion order from a provided id list is preserved (`ui/src/actions/player.js`).
- Add `normalizeQueueKey` and compare normalized keys in the reducer so the selected track is matched correctly even when keys are prefixed (`ui/src/reducers/playerReducer.js`).
- Ensure `playTracks`/`playNext` continue to work with the prefixed keys by mapping to audio list entries unchanged and preserving playback order. 
- Add unit tests covering ordered queue construction and reducer behavior (`ui/src/actions/player.test.js`).

### Testing
- Ran `cd ui && npm test -- src/actions/player.test.js` and the new tests passed. ✅
- Ran `cd ui && npm test -- src/playlist/PlaylistSongs.test.jsx` which failed in this environment due to a test transform error resolving `@dnd-kit/core`, unrelated to the changes. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994b7d4f16883228c55219c123340d5)