### PR TITLE
Reorder Cover Art to first and align CoverArt panel UI

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -107,10 +107,10 @@ const Admin = (props) => {
       {...props}
     >
       {(permissions) => [
+        <Resource name="covertart" {...covertart} />,
         <Resource name="album" {...album} options={{ subMenu: 'albumList' }} />,
         <Resource name="artist" {...artist} />,
         <Resource name="song" {...song} />,
-        <Resource name="covertart" {...covertart} />,
         <Resource
           name="radio"
           {...(permissions === 'admin' ? radio.admin : radio.all)}

--- a/ui/src/layout/CoverArtPanel.jsx
+++ b/ui/src/layout/CoverArtPanel.jsx
@@ -29,7 +29,6 @@ const emptyProgress = {
 
 const useStyles = makeStyles((theme) => ({
   iconButton: {
-    marginLeft: theme.spacing(1),
     color: 'inherit',
     padding: theme.spacing(1),
   },
@@ -225,6 +224,14 @@ const CoverArtPanel = () => {
             <Grid container spacing={2}>
               <Grid item xs={12} md={4}>
                 <ProgressCard
+                  title="Cover Art"
+                  progress={status.coverArt || emptyProgress}
+                  translate={translate}
+                  classes={classes}
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <ProgressCard
                   title={translate('activity.musicbrainz.album')}
                   progress={status.album || emptyProgress}
                   translate={translate}
@@ -259,14 +266,6 @@ const CoverArtPanel = () => {
                 <ProgressCard
                   title="Release MBID"
                   progress={status.releaseMbid || emptyProgress}
-                  translate={translate}
-                  classes={classes}
-                />
-              </Grid>
-              <Grid item xs={12} md={4}>
-                <ProgressCard
-                  title="Cover Art"
-                  progress={status.coverArt || emptyProgress}
                   translate={translate}
                   classes={classes}
                 />


### PR DESCRIPTION
### Motivation
- Move the Cover Art (covertart) entry to the first position in the main resources list so it appears before Albums and shift the remaining items right. 
- Show the Cover Art metric first inside the CoverArt panel and shift all other metric cards one position to the right. 
- Correct the visual alignment of the CoverArt toolbar icon so its icon lines up with the neighboring activity icon.

### Description
- Reordered resources in `ui/src/App.jsx` so the `covertart` resource is declared before `album`, causing it to show first in the sidebar. 
- Reordered the grid of metric cards in `ui/src/layout/CoverArtPanel.jsx` so the "Cover Art" `ProgressCard` is the first card and the remaining cards appear after it. 
- Removed an extra left margin from the `iconButton` style in `ui/src/layout/CoverArtPanel.jsx` to better align the coverart icon with the activity icon.

### Testing
- Ran `cd ui && npx eslint src/App.jsx src/layout/CoverArtPanel.jsx` which completed successfully. 
- Attempted to run the dev server with `cd ui && npm start -- --host 0.0.0.0 --port 4173`; the server started but the client reported a dependency-resolution error for `@dnd-kit/core` (an unrelated dependency issue), so full visual verification in-browser was blocked by that unrelated error. 
- Captured a screenshot of the running UI using an automated Playwright script for visual verification (screenshot run succeeded and an artifact was generated during validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c594dd0c083229438f8407b2e6148)