### PR TITLE
Prefer MusicBrainz releases with cover art

### DIFF
--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -532,29 +532,65 @@ func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (metadataRe
 		return metadataResult{}, nil
 	}
 
-	bestRecording := selectBestRecording(payload.Recordings, artist)
-	if bestRecording == nil {
+	bestCandidates := collectReleaseCandidates(payload.Recordings, artist)
+	if len(bestCandidates) == 0 {
 		return metadataResult{}, nil
 	}
 
-	bestRelease := selectBestRelease(bestRecording.Releases)
-	if bestRelease == nil {
-		return metadataResult{Genre: collectRecordingGenre(*bestRecording), RecordingMBID: strings.TrimSpace(bestRecording.ID)}, nil
+	coverCache := make(map[string]bool, len(bestCandidates))
+	best := selectBestReleaseCandidate(bestCandidates, func(releaseID string) bool {
+		return j.releaseHasCover(releaseID, coverCache)
+	})
+	if best == nil {
+		return metadataResult{}, nil
 	}
 
-	album := strings.TrimSpace(bestRelease.Title)
-	year := yearFromDate(bestRelease.Date)
+	album := strings.TrimSpace(best.release.Title)
+	year := yearFromDate(best.release.Date)
 	if year == 0 {
-		year = yearFromDate(bestRecording.FirstReleaseDate)
+		year = yearFromDate(best.recording.FirstReleaseDate)
 	}
-	genre := collectGenre(*bestRecording, *bestRelease)
+	genre := collectGenre(*best.recording, *best.release)
 	return metadataResult{
 		Album:         album,
 		Year:          year,
 		Genre:         genre,
-		RecordingMBID: strings.TrimSpace(bestRecording.ID),
-		ReleaseMBID:   strings.TrimSpace(bestRelease.ID),
+		RecordingMBID: strings.TrimSpace(best.recording.ID),
+		ReleaseMBID:   strings.TrimSpace(best.release.ID),
 	}, nil
+}
+
+func (j *musicBrainzMetadataJob) releaseHasCover(releaseID string, cache map[string]bool) bool {
+	releaseID = strings.TrimSpace(releaseID)
+	if releaseID == "" {
+		return false
+	}
+	if cached, ok := cache[releaseID]; ok {
+		return cached
+	}
+
+	u := "https://coverartarchive.org/release/" + url.PathEscape(releaseID)
+	req, err := http.NewRequest(http.MethodHead, u, nil)
+	if err != nil {
+		cache[releaseID] = false
+		return false
+	}
+	req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	resp, err := j.client.Do(req)
+	if err != nil {
+		cache[releaseID] = false
+		return false
+	}
+	defer resp.Body.Close()
+
+	hasCover := resp.StatusCode == http.StatusOK
+	cache[releaseID] = hasCover
+	return hasCover
 }
 
 func selectBestRecording(recordings []mbRecording, artist string) *mbRecording {
@@ -637,52 +673,69 @@ func artistCreditMatches(credits []struct {
 	return false
 }
 
-func selectBestRelease(releases []mbRelease) *mbRelease {
-	type relCandidate struct {
-		release               *mbRelease
-		official              bool
-		album                 bool
-		hasDiscouragedSubtype bool
-		usCountry             bool
-		year                  int
-	}
+type releaseCandidate struct {
+	recording *mbRecording
+	release   *mbRelease
+}
 
-	candidates := make([]relCandidate, 0, len(releases))
-	for i := range releases {
-		release := &releases[i]
-		if !isValidRelease(*release) {
-			continue
-		}
-		candidates = append(candidates, relCandidate{
-			release:               release,
-			official:              strings.EqualFold(strings.TrimSpace(release.Status), "Official"),
-			album:                 isAlbumRelease(*release),
-			hasDiscouragedSubtype: hasDiscouragedSecondaryType(*release),
-			usCountry:             strings.EqualFold(strings.TrimSpace(release.Country), "US"),
-			year:                  yearFromDate(release.Date),
-		})
-	}
-	if len(candidates) == 0 {
+func collectReleaseCandidates(recordings []mbRecording, artist string) []releaseCandidate {
+	bestRecording := selectBestRecording(recordings, artist)
+	if bestRecording == nil {
 		return nil
 	}
 
-	slices.SortFunc(candidates, func(a, b relCandidate) int {
-		if a.official && !b.official {
+	matches := make([]releaseCandidate, 0, len(bestRecording.Releases))
+	fallback := make([]releaseCandidate, 0, len(bestRecording.Releases))
+	for i := range bestRecording.Releases {
+		release := &bestRecording.Releases[i]
+		if !isValidRelease(*release) {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(release.Status), "Official") {
+			continue
+		}
+
+		candidate := releaseCandidate{recording: bestRecording, release: release}
+		fallback = append(fallback, candidate)
+		if isAlbumRelease(*release) && !hasDiscouragedSecondaryType(*release) {
+			matches = append(matches, candidate)
+		}
+	}
+
+	if len(matches) > 0 {
+		return matches
+	}
+	return fallback
+}
+
+func selectBestReleaseCandidate(candidates []releaseCandidate, hasCover func(releaseID string) bool) *releaseCandidate {
+	type relCandidate struct {
+		candidate *releaseCandidate
+		hasCover  bool
+		usCountry bool
+		year      int
+	}
+
+	sortedCandidates := make([]relCandidate, 0, len(candidates))
+	for i := range candidates {
+		candidate := &candidates[i]
+		releaseID := strings.TrimSpace(candidate.release.ID)
+		sortedCandidates = append(sortedCandidates, relCandidate{
+			candidate: candidate,
+			hasCover:  hasCover(releaseID),
+			usCountry: strings.EqualFold(strings.TrimSpace(candidate.release.Country), "US"),
+			year:      yearFromDate(candidate.release.Date),
+		})
+	}
+	if len(sortedCandidates) == 0 {
+		return nil
+	}
+
+	slices.SortFunc(sortedCandidates, func(a, b relCandidate) int {
+		if a.hasCover && !b.hasCover {
 			return -1
 		}
-		if !a.official && b.official {
-			return 1
-		}
-		if a.album && !b.album {
-			return -1
-		}
-		if !a.album && b.album {
-			return 1
-		}
-		if !a.hasDiscouragedSubtype && b.hasDiscouragedSubtype {
-			return -1
-		}
-		if a.hasDiscouragedSubtype && !b.hasDiscouragedSubtype {
+		if !a.hasCover && b.hasCover {
 			return 1
 		}
 		if a.year == 0 && b.year > 0 {
@@ -703,7 +756,7 @@ func selectBestRelease(releases []mbRelease) *mbRelease {
 		return 0
 	})
 
-	return candidates[0].release
+	return sortedCandidates[0].candidate
 }
 
 func isValidRelease(release mbRelease) bool {

--- a/server/nativeapi/musicbrainz_metadata_test.go
+++ b/server/nativeapi/musicbrainz_metadata_test.go
@@ -42,18 +42,73 @@ func TestSelectBestRecording(t *testing.T) {
 	}
 }
 
-func TestSelectBestRelease(t *testing.T) {
-	releases := []mbRelease{
-		{Title: "Live Cut", Date: "1990", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album", SecondaryType: []string{"Live"}}},
-		{Title: "US Album Cut", Date: "2001", Country: "US", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
-		{Title: "Album Cut", Date: "2001", Country: "GB", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
+func TestCollectReleaseCandidates(t *testing.T) {
+	recordings := []mbRecording{{
+		Score: "95",
+		ArtistCredit: []struct {
+			Name string `json:"name"`
+		}{{Name: "The Artist"}},
+		Releases: []mbRelease{
+			{ID: "live", Title: "Live Cut", Date: "1990", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album", SecondaryType: []string{"Live"}}},
+			{ID: "comp", Title: "Compilation", Date: "1992", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album", SecondaryType: []string{"Compilation"}}},
+			{ID: "album", Title: "Studio Album", Date: "2001", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
+		},
+	}}
+
+	candidates := collectReleaseCandidates(recordings, "the artist")
+	if len(candidates) != 1 {
+		t.Fatalf("expected 1 preferred candidate, got %d", len(candidates))
+	}
+	if candidates[0].release.ID != "album" {
+		t.Fatalf("expected album candidate, got %q", candidates[0].release.ID)
+	}
+}
+
+func TestCollectReleaseCandidatesFallsBackToOfficial(t *testing.T) {
+	recordings := []mbRecording{{
+		Score: "95",
+		ArtistCredit: []struct {
+			Name string `json:"name"`
+		}{{Name: "The Artist"}},
+		Releases: []mbRelease{
+			{ID: "live", Title: "Live Cut", Date: "1990", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album", SecondaryType: []string{"Live"}}},
+			{ID: "single", Title: "Official Single", Date: "1991", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Single"}},
+		},
+	}}
+
+	candidates := collectReleaseCandidates(recordings, "the artist")
+	if len(candidates) != 2 {
+		t.Fatalf("expected official fallback candidates, got %d", len(candidates))
+	}
+}
+
+func TestSelectBestReleaseCandidatePrefersCover(t *testing.T) {
+	candidates := []releaseCandidate{
+		{release: &mbRelease{ID: "a", Title: "No Cover", Date: "1980", Country: "US"}},
+		{release: &mbRelease{ID: "b", Title: "Has Cover", Date: "2001", Country: "GB"}},
 	}
 
-	rel := selectBestRelease(releases)
+	rel := selectBestReleaseCandidate(candidates, func(releaseID string) bool { return releaseID == "b" })
 	if rel == nil {
 		t.Fatal("expected release")
 	}
-	if rel.Title != "US Album Cut" {
-		t.Fatalf("expected US Album Cut, got %q", rel.Title)
+	if rel.release.ID != "b" {
+		t.Fatalf("expected release with cover, got %q", rel.release.ID)
+	}
+}
+
+func TestSelectBestReleaseCandidatePrefersEarliestThenUS(t *testing.T) {
+	candidates := []releaseCandidate{
+		{release: &mbRelease{ID: "a", Title: "Album A", Date: "2001", Country: "GB"}},
+		{release: &mbRelease{ID: "b", Title: "Album B", Date: "2001", Country: "US"}},
+		{release: &mbRelease{ID: "c", Title: "Album C", Date: "1999", Country: "GB"}},
+	}
+
+	rel := selectBestReleaseCandidate(candidates, func(string) bool { return false })
+	if rel == nil {
+		t.Fatal("expected release")
+	}
+	if rel.release.ID != "c" {
+		t.Fatalf("expected earliest release when no cover exists, got %q", rel.release.ID)
 	}
 }


### PR DESCRIPTION
### Motivation
- Avoid storing releases that lack cover art (which leads to white/blank covers) by preferring releases that actually have cover images in the Cover Art Archive when selecting a MusicBrainz release for a recording.  
- Keep selection constrained to official Album releases (avoid Compilation/Live secondary types) and fall back to any Official release if no preferred Album candidates are available.  

### Description
- Added `collectReleaseCandidates` to gather candidate `release` objects from the best recording by requiring `status == "Official"` and preferring `primary-type == "Album"` while excluding discouraged secondary types like `Compilation` and `Live`, and falling back to any Official release when no preferred albums exist.  
- Implemented `releaseHasCover` which issues a single `HEAD` request to `https://coverartarchive.org/release/{id}` with a 2 second timeout, treats non-200 or errors as no-cover, does not retry, and records the result in an in-memory per-fetch cache to avoid duplicate checks.  
- Added `selectBestReleaseCandidate` which ranks candidates by `HasCover` first, then earliest `Year`, then `Country == "US"` as a tie-breaker, and returns the chosen `recording`+`release` pair; the selected values are persisted exactly as before (`RecordingMBID`, `ReleaseMBID`, `Album`, `Year`, `Genre`).  
- All cover checks run inside the metadata background job using the job's shared HTTP client and do not modify DB schema, existing metadata structs, cover download logic, or API routes.  
- Added/updated unit tests exercising candidate collection, official fallback behavior, and cover-aware sorting (`collectReleaseCandidates` + `selectBestReleaseCandidate`).  

### Testing
- Ran unit test command `go test ./server/nativeapi -run 'Test(CollectReleaseCandidates|SelectBestReleaseCandidate|SelectBestRecording|NormalizeMBString)' -count=1 -timeout 60s`, which could not complete in this environment due to missing system `taglib`/sqlite build dependencies causing unrelated build failures.  
- Also attempted `CGO_ENABLED=0 go test ./server/nativeapi -run 'Test(CollectReleaseCandidates|SelectBestReleaseCandidate|SelectBestRecording|NormalizeMBString)' -count=1`, which likewise could not complete due to environment-level sqlite/taglib build constraints unrelated to the changed logic.  
- The added tests are focused and should pass in CI or a developer environment with the normal build dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a22fe55d48322b823ecf08de6fa0f)