### PR TITLE
Add Cover Art Manager sidebar page with read-only song metadata table

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,8 +75,12 @@ func postRun() {
 func runNavidrome(ctx context.Context) {
 	defer db.Init(ctx)()
 
-	if err := metadataenrichment.NewService().InitAndImport(ctx); err != nil {
+	metadataEnrichmentService := metadataenrichment.NewService()
+	if err := metadataEnrichmentService.InitAndImport(ctx); err != nil {
 		log.Error(ctx, "Metadata enrichment startup failed", err)
+	}
+	if err := metadataEnrichmentService.VerifyMusicBrainzConnectivity(ctx); err != nil {
+		log.Error(ctx, "MusicBrainz connectivity verification failed", err)
 	}
 
 	g, ctx := errgroup.WithContext(ctx)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/navidrome/navidrome/adapters/taglib"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/consts"
+	"github.com/navidrome/navidrome/core/metadataenrichment"
 	"github.com/navidrome/navidrome/db"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -73,6 +74,10 @@ func postRun() {
 // it will cancel the context and exit gracefully.
 func runNavidrome(ctx context.Context) {
 	defer db.Init(ctx)()
+
+	if err := metadataenrichment.NewService().InitAndImport(ctx); err != nil {
+		log.Error(ctx, "Metadata enrichment startup failed", err)
+	}
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(startServer(ctx))

--- a/core/metadataenrichment/metadata_enrichment.go
+++ b/core/metadataenrichment/metadata_enrichment.go
@@ -1,0 +1,169 @@
+package metadataenrichment
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/db"
+	"github.com/navidrome/navidrome/log"
+)
+
+const defaultStatus = "pending"
+
+var (
+	extraSpacesRegex = regexp.MustCompile(`\s+`)
+	featRegex        = regexp.MustCompile(`\bfeat\.?\b`)
+	punctRegex       = regexp.MustCompile(`[^\p{L}\p{N}\s]`)
+)
+
+type Service struct {
+	dbPath string
+}
+
+func NewService() *Service {
+	return &Service{dbPath: enrichmentDBPath()}
+}
+
+func enrichmentDBPath() string {
+	if conf.Server.DbPath == ":memory:" || strings.HasPrefix(conf.Server.DbPath, "file::memory") {
+		return "enrichment.db"
+	}
+	return filepath.Join(filepath.Dir(conf.Server.DbPath), "enrichment.db")
+}
+
+func (s *Service) InitAndImport(ctx context.Context) error {
+	enrichmentDB, err := sql.Open("sqlite3", s.dbPath)
+	if err != nil {
+		return fmt.Errorf("open enrichment db: %w", err)
+	}
+	defer enrichmentDB.Close()
+
+	if err := s.ensureSchema(ctx, enrichmentDB); err != nil {
+		return err
+	}
+	if err := s.importSongs(ctx, db.Db(), enrichmentDB); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Service) ensureSchema(ctx context.Context, enrichmentDB *sql.DB) error {
+	const stmt = `
+create table if not exists tracks (
+	id integer primary key autoincrement,
+	navidrome_track_id text not null unique,
+	file_path text not null,
+	title text not null,
+	artist text not null,
+	album text not null,
+	duration real not null,
+	status text not null default 'pending',
+	normalized_title text not null,
+	normalized_artist text not null
+);`
+	_, err := enrichmentDB.ExecContext(ctx, stmt)
+	if err != nil {
+		return fmt.Errorf("create tracks table: %w", err)
+	}
+	return nil
+}
+
+func (s *Service) importSongs(ctx context.Context, sourceDB, enrichmentDB *sql.DB) error {
+	rows, err := sourceDB.QueryContext(ctx, `
+select id, path, title, artist, album, duration
+from media_file
+`)
+	if err != nil {
+		return fmt.Errorf("query navidrome songs: %w", err)
+	}
+	defer rows.Close()
+
+	tx, err := enrichmentDB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin enrichment transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	stmt, err := tx.PrepareContext(ctx, `
+insert into tracks (
+	navidrome_track_id,
+	file_path,
+	title,
+	artist,
+	album,
+	duration,
+	status,
+	normalized_title,
+	normalized_artist
+)
+values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+on conflict(navidrome_track_id) do update set
+	file_path=excluded.file_path,
+	title=excluded.title,
+	artist=excluded.artist,
+	album=excluded.album,
+	duration=excluded.duration,
+	normalized_title=excluded.normalized_title,
+	normalized_artist=excluded.normalized_artist
+`)
+	if err != nil {
+		return fmt.Errorf("prepare upsert tracks: %w", err)
+	}
+	defer stmt.Close()
+
+	for rows.Next() {
+		var (
+			trackID  string
+			path     string
+			title    string
+			artist   string
+			album    string
+			duration float64
+		)
+		if err = rows.Scan(&trackID, &path, &title, &artist, &album, &duration); err != nil {
+			return fmt.Errorf("scan song row: %w", err)
+		}
+
+		if _, err = stmt.ExecContext(ctx,
+			trackID,
+			path,
+			title,
+			artist,
+			album,
+			duration,
+			defaultStatus,
+			normalizeMetadata(title),
+			normalizeMetadata(artist),
+		); err != nil {
+			return fmt.Errorf("upsert track %s: %w", trackID, err)
+		}
+	}
+
+	if err = rows.Err(); err != nil {
+		return fmt.Errorf("iterate songs rows: %w", err)
+	}
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("commit enrichment import: %w", err)
+	}
+
+	log.Info(ctx, "Metadata enrichment import completed", "dbPath", s.dbPath)
+	return nil
+}
+
+func normalizeMetadata(value string) string {
+	normalized := strings.ToLower(value)
+	normalized = featRegex.ReplaceAllString(normalized, " ")
+	normalized = punctRegex.ReplaceAllString(normalized, " ")
+	normalized = extraSpacesRegex.ReplaceAllString(normalized, " ")
+	return strings.TrimSpace(normalized)
+}

--- a/core/metadataenrichment/metadata_enrichment.go
+++ b/core/metadataenrichment/metadata_enrichment.go
@@ -160,6 +160,58 @@ on conflict(navidrome_track_id) do update set
 	return nil
 }
 
+func (s *Service) VerifyMusicBrainzConnectivity(ctx context.Context) error {
+	enrichmentDB, err := sql.Open("sqlite3", s.dbPath)
+	if err != nil {
+		return fmt.Errorf("open enrichment db: %w", err)
+	}
+	defer enrichmentDB.Close()
+
+	rows, err := enrichmentDB.QueryContext(ctx, `
+select navidrome_track_id, title, artist
+from tracks
+where status = ?
+limit 5
+`, defaultStatus)
+	if err != nil {
+		return fmt.Errorf("query pending tracks: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var trackID, title, artist string
+		if err := rows.Scan(&trackID, &title, &artist); err != nil {
+			return fmt.Errorf("scan pending track: %w", err)
+		}
+
+		body, statusCode, err := SearchMusicBrainzRecording(title, artist)
+		preview := firstN(string(body), 500)
+		if err != nil {
+			log.Error(ctx, "MusicBrainz connectivity check failed", "navidrome_track_id", trackID, "title", title, "artist", artist, "http_status", statusCode, err)
+			continue
+		}
+
+		log.Info(ctx, "MusicBrainz connectivity check", "navidrome_track_id", trackID, "title", title, "artist", artist, "http_status", statusCode, "response_preview", preview)
+	}
+
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate pending tracks: %w", err)
+	}
+
+	return nil
+}
+
+func firstN(value string, maxLen int) string {
+	if maxLen <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= maxLen {
+		return value
+	}
+	return string(runes[:maxLen])
+}
+
 func normalizeMetadata(value string) string {
 	normalized := strings.ToLower(value)
 	normalized = featRegex.ReplaceAllString(normalized, " ")

--- a/core/metadataenrichment/metadata_enrichment_test.go
+++ b/core/metadataenrichment/metadata_enrichment_test.go
@@ -33,3 +33,14 @@ func TestNormalizeMetadata(t *testing.T) {
 		})
 	}
 }
+
+func TestFirstN(t *testing.T) {
+	t.Parallel()
+
+	if got := firstN("abcdef", 3); got != "abc" {
+		t.Fatalf("firstN truncation failed: got %q", got)
+	}
+	if got := firstN("abc", 10); got != "abc" {
+		t.Fatalf("firstN no-truncate failed: got %q", got)
+	}
+}

--- a/core/metadataenrichment/metadata_enrichment_test.go
+++ b/core/metadataenrichment/metadata_enrichment_test.go
@@ -1,0 +1,35 @@
+package metadataenrichment
+
+import "testing"
+
+func TestNormalizeMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		input    string
+		expected string
+	}{
+		"lowercases and trims": {
+			input:    "  The Song Title  ",
+			expected: "the song title",
+		},
+		"removes feat and punctuation": {
+			input:    "Artist feat. Guest, Vol. 2!",
+			expected: "artist guest vol 2",
+		},
+		"collapses spaces": {
+			input:    "A   B\t\tC",
+			expected: "a b c",
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeMetadata(tc.input); got != tc.expected {
+				t.Fatalf("normalizeMetadata(%q) = %q, expected %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}

--- a/core/metadataenrichment/musicbrainz.go
+++ b/core/metadataenrichment/musicbrainz.go
@@ -1,0 +1,50 @@
+package metadataenrichment
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	musicBrainzRecordingURL = "https://musicbrainz.org/ws/2/recording"
+	musicBrainzUserAgent    = "Navidrome-MetadataEnrichment/1.0"
+)
+
+var (
+	musicBrainzHTTPClient = &http.Client{Timeout: 30 * time.Second}
+	musicBrainzTicker     = time.NewTicker(time.Second)
+	musicBrainzRateLimit  = musicBrainzTicker.C
+)
+
+// SearchMusicBrainzRecording searches for recordings in MusicBrainz by title and artist.
+// It returns the response body, HTTP status code and an error.
+func SearchMusicBrainzRecording(title string, artist string) ([]byte, int, error) {
+	<-musicBrainzRateLimit
+
+	mbQuery := fmt.Sprintf(`recording:"%s" AND artist:"%s"`, title, artist)
+	values := url.Values{}
+	values.Set("query", mbQuery)
+	values.Set("fmt", "json")
+
+	endpoint := musicBrainzRecordingURL + "?" + values.Encode()
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("User-Agent", musicBrainzUserAgent)
+
+	resp, err := musicBrainzHTTPClient.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+	return body, resp.StatusCode, nil
+}

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -15,6 +15,7 @@ import artist from './artist'
 import playlist from './playlist'
 import playlist_folder from './playlist_folder'
 import discovery from './discovery'
+import coverArtManager from './coverArtManager'
 import radio from './radio'
 import share from './share'
 import library from './library'
@@ -109,6 +110,7 @@ const Admin = (props) => {
         <Resource name="album" {...album} options={{ subMenu: 'albumList' }} />,
         <Resource name="artist" {...artist} />,
         <Resource name="song" {...song} />,
+        <Resource name="coverArtManager" {...coverArtManager} />,
         <Resource
           name="radio"
           {...(permissions === 'admin' ? radio.admin : radio.all)}

--- a/ui/src/coverArtManager/CoverArtManagerList.jsx
+++ b/ui/src/coverArtManager/CoverArtManagerList.jsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { Datagrid, FunctionField, NumberField, TextField, useTranslate } from 'react-admin'
+import { DurationField, List, PathField, QualityInfo, SongTitleField } from '../common'
+
+const CoverArtStatusField = (props) => {
+  const translate = useTranslate()
+
+  return (
+    <FunctionField
+      {...props}
+      render={(record) =>
+        translate(
+          record?.hasCoverArt
+            ? 'resources.coverArtManager.fields.coverArtAvailable'
+            : 'resources.coverArtManager.fields.coverArtMissing',
+        )
+      }
+    />
+  )
+}
+
+const CoverArtManagerList = (props) => (
+  <List
+    {...props}
+    resource="song"
+    sort={{ field: 'title', order: 'ASC' }}
+    exporter={false}
+    bulkActionButtons={false}
+    perPage={50}
+  >
+    <Datagrid rowClick={false}>
+      <SongTitleField source="title" showTrackNumbers={false} />
+      <TextField source="artist" />
+      <TextField source="album" />
+      <NumberField source="trackNumber" />
+      <FunctionField source="year" render={(record) => record?.year || ''} />
+      <TextField source="genre" />
+      <DurationField source="duration" />
+      <PathField source="path" />
+      <QualityInfo source="quality" sortable={false} />
+      <NumberField source="channels" />
+      <CoverArtStatusField
+        source="coverArtStatus"
+        label="resources.coverArtManager.fields.coverArtStatus"
+        sortable={false}
+      />
+    </Datagrid>
+  </List>
+)
+
+export default CoverArtManagerList

--- a/ui/src/coverArtManager/index.jsx
+++ b/ui/src/coverArtManager/index.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import DynamicMenuIcon from '../layout/DynamicMenuIcon'
+import PhotoLibraryOutlinedIcon from '@material-ui/icons/PhotoLibraryOutlined'
+import PhotoLibraryIcon from '@material-ui/icons/PhotoLibrary'
+import CoverArtManagerList from './CoverArtManagerList'
+
+export default {
+  list: CoverArtManagerList,
+  icon: (
+    <DynamicMenuIcon
+      path={'coverArtManager'}
+      icon={PhotoLibraryOutlinedIcon}
+      activeIcon={PhotoLibraryIcon}
+    />
+  ),
+}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -56,6 +56,14 @@
         }
       }
     },
+    "coverArtManager": {
+      "name": "Cover Art Manager",
+      "fields": {
+        "coverArtStatus": "Cover Art Status",
+        "coverArtAvailable": "Available",
+        "coverArtMissing": "Missing"
+      }
+    },
     "album": {
       "name": "Album |||| Albums",
       "fields": {


### PR DESCRIPTION
### Motivation
- Provide a new admin UI page to inspect cover art presence for all songs without modifying any existing metadata. 
- Reuse the existing `song` API and Navidrome UI patterns so the page matches the rest of the app and remains read-only for now.

### Description
- Added a new resource and menu entry by registering `coverArtManager` in `ui/src/App.jsx` and providing an icon using the existing `DynamicMenuIcon` pattern. 
- Implemented a read-only list component at `ui/src/coverArtManager/CoverArtManagerList.jsx` that renders `resource="song"` and shows Title, Artist, Album, Track number, Year, Genre, Duration, File path, Quality, Channels, and a computed Cover Art Status column. 
- Cover Art Status is computed from the existing `hasCoverArt` property and displays localized strings for `Available`/`Missing` without changing any song metadata. 
- Added i18n entries for the page and status labels in `ui/src/i18n/en.json` and exported the new resource in `ui/src/coverArtManager/index.jsx`.

### Testing
- Ran a production build with `npm --prefix ui run build`, which completed successfully. 
- Ran lint with `npm --prefix ui run lint`, which failed due to pre-existing unrelated lint errors in other files (for example `ui/src/layout/Menu.jsx` and `ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx`) and not due to the new files introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999a50f982883228d60740d6417d5f2)