### PR TITLE
MusicBrainz: normalize query input and filter recordings by duration

### DIFF
--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -21,6 +22,7 @@ import (
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
+	"golang.org/x/text/unicode/norm"
 )
 
 type metadataFieldProgress struct {
@@ -136,7 +138,7 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 		}
 		j.setFetching(c.flags, 1)
 
-		metadata, fetchErr := j.fetchMetadata(c.mf.Title, c.mf.Artist)
+		metadata, fetchErr := j.fetchMetadata(c.mf.Title, c.mf.Artist, c.mf.Duration)
 		if fetchErr != nil {
 			failed++
 			log.Warn(ctx, "Could not fetch metadata from MusicBrainz", "songId", c.mf.ID, "title", c.mf.Title, "artist", c.mf.Artist, fetchErr)
@@ -444,6 +446,7 @@ type mbSearchResponse struct {
 type mbRecording struct {
 	ID               string  `json:"id"`
 	Score            mbScore `json:"score"`
+	Length           int     `json:"length"`
 	FirstReleaseDate string  `json:"first-release-date"`
 	ArtistCredit     []struct {
 		Name string `json:"name"`
@@ -506,8 +509,14 @@ func valueOrNil(v string) *string {
 	return &v
 }
 
-func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (metadataResult, error) {
-	query := fmt.Sprintf("artist:%s AND recording:%s", artist, title)
+func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string, localDurationSeconds float32) (metadataResult, error) {
+	normalizedTitle := normalizeTitle(title)
+	normalizedArtist := normalizeArtist(artist)
+	query := fmt.Sprintf(
+		"recording:\"%s\" AND artist:\"%s\"",
+		normalizedTitle,
+		normalizedArtist,
+	)
 	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json&inc=releases+release-groups"
 	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
@@ -532,7 +541,8 @@ func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (metadataRe
 		return metadataResult{}, nil
 	}
 
-	bestCandidates := collectReleaseCandidates(payload.Recordings, artist)
+	localDurationMillis := int(math.Round(float64(localDurationSeconds) * 1000))
+	bestCandidates := collectReleaseCandidates(payload.Recordings, artist, localDurationMillis)
 	if len(bestCandidates) == 0 {
 		return metadataResult{}, nil
 	}
@@ -593,7 +603,7 @@ func (j *musicBrainzMetadataJob) releaseHasCover(releaseID string, cache map[str
 	return hasCover
 }
 
-func selectBestRecording(recordings []mbRecording, artist string) *mbRecording {
+func selectBestRecording(recordings []mbRecording, artist string, localDurationMillis int) *mbRecording {
 	normalizedArtist := normalizeMBString(artist)
 
 	type recCandidate struct {
@@ -612,6 +622,9 @@ func selectBestRecording(recordings []mbRecording, artist string) *mbRecording {
 			continue
 		}
 		if !artistCreditMatches(rec.ArtistCredit, normalizedArtist) {
+			continue
+		}
+		if !recordingDurationMatches(rec.Length, localDurationMillis) {
 			continue
 		}
 
@@ -673,13 +686,30 @@ func artistCreditMatches(credits []struct {
 	return false
 }
 
+func recordingDurationMatches(mbDurationMillis, localDurationMillis int) bool {
+	if localDurationMillis <= 0 {
+		return true
+	}
+	if mbDurationMillis <= 0 {
+		return false
+	}
+	return absInt(mbDurationMillis-localDurationMillis) <= 5000
+}
+
+func absInt(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
 type releaseCandidate struct {
 	recording *mbRecording
 	release   *mbRelease
 }
 
-func collectReleaseCandidates(recordings []mbRecording, artist string) []releaseCandidate {
-	bestRecording := selectBestRecording(recordings, artist)
+func collectReleaseCandidates(recordings []mbRecording, artist string, localDurationMillis int) []releaseCandidate {
+	bestRecording := selectBestRecording(recordings, artist, localDurationMillis)
 	if bestRecording == nil {
 		return nil
 	}
@@ -831,6 +861,43 @@ func collectGenres(genres, tags []mbName) string {
 }
 
 var punctuationRegex = regexp.MustCompile(`[\p{P}\p{S}]`)
+var titleMetaRegex = regexp.MustCompile(`\([^)]*\)|\[[^\]]*\]`)
+var titleKeywordRegex = regexp.MustCompile(`\b(remix|remastered|live|edit|version)\b`)
+var trailingDashRegex = regexp.MustCompile(`\s*-\s*.*$`)
+var featureRegex = regexp.MustCompile(`\b(feat\.?|ft\.?|featuring)\b.*$`)
+var apostropheRegex = regexp.MustCompile(`['’]`)
+
+func stripDiacritics(v string) string {
+	decomposed := norm.NFD.String(v)
+	return strings.Map(func(r rune) rune {
+		if unicode.Is(unicode.Mn, r) {
+			return -1
+		}
+		return r
+	}, decomposed)
+}
+
+func normalizeTitle(title string) string {
+	title = strings.ToLower(strings.TrimSpace(title))
+	title = stripDiacritics(title)
+	title = apostropheRegex.ReplaceAllString(title, "")
+	title = titleMetaRegex.ReplaceAllString(title, " ")
+	title = trailingDashRegex.ReplaceAllString(title, " ")
+	title = titleKeywordRegex.ReplaceAllString(title, " ")
+	title = punctuationRegex.ReplaceAllString(title, " ")
+	return strings.Join(strings.Fields(title), " ")
+}
+
+func normalizeArtist(artist string) string {
+	artist = strings.ToLower(strings.TrimSpace(artist))
+	artist = stripDiacritics(artist)
+	artist = apostropheRegex.ReplaceAllString(artist, "")
+	artist = featureRegex.ReplaceAllString(artist, " ")
+	artist = strings.ReplaceAll(artist, "&", " ")
+	artist = strings.ReplaceAll(artist, ",", " ")
+	artist = punctuationRegex.ReplaceAllString(artist, " ")
+	return strings.Join(strings.Fields(artist), " ")
+}
 
 func normalizeMBString(v string) string {
 	v = strings.ToLower(strings.TrimSpace(v))

--- a/server/nativeapi/musicbrainz_metadata_test.go
+++ b/server/nativeapi/musicbrainz_metadata_test.go
@@ -33,7 +33,7 @@ func TestSelectBestRecording(t *testing.T) {
 		},
 	}}
 
-	rec := selectBestRecording(payload.Recordings, "the artist")
+	rec := selectBestRecording(payload.Recordings, "the artist", 0)
 	if rec == nil {
 		t.Fatal("expected a recording")
 	}
@@ -55,7 +55,7 @@ func TestCollectReleaseCandidates(t *testing.T) {
 		},
 	}}
 
-	candidates := collectReleaseCandidates(recordings, "the artist")
+	candidates := collectReleaseCandidates(recordings, "the artist", 0)
 	if len(candidates) != 1 {
 		t.Fatalf("expected 1 preferred candidate, got %d", len(candidates))
 	}
@@ -76,7 +76,7 @@ func TestCollectReleaseCandidatesFallsBackToOfficial(t *testing.T) {
 		},
 	}}
 
-	candidates := collectReleaseCandidates(recordings, "the artist")
+	candidates := collectReleaseCandidates(recordings, "the artist", 0)
 	if len(candidates) != 2 {
 		t.Fatalf("expected official fallback candidates, got %d", len(candidates))
 	}
@@ -110,5 +110,48 @@ func TestSelectBestReleaseCandidatePrefersEarliestThenUS(t *testing.T) {
 	}
 	if rel.release.ID != "c" {
 		t.Fatalf("expected earliest release when no cover exists, got %q", rel.release.ID)
+	}
+}
+
+func TestNormalizeTitle(t *testing.T) {
+	got := normalizeTitle("Baby, I'm Bad Weather (Live)")
+	if got != "baby im bad weather" {
+		t.Fatalf("unexpected normalized title: %q", got)
+	}
+}
+
+func TestNormalizeArtist(t *testing.T) {
+	got := normalizeArtist("Beyoncé, Jay-Z & Artist feat. Someone")
+	if got != "beyonce jay z artist" {
+		t.Fatalf("unexpected normalized artist: %q", got)
+	}
+}
+
+func TestSelectBestRecordingFiltersByDuration(t *testing.T) {
+	recordings := []mbRecording{
+		{
+			Score:  "99",
+			Length: 220000,
+			ArtistCredit: []struct {
+				Name string `json:"name"`
+			}{{Name: "The Artist"}},
+			Releases: []mbRelease{{Title: "Album A", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}},
+		},
+		{
+			Score:  "90",
+			Length: 180500,
+			ArtistCredit: []struct {
+				Name string `json:"name"`
+			}{{Name: "The Artist"}},
+			Releases: []mbRelease{{Title: "Album B", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}},
+		},
+	}
+
+	rec := selectBestRecording(recordings, "the artist", 180000)
+	if rec == nil {
+		t.Fatal("expected recording match")
+	}
+	if rec.Length != 180500 {
+		t.Fatalf("expected duration-matched recording, got %d", rec.Length)
 	}
 }


### PR DESCRIPTION
### Motivation
- Improve accuracy of MusicBrainz matches by normalizing title/artist before issuing the search query. 
- Reduce false-positives by verifying MusicBrainz recording duration against the local track duration before selecting releases.

### Description
- Add `normalizeTitle` and `normalizeArtist` helpers that strip parentheses/brackets, remove keywords (`remix`, `remastered`, `live`, `edit`, `version`), drop trailing `- ...`, collapse spaces, lowercase and remove diacritics using Unicode normalization, and clean artist featuring tokens and punctuation. 
- Use the normalized values when building the MusicBrainz recording query as `recording:"%s" AND artist:"%s"` without removing any existing logic. 
- Parse `recording.length` from MusicBrainz responses (added `Length int` to `mbRecording`) and pass the local file duration (converted to milliseconds) into `fetchMetadata`. 
- Filter recordings in `selectBestRecording` with a duration match check that accepts only recordings where `abs(mbDuration - localDuration) <= 5000` ms; preserve score and existing release-selection logic and prefer highest score among duration-matching candidates. 
- Propagate the local-duration parameter into `collectReleaseCandidates` and update function signatures accordingly. 
- Add unit tests for `normalizeTitle`, `normalizeArtist`, and a duration-filtering test for `selectBestRecording`, and update existing tests to the new signatures. 

### Testing
- Ran `gofmt -w` on the modified files to ensure formatting (succeeded). 
- Attempted to run package tests for the `server/nativeapi` changes (`go test ./server/nativeapi` / targeted tests for normalization and duration), however the repository build failed in this environment due to missing external system dependencies (missing `taglib` / pkg-config and other package-level build issues), so the full automated test run could not complete here. The new unit tests are included and exercise normalization and duration filtering locally when the repo is built in an environment with the required native dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ab85c9cdc83228ef9319fb5800c47)