### PR TITLE
Fetch MusicBrainz release MBID and persist it; improve release selection

### DIFF
--- a/db/migrations/20260221010101_add_musicbrainz_release_id.go
+++ b/db/migrations/20260221010101_add_musicbrainz_release_id.go
@@ -1,0 +1,47 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upAddMusicbrainzReleaseID, downAddMusicbrainzReleaseID)
+}
+
+func upAddMusicbrainzReleaseID(_ context.Context, tx *sql.Tx) error {
+	rows, err := tx.Query(`pragma table_info(media_file)`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			cid       int
+			name      string
+			ctype     string
+			notnull   int
+			dfltValue sql.NullString
+			pk        int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dfltValue, &pk); err != nil {
+			return err
+		}
+		if name == "mbz_release_id" {
+			return nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	_, err = tx.Exec(`alter table media_file add mbz_release_id text not null default ''`)
+	return err
+}
+
+func downAddMusicbrainzReleaseID(_ context.Context, _ *sql.Tx) error {
+	return nil
+}

--- a/db/migrations/20260222010101_add_cover_path_to_media_file.go
+++ b/db/migrations/20260222010101_add_cover_path_to_media_file.go
@@ -1,0 +1,47 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upAddCoverPathToMediaFile, downAddCoverPathToMediaFile)
+}
+
+func upAddCoverPathToMediaFile(_ context.Context, tx *sql.Tx) error {
+	rows, err := tx.Query(`pragma table_info(media_file)`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			cid       int
+			name      string
+			ctype     string
+			notnull   int
+			dfltValue sql.NullString
+			pk        int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dfltValue, &pk); err != nil {
+			return err
+		}
+		if name == "cover_path" {
+			return nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	_, err = tx.Exec(`alter table media_file add cover_path text not null default ''`)
+	return err
+}
+
+func downAddCoverPathToMediaFile(_ context.Context, _ *sql.Tx) error {
+	return nil
+}

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -75,6 +75,7 @@ type MediaFile struct {
 	ExplicitStatus       string   `structs:"explicit_status" json:"explicitStatus"`
 	CatalogNum           string   `structs:"catalog_num" json:"catalogNum,omitempty"`
 	MbzRecordingID       string   `structs:"mbz_recording_id" json:"mbzRecordingID,omitempty"`
+	MbzReleaseID         string   `structs:"mbz_release_id" json:"mbzReleaseId,omitempty"`
 	MbzReleaseTrackID    string   `structs:"mbz_release_track_id" json:"mbzReleaseTrackId,omitempty"`
 	MbzAlbumID           string   `structs:"mbz_album_id" json:"mbzAlbumId,omitempty"`
 	MbzReleaseGroupID    string   `structs:"mbz_release_group_id" json:"mbzReleaseGroupId,omitempty"`
@@ -359,7 +360,7 @@ type MediaFileRepository interface {
 	DeleteAllMissing() (int64, error)
 	FindByPaths(paths []string) (MediaFiles, error)
 	UpdateComment(ids []string, comment string) error
-	UpdateMissingMetadata(id string, album *string, year *int, genre *string) error
+	UpdateMissingMetadata(id string, album *string, year *int, genre *string, mbzRecordingID *string, mbzReleaseID *string) error
 
 	// The following methods are used exclusively by the scanner:
 	MarkMissing(bool, ...*MediaFile) error

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -43,6 +43,7 @@ type MediaFile struct {
 	ArtworkID            string   `structs:"-" json:"artworkId,omitempty"`
 	ArtworkURL           string   `structs:"-" json:"artworkUrl,omitempty"`
 	CoverArtURL          string   `structs:"-" json:"cover_art_url,omitempty"`
+	CoverPath            string   `structs:"cover_path" json:"coverPath,omitempty"`
 	TrackNumber          int      `structs:"track_number" json:"trackNumber"`
 	DiscNumber           int      `structs:"disc_number" json:"discNumber"`
 	DiscSubtitle         string   `structs:"disc_subtitle" json:"discSubtitle,omitempty"`
@@ -362,6 +363,7 @@ type MediaFileRepository interface {
 	FindByPaths(paths []string) (MediaFiles, error)
 	UpdateComment(ids []string, comment string) error
 	UpdateMissingMetadata(id string, album *string, year *int, genre *string, mbzRecordingID *string, mbzReleaseID *string) error
+	UpdateCoverPath(id string, coverPath string) error
 
 	// The following methods are used exclusively by the scanner:
 	MarkMissing(bool, ...*MediaFile) error

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -42,6 +42,7 @@ type MediaFile struct {
 	HasCoverArt          bool     `structs:"has_cover_art" json:"hasCoverArt"`
 	ArtworkID            string   `structs:"-" json:"artworkId,omitempty"`
 	ArtworkURL           string   `structs:"-" json:"artworkUrl,omitempty"`
+	CoverArtURL          string   `structs:"-" json:"cover_art_url,omitempty"`
 	TrackNumber          int      `structs:"track_number" json:"trackNumber"`
 	DiscNumber           int      `structs:"disc_number" json:"discNumber"`
 	DiscSubtitle         string   `structs:"disc_subtitle" json:"discSubtitle,omitempty"`

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -275,8 +275,8 @@ func (r *mediaFileRepository) UpdateComment(ids []string, comment string) error 
 	return nil
 }
 
-func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, year *int, genre *string) error {
-	if album == nil && year == nil && genre == nil {
+func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, year *int, genre *string, mbzRecordingID *string, mbzReleaseID *string) error {
+	if album == nil && year == nil && genre == nil && mbzRecordingID == nil && mbzReleaseID == nil {
 		return nil
 	}
 
@@ -290,6 +290,12 @@ func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, ye
 	}
 	if genre != nil {
 		up = up.Set("genre", Expr("case when trim(ifnull(genre, '')) = '' then ? else genre end", *genre))
+	}
+	if mbzRecordingID != nil {
+		up = up.Set("mbz_recording_id", Expr("case when trim(ifnull(mbz_recording_id, '')) = '' then ? else mbz_recording_id end", *mbzRecordingID))
+	}
+	if mbzReleaseID != nil {
+		up = up.Set("mbz_release_id", Expr("case when trim(ifnull(mbz_release_id, '')) = '' then ? else mbz_release_id end", *mbzReleaseID))
 	}
 
 	up = up.Set("updated_at", time.Now())

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -299,6 +300,20 @@ func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, ye
 	}
 
 	up = up.Set("updated_at", time.Now())
+	_, err := r.executeSQL(up)
+	return err
+}
+
+func (r *mediaFileRepository) UpdateCoverPath(id string, coverPath string) error {
+	coverPath = strings.TrimSpace(coverPath)
+	if id == "" || coverPath == "" {
+		return nil
+	}
+
+	up := Update(r.tableName).
+		Set("cover_path", Expr("case when trim(ifnull(cover_path, '')) = '' then ? else cover_path end", coverPath)).
+		Set("updated_at", time.Now()).
+		Where(Eq{"id": id})
 	_, err := r.executeSQL(up)
 	return err
 }

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -467,7 +467,7 @@ var _ = Describe("MediaRepository", func() {
 			album := "Real Album"
 			year := 2014
 			genre := "Rock"
-			Expect(mr.UpdateMissingMetadata(mf.ID, &album, &year, &genre)).To(Succeed())
+			Expect(mr.UpdateMissingMetadata(mf.ID, &album, &year, &genre, nil, nil)).To(Succeed())
 
 			updated, err := mr.Get(mf.ID)
 			Expect(err).ToNot(HaveOccurred())

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -48,12 +48,15 @@ type musicBrainzMetadataJob struct {
 	mu          sync.RWMutex
 	status      musicBrainzMetadataStatus
 	client      *http.Client
+	coverClient *http.Client
 	coverMisses sync.Map
+	coverChecks sync.Map
 }
 
 func newMusicBrainzMetadataJob() *musicBrainzMetadataJob {
 	return &musicBrainzMetadataJob{
-		client: &http.Client{Timeout: 15 * time.Second},
+		client:      &http.Client{Timeout: 15 * time.Second},
+		coverClient: &http.Client{Timeout: 2 * time.Second},
 	}
 }
 
@@ -532,95 +535,178 @@ func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (metadataRe
 		return metadataResult{}, nil
 	}
 
-	bestRecording := selectBestRecording(payload.Recordings, artist)
-	if bestRecording == nil {
+	recordings := filterCandidateRecordings(payload.Recordings, artist)
+	if len(recordings) == 0 {
 		return metadataResult{}, nil
 	}
 
-	bestRelease := selectBestRelease(bestRecording.Releases)
-	if bestRelease == nil {
-		return metadataResult{Genre: collectRecordingGenre(*bestRecording), RecordingMBID: strings.TrimSpace(bestRecording.ID)}, nil
+	best := j.selectBestRecordingRelease(context.Background(), recordings)
+	if best == nil {
+		return metadataResult{}, nil
 	}
 
-	album := strings.TrimSpace(bestRelease.Title)
-	year := yearFromDate(bestRelease.Date)
+	album := strings.TrimSpace(best.release.Title)
+	year := yearFromDate(best.release.Date)
 	if year == 0 {
-		year = yearFromDate(bestRecording.FirstReleaseDate)
+		year = yearFromDate(best.recording.FirstReleaseDate)
 	}
-	genre := collectGenre(*bestRecording, *bestRelease)
+	genre := collectGenre(*best.recording, *best.release)
 	return metadataResult{
 		Album:         album,
 		Year:          year,
 		Genre:         genre,
-		RecordingMBID: strings.TrimSpace(bestRecording.ID),
-		ReleaseMBID:   strings.TrimSpace(bestRelease.ID),
+		RecordingMBID: strings.TrimSpace(best.recording.ID),
+		ReleaseMBID:   strings.TrimSpace(best.release.ID),
 	}, nil
 }
 
-func selectBestRecording(recordings []mbRecording, artist string) *mbRecording {
+type mbReleaseCandidate struct {
+	recording *mbRecording
+	release   *mbRelease
+	hasCover  bool
+	year      int
+	usCountry bool
+}
+
+func filterCandidateRecordings(recordings []mbRecording, artist string) []mbRecording {
 	normalizedArtist := normalizeMBString(artist)
-
-	type recCandidate struct {
-		rec      *mbRecording
-		score    int
-		releases int
-		hasAlbum bool
-		earliest int
-	}
-
-	candidates := make([]recCandidate, 0, len(recordings))
-	for i := range recordings {
-		rec := &recordings[i]
-		score := rec.Score.Int()
-		if score < 80 {
+	filtered := make([]mbRecording, 0, len(recordings))
+	for _, rec := range recordings {
+		if rec.Score.Int() < 80 {
 			continue
 		}
 		if !artistCreditMatches(rec.ArtistCredit, normalizedArtist) {
 			continue
 		}
+		filtered = append(filtered, rec)
+	}
+	return filtered
+}
 
-		hasAlbum := false
-		earliest := 9999
-		for _, rel := range rec.Releases {
-			if !isValidRelease(rel) {
+func (j *musicBrainzMetadataJob) selectBestRecordingRelease(ctx context.Context, recordings []mbRecording) *mbReleaseCandidate {
+	preferred := make([]mbReleaseCandidate, 0)
+	officialFallback := make([]mbReleaseCandidate, 0)
+
+	for i := range recordings {
+		rec := &recordings[i]
+		for k := range rec.Releases {
+			rel := &rec.Releases[k]
+			if !isValidRelease(*rel) {
 				continue
 			}
-			if isAlbumRelease(rel) {
-				hasAlbum = true
-			}
-			if y := yearFromDate(rel.Date); y > 0 && y < earliest {
-				earliest = y
+			if strings.EqualFold(strings.TrimSpace(rel.Status), "Official") {
+				candidate := mbReleaseCandidate{
+					recording: rec,
+					release:   rel,
+					year:      yearFromDate(rel.Date),
+					usCountry: strings.EqualFold(strings.TrimSpace(rel.Country), "US"),
+				}
+				officialFallback = append(officialFallback, candidate)
+				if isAlbumRelease(*rel) {
+					preferred = append(preferred, candidate)
+				}
 			}
 		}
-		candidates = append(candidates, recCandidate{rec: rec, score: score, releases: len(rec.Releases), hasAlbum: hasAlbum, earliest: earliest})
+	}
+
+	candidates := preferred
+	if len(candidates) == 0 {
+		candidates = officialFallback
 	}
 	if len(candidates) == 0 {
 		return nil
 	}
 
-	slices.SortFunc(candidates, func(a, b recCandidate) int {
-		if a.releases > 0 && b.releases == 0 {
+	if hasPreferredSubtype(candidates) {
+		filtered := make([]mbReleaseCandidate, 0, len(candidates))
+		for _, c := range candidates {
+			if !hasDiscouragedSecondaryType(*c.release) {
+				filtered = append(filtered, c)
+			}
+		}
+		if len(filtered) > 0 {
+			candidates = filtered
+		}
+	}
+
+	for i := range candidates {
+		candidates[i].hasCover = j.releaseHasCover(ctx, strings.TrimSpace(candidates[i].release.ID))
+	}
+
+	slices.SortFunc(candidates, func(a, b mbReleaseCandidate) int {
+		if a.hasCover && !b.hasCover {
 			return -1
 		}
-		if a.releases == 0 && b.releases > 0 {
+		if !a.hasCover && b.hasCover {
 			return 1
 		}
-		if a.score != b.score {
-			return b.score - a.score
+		if a.year == 0 && b.year > 0 {
+			return 1
 		}
-		if a.hasAlbum && !b.hasAlbum {
+		if b.year == 0 && a.year > 0 {
 			return -1
 		}
-		if !a.hasAlbum && b.hasAlbum {
-			return 1
+		if a.year != b.year {
+			return a.year - b.year
 		}
-		if a.earliest != b.earliest {
-			return a.earliest - b.earliest
+		if a.usCountry && !b.usCountry {
+			return -1
+		}
+		if !a.usCountry && b.usCountry {
+			return 1
 		}
 		return 0
 	})
 
-	return candidates[0].rec
+	return &candidates[0]
+}
+
+func hasPreferredSubtype(candidates []mbReleaseCandidate) bool {
+	for _, c := range candidates {
+		if !hasDiscouragedSecondaryType(*c.release) {
+			return true
+		}
+	}
+	return false
+}
+
+func (j *musicBrainzMetadataJob) releaseHasCover(ctx context.Context, releaseID string) bool {
+	if releaseID == "" {
+		return false
+	}
+	if cached, ok := j.coverChecks.Load(releaseID); ok {
+		if hasCover, ok := cached.(bool); ok {
+			return hasCover
+		}
+	}
+
+	headCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(headCtx, http.MethodHead, "https://coverartarchive.org/release/"+releaseID, nil)
+	if err != nil {
+		j.coverChecks.Store(releaseID, false)
+		return false
+	}
+	req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
+
+	resp, err := j.coverClient.Do(req)
+	if err != nil {
+		j.coverChecks.Store(releaseID, false)
+		return false
+	}
+	defer resp.Body.Close()
+
+	hasCover := resp.StatusCode == http.StatusOK
+	j.coverChecks.Store(releaseID, hasCover)
+	return hasCover
+}
+
+func selectBestRecording(recordings []mbRecording, artist string) *mbRecording {
+	filtered := filterCandidateRecordings(recordings, artist)
+	if len(filtered) == 0 {
+		return nil
+	}
+	return &filtered[0]
 }
 
 func artistCreditMatches(credits []struct {

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -80,6 +80,14 @@ type mbMetadataCandidate struct {
 	flags missingFlags
 }
 
+type metadataResult struct {
+	Album         string
+	Year          int
+	Genre         string
+	RecordingMBID string
+	ReleaseMBID   string
+}
+
 func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 	ctx := context.Background()
 	defer func() {
@@ -117,7 +125,7 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 		}
 		j.setFetching(c.flags, 1)
 
-		album, year, genre, fetchErr := j.fetchMetadata(c.mf.Title, c.mf.Artist)
+		metadata, fetchErr := j.fetchMetadata(c.mf.Title, c.mf.Artist)
 		if fetchErr != nil {
 			failed++
 			log.Warn(ctx, "Could not fetch metadata from MusicBrainz", "songId", c.mf.ID, "title", c.mf.Title, "artist", c.mf.Artist, fetchErr)
@@ -131,18 +139,18 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 		var setYear *int
 		var setGenre *string
 
-		if c.flags.album && album != "" {
-			setAlbum = &album
+		if c.flags.album && metadata.Album != "" {
+			setAlbum = &metadata.Album
 		}
-		if c.flags.year && year > 0 {
-			setYear = &year
+		if c.flags.year && metadata.Year > 0 {
+			setYear = &metadata.Year
 		}
-		if c.flags.genre && genre != "" {
-			setGenre = &genre
+		if c.flags.genre && metadata.Genre != "" {
+			setGenre = &metadata.Genre
 		}
 
-		if setAlbum != nil || setYear != nil || setGenre != nil {
-			if err := ds.MediaFile(ctx).UpdateMissingMetadata(c.mf.ID, setAlbum, setYear, setGenre); err != nil {
+		if setAlbum != nil || setYear != nil || setGenre != nil || metadata.RecordingMBID != "" || metadata.ReleaseMBID != "" {
+			if err := ds.MediaFile(ctx).UpdateMissingMetadata(c.mf.ID, setAlbum, setYear, setGenre, valueOrNil(metadata.RecordingMBID), valueOrNil(metadata.ReleaseMBID)); err != nil {
 				failed++
 				log.Error(ctx, "Could not update fetched MusicBrainz metadata", "songId", c.mf.ID, err)
 			} else {
@@ -153,7 +161,7 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 			skipped++
 		}
 
-		j.finishFetch(c.flags, album != "", year > 0, genre != "")
+		j.finishFetch(c.flags, metadata.Album != "", metadata.Year > 0, metadata.Genre != "")
 	}
 
 	log.Info(ctx, "MusicBrainz metadata fetch completed",
@@ -278,23 +286,30 @@ func (j *musicBrainzMetadataJob) setError(err error) {
 }
 
 type mbSearchResponse struct {
-	Recordings []struct {
-		Score            mbScore `json:"score"`
-		FirstReleaseDate string  `json:"first-release-date"`
-		ArtistCredit     []struct {
-			Name string `json:"name"`
-		} `json:"artist-credit"`
-		Releases []struct {
-			Title        string   `json:"title"`
-			Date         string   `json:"date"`
-			Status       string   `json:"status"`
-			ReleaseGroup mbGroup  `json:"release-group"`
-			Tags         []mbName `json:"tags"`
-			Genres       []mbName `json:"genres"`
-		} `json:"releases"`
-		Tags   []mbName `json:"tags"`
-		Genres []mbName `json:"genres"`
-	} `json:"recordings"`
+	Recordings []mbRecording `json:"recordings"`
+}
+
+type mbRecording struct {
+	ID               string  `json:"id"`
+	Score            mbScore `json:"score"`
+	FirstReleaseDate string  `json:"first-release-date"`
+	ArtistCredit     []struct {
+		Name string `json:"name"`
+	} `json:"artist-credit"`
+	Releases []mbRelease `json:"releases"`
+	Tags     []mbName    `json:"tags"`
+	Genres   []mbName    `json:"genres"`
+}
+
+type mbRelease struct {
+	ID           string   `json:"id"`
+	Title        string   `json:"title"`
+	Date         string   `json:"date"`
+	Status       string   `json:"status"`
+	Country      string   `json:"country"`
+	ReleaseGroup mbGroup  `json:"release-group"`
+	Tags         []mbName `json:"tags"`
+	Genres       []mbName `json:"genres"`
 }
 
 type mbScore string
@@ -331,40 +346,48 @@ type mbGroup struct {
 	SecondaryType []string `json:"secondary-types"`
 }
 
-func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (string, int, string, error) {
+func valueOrNil(v string) *string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return nil
+	}
+	return &v
+}
+
+func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (metadataResult, error) {
 	query := fmt.Sprintf("artist:%s AND recording:%s", artist, title)
-	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json"
+	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json&inc=releases+release-groups"
 	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
-		return "", 0, "", err
+		return metadataResult{}, err
 	}
 	req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
 
 	resp, err := j.client.Do(req)
 	if err != nil {
-		return "", 0, "", err
+		return metadataResult{}, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", 0, "", fmt.Errorf("musicbrainz status %d", resp.StatusCode)
+		return metadataResult{}, fmt.Errorf("musicbrainz status %d", resp.StatusCode)
 	}
 
 	var payload mbSearchResponse
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return "", 0, "", err
+		return metadataResult{}, err
 	}
 	if len(payload.Recordings) == 0 {
-		return "", 0, "", nil
+		return metadataResult{}, nil
 	}
 
 	bestRecording := selectBestRecording(payload.Recordings, artist)
 	if bestRecording == nil {
-		return "", 0, "", nil
+		return metadataResult{}, nil
 	}
 
 	bestRelease := selectBestRelease(bestRecording.Releases)
 	if bestRelease == nil {
-		return "", 0, collectRecordingGenre(*bestRecording), nil
+		return metadataResult{Genre: collectRecordingGenre(*bestRecording), RecordingMBID: strings.TrimSpace(bestRecording.ID)}, nil
 	}
 
 	album := strings.TrimSpace(bestRelease.Title)
@@ -373,62 +396,20 @@ func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (string, in
 		year = yearFromDate(bestRecording.FirstReleaseDate)
 	}
 	genre := collectGenre(*bestRecording, *bestRelease)
-	return album, year, genre, nil
+	return metadataResult{
+		Album:         album,
+		Year:          year,
+		Genre:         genre,
+		RecordingMBID: strings.TrimSpace(bestRecording.ID),
+		ReleaseMBID:   strings.TrimSpace(bestRelease.ID),
+	}, nil
 }
 
-func selectBestRecording(recordings []struct {
-	Score            mbScore `json:"score"`
-	FirstReleaseDate string  `json:"first-release-date"`
-	ArtistCredit     []struct {
-		Name string `json:"name"`
-	} `json:"artist-credit"`
-	Releases []struct {
-		Title        string   `json:"title"`
-		Date         string   `json:"date"`
-		Status       string   `json:"status"`
-		ReleaseGroup mbGroup  `json:"release-group"`
-		Tags         []mbName `json:"tags"`
-		Genres       []mbName `json:"genres"`
-	} `json:"releases"`
-	Tags   []mbName `json:"tags"`
-	Genres []mbName `json:"genres"`
-}, artist string) *struct {
-	Score            mbScore `json:"score"`
-	FirstReleaseDate string  `json:"first-release-date"`
-	ArtistCredit     []struct {
-		Name string `json:"name"`
-	} `json:"artist-credit"`
-	Releases []struct {
-		Title        string   `json:"title"`
-		Date         string   `json:"date"`
-		Status       string   `json:"status"`
-		ReleaseGroup mbGroup  `json:"release-group"`
-		Tags         []mbName `json:"tags"`
-		Genres       []mbName `json:"genres"`
-	} `json:"releases"`
-	Tags   []mbName `json:"tags"`
-	Genres []mbName `json:"genres"`
-} {
+func selectBestRecording(recordings []mbRecording, artist string) *mbRecording {
 	normalizedArtist := normalizeMBString(artist)
 
 	type recCandidate struct {
-		rec *struct {
-			Score            mbScore `json:"score"`
-			FirstReleaseDate string  `json:"first-release-date"`
-			ArtistCredit     []struct {
-				Name string `json:"name"`
-			} `json:"artist-credit"`
-			Releases []struct {
-				Title        string   `json:"title"`
-				Date         string   `json:"date"`
-				Status       string   `json:"status"`
-				ReleaseGroup mbGroup  `json:"release-group"`
-				Tags         []mbName `json:"tags"`
-				Genres       []mbName `json:"genres"`
-			} `json:"releases"`
-			Tags   []mbName `json:"tags"`
-			Genres []mbName `json:"genres"`
-		}
+		rec      *mbRecording
 		score    int
 		releases int
 		hasAlbum bool
@@ -504,33 +485,14 @@ func artistCreditMatches(credits []struct {
 	return false
 }
 
-func selectBestRelease(releases []struct {
-	Title        string   `json:"title"`
-	Date         string   `json:"date"`
-	Status       string   `json:"status"`
-	ReleaseGroup mbGroup  `json:"release-group"`
-	Tags         []mbName `json:"tags"`
-	Genres       []mbName `json:"genres"`
-}) *struct {
-	Title        string   `json:"title"`
-	Date         string   `json:"date"`
-	Status       string   `json:"status"`
-	ReleaseGroup mbGroup  `json:"release-group"`
-	Tags         []mbName `json:"tags"`
-	Genres       []mbName `json:"genres"`
-} {
+func selectBestRelease(releases []mbRelease) *mbRelease {
 	type relCandidate struct {
-		release *struct {
-			Title        string   `json:"title"`
-			Date         string   `json:"date"`
-			Status       string   `json:"status"`
-			ReleaseGroup mbGroup  `json:"release-group"`
-			Tags         []mbName `json:"tags"`
-			Genres       []mbName `json:"genres"`
-		}
-		official bool
-		album    bool
-		year     int
+		release               *mbRelease
+		official              bool
+		album                 bool
+		hasDiscouragedSubtype bool
+		usCountry             bool
+		year                  int
 	}
 
 	candidates := make([]relCandidate, 0, len(releases))
@@ -540,10 +502,12 @@ func selectBestRelease(releases []struct {
 			continue
 		}
 		candidates = append(candidates, relCandidate{
-			release:  release,
-			official: strings.EqualFold(strings.TrimSpace(release.Status), "Official"),
-			album:    isAlbumRelease(*release),
-			year:     yearFromDate(release.Date),
+			release:               release,
+			official:              strings.EqualFold(strings.TrimSpace(release.Status), "Official"),
+			album:                 isAlbumRelease(*release),
+			hasDiscouragedSubtype: hasDiscouragedSecondaryType(*release),
+			usCountry:             strings.EqualFold(strings.TrimSpace(release.Country), "US"),
+			year:                  yearFromDate(release.Date),
 		})
 	}
 	if len(candidates) == 0 {
@@ -563,6 +527,12 @@ func selectBestRelease(releases []struct {
 		if !a.album && b.album {
 			return 1
 		}
+		if !a.hasDiscouragedSubtype && b.hasDiscouragedSubtype {
+			return -1
+		}
+		if a.hasDiscouragedSubtype && !b.hasDiscouragedSubtype {
+			return 1
+		}
 		if a.year == 0 && b.year > 0 {
 			return 1
 		}
@@ -572,91 +542,51 @@ func selectBestRelease(releases []struct {
 		if a.year != b.year {
 			return a.year - b.year
 		}
+		if a.usCountry && !b.usCountry {
+			return -1
+		}
+		if !a.usCountry && b.usCountry {
+			return 1
+		}
 		return 0
 	})
 
 	return candidates[0].release
 }
 
-func isValidRelease(release struct {
-	Title        string   `json:"title"`
-	Date         string   `json:"date"`
-	Status       string   `json:"status"`
-	ReleaseGroup mbGroup  `json:"release-group"`
-	Tags         []mbName `json:"tags"`
-	Genres       []mbName `json:"genres"`
-}) bool {
+func isValidRelease(release mbRelease) bool {
 	if strings.TrimSpace(release.Title) == "" {
 		return false
 	}
-	types := make([]string, 0, len(release.ReleaseGroup.SecondaryType)+1)
-	types = append(types, release.ReleaseGroup.PrimaryType)
-	types = append(types, release.ReleaseGroup.SecondaryType...)
-	for _, t := range types {
+	for _, t := range release.ReleaseGroup.SecondaryType {
 		n := normalizeMBString(t)
-		if n == "compilation" || n == "live" || n == "unofficial" || n == "promo" {
+		if n == "unofficial" || n == "promo" {
 			return false
 		}
 	}
 	return true
 }
 
-func isAlbumRelease(release struct {
-	Title        string   `json:"title"`
-	Date         string   `json:"date"`
-	Status       string   `json:"status"`
-	ReleaseGroup mbGroup  `json:"release-group"`
-	Tags         []mbName `json:"tags"`
-	Genres       []mbName `json:"genres"`
-}) bool {
+func hasDiscouragedSecondaryType(release mbRelease) bool {
+	for _, t := range release.ReleaseGroup.SecondaryType {
+		n := normalizeMBString(t)
+		if n == "compilation" || n == "live" {
+			return true
+		}
+	}
+	return false
+}
+
+func isAlbumRelease(release mbRelease) bool {
 	primaryType := normalizeMBString(release.ReleaseGroup.PrimaryType)
 	return primaryType == "album"
 }
 
-func collectRecordingGenre(rec struct {
-	Score            mbScore `json:"score"`
-	FirstReleaseDate string  `json:"first-release-date"`
-	ArtistCredit     []struct {
-		Name string `json:"name"`
-	} `json:"artist-credit"`
-	Releases []struct {
-		Title        string   `json:"title"`
-		Date         string   `json:"date"`
-		Status       string   `json:"status"`
-		ReleaseGroup mbGroup  `json:"release-group"`
-		Tags         []mbName `json:"tags"`
-		Genres       []mbName `json:"genres"`
-	} `json:"releases"`
-	Tags   []mbName `json:"tags"`
-	Genres []mbName `json:"genres"`
-}) string {
+func collectRecordingGenre(rec mbRecording) string {
 	return collectGenres(rec.Genres, rec.Tags)
 }
 
-func collectGenre(rec struct {
-	Score            mbScore `json:"score"`
-	FirstReleaseDate string  `json:"first-release-date"`
-	ArtistCredit     []struct {
-		Name string `json:"name"`
-	} `json:"artist-credit"`
-	Releases []struct {
-		Title        string   `json:"title"`
-		Date         string   `json:"date"`
-		Status       string   `json:"status"`
-		ReleaseGroup mbGroup  `json:"release-group"`
-		Tags         []mbName `json:"tags"`
-		Genres       []mbName `json:"genres"`
-	} `json:"releases"`
-	Tags   []mbName `json:"tags"`
-	Genres []mbName `json:"genres"`
-}, release struct {
-	Title        string   `json:"title"`
-	Date         string   `json:"date"`
-	Status       string   `json:"status"`
-	ReleaseGroup mbGroup  `json:"release-group"`
-	Tags         []mbName `json:"tags"`
-	Genres       []mbName `json:"genres"`
-}) string {
+func collectGenre(rec mbRecording, release mbRelease) string {
 	genre := collectGenres(release.Genres, release.Tags)
 	if genre != "" {
 		return genre

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strconv"
@@ -15,6 +18,7 @@ import (
 	"unicode"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 )
@@ -37,12 +41,14 @@ type musicBrainzMetadataStatus struct {
 	Genre         metadataFieldProgress `json:"genre"`
 	RecordingMBID metadataFieldProgress `json:"recordingMbid"`
 	ReleaseMBID   metadataFieldProgress `json:"releaseMbid"`
+	CoverArt      metadataFieldProgress `json:"coverArt"`
 }
 
 type musicBrainzMetadataJob struct {
-	mu     sync.RWMutex
-	status musicBrainzMetadataStatus
-	client *http.Client
+	mu          sync.RWMutex
+	status      musicBrainzMetadataStatus
+	client      *http.Client
+	coverMisses sync.Map
 }
 
 func newMusicBrainzMetadataJob() *musicBrainzMetadataJob {
@@ -77,6 +83,7 @@ type missingFlags struct {
 	genre         bool
 	recordingMBID bool
 	releaseMBID   bool
+	coverArt      bool
 }
 
 type mbMetadataCandidate struct {
@@ -133,7 +140,7 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 		if fetchErr != nil {
 			failed++
 			log.Warn(ctx, "Could not fetch metadata from MusicBrainz", "songId", c.mf.ID, "title", c.mf.Title, "artist", c.mf.Artist, fetchErr)
-			j.finishFetch(c.flags, false, false, false, false, false)
+			j.finishFetch(c.flags, false, false, false, false, false, false)
 			continue
 		}
 
@@ -159,13 +166,36 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 				log.Error(ctx, "Could not update fetched MusicBrainz metadata", "songId", c.mf.ID, err)
 			} else {
 				updated++
-				j.setUpdated(setAlbum != nil, setYear != nil, setGenre != nil, c.flags.recordingMBID && metadata.RecordingMBID != "", c.flags.releaseMBID && metadata.ReleaseMBID != "")
+				j.setUpdated(setAlbum != nil, setYear != nil, setGenre != nil, c.flags.recordingMBID && metadata.RecordingMBID != "", c.flags.releaseMBID && metadata.ReleaseMBID != "", false)
 			}
 		} else {
 			skipped++
 		}
 
-		j.finishFetch(c.flags, metadata.Album != "", metadata.Year > 0, metadata.Genre != "", metadata.RecordingMBID != "", metadata.ReleaseMBID != "")
+		coverFetched := false
+		coverUpdated := false
+		if c.flags.coverArt && !c.mf.HasCoverArt && strings.TrimSpace(c.mf.CoverPath) == "" {
+			releaseMBID := strings.TrimSpace(c.mf.MbzReleaseID)
+			if releaseMBID == "" {
+				releaseMBID = strings.TrimSpace(metadata.ReleaseMBID)
+			}
+			if releaseMBID != "" && releaseMBIDRegex.MatchString(releaseMBID) {
+				relPath, ok := j.ensureReleaseCover(ctx, releaseMBID)
+				if ok {
+					coverFetched = true
+					if err := ds.MediaFile(ctx).UpdateCoverPath(c.mf.ID, relPath); err != nil {
+						log.Warn(ctx, "Could not update cover path", "songId", c.mf.ID, "releaseMBID", releaseMBID, "err", err)
+					} else {
+						coverUpdated = true
+					}
+				}
+			}
+		}
+
+		if coverUpdated {
+			j.setUpdated(false, false, false, false, false, true)
+		}
+		j.finishFetch(c.flags, metadata.Album != "", metadata.Year > 0, metadata.Genre != "", metadata.RecordingMBID != "", metadata.ReleaseMBID != "", coverFetched)
 	}
 
 	log.Info(ctx, "MusicBrainz metadata fetch completed",
@@ -198,8 +228,9 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 			genre:         strings.TrimSpace(mf.Genre) == "",
 			recordingMBID: strings.TrimSpace(mf.MbzRecordingID) == "",
 			releaseMBID:   strings.TrimSpace(mf.MbzReleaseID) == "",
+			coverArt:      !mf.HasCoverArt && strings.TrimSpace(mf.CoverPath) == "",
 		}
-		if !flags.album && !flags.year && !flags.genre && !flags.recordingMBID && !flags.releaseMBID {
+		if !flags.album && !flags.year && !flags.genre && !flags.recordingMBID && !flags.releaseMBID && !flags.coverArt {
 			continue
 		}
 
@@ -237,6 +268,10 @@ func (j *musicBrainzMetadataJob) incrementMissing(flags missingFlags) {
 		j.status.ReleaseMBID.Missing++
 		j.status.ReleaseMBID.Left++
 	}
+	if flags.coverArt {
+		j.status.CoverArt.Missing++
+		j.status.CoverArt.Left++
+	}
 }
 
 func (j *musicBrainzMetadataJob) setFetching(flags missingFlags, delta int) {
@@ -257,9 +292,12 @@ func (j *musicBrainzMetadataJob) setFetching(flags missingFlags, delta int) {
 	if flags.releaseMBID {
 		j.status.ReleaseMBID.Fetching += delta
 	}
+	if flags.coverArt {
+		j.status.CoverArt.Fetching += delta
+	}
 }
 
-func (j *musicBrainzMetadataJob) setUpdated(album, year, genre, recordingMBID, releaseMBID bool) {
+func (j *musicBrainzMetadataJob) setUpdated(album, year, genre, recordingMBID, releaseMBID, coverArt bool) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	if album {
@@ -277,9 +315,12 @@ func (j *musicBrainzMetadataJob) setUpdated(album, year, genre, recordingMBID, r
 	if releaseMBID {
 		j.status.ReleaseMBID.Updated++
 	}
+	if coverArt {
+		j.status.CoverArt.Updated++
+	}
 }
 
-func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, fetchedYear, fetchedGenre, fetchedRecordingMBID, fetchedReleaseMBID bool) {
+func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, fetchedYear, fetchedGenre, fetchedRecordingMBID, fetchedReleaseMBID, fetchedCoverArt bool) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	if flags.album {
@@ -317,12 +358,83 @@ func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, f
 			j.status.ReleaseMBID.Fetched++
 		}
 	}
+	if flags.coverArt {
+		j.status.CoverArt.Fetching--
+		j.status.CoverArt.Left--
+		if fetchedCoverArt {
+			j.status.CoverArt.Fetched++
+		}
+	}
 }
 
 func (j *musicBrainzMetadataJob) setError(err error) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	j.status.LastError = err.Error()
+}
+
+func (j *musicBrainzMetadataJob) ensureReleaseCover(ctx context.Context, releaseMBID string) (string, bool) {
+	if _, err := os.Stat(filepath.Join(conf.Server.DataFolder, coverCacheDirName)); err != nil {
+		if err := os.MkdirAll(filepath.Join(conf.Server.DataFolder, coverCacheDirName), 0o755); err != nil {
+			log.Warn(ctx, "Could not create cover cache directory", "err", err)
+			return "", false
+		}
+	}
+
+	coverPath := filepath.Join(conf.Server.DataFolder, coverCacheDirName, releaseMBID+".jpg")
+	if _, err := os.Stat(coverPath); err == nil {
+		return filepath.ToSlash(filepath.Join(coverCacheDirName, releaseMBID+".jpg")), true
+	}
+	if _, missed := j.coverMisses.Load(releaseMBID); missed {
+		return "", false
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://coverartarchive.org/release/"+releaseMBID+"/front-500", nil)
+	if err != nil {
+		log.Warn(ctx, "Could not build cover request", "releaseMBID", releaseMBID, "err", err)
+		return "", false
+	}
+	req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
+
+	resp, err := j.client.Do(req)
+	if err != nil {
+		log.Warn(ctx, "Could not fetch cover art", "releaseMBID", releaseMBID, "err", err)
+		return "", false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		j.coverMisses.Store(releaseMBID, true)
+		return "", false
+	}
+	if resp.StatusCode != http.StatusOK {
+		log.Warn(ctx, "Unexpected cover status", "releaseMBID", releaseMBID, "status", resp.StatusCode)
+		return "", false
+	}
+
+	tmpPath := coverPath + ".tmp"
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		log.Warn(ctx, "Could not create cover file", "path", tmpPath, "err", err)
+		return "", false
+	}
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		log.Warn(ctx, "Could not save cover file", "path", tmpPath, "err", err)
+		return "", false
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", false
+	}
+	if err := os.Rename(tmpPath, coverPath); err != nil {
+		_ = os.Remove(tmpPath)
+		log.Warn(ctx, "Could not store cover file", "path", coverPath, "err", err)
+		return "", false
+	}
+
+	return filepath.ToSlash(filepath.Join(coverCacheDirName, releaseMBID+".jpg")), true
 }
 
 type mbSearchResponse struct {

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -28,13 +28,15 @@ type metadataFieldProgress struct {
 }
 
 type musicBrainzMetadataStatus struct {
-	Running    bool                  `json:"running"`
-	StartedAt  *time.Time            `json:"startedAt,omitempty"`
-	FinishedAt *time.Time            `json:"finishedAt,omitempty"`
-	LastError  string                `json:"lastError,omitempty"`
-	Album      metadataFieldProgress `json:"album"`
-	Year       metadataFieldProgress `json:"year"`
-	Genre      metadataFieldProgress `json:"genre"`
+	Running       bool                  `json:"running"`
+	StartedAt     *time.Time            `json:"startedAt,omitempty"`
+	FinishedAt    *time.Time            `json:"finishedAt,omitempty"`
+	LastError     string                `json:"lastError,omitempty"`
+	Album         metadataFieldProgress `json:"album"`
+	Year          metadataFieldProgress `json:"year"`
+	Genre         metadataFieldProgress `json:"genre"`
+	RecordingMBID metadataFieldProgress `json:"recordingMbid"`
+	ReleaseMBID   metadataFieldProgress `json:"releaseMbid"`
 }
 
 type musicBrainzMetadataJob struct {
@@ -70,9 +72,11 @@ func (j *musicBrainzMetadataJob) start(ds model.DataStore) bool {
 }
 
 type missingFlags struct {
-	album bool
-	year  bool
-	genre bool
+	album         bool
+	year          bool
+	genre         bool
+	recordingMBID bool
+	releaseMBID   bool
 }
 
 type mbMetadataCandidate struct {
@@ -129,7 +133,7 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 		if fetchErr != nil {
 			failed++
 			log.Warn(ctx, "Could not fetch metadata from MusicBrainz", "songId", c.mf.ID, "title", c.mf.Title, "artist", c.mf.Artist, fetchErr)
-			j.finishFetch(c.flags, false, false, false)
+			j.finishFetch(c.flags, false, false, false, false, false)
 			continue
 		}
 
@@ -155,13 +159,13 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 				log.Error(ctx, "Could not update fetched MusicBrainz metadata", "songId", c.mf.ID, err)
 			} else {
 				updated++
-				j.setUpdated(setAlbum != nil, setYear != nil, setGenre != nil)
+				j.setUpdated(setAlbum != nil, setYear != nil, setGenre != nil, c.flags.recordingMBID && metadata.RecordingMBID != "", c.flags.releaseMBID && metadata.ReleaseMBID != "")
 			}
 		} else {
 			skipped++
 		}
 
-		j.finishFetch(c.flags, metadata.Album != "", metadata.Year > 0, metadata.Genre != "")
+		j.finishFetch(c.flags, metadata.Album != "", metadata.Year > 0, metadata.Genre != "", metadata.RecordingMBID != "", metadata.ReleaseMBID != "")
 	}
 
 	log.Info(ctx, "MusicBrainz metadata fetch completed",
@@ -189,11 +193,13 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 		}
 
 		flags := missingFlags{
-			album: isMissingAlbum(mf.Album),
-			year:  mf.Year == 0,
-			genre: strings.TrimSpace(mf.Genre) == "",
+			album:         isMissingAlbum(mf.Album),
+			year:          mf.Year == 0,
+			genre:         strings.TrimSpace(mf.Genre) == "",
+			recordingMBID: strings.TrimSpace(mf.MbzRecordingID) == "",
+			releaseMBID:   strings.TrimSpace(mf.MbzReleaseID) == "",
 		}
-		if !flags.album && !flags.year && !flags.genre {
+		if !flags.album && !flags.year && !flags.genre && !flags.recordingMBID && !flags.releaseMBID {
 			continue
 		}
 
@@ -223,6 +229,14 @@ func (j *musicBrainzMetadataJob) incrementMissing(flags missingFlags) {
 		j.status.Genre.Missing++
 		j.status.Genre.Left++
 	}
+	if flags.recordingMBID {
+		j.status.RecordingMBID.Missing++
+		j.status.RecordingMBID.Left++
+	}
+	if flags.releaseMBID {
+		j.status.ReleaseMBID.Missing++
+		j.status.ReleaseMBID.Left++
+	}
 }
 
 func (j *musicBrainzMetadataJob) setFetching(flags missingFlags, delta int) {
@@ -237,9 +251,15 @@ func (j *musicBrainzMetadataJob) setFetching(flags missingFlags, delta int) {
 	if flags.genre {
 		j.status.Genre.Fetching += delta
 	}
+	if flags.recordingMBID {
+		j.status.RecordingMBID.Fetching += delta
+	}
+	if flags.releaseMBID {
+		j.status.ReleaseMBID.Fetching += delta
+	}
 }
 
-func (j *musicBrainzMetadataJob) setUpdated(album, year, genre bool) {
+func (j *musicBrainzMetadataJob) setUpdated(album, year, genre, recordingMBID, releaseMBID bool) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	if album {
@@ -251,9 +271,15 @@ func (j *musicBrainzMetadataJob) setUpdated(album, year, genre bool) {
 	if genre {
 		j.status.Genre.Updated++
 	}
+	if recordingMBID {
+		j.status.RecordingMBID.Updated++
+	}
+	if releaseMBID {
+		j.status.ReleaseMBID.Updated++
+	}
 }
 
-func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, fetchedYear, fetchedGenre bool) {
+func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, fetchedYear, fetchedGenre, fetchedRecordingMBID, fetchedReleaseMBID bool) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	if flags.album {
@@ -275,6 +301,20 @@ func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, f
 		j.status.Genre.Left--
 		if fetchedGenre {
 			j.status.Genre.Fetched++
+		}
+	}
+	if flags.recordingMBID {
+		j.status.RecordingMBID.Fetching--
+		j.status.RecordingMBID.Left--
+		if fetchedRecordingMBID {
+			j.status.RecordingMBID.Fetched++
+		}
+	}
+	if flags.releaseMBID {
+		j.status.ReleaseMBID.Fetching--
+		j.status.ReleaseMBID.Left--
+		if fetchedReleaseMBID {
+			j.status.ReleaseMBID.Fetched++
 		}
 	}
 }

--- a/server/nativeapi/musicbrainz_metadata_test.go
+++ b/server/nativeapi/musicbrainz_metadata_test.go
@@ -1,6 +1,12 @@
 package nativeapi
 
-import "testing"
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
 
 func TestNormalizeMBString(t *testing.T) {
 	got := normalizeMBString("  AC/DC - Live!  ")
@@ -42,6 +48,39 @@ func TestSelectBestRecording(t *testing.T) {
 	}
 }
 
+func TestSelectBestRecordingReleasePrefersCover(t *testing.T) {
+	job := newMusicBrainzMetadataJob()
+	job.coverClient = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if strings.Contains(r.URL.Path, "rel-no-cover") {
+			return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("")), Header: make(http.Header)}, nil
+		}
+		if strings.Contains(r.URL.Path, "rel-cover") {
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("")), Header: make(http.Header)}, nil
+		}
+		return &http.Response{StatusCode: http.StatusInternalServerError, Body: io.NopCloser(strings.NewReader("")), Header: make(http.Header)}, nil
+	})}
+
+	recordings := []mbRecording{{
+		ID:    "rec-1",
+		Score: "99",
+		ArtistCredit: []struct {
+			Name string `json:"name"`
+		}{{Name: "Artist"}},
+		Releases: []mbRelease{
+			{ID: "rel-no-cover", Title: "No Cover", Date: "1999-01-01", Status: "Official", Country: "US", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
+			{ID: "rel-cover", Title: "Has Cover", Date: "2005-01-01", Status: "Official", Country: "GB", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
+		},
+	}}
+
+	best := job.selectBestRecordingRelease(context.Background(), filterCandidateRecordings(recordings, "Artist"))
+	if best == nil {
+		t.Fatal("expected release candidate")
+	}
+	if best.release.ID != "rel-cover" {
+		t.Fatalf("expected rel-cover, got %q", best.release.ID)
+	}
+}
+
 func TestSelectBestRelease(t *testing.T) {
 	releases := []mbRelease{
 		{Title: "Live Cut", Date: "1990", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album", SecondaryType: []string{"Live"}}},
@@ -56,4 +95,10 @@ func TestSelectBestRelease(t *testing.T) {
 	if rel.Title != "US Album Cut" {
 		t.Fatalf("expected US Album Cut, got %q", rel.Title)
 	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
 }

--- a/server/nativeapi/musicbrainz_metadata_test.go
+++ b/server/nativeapi/musicbrainz_metadata_test.go
@@ -10,50 +10,20 @@ func TestNormalizeMBString(t *testing.T) {
 }
 
 func TestSelectBestRecording(t *testing.T) {
-	payload := mbSearchResponse{Recordings: []struct {
-		Score            mbScore `json:"score"`
-		FirstReleaseDate string  `json:"first-release-date"`
-		ArtistCredit     []struct {
-			Name string `json:"name"`
-		} `json:"artist-credit"`
-		Releases []struct {
-			Title        string   `json:"title"`
-			Date         string   `json:"date"`
-			Status       string   `json:"status"`
-			ReleaseGroup mbGroup  `json:"release-group"`
-			Tags         []mbName `json:"tags"`
-			Genres       []mbName `json:"genres"`
-		} `json:"releases"`
-		Tags   []mbName `json:"tags"`
-		Genres []mbName `json:"genres"`
-	}{
+	payload := mbSearchResponse{Recordings: []mbRecording{
 		{
 			Score: "95",
 			ArtistCredit: []struct {
 				Name string `json:"name"`
 			}{{Name: "Wrong Artist"}},
-			Releases: []struct {
-				Title        string   `json:"title"`
-				Date         string   `json:"date"`
-				Status       string   `json:"status"`
-				ReleaseGroup mbGroup  `json:"release-group"`
-				Tags         []mbName `json:"tags"`
-				Genres       []mbName `json:"genres"`
-			}{{Title: "Wrong Album", Date: "2010-01-01", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}},
+			Releases: []mbRelease{{Title: "Wrong Album", Date: "2010-01-01", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}},
 		},
 		{
 			Score: "92",
 			ArtistCredit: []struct {
 				Name string `json:"name"`
 			}{{Name: "The Artist"}},
-			Releases: []struct {
-				Title        string   `json:"title"`
-				Date         string   `json:"date"`
-				Status       string   `json:"status"`
-				ReleaseGroup mbGroup  `json:"release-group"`
-				Tags         []mbName `json:"tags"`
-				Genres       []mbName `json:"genres"`
-			}{{Title: "Best Album", Date: "2001-01-01", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}},
+			Releases: []mbRelease{{Title: "Best Album", Date: "2001-01-01", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}},
 		},
 		{
 			Score: "79",
@@ -73,24 +43,17 @@ func TestSelectBestRecording(t *testing.T) {
 }
 
 func TestSelectBestRelease(t *testing.T) {
-	releases := []struct {
-		Title        string   `json:"title"`
-		Date         string   `json:"date"`
-		Status       string   `json:"status"`
-		ReleaseGroup mbGroup  `json:"release-group"`
-		Tags         []mbName `json:"tags"`
-		Genres       []mbName `json:"genres"`
-	}{
+	releases := []mbRelease{
 		{Title: "Live Cut", Date: "1990", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album", SecondaryType: []string{"Live"}}},
-		{Title: "Single Cut", Date: "2003", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Single"}},
-		{Title: "Album Cut", Date: "2001", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
+		{Title: "US Album Cut", Date: "2001", Country: "US", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
+		{Title: "Album Cut", Date: "2001", Country: "GB", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
 	}
 
 	rel := selectBestRelease(releases)
 	if rel == nil {
 		t.Fatal("expected release")
 	}
-	if rel.Title != "Album Cut" {
-		t.Fatalf("expected Album Cut, got %q", rel.Title)
+	if rel.Title != "US Album Cut" {
+		t.Fatalf("expected US Album Cut, got %q", rel.Title)
 	}
 }

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -241,22 +241,36 @@ func (n *Router) populateSongArtwork(r *http.Request, song *model.MediaFile) {
 		return
 	}
 
-	coverArtID := song.CoverArtID().String()
-	song.ArtworkID = coverArtID
-
-	if coverArtID == "" {
+	if strings.TrimSpace(song.ArtworkID) != "" || strings.TrimSpace(song.ArtworkURL) != "" || song.HasCoverArt {
+		coverArtID := strings.TrimSpace(song.ArtworkID)
+		if coverArtID == "" {
+			coverArtID = song.CoverArtID().String()
+		}
+		song.ArtworkID = coverArtID
+		coverArtURL := strings.TrimSpace(song.ArtworkURL)
+		if coverArtURL == "" && coverArtID != "" {
+			coverArtURL = public.ImageURL(r, song.CoverArtID(), coverArtDefaultSize)
+		}
+		if coverArtURL != "" {
+			if strings.Contains(coverArtURL, "?") {
+				coverArtURL += "&square=true"
+			} else {
+				coverArtURL += "?square=true"
+			}
+		}
+		song.ArtworkURL = coverArtURL
+		song.CoverArtURL = coverArtURL
 		return
 	}
 
-	coverArtURL := public.ImageURL(r, song.CoverArtID(), coverArtDefaultSize)
-	if coverArtURL != "" {
-		if strings.Contains(coverArtURL, "?") {
-			coverArtURL += "&square=true"
-		} else {
-			coverArtURL += "?square=true"
-		}
+	if strings.TrimSpace(song.MbzReleaseID) != "" {
+		coverArtURL := "https://coverartarchive.org/release/" + strings.TrimSpace(song.MbzReleaseID) + "/front-250"
+		song.ArtworkURL = coverArtURL
+		song.CoverArtURL = coverArtURL
+		return
 	}
-	song.ArtworkURL = coverArtURL
+
+	song.CoverArtURL = ""
 }
 
 func (n *Router) addSongRoute(r chi.Router) {

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -7,8 +7,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/deluan/rest"
@@ -27,7 +31,19 @@ import (
 
 const (
 	coverArtDefaultSize = consts.UICoverArtSize
+	coverCacheDirName   = "covercache"
 )
+
+var releaseMBIDRegex = regexp.MustCompile(`^[a-fA-F0-9-]+$`)
+
+var defaultCoverPlaceholder = []byte{
+	0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+	0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+	0x08, 0x04, 0x00, 0x00, 0x00, 0xB5, 0x1C, 0x0C, 0x02, 0x00, 0x00, 0x00,
+	0x0B, 0x49, 0x44, 0x41, 0x54, 0x78, 0xDA, 0x63, 0xFC, 0xFF, 0x1F, 0x00,
+	0x03, 0x03, 0x02, 0x00, 0xEF, 0x26, 0x05, 0x9B, 0x00, 0x00, 0x00, 0x00,
+	0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+}
 
 type Router struct {
 	http.Handler
@@ -38,6 +54,8 @@ type Router struct {
 	libs        core.Library
 	devices     *retailPlayerDeviceResolver
 	metadataJob *musicBrainzMetadataJob
+	coverClient *http.Client
+	coverMisses sync.Map
 }
 
 func New(ds model.DataStore, share core.Share, playlists core.Playlists, insights metrics.Insights, libraryService core.Library) *Router {
@@ -49,7 +67,9 @@ func New(ds model.DataStore, share core.Share, playlists core.Playlists, insight
 		libs:        libraryService,
 		devices:     newRetailPlayerDeviceResolver(),
 		metadataJob: newMusicBrainzMetadataJob(),
+		coverClient: &http.Client{Timeout: 10 * time.Second},
 	}
+	r.ensureCoverCacheDir()
 	r.preloadRetailPlayerDeviceMappings()
 	r.Handler = r.routes()
 	return r
@@ -101,6 +121,7 @@ func (n *Router) routes() http.Handler {
 
 	// Public
 	n.addRetailPlayerPublicRoutes(r)
+	n.addCoverRoute(r)
 	n.addSongRoute(r)
 	n.RX(r, "/translation", newTranslationRepository, false)
 
@@ -170,6 +191,44 @@ func (n *Router) RX(r chi.Router, pathPrefix string, constructor rest.Repository
 			}
 		})
 	})
+}
+
+func (n *Router) coverCacheDir() string {
+	return filepath.Join(conf.Server.DataFolder, coverCacheDirName)
+}
+
+func (n *Router) ensureCoverCacheDir() {
+	if err := os.MkdirAll(n.coverCacheDir(), 0o755); err != nil {
+		log.Error(context.Background(), "Could not create cover cache directory", "dir", n.coverCacheDir(), "err", err)
+	}
+}
+
+func (n *Router) coverFilePath(releaseMBID string) string {
+	return filepath.Join(n.coverCacheDir(), releaseMBID+".jpg")
+}
+
+func (n *Router) addCoverRoute(r chi.Router) {
+	r.Get("/cover/{releaseMBID}", func(w http.ResponseWriter, req *http.Request) {
+		releaseMBID := strings.TrimSpace(chi.URLParam(req, "releaseMBID"))
+		if releaseMBID == "" || !releaseMBIDRegex.MatchString(releaseMBID) {
+			n.writeDefaultCover(w)
+			return
+		}
+
+		filePath := n.coverFilePath(releaseMBID)
+		if _, err := os.Stat(filePath); err == nil {
+			http.ServeFile(w, req, filePath)
+			return
+		}
+
+		n.writeDefaultCover(w)
+	})
+}
+
+func (n *Router) writeDefaultCover(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "image/png")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	_, _ = w.Write(defaultCoverPlaceholder)
 }
 
 func (n *Router) withSongArtwork(handler http.HandlerFunc) http.HandlerFunc {
@@ -264,13 +323,86 @@ func (n *Router) populateSongArtwork(r *http.Request, song *model.MediaFile) {
 	}
 
 	if strings.TrimSpace(song.MbzReleaseID) != "" {
-		coverArtURL := "https://coverartarchive.org/release/" + strings.TrimSpace(song.MbzReleaseID) + "/front-250"
-		song.ArtworkURL = coverArtURL
-		song.CoverArtURL = coverArtURL
+		releaseMBID := strings.TrimSpace(song.MbzReleaseID)
+		if releaseMBIDRegex.MatchString(releaseMBID) {
+			if strings.TrimSpace(song.CoverPath) == "" {
+				if _, err := os.Stat(n.coverFilePath(releaseMBID)); err == nil {
+					coverPath := filepath.ToSlash(filepath.Join(coverCacheDirName, releaseMBID+".jpg"))
+					song.CoverPath = coverPath
+					if err := n.ds.MediaFile(r.Context()).UpdateCoverPath(song.ID, coverPath); err != nil {
+						log.Warn(r.Context(), "Could not persist cover path", "songId", song.ID, "releaseMBID", releaseMBID, "err", err)
+					}
+				} else if _, attempted := n.coverMisses.Load(releaseMBID); !attempted {
+					downloaded, notFound := n.downloadReleaseCover(r.Context(), releaseMBID)
+					if downloaded {
+						coverPath := filepath.ToSlash(filepath.Join(coverCacheDirName, releaseMBID+".jpg"))
+						song.CoverPath = coverPath
+						if err := n.ds.MediaFile(r.Context()).UpdateCoverPath(song.ID, coverPath); err != nil {
+							log.Warn(r.Context(), "Could not persist downloaded cover path", "songId", song.ID, "releaseMBID", releaseMBID, "err", err)
+						}
+					}
+					if notFound {
+						n.coverMisses.Store(releaseMBID, true)
+					}
+				}
+			}
+			song.CoverArtURL = "/api/cover/" + releaseMBID
+			song.ArtworkURL = song.CoverArtURL
+		}
 		return
 	}
 
 	song.CoverArtURL = ""
+}
+
+func (n *Router) downloadReleaseCover(ctx context.Context, releaseMBID string) (downloaded bool, notFound bool) {
+	url := "https://coverartarchive.org/release/" + releaseMBID + "/front-500"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		log.Warn(ctx, "Could not build cover download request", "releaseMBID", releaseMBID, "err", err)
+		return false, false
+	}
+
+	resp, err := n.coverClient.Do(req)
+	if err != nil {
+		log.Warn(ctx, "Could not download release cover", "releaseMBID", releaseMBID, "err", err)
+		return false, false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return false, true
+	}
+	if resp.StatusCode != http.StatusOK {
+		log.Warn(ctx, "Unexpected cover download status", "releaseMBID", releaseMBID, "status", resp.StatusCode)
+		return false, false
+	}
+
+	coverPath := n.coverFilePath(releaseMBID)
+	tmpPath := coverPath + ".tmp"
+	file, err := os.Create(tmpPath)
+	if err != nil {
+		log.Warn(ctx, "Could not create temporary cover file", "path", tmpPath, "err", err)
+		return false, false
+	}
+	if _, err := io.Copy(file, resp.Body); err != nil {
+		_ = file.Close()
+		_ = os.Remove(tmpPath)
+		log.Warn(ctx, "Could not write cover file", "path", tmpPath, "err", err)
+		return false, false
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		log.Warn(ctx, "Could not close temporary cover file", "path", tmpPath, "err", err)
+		return false, false
+	}
+	if err := os.Rename(tmpPath, coverPath); err != nil {
+		_ = os.Remove(tmpPath)
+		log.Warn(ctx, "Could not move cover file into cache", "path", coverPath, "err", err)
+		return false, false
+	}
+
+	return true, false
 }
 
 func (n *Router) addSongRoute(r chi.Router) {

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/deluan/rest"
@@ -54,8 +53,6 @@ type Router struct {
 	libs        core.Library
 	devices     *retailPlayerDeviceResolver
 	metadataJob *musicBrainzMetadataJob
-	coverClient *http.Client
-	coverMisses sync.Map
 }
 
 func New(ds model.DataStore, share core.Share, playlists core.Playlists, insights metrics.Insights, libraryService core.Library) *Router {
@@ -67,7 +64,6 @@ func New(ds model.DataStore, share core.Share, playlists core.Playlists, insight
 		libs:        libraryService,
 		devices:     newRetailPlayerDeviceResolver(),
 		metadataJob: newMusicBrainzMetadataJob(),
-		coverClient: &http.Client{Timeout: 10 * time.Second},
 	}
 	r.ensureCoverCacheDir()
 	r.preloadRetailPlayerDeviceMappings()
@@ -322,87 +318,13 @@ func (n *Router) populateSongArtwork(r *http.Request, song *model.MediaFile) {
 		return
 	}
 
-	if strings.TrimSpace(song.MbzReleaseID) != "" {
-		releaseMBID := strings.TrimSpace(song.MbzReleaseID)
-		if releaseMBIDRegex.MatchString(releaseMBID) {
-			if strings.TrimSpace(song.CoverPath) == "" {
-				if _, err := os.Stat(n.coverFilePath(releaseMBID)); err == nil {
-					coverPath := filepath.ToSlash(filepath.Join(coverCacheDirName, releaseMBID+".jpg"))
-					song.CoverPath = coverPath
-					if err := n.ds.MediaFile(r.Context()).UpdateCoverPath(song.ID, coverPath); err != nil {
-						log.Warn(r.Context(), "Could not persist cover path", "songId", song.ID, "releaseMBID", releaseMBID, "err", err)
-					}
-				} else if _, attempted := n.coverMisses.Load(releaseMBID); !attempted {
-					downloaded, notFound := n.downloadReleaseCover(r.Context(), releaseMBID)
-					if downloaded {
-						coverPath := filepath.ToSlash(filepath.Join(coverCacheDirName, releaseMBID+".jpg"))
-						song.CoverPath = coverPath
-						if err := n.ds.MediaFile(r.Context()).UpdateCoverPath(song.ID, coverPath); err != nil {
-							log.Warn(r.Context(), "Could not persist downloaded cover path", "songId", song.ID, "releaseMBID", releaseMBID, "err", err)
-						}
-					}
-					if notFound {
-						n.coverMisses.Store(releaseMBID, true)
-					}
-				}
-			}
-			song.CoverArtURL = "/api/cover/" + releaseMBID
-			song.ArtworkURL = song.CoverArtURL
-		}
+	if releaseMBID := strings.TrimSpace(song.MbzReleaseID); releaseMBID != "" && releaseMBIDRegex.MatchString(releaseMBID) {
+		song.CoverArtURL = "/api/cover/" + releaseMBID
+		song.ArtworkURL = song.CoverArtURL
 		return
 	}
 
 	song.CoverArtURL = ""
-}
-
-func (n *Router) downloadReleaseCover(ctx context.Context, releaseMBID string) (downloaded bool, notFound bool) {
-	url := "https://coverartarchive.org/release/" + releaseMBID + "/front-500"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		log.Warn(ctx, "Could not build cover download request", "releaseMBID", releaseMBID, "err", err)
-		return false, false
-	}
-
-	resp, err := n.coverClient.Do(req)
-	if err != nil {
-		log.Warn(ctx, "Could not download release cover", "releaseMBID", releaseMBID, "err", err)
-		return false, false
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return false, true
-	}
-	if resp.StatusCode != http.StatusOK {
-		log.Warn(ctx, "Unexpected cover download status", "releaseMBID", releaseMBID, "status", resp.StatusCode)
-		return false, false
-	}
-
-	coverPath := n.coverFilePath(releaseMBID)
-	tmpPath := coverPath + ".tmp"
-	file, err := os.Create(tmpPath)
-	if err != nil {
-		log.Warn(ctx, "Could not create temporary cover file", "path", tmpPath, "err", err)
-		return false, false
-	}
-	if _, err := io.Copy(file, resp.Body); err != nil {
-		_ = file.Close()
-		_ = os.Remove(tmpPath)
-		log.Warn(ctx, "Could not write cover file", "path", tmpPath, "err", err)
-		return false, false
-	}
-	if err := file.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-		log.Warn(ctx, "Could not close temporary cover file", "path", tmpPath, "err", err)
-		return false, false
-	}
-	if err := os.Rename(tmpPath, coverPath); err != nil {
-		_ = os.Remove(tmpPath)
-		log.Warn(ctx, "Could not move cover file into cache", "path", coverPath, "err", err)
-		return false, false
-	}
-
-	return true, false
 }
 
 func (n *Router) addSongRoute(r chi.Router) {

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -212,6 +212,7 @@ func (n *Router) addCoverRoute(r chi.Router) {
 		}
 
 		filePath := n.coverFilePath(releaseMBID)
+		w.Header().Set("Cache-Control", "public, max-age=86400, stale-while-revalidate=604800")
 		if _, err := os.Stat(filePath); err == nil {
 			http.ServeFile(w, req, filePath)
 			return

--- a/tests/mock_mediafile_repo.go
+++ b/tests/mock_mediafile_repo.go
@@ -132,6 +132,18 @@ func (m *MockMediaFileRepo) UpdateComment(ids []string, comment string) error {
 	return nil
 }
 
+func (m *MockMediaFileRepo) UpdateCoverPath(id string, coverPath string) error {
+	if m.Err {
+		return errors.New("error")
+	}
+	if mf, ok := m.Data[id]; ok {
+		if mf.CoverPath == "" {
+			mf.CoverPath = coverPath
+		}
+	}
+	return nil
+}
+
 func (m *MockMediaFileRepo) IncPlayCount(id string, timestamp time.Time) error {
 	if m.Err {
 		return errors.New("error")

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -72,6 +72,7 @@ const CovertartListActions = () => {
     genre: emptyProgress,
     recordingMbid: emptyProgress,
     releaseMbid: emptyProgress,
+    coverArt: emptyProgress,
   })
 
   const loadStatus = useCallback(() => {
@@ -88,6 +89,7 @@ const CovertartListActions = () => {
             genre: emptyProgress,
             recordingMbid: emptyProgress,
             releaseMbid: emptyProgress,
+            coverArt: emptyProgress,
           },
         )
       })
@@ -171,6 +173,13 @@ const CovertartListActions = () => {
               <MetadataProgressCard
                 title="Release MBID"
                 progress={status.releaseMbid || emptyProgress}
+                translate={translate}
+              />
+            </Grid>
+            <Grid item xs={12} md={2}>
+              <MetadataProgressCard
+                title="Cover Art"
+                progress={status.coverArt || emptyProgress}
                 translate={translate}
               />
             </Grid>

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -15,7 +15,6 @@ import { Box, Button, Card, CardContent, Grid, Typography } from '@material-ui/c
 import { makeStyles } from '@material-ui/core/styles'
 import { BiDownload } from 'react-icons/bi'
 import { DurationField } from '../common'
-import subsonic from '../subsonic'
 import { httpClient } from '../dataProvider'
 
 const useStyles = makeStyles({
@@ -201,10 +200,13 @@ const CovertartList = (props) => {
           sortable={false}
           render={(record) => (
             <img
-              src={subsonic.getCoverArtUrl(record, 64, true)}
+              src={record?.cover_art_url || '/default-cover.png'}
               alt={record.title || 'cover art'}
-              width="64"
-              height="64"
+              width="50"
+              height="50"
+              onError={(e) => {
+                e.currentTarget.src = '/default-cover.png'
+              }}
             />
           )}
         />

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -200,7 +200,7 @@ const CovertartList = (props) => {
           sortable={false}
           render={(record) => (
             <img
-              src={record?.cover_art_url || '/default-cover.png'}
+              src={record?.mbzReleaseId ? `/api/cover/${record.mbzReleaseId}` : '/default-cover.png'}
               alt={record.title || 'cover art'}
               width="50"
               height="50"

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -207,17 +207,21 @@ const CovertartList = (props) => {
         <FunctionField
           label="Cover Art"
           sortable={false}
-          render={(record) => (
-            <img
-              src={record?.mbzReleaseId ? `/api/cover/${record.mbzReleaseId}` : '/default-cover.png'}
-              alt={record.title || 'cover art'}
-              width="50"
-              height="50"
-              onError={(e) => {
-                e.currentTarget.src = '/default-cover.png'
-              }}
-            />
-          )}
+          render={(record) => {
+            const coverSrc = record?.mbzReleaseId
+              ? `/api/cover/${record.mbzReleaseId}`
+              : '/default-cover.png'
+
+            return (
+              <img
+                src={coverSrc}
+                alt={record.title || 'cover art'}
+                width="50"
+                height="50"
+                loading="lazy"
+              />
+            )
+          }}
         />
         <TextField source="title" />
         <TextField source="artist" label="Artist" />

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -12,10 +12,18 @@ import {
   useTranslate,
 } from 'react-admin'
 import { Box, Button, Card, CardContent, Grid, Typography } from '@material-ui/core'
+import { makeStyles } from '@material-ui/core/styles'
 import { BiDownload } from 'react-icons/bi'
 import { DurationField } from '../common'
 import subsonic from '../subsonic'
 import { httpClient } from '../dataProvider'
+
+const useStyles = makeStyles({
+  mbidText: {
+    fontFamily: 'monospace',
+    fontSize: '0.75rem',
+  },
+})
 
 const CovertartFilter = (props) => (
   <Filter {...props} variant={'outlined'}>
@@ -63,6 +71,8 @@ const CovertartListActions = () => {
     album: emptyProgress,
     year: emptyProgress,
     genre: emptyProgress,
+    recordingMbid: emptyProgress,
+    releaseMbid: emptyProgress,
   })
 
   const loadStatus = useCallback(() => {
@@ -77,6 +87,8 @@ const CovertartListActions = () => {
             album: emptyProgress,
             year: emptyProgress,
             genre: emptyProgress,
+            recordingMbid: emptyProgress,
+            releaseMbid: emptyProgress,
           },
         )
       })
@@ -128,24 +140,38 @@ const CovertartListActions = () => {
             {translate('activity.musicbrainz.title')}
           </Typography>
           <Grid container spacing={2}>
-            <Grid item xs={12} md={4}>
+            <Grid item xs={12} md={3}>
               <MetadataProgressCard
                 title={translate('activity.musicbrainz.album')}
                 progress={status.album || emptyProgress}
                 translate={translate}
               />
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid item xs={12} md={3}>
               <MetadataProgressCard
                 title={translate('activity.musicbrainz.year')}
                 progress={status.year || emptyProgress}
                 translate={translate}
               />
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid item xs={12} md={2}>
               <MetadataProgressCard
                 title={translate('activity.musicbrainz.genre')}
                 progress={status.genre || emptyProgress}
+                translate={translate}
+              />
+            </Grid>
+            <Grid item xs={12} md={2}>
+              <MetadataProgressCard
+                title="Recording MBID"
+                progress={status.recordingMbid || emptyProgress}
+                translate={translate}
+              />
+            </Grid>
+            <Grid item xs={12} md={2}>
+              <MetadataProgressCard
+                title="Release MBID"
+                progress={status.releaseMbid || emptyProgress}
                 translate={translate}
               />
             </Grid>
@@ -156,37 +182,55 @@ const CovertartListActions = () => {
   )
 }
 
-const CovertartList = (props) => (
-  <List
-    {...props}
-    sort={{ field: 'title', order: 'ASC' }}
-    filters={<CovertartFilter />}
-    exporter={false}
-    bulkActionButtons={false}
-    perPage={50}
-    actions={<CovertartListActions />}
-  >
-    <Datagrid rowClick={false}>
-      <FunctionField
-        label="Cover Art"
-        sortable={false}
-        render={(record) => (
-          <img
-            src={subsonic.getCoverArtUrl(record, 64, true)}
-            alt={record.title || 'cover art'}
-            width="64"
-            height="64"
-          />
-        )}
-      />
-      <TextField source="title" />
-      <TextField source="artist" label="Artist" />
-      <TextField source="album" label="Album" />
-      <TextField source="year" label="Release Year" />
-      <TextField source="genre" label="Genre" />
-      <DurationField source="duration" />
-    </Datagrid>
-  </List>
-)
+const CovertartList = (props) => {
+  const classes = useStyles()
+
+  return (
+    <List
+      {...props}
+      sort={{ field: 'title', order: 'ASC' }}
+      filters={<CovertartFilter />}
+      exporter={false}
+      bulkActionButtons={false}
+      perPage={50}
+      actions={<CovertartListActions />}
+    >
+      <Datagrid rowClick={false}>
+        <FunctionField
+          label="Cover Art"
+          sortable={false}
+          render={(record) => (
+            <img
+              src={subsonic.getCoverArtUrl(record, 64, true)}
+              alt={record.title || 'cover art'}
+              width="64"
+              height="64"
+            />
+          )}
+        />
+        <TextField source="title" />
+        <TextField source="artist" label="Artist" />
+        <TextField source="album" label="Album" />
+        <TextField source="year" label="Release Year" />
+        <TextField source="genre" label="Genre" />
+        <FunctionField
+          label="Recording MBID"
+          sortable={false}
+          render={(record) => (
+            <span className={classes.mbidText}>{record?.mbzRecordingID || ''}</span>
+          )}
+        />
+        <FunctionField
+          label="Release MBID"
+          sortable={false}
+          render={(record) => (
+            <span className={classes.mbidText}>{record?.mbzReleaseId || ''}</span>
+          )}
+        />
+        <DurationField source="duration" />
+      </Datagrid>
+    </List>
+  )
+}
 
 export default CovertartList

--- a/ui/src/song/ReorderableSongList.jsx
+++ b/ui/src/song/ReorderableSongList.jsx
@@ -70,10 +70,6 @@ const useStyles = makeStyles({
     margin: 0,
     height: '24px',
   },
-  debugMbid: {
-    fontFamily: 'monospace',
-    fontSize: '0.75rem',
-  },
 })
 
 const DEFAULT_OFF_COLUMNS = [
@@ -316,16 +312,6 @@ const ReorderableSongList = (props) => {
         />
       ) : null,
       comment: <TextField source="comment" sortBy="comment" />,
-      releaseMbid: (
-        <FunctionField
-          source="mbzReleaseId"
-          sortable={false}
-          label="Release MBID"
-          render={(record) => (
-            <span className={classes.debugMbid}>{record?.mbzReleaseId || ''}</span>
-          )}
-        />
-      ),
       path: <PathField source="path" />,
       createdAt: <DateField source="createdAt" sortBy="recently_added" showTime />,
     }

--- a/ui/src/song/ReorderableSongList.jsx
+++ b/ui/src/song/ReorderableSongList.jsx
@@ -70,6 +70,10 @@ const useStyles = makeStyles({
     margin: 0,
     height: '24px',
   },
+  debugMbid: {
+    fontFamily: 'monospace',
+    fontSize: '0.75rem',
+  },
 })
 
 const DEFAULT_OFF_COLUMNS = [
@@ -312,6 +316,16 @@ const ReorderableSongList = (props) => {
         />
       ) : null,
       comment: <TextField source="comment" sortBy="comment" />,
+      releaseMbid: (
+        <FunctionField
+          source="mbzReleaseId"
+          sortable={false}
+          label="Release MBID"
+          render={(record) => (
+            <span className={classes.debugMbid}>{record?.mbzReleaseId || ''}</span>
+          )}
+        />
+      ),
       path: <PathField source="path" />,
       createdAt: <DateField source="createdAt" sortBy="recently_added" showTime />,
     }


### PR DESCRIPTION
### Motivation
- Improve MusicBrainz metadata lookup to retrieve and persist the correct release MBID (and recording MBID) so album identification is accurate. 
- Prefer Official album releases while avoiding compilation/live secondary types and pick the earliest (and optionally US) release when multiple matches exist. 
- Expose the release MBID in the UI temporarily for debugging and add DB migration to safely persist the new field for existing installs.

### Description
- Update MusicBrainz request to include releases and release-groups (`inc=releases+release-groups`) and ensure a proper `User-Agent` header is set. 
- Parse recording and release IDs and return a new structured `metadataResult` containing `Album`, `Year`, `Genre`, `RecordingMBID`, and `ReleaseMBID` from `fetchMetadata()`. 
- Improve release selection: prefer `status == "Official"`, `primary-type == "Album"`, avoid `Compilation`/`Live` secondary types when possible, prefer earliest release date, and prefer `country == US` on ties. 
- Extend `MediaFile` model with `MbzReleaseID` and update `MediaFileRepository.UpdateMissingMetadata()` signature to accept optional `mbzRecordingID` and `mbzReleaseID`, writing these to the DB only when empty to preserve existing data. 
- Add a safe migration (`db/migrations/20260221010101_add_musicbrainz_release_id.go`) that adds `media_file.mbz_release_id` only if it does not already exist. 
- Add a temporary UI debug column in the Songs table labeled `Release MBID`, showing `song.mbzReleaseId` in small monospace font without removing existing columns. 
- Minor test adjustments to use the new structs and selection logic in `server/nativeapi/musicbrainz_metadata_test.go`.

### Testing
- Ran `gofmt` on modified files (succeeded). 
- Attempted `go test ./server/nativeapi ./persistence`, which could not complete because the build environment is missing native dependencies (`taglib` via pkg-config and some sqlite cgo symbols), so package build/tests failed in this environment. 
- Attempted `CGO_ENABLED=0 go test ./server/nativeapi` which also failed due to missing cgo-backed symbols/dependencies in this environment. 
- Attempted a Playwright UI snapshot of the local UI, but no UI service was reachable at the expected port (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ffa3aec88322950bd0c2af97c7c4)