### PR TITLE
ui: update coverart pagination; add CoverArt panel; expose MusicBrainz existing counts

### DIFF
--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -24,12 +24,13 @@ import (
 )
 
 type metadataFieldProgress struct {
-	Existing int `json:"existing"`
-	Missing  int `json:"missing"`
-	Fetching int `json:"fetching"`
-	Fetched  int `json:"fetched"`
-	Updated  int `json:"updated"`
-	Left     int `json:"left"`
+	Existing     int `json:"existing"`
+	Missing      int `json:"missing"`
+	Fetching     int `json:"fetching"`
+	Fetched      int `json:"fetched"`
+	Updated      int `json:"updated"`
+	Left         int `json:"left"`
+	CouldntFetch int `json:"couldntFetch"`
 }
 
 type musicBrainzMetadataStatus struct {
@@ -353,6 +354,8 @@ func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, f
 		j.status.Album.Left--
 		if fetchedAlbum {
 			j.status.Album.Fetched++
+		} else {
+			j.status.Album.CouldntFetch++
 		}
 	}
 	if flags.year {
@@ -360,6 +363,8 @@ func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, f
 		j.status.Year.Left--
 		if fetchedYear {
 			j.status.Year.Fetched++
+		} else {
+			j.status.Year.CouldntFetch++
 		}
 	}
 	if flags.genre {
@@ -367,6 +372,8 @@ func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, f
 		j.status.Genre.Left--
 		if fetchedGenre {
 			j.status.Genre.Fetched++
+		} else {
+			j.status.Genre.CouldntFetch++
 		}
 	}
 	if flags.recordingMBID {
@@ -374,6 +381,8 @@ func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, f
 		j.status.RecordingMBID.Left--
 		if fetchedRecordingMBID {
 			j.status.RecordingMBID.Fetched++
+		} else {
+			j.status.RecordingMBID.CouldntFetch++
 		}
 	}
 	if flags.releaseMBID {
@@ -381,6 +390,8 @@ func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, f
 		j.status.ReleaseMBID.Left--
 		if fetchedReleaseMBID {
 			j.status.ReleaseMBID.Fetched++
+		} else {
+			j.status.ReleaseMBID.CouldntFetch++
 		}
 	}
 	if flags.coverArt {
@@ -388,6 +399,8 @@ func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, f
 		j.status.CoverArt.Left--
 		if fetchedCoverArt {
 			j.status.CoverArt.Fetched++
+		} else {
+			j.status.CoverArt.CouldntFetch++
 		}
 	}
 }

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -24,6 +24,7 @@ import (
 )
 
 type metadataFieldProgress struct {
+	Existing int `json:"existing"`
 	Missing  int `json:"missing"`
 	Fetching int `json:"fetching"`
 	Fetched  int `json:"fetched"`
@@ -230,6 +231,7 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 			releaseMBID:   strings.TrimSpace(mf.MbzReleaseID) == "",
 			coverArt:      !mf.HasCoverArt && strings.TrimSpace(mf.CoverPath) == "",
 		}
+		j.incrementExisting(flags)
 		if !flags.album && !flags.year && !flags.genre && !flags.recordingMBID && !flags.releaseMBID && !flags.coverArt {
 			continue
 		}
@@ -238,6 +240,29 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 		j.incrementMissing(flags)
 	}
 	return res, nil
+}
+
+func (j *musicBrainzMetadataJob) incrementExisting(flags missingFlags) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if !flags.album {
+		j.status.Album.Existing++
+	}
+	if !flags.year {
+		j.status.Year.Existing++
+	}
+	if !flags.genre {
+		j.status.Genre.Existing++
+	}
+	if !flags.recordingMBID {
+		j.status.RecordingMBID.Existing++
+	}
+	if !flags.releaseMBID {
+		j.status.ReleaseMBID.Existing++
+	}
+	if !flags.coverArt {
+		j.status.CoverArt.Existing++
+	}
 }
 
 func isMissingAlbum(album string) bool {

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React from 'react'
 import {
   Datagrid,
   Filter,
@@ -6,16 +6,9 @@ import {
   List,
   SearchInput,
   TextField,
-  TopToolbar,
-  useNotify,
-  usePermissions,
-  useTranslate,
 } from 'react-admin'
-import { Box, Button, Card, CardContent, Grid, Typography } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core/styles'
-import { BiDownload } from 'react-icons/bi'
-import { DurationField } from '../common'
-import { httpClient } from '../dataProvider'
+import { DurationField, Pagination } from '../common'
 
 const useStyles = makeStyles({
   mbidText: {
@@ -30,166 +23,6 @@ const CovertartFilter = (props) => (
   </Filter>
 )
 
-const emptyProgress = { missing: 0, fetching: 0, fetched: 0, updated: 0, left: 0 }
-
-const MetadataProgressCard = ({ title, progress, translate }) => (
-  <Card>
-    <CardContent>
-      <Typography variant="subtitle2">{title}</Typography>
-      <Box display="flex" justifyContent="space-between" mt={1}>
-        <span>{translate('activity.musicbrainz.missing')}</span>
-        <span>{progress.missing || 0}</span>
-      </Box>
-      <Box display="flex" justifyContent="space-between">
-        <span>{translate('activity.musicbrainz.fetching')}</span>
-        <span>{progress.fetching || 0}</span>
-      </Box>
-      <Box display="flex" justifyContent="space-between">
-        <span>{translate('activity.musicbrainz.fetched')}</span>
-        <span>{progress.fetched || 0}</span>
-      </Box>
-      <Box display="flex" justifyContent="space-between">
-        <span>{translate('activity.musicbrainz.updated')}</span>
-        <span>{progress.updated || 0}</span>
-      </Box>
-      <Box display="flex" justifyContent="space-between">
-        <span>{translate('activity.musicbrainz.left')}</span>
-        <span>{progress.left || 0}</span>
-      </Box>
-    </CardContent>
-  </Card>
-)
-
-const CovertartListActions = () => {
-  const translate = useTranslate()
-  const notify = useNotify()
-  const { permissions } = usePermissions()
-  const isAdmin = permissions === 'admin'
-  const [status, setStatus] = useState({
-    running: false,
-    album: emptyProgress,
-    year: emptyProgress,
-    genre: emptyProgress,
-    recordingMbid: emptyProgress,
-    releaseMbid: emptyProgress,
-    coverArt: emptyProgress,
-  })
-
-  const loadStatus = useCallback(() => {
-    if (!isAdmin) {
-      return
-    }
-    httpClient('/api/metadata/musicbrainz/status')
-      .then(({ json }) => {
-        setStatus(
-          json || {
-            running: false,
-            album: emptyProgress,
-            year: emptyProgress,
-            genre: emptyProgress,
-            recordingMbid: emptyProgress,
-            releaseMbid: emptyProgress,
-            coverArt: emptyProgress,
-          },
-        )
-      })
-      .catch(() => {})
-  }, [isAdmin])
-
-  useEffect(() => {
-    loadStatus()
-  }, [loadStatus])
-
-  useEffect(() => {
-    if (!status.running) {
-      return undefined
-    }
-    const timer = setInterval(() => loadStatus(), 2000)
-    return () => clearInterval(timer)
-  }, [status.running, loadStatus])
-
-  const startFetch = () => {
-    httpClient('/api/metadata/musicbrainz/fetch', { method: 'POST' })
-      .then(({ status: code }) => {
-        if (code === 202) {
-          notify('activity.musicbrainz.started', 'info')
-        } else {
-          notify('activity.musicbrainz.alreadyRunning', 'warning')
-        }
-        loadStatus()
-      })
-      .catch(() => notify('activity.musicbrainz.failed', 'warning'))
-  }
-
-  return (
-    <TopToolbar>
-      {isAdmin && (
-        <Button
-          color="primary"
-          variant="contained"
-          startIcon={<BiDownload />}
-          onClick={startFetch}
-          disabled={status.running}
-          data-testid="covertart-metadata-fetch-btn"
-        >
-          {translate('activity.musicbrainz.fetch')}
-        </Button>
-      )}
-      {isAdmin && (
-        <Box width="100%" mt={2}>
-          <Typography variant="subtitle1">
-            {translate('activity.musicbrainz.title')}
-          </Typography>
-          <Grid container spacing={2}>
-            <Grid item xs={12} md={3}>
-              <MetadataProgressCard
-                title={translate('activity.musicbrainz.album')}
-                progress={status.album || emptyProgress}
-                translate={translate}
-              />
-            </Grid>
-            <Grid item xs={12} md={3}>
-              <MetadataProgressCard
-                title={translate('activity.musicbrainz.year')}
-                progress={status.year || emptyProgress}
-                translate={translate}
-              />
-            </Grid>
-            <Grid item xs={12} md={2}>
-              <MetadataProgressCard
-                title={translate('activity.musicbrainz.genre')}
-                progress={status.genre || emptyProgress}
-                translate={translate}
-              />
-            </Grid>
-            <Grid item xs={12} md={2}>
-              <MetadataProgressCard
-                title="Recording MBID"
-                progress={status.recordingMbid || emptyProgress}
-                translate={translate}
-              />
-            </Grid>
-            <Grid item xs={12} md={2}>
-              <MetadataProgressCard
-                title="Release MBID"
-                progress={status.releaseMbid || emptyProgress}
-                translate={translate}
-              />
-            </Grid>
-            <Grid item xs={12} md={2}>
-              <MetadataProgressCard
-                title="Cover Art"
-                progress={status.coverArt || emptyProgress}
-                translate={translate}
-              />
-            </Grid>
-          </Grid>
-        </Box>
-      )}
-    </TopToolbar>
-  )
-}
-
 const CovertartList = (props) => {
   const classes = useStyles()
 
@@ -201,7 +34,7 @@ const CovertartList = (props) => {
       exporter={false}
       bulkActionButtons={false}
       perPage={50}
-      actions={<CovertartListActions />}
+      pagination={<Pagination />}
     >
       <Datagrid rowClick={false}>
         <FunctionField
@@ -232,14 +65,18 @@ const CovertartList = (props) => {
           label="Recording MBID"
           sortable={false}
           render={(record) => (
-            <span className={classes.mbidText}>{record?.mbzRecordingID || ''}</span>
+            <span className={classes.mbidText}>
+              {record?.mbzRecordingID || ''}
+            </span>
           )}
         />
         <FunctionField
           label="Release MBID"
           sortable={false}
           render={(record) => (
-            <span className={classes.mbidText}>{record?.mbzReleaseId || ''}</span>
+            <span className={classes.mbidText}>
+              {record?.mbzReleaseId || ''}
+            </span>
           )}
         />
         <DurationField source="duration" />

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -695,7 +695,8 @@
       "fetching": "Fetching",
       "fetched": "Fetched",
       "updated": "Updated",
-      "missingAfterUpdate": "Missing after updates",
+      "toBeFetch": "To be fetch",
+      "couldntFetch": "Couldn't fetched",
       "left": "Left"
     }
   },

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -683,17 +683,19 @@
     "elapsedTime": "Elapsed Time",
     "musicbrainz": {
       "title": "MusicBrainz Metadata",
-      "fetch": "Fetch metadata from MusicBrainz",
+      "fetch": "Fetch metadata",
       "started": "Metadata fetch started",
       "alreadyRunning": "Metadata fetch is already running",
       "failed": "Metadata fetch failed",
       "album": "Album",
       "year": "Year",
       "genre": "Genre",
+      "existing": "Already exist",
       "missing": "Missing",
       "fetching": "Fetching",
       "fetched": "Fetched",
       "updated": "Updated",
+      "missingAfterUpdate": "Missing after updates",
       "left": "Left"
     }
   },

--- a/ui/src/layout/ActivityPanel.jsx
+++ b/ui/src/layout/ActivityPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { useNotify, useTranslate } from 'react-admin'
 import {
@@ -15,7 +15,7 @@ import {
   Typography,
 } from '@material-ui/core'
 import { FiActivity } from 'react-icons/fi'
-import { BiError, BiLink, BiDownload } from 'react-icons/bi'
+import { BiError, BiLink } from 'react-icons/bi'
 import { VscSync } from 'react-icons/vsc'
 import { GiMagnifyingGlass } from 'react-icons/gi'
 import subsonic from '../subsonic'
@@ -54,23 +54,6 @@ const useStyles = makeStyles((theme) => ({
   cardContent: {
     padding: theme.spacing(2, 3),
   },
-  metadataGrid: {
-    display: 'grid',
-    gap: theme.spacing(1),
-    gridTemplateColumns: 'repeat(3, minmax(11em, 1fr))',
-    marginTop: theme.spacing(2),
-  },
-  metadataCard: {
-    border: `1px solid ${theme.palette.divider}`,
-    borderRadius: theme.shape.borderRadius,
-    padding: theme.spacing(1.2),
-  },
-  metadataRow: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    fontSize: '0.8rem',
-    marginTop: theme.spacing(0.5),
-  },
 }))
 
 const getUptime = (serverStart) =>
@@ -83,14 +66,6 @@ const Uptime = () => {
     setUptime(getUptime(serverStart))
   }, 1000)
   return <span>{uptime}</span>
-}
-
-const emptyProgress = { missing: 0, fetching: 0, fetched: 0, updated: 0, left: 0 }
-const emptyMetadataStatus = {
-  running: false,
-  album: emptyProgress,
-  year: emptyProgress,
-  genre: emptyProgress,
 }
 
 const ActivityPanel = () => {
@@ -110,15 +85,8 @@ const ActivityPanel = () => {
   const translate = useTranslate()
   const notify = useNotify()
   const [anchorEl, setAnchorEl] = useState(null)
-  const [metadataStatus, setMetadataStatus] = useState(emptyMetadataStatus)
   const open = Boolean(anchorEl)
   useInitialScanStatus()
-
-  const fetchMetadataStatus = useCallback(() => {
-    httpClient('/api/metadata/musicbrainz/status')
-      .then(({ json }) => setMetadataStatus(json || emptyMetadataStatus))
-      .catch(() => {})
-  }, [])
 
   const handleMenuOpen = (event) => {
     if (scanStatus.error) {
@@ -138,35 +106,11 @@ const ActivityPanel = () => {
       })
       .catch(() => notify('Sync failed', 'warning'))
 
-  const triggerMetadataFetch = () =>
-    httpClient('/api/metadata/musicbrainz/fetch', { method: 'POST' })
-      .then(({ status }) => {
-        if (status === 202) {
-          notify('activity.musicbrainz.started', 'info')
-        } else {
-          notify('activity.musicbrainz.alreadyRunning', 'warning')
-        }
-        fetchMetadataStatus()
-      })
-      .catch(() => notify('activity.musicbrainz.failed', 'warning'))
-
   useEffect(() => {
     if (serverStart.version && serverStart.version !== config.version) {
       notify('ra.notification.new_version', 'info', {}, false, 604800000 * 50)
     }
   }, [serverStart, notify])
-
-  useEffect(() => {
-    if (open) {
-      fetchMetadataStatus()
-    }
-  }, [open, fetchMetadataStatus])
-
-  useInterval(() => {
-    if (open && metadataStatus.running) {
-      fetchMetadataStatus()
-    }
-  }, open && metadataStatus.running ? 2000 : null)
 
   const tooltipTitle = scanStatus.error
     ? `${translate('activity.status')}: ${scanStatus.error}`
@@ -182,35 +126,6 @@ const ActivityPanel = () => {
         return ''
     }
   })()
-
-  const renderMetadataCard = (title, key) => {
-    const progress = metadataStatus?.[key] || emptyProgress
-    return (
-      <Box className={classes.metadataCard}>
-        <Typography variant="subtitle2">{title}</Typography>
-        <Box className={classes.metadataRow}>
-          <span>{translate('activity.musicbrainz.missing')}</span>
-          <span>{progress.missing || 0}</span>
-        </Box>
-        <Box className={classes.metadataRow}>
-          <span>{translate('activity.musicbrainz.fetching')}</span>
-          <span>{progress.fetching || 0}</span>
-        </Box>
-        <Box className={classes.metadataRow}>
-          <span>{translate('activity.musicbrainz.fetched')}</span>
-          <span>{progress.fetched || 0}</span>
-        </Box>
-        <Box className={classes.metadataRow}>
-          <span>{translate('activity.musicbrainz.updated')}</span>
-          <span>{progress.updated || 0}</span>
-        </Box>
-        <Box className={classes.metadataRow}>
-          <span>{translate('activity.musicbrainz.left')}</span>
-          <span>{progress.left || 0}</span>
-        </Box>
-      </Box>
-    )
-  }
 
   return (
     <div className={classes.wrapper}>
@@ -280,23 +195,6 @@ const ActivityPanel = () => {
               </Box>
             </Box>
 
-            <Box mt={2}>
-              <Typography variant="subtitle2">
-                {translate('activity.musicbrainz.title')}
-              </Typography>
-              <Box className={classes.metadataGrid}>
-                {renderMetadataCard(
-                  translate('activity.musicbrainz.album'),
-                  'album',
-                )}
-                {renderMetadataCard(translate('activity.musicbrainz.year'), 'year')}
-                {renderMetadataCard(
-                  translate('activity.musicbrainz.genre'),
-                  'genre',
-                )}
-              </Box>
-            </Box>
-
             {scanStatus.error && (
               <Box
                 display="flex"
@@ -332,14 +230,6 @@ const ActivityPanel = () => {
                 disabled={scanStatus.scanning}
               >
                 <GiMagnifyingGlass />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title={translate('activity.musicbrainz.fetch')}>
-              <IconButton
-                onClick={triggerMetadataFetch}
-                disabled={metadataStatus.running}
-              >
-                <BiDownload />
               </IconButton>
             </Tooltip>
           </CardActions>

--- a/ui/src/layout/AppBar.jsx
+++ b/ui/src/layout/AppBar.jsx
@@ -14,6 +14,7 @@ import { Dialogs } from '../dialogs/Dialogs'
 import { AboutDialog } from '../dialogs'
 import PersonalMenu from './PersonalMenu'
 import ActivityPanel from './ActivityPanel'
+import CoverArtPanel from './CoverArtPanel'
 import MissingTracksPanel from './MissingTracksPanel'
 import NowPlayingPanel from './NowPlayingPanel'
 import UserMenu from './UserMenu'
@@ -128,6 +129,7 @@ const CustomUserMenu = ({ onClick, ...rest }) => {
         permissions === 'admin' &&
         config.enableNowPlaying && <NowPlayingPanel />}
       {config.devActivityPanel && permissions === 'admin' && <ActivityPanel />}
+      {config.devActivityPanel && permissions === 'admin' && <CoverArtPanel />}
       <UserMenu {...rest}>
         <PersonalMenu sidebarIsOpen={true} onClick={onClick} />
         <Divider />

--- a/ui/src/layout/AppBar.test.jsx
+++ b/ui/src/layout/AppBar.test.jsx
@@ -22,6 +22,10 @@ vi.mock('./NowPlayingPanel', () => ({
 vi.mock('./ActivityPanel', () => ({
   default: () => <div data-testid="activity-panel" />,
 }))
+
+vi.mock('./CoverArtPanel', () => ({
+  default: () => <div data-testid="coverart-panel" />,
+}))
 vi.mock('./PersonalMenu', () => ({
   default: () => <div />,
 }))
@@ -51,6 +55,7 @@ describe('<AppBar />', () => {
       </Provider>,
     )
     expect(screen.getByTestId('now-playing-panel')).toBeInTheDocument()
+    expect(screen.getByTestId('coverart-panel')).toBeInTheDocument()
   })
 
   it('hides NowPlayingPanel when disabled', () => {

--- a/ui/src/layout/CoverArtPanel.jsx
+++ b/ui/src/layout/CoverArtPanel.jsx
@@ -1,0 +1,247 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { useNotify, useTranslate } from 'react-admin'
+import {
+  Popover,
+  Button,
+  makeStyles,
+  Card,
+  CardContent,
+  Box,
+  Typography,
+  Grid,
+  IconButton,
+  Tooltip,
+} from '@material-ui/core'
+import ImageOutlinedIcon from '@material-ui/icons/ImageOutlined'
+import { BiDownload } from 'react-icons/bi'
+import { httpClient } from '../dataProvider'
+
+const emptyProgress = {
+  existing: 0,
+  missing: 0,
+  fetching: 0,
+  fetched: 0,
+  updated: 0,
+  left: 0,
+}
+
+const useStyles = makeStyles((theme) => ({
+  iconButton: {
+    marginLeft: theme.spacing(1),
+    color: 'inherit',
+    padding: theme.spacing(1),
+  },
+  card: {
+    minWidth: 680,
+    maxWidth: 920,
+    padding: theme.spacing(1),
+  },
+  title: {
+    fontWeight: 600,
+    marginBottom: theme.spacing(1.5),
+  },
+  actionBar: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: theme.spacing(2),
+    gap: theme.spacing(2),
+  },
+  progressCard: {
+    height: '100%',
+  },
+  row: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    marginTop: theme.spacing(0.5),
+  },
+}))
+
+const ProgressCard = ({ title, progress, translate, classes }) => (
+  <Card variant="outlined" className={classes.progressCard}>
+    <CardContent>
+      <Typography variant="subtitle2">{title}</Typography>
+      <Box className={classes.row}>
+        <span>{translate('activity.musicbrainz.existing')}</span>
+        <span>{progress.existing || 0}</span>
+      </Box>
+      <Box className={classes.row}>
+        <span>{translate('activity.musicbrainz.missing')}</span>
+        <span>{progress.missing || 0}</span>
+      </Box>
+      <Box className={classes.row}>
+        <span>{translate('activity.musicbrainz.fetching')}</span>
+        <span>{progress.fetching || 0}</span>
+      </Box>
+      <Box className={classes.row}>
+        <span>{translate('activity.musicbrainz.fetched')}</span>
+        <span>{progress.fetched || 0}</span>
+      </Box>
+      <Box className={classes.row}>
+        <span>{translate('activity.musicbrainz.updated')}</span>
+        <span>{progress.updated || 0}</span>
+      </Box>
+      <Box className={classes.row}>
+        <span>{translate('activity.musicbrainz.missingAfterUpdate')}</span>
+        <span>{progress.left || 0}</span>
+      </Box>
+    </CardContent>
+  </Card>
+)
+
+const CoverArtPanel = () => {
+  const classes = useStyles()
+  const translate = useTranslate()
+  const notify = useNotify()
+  const [anchorEl, setAnchorEl] = useState(null)
+  const [status, setStatus] = useState({
+    running: false,
+    album: emptyProgress,
+    year: emptyProgress,
+    genre: emptyProgress,
+    recordingMbid: emptyProgress,
+    releaseMbid: emptyProgress,
+    coverArt: emptyProgress,
+  })
+
+  const open = Boolean(anchorEl)
+
+  const loadStatus = useCallback(() => {
+    httpClient('/api/metadata/musicbrainz/status')
+      .then(({ json }) => {
+        setStatus(
+          json || {
+            running: false,
+            album: emptyProgress,
+            year: emptyProgress,
+            genre: emptyProgress,
+            recordingMbid: emptyProgress,
+            releaseMbid: emptyProgress,
+            coverArt: emptyProgress,
+          },
+        )
+      })
+      .catch(() => {})
+  }, [])
+
+  useEffect(() => {
+    if (!open) {
+      return undefined
+    }
+    loadStatus()
+    const interval = setInterval(
+      () => {
+        loadStatus()
+      },
+      status.running ? 2000 : 5000,
+    )
+    return () => clearInterval(interval)
+  }, [open, status.running, loadStatus])
+
+  const startFetch = () => {
+    httpClient('/api/metadata/musicbrainz/fetch', { method: 'POST' })
+      .then(({ status: code }) => {
+        if (code === 202) {
+          notify('activity.musicbrainz.started', 'info')
+        } else {
+          notify('activity.musicbrainz.alreadyRunning', 'warning')
+        }
+        loadStatus()
+      })
+      .catch(() => notify('activity.musicbrainz.failed', 'warning'))
+  }
+
+  return (
+    <>
+      <Tooltip title="Coverart">
+        <IconButton
+          className={classes.iconButton}
+          onClick={(event) => setAnchorEl(event.currentTarget)}
+          data-testid="coverart-panel-btn"
+        >
+          <ImageOutlinedIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+      <Popover
+        id="panel-coverart"
+        anchorEl={anchorEl}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        open={open}
+        onClose={() => setAnchorEl(null)}
+      >
+        <Card className={classes.card}>
+          <CardContent>
+            <Box className={classes.actionBar}>
+              <Typography variant="h6" className={classes.title}>
+                {translate('activity.musicbrainz.title')}
+              </Typography>
+              <Button
+                color="primary"
+                variant="contained"
+                startIcon={<BiDownload />}
+                onClick={startFetch}
+                disabled={status.running}
+                data-testid="coverart-metadata-fetch-btn"
+              >
+                {translate('activity.musicbrainz.fetch')}
+              </Button>
+            </Box>
+            <Grid container spacing={2}>
+              <Grid item xs={12} md={4}>
+                <ProgressCard
+                  title={translate('activity.musicbrainz.album')}
+                  progress={status.album || emptyProgress}
+                  translate={translate}
+                  classes={classes}
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <ProgressCard
+                  title={translate('activity.musicbrainz.year')}
+                  progress={status.year || emptyProgress}
+                  translate={translate}
+                  classes={classes}
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <ProgressCard
+                  title={translate('activity.musicbrainz.genre')}
+                  progress={status.genre || emptyProgress}
+                  translate={translate}
+                  classes={classes}
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <ProgressCard
+                  title="Recording MBID"
+                  progress={status.recordingMbid || emptyProgress}
+                  translate={translate}
+                  classes={classes}
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <ProgressCard
+                  title="Release MBID"
+                  progress={status.releaseMbid || emptyProgress}
+                  translate={translate}
+                  classes={classes}
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <ProgressCard
+                  title="Cover Art"
+                  progress={status.coverArt || emptyProgress}
+                  translate={translate}
+                  classes={classes}
+                />
+              </Grid>
+            </Grid>
+          </CardContent>
+        </Card>
+      </Popover>
+    </>
+  )
+}
+
+export default CoverArtPanel

--- a/ui/src/layout/CoverArtPanel.jsx
+++ b/ui/src/layout/CoverArtPanel.jsx
@@ -23,6 +23,7 @@ const emptyProgress = {
   fetched: 0,
   updated: 0,
   left: 0,
+  couldntFetch: 0,
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -82,8 +83,12 @@ const ProgressCard = ({ title, progress, translate, classes }) => (
         <span>{progress.updated || 0}</span>
       </Box>
       <Box className={classes.row}>
-        <span>{translate('activity.musicbrainz.missingAfterUpdate')}</span>
+        <span>{translate('activity.musicbrainz.toBeFetch')}</span>
         <span>{progress.left || 0}</span>
+      </Box>
+      <Box className={classes.row}>
+        <span>{translate('activity.musicbrainz.couldntFetch')}</span>
+        <span>{progress.couldntFetch || 0}</span>
       </Box>
     </CardContent>
   </Card>


### PR DESCRIPTION
### Motivation
- Reduce visual noise and centralize CoverArt metadata controls by moving fetch actions out of the covertart list and into an app-bar panel.  
- Surface how many metadata values already exist so admins can see pre-fetch coverage for MusicBrainz fields.  
- Change small page-size options to larger, more useful choices by replacing `5, 10` with `25, 50, 100, 200, 500` for coverart listing pagination.

### Description
- UI: `ui/src/covertart/CovertartList.jsx` now uses the shared `<Pagination />` (from `ui/src/common/Pagination.jsx`) and sets `perPage={50}`, enabling `rowsPerPageOptions` of `[25, 50, 100, 200, 500]`.  
- UI: Added a new `CoverArtPanel` component and wired it into the app bar via `ui/src/layout/CoverArtPanel.jsx` and `ui/src/layout/AppBar.jsx`, and updated `ui/src/layout/AppBar.test.jsx` to mock the new panel.  
- Backend: `server/nativeapi/musicbrainz_metadata.go` exposes an `Existing` counter in `metadataFieldProgress`, implements `incrementExisting`, and invokes it when collecting candidates so the status API returns pre-fetch existing counts.  
- Misc: Simplified `ActivityPanel` by removing inline CoverArt metadata UI and fetch controls, and updated i18n (`ui/src/i18n/en.json`) to add `existing` and `missingAfterUpdate` labels and shorten the fetch label.

### Testing
- Ran `cd ui && npx prettier --write src/covertart/CovertartList.jsx`, which completed successfully.  
- Ran `cd ui && npx eslint src/covertart/CovertartList.jsx`, which completed successfully with no new lint errors.  
- Started the dev server and captured a screenshot of the `#/coverart` page to validate the pagination UI via Playwright; the capture succeeded but the environment still shows a pre-existing Vite unresolved import overlay for `@dnd-kit/core`.  
- Updated `AppBar` unit test mocks to include `CoverArtPanel` (test file changed), though unit tests were not executed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699adec1aa508322b46bc621ddeeb259)