### PR TITLE
Persist fetched MusicBrainz metadata into media files on Save

### DIFF
--- a/adapters/taglib/taglib_wrapper.cpp
+++ b/adapters/taglib/taglib_wrapper.cpp
@@ -1,5 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
+#include <fstream>
+#include <vector>
 
 #define TAGLIB_STATIC
 #include <apeproperties.h>
@@ -10,6 +12,7 @@
 #include <fileref.h>
 #include <flacfile.h>
 #include <id3v2tag.h>
+#include <attachedpictureframe.h>
 #include <unsynchronizedlyricsframe.h>
 #include <synchronizedlyricsframe.h>
 #include <mp4file.h>
@@ -24,6 +27,53 @@
 #include "taglib_wrapper.h"
 
 char has_cover(const TagLib::FileRef f);
+
+static void put_property(TagLib::PropertyMap &properties, const char *key, const char *value) {
+  if (value == nullptr) {
+    return;
+  }
+  TagLib::String v(value, TagLib::String::UTF8);
+  if (v.isEmpty()) {
+    return;
+  }
+  TagLib::StringList list;
+  list.append(v);
+  properties.replace(key, list);
+}
+
+static bool attach_cover_mp3(TagLib::MPEG::File *mp3File, const char *coverPath) {
+  if (mp3File == nullptr || coverPath == nullptr || *coverPath == '\0') {
+    return false;
+  }
+
+  std::ifstream image(coverPath, std::ios::binary);
+  if (!image) {
+    return false;
+  }
+
+  std::vector<char> data((std::istreambuf_iterator<char>(image)), std::istreambuf_iterator<char>());
+  if (data.empty()) {
+    return false;
+  }
+
+  auto *tag = mp3File->ID3v2Tag(true);
+  if (tag == nullptr) {
+    return false;
+  }
+
+  auto existing = tag->frameListMap()["APIC"];
+  for (auto *frame : existing) {
+    tag->removeFrame(frame, true);
+  }
+
+  auto *picture = new TagLib::ID3v2::AttachedPictureFrame;
+  picture->setType(TagLib::ID3v2::AttachedPictureFrame::FrontCover);
+  picture->setMimeType("image/jpeg");
+  picture->setDescription("Front cover");
+  picture->setPicture(TagLib::ByteVector(data.data(), (unsigned int)data.size()));
+  tag->addFrame(picture);
+  return true;
+}
 
 int taglib_write_comment(const FILENAME_CHAR_T *filename, const char *comment) {
   TagLib::FileRef f(filename, false, TagLib::AudioProperties::Fast);
@@ -50,6 +100,43 @@ int taglib_write_comment(const FILENAME_CHAR_T *filename, const char *comment) {
     properties.replace("comment", list);
   }
   f.file()->setProperties(properties);
+
+  if (!f.file()->save()) {
+    return TAGLIB_ERR_SAVE;
+  }
+
+  return 0;
+}
+
+int taglib_write_fetched_metadata(const FILENAME_CHAR_T *filename, const char *album, const char *year, const char *genre, const char *recording_mbid, const char *release_mbid, const char *cover_path) {
+  TagLib::FileRef f(filename, false, TagLib::AudioProperties::Fast);
+  if (f.isNull() || f.file() == nullptr) {
+    return TAGLIB_ERR_PARSE;
+  }
+
+  if (f.tag() != nullptr) {
+    if (album != nullptr && *album != '\0') {
+      f.tag()->setAlbum(TagLib::String(album, TagLib::String::UTF8));
+    }
+    if (genre != nullptr && *genre != '\0') {
+      f.tag()->setGenre(TagLib::String(genre, TagLib::String::UTF8));
+    }
+    if (year != nullptr && *year != '\0') {
+      f.tag()->setYear((unsigned int)atoi(year));
+    }
+  }
+
+  TagLib::PropertyMap properties = f.file()->properties();
+  put_property(properties, "ALBUM", album);
+  put_property(properties, "DATE", year);
+  put_property(properties, "YEAR", year);
+  put_property(properties, "GENRE", genre);
+  put_property(properties, "MUSICBRAINZ_RECORDINGID", recording_mbid);
+  put_property(properties, "MUSICBRAINZ_RELEASEID", release_mbid);
+  f.file()->setProperties(properties);
+
+  TagLib::MPEG::File *mp3File = dynamic_cast<TagLib::MPEG::File *>(f.file());
+  attach_cover_mp3(mp3File, cover_path);
 
   if (!f.file()->save()) {
     return TAGLIB_ERR_SAVE;

--- a/adapters/taglib/taglib_wrapper.cpp
+++ b/adapters/taglib/taglib_wrapper.cpp
@@ -11,11 +11,13 @@
 #include <dsffile.h>
 #include <fileref.h>
 #include <flacfile.h>
+#include <flacpicture.h>
 #include <id3v2tag.h>
 #include <attachedpictureframe.h>
 #include <unsynchronizedlyricsframe.h>
 #include <synchronizedlyricsframe.h>
 #include <mp4file.h>
+#include <mp4coverart.h>
 #include <mpegfile.h>
 #include <opusfile.h>
 #include <tpropertymap.h>
@@ -72,6 +74,54 @@ static bool attach_cover_mp3(TagLib::MPEG::File *mp3File, const char *coverPath)
   picture->setDescription("Front cover");
   picture->setPicture(TagLib::ByteVector(data.data(), (unsigned int)data.size()));
   tag->addFrame(picture);
+  return true;
+}
+
+static bool read_cover_bytes(const char *coverPath, std::vector<char> &data) {
+  if (coverPath == nullptr || *coverPath == '\0') {
+    return false;
+  }
+  std::ifstream image(coverPath, std::ios::binary);
+  if (!image) {
+    return false;
+  }
+  data.assign(std::istreambuf_iterator<char>(image), std::istreambuf_iterator<char>());
+  return !data.empty();
+}
+
+static bool attach_cover_flac(TagLib::FLAC::File *flacFile, const char *coverPath) {
+  if (flacFile == nullptr) {
+    return false;
+  }
+
+  std::vector<char> data;
+  if (!read_cover_bytes(coverPath, data)) {
+    return false;
+  }
+
+  flacFile->removePictures();
+  auto *picture = new TagLib::FLAC::Picture;
+  picture->setType(TagLib::FLAC::Picture::FrontCover);
+  picture->setMimeType("image/jpeg");
+  picture->setDescription("Front cover");
+  picture->setData(TagLib::ByteVector(data.data(), (unsigned int)data.size()));
+  flacFile->addPicture(picture);
+  return true;
+}
+
+static bool attach_cover_mp4(TagLib::MP4::File *mp4File, const char *coverPath) {
+  if (mp4File == nullptr || mp4File->tag() == nullptr) {
+    return false;
+  }
+
+  std::vector<char> data;
+  if (!read_cover_bytes(coverPath, data)) {
+    return false;
+  }
+
+  TagLib::MP4::CoverArtList coverArtList;
+  coverArtList.append(TagLib::MP4::CoverArt(TagLib::MP4::CoverArt::JPEG, TagLib::ByteVector(data.data(), (unsigned int)data.size())));
+  mp4File->tag()->itemMap()["covr"] = coverArtList;
   return true;
 }
 
@@ -137,6 +187,10 @@ int taglib_write_fetched_metadata(const FILENAME_CHAR_T *filename, const char *a
 
   TagLib::MPEG::File *mp3File = dynamic_cast<TagLib::MPEG::File *>(f.file());
   attach_cover_mp3(mp3File, cover_path);
+  TagLib::FLAC::File *flacFile = dynamic_cast<TagLib::FLAC::File *>(f.file());
+  attach_cover_flac(flacFile, cover_path);
+  TagLib::MP4::File *mp4File = dynamic_cast<TagLib::MP4::File *>(f.file());
+  attach_cover_mp4(mp4File, cover_path);
 
   if (!f.file()->save()) {
     return TAGLIB_ERR_SAVE;

--- a/adapters/taglib/taglib_wrapper.go
+++ b/adapters/taglib/taglib_wrapper.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -100,6 +101,66 @@ func WriteComment(filename, comment string) (err error) {
 		return fmt.Errorf("cannot save media file after writing comment")
 	default:
 		return fmt.Errorf("unknown error writing comment: %d", int(res))
+	}
+}
+
+type FetchedMetadata struct {
+	Album         string
+	Year          int
+	Genre         string
+	RecordingMBID string
+	ReleaseMBID   string
+	CoverPath     string
+}
+
+func WriteFetchedMetadata(filename string, md FetchedMetadata) (err error) {
+	debug.SetPanicOnFault(true)
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("extractor: recovered from panic when writing fetched metadata", "file", filename, "error", r)
+			err = fmt.Errorf("extractor: recovered from panic: %s", r)
+		}
+	}()
+
+	fp := getFilename(filename)
+	defer C.free(unsafe.Pointer(fp))
+
+	cAlbum := C.CString(strings.TrimSpace(md.Album))
+	defer C.free(unsafe.Pointer(cAlbum))
+
+	year := ""
+	if md.Year > 0 {
+		year = strconv.Itoa(md.Year)
+	}
+	cYear := C.CString(year)
+	defer C.free(unsafe.Pointer(cYear))
+
+	cGenre := C.CString(strings.TrimSpace(md.Genre))
+	defer C.free(unsafe.Pointer(cGenre))
+
+	cRecordingMBID := C.CString(strings.TrimSpace(md.RecordingMBID))
+	defer C.free(unsafe.Pointer(cRecordingMBID))
+
+	cReleaseMBID := C.CString(strings.TrimSpace(md.ReleaseMBID))
+	defer C.free(unsafe.Pointer(cReleaseMBID))
+
+	coverPath := strings.TrimSpace(md.CoverPath)
+	if coverPath != "" {
+		coverPath = filepath.Clean(coverPath)
+	}
+	cCoverPath := C.CString(coverPath)
+	defer C.free(unsafe.Pointer(cCoverPath))
+
+	res := C.taglib_write_fetched_metadata(fp, cAlbum, cYear, cGenre, cRecordingMBID, cReleaseMBID, cCoverPath)
+	switch res {
+	case 0:
+		return nil
+	case C.TAGLIB_ERR_PARSE:
+		return fmt.Errorf("cannot open media file for writing metadata")
+	case C.TAGLIB_ERR_SAVE:
+		return fmt.Errorf("cannot save media file after writing metadata")
+	default:
+		return fmt.Errorf("unknown error writing metadata: %d", int(res))
 	}
 }
 

--- a/adapters/taglib/taglib_wrapper.h
+++ b/adapters/taglib/taglib_wrapper.h
@@ -20,6 +20,7 @@ extern void goPutLyricLine(unsigned long id, char *lang, char *text, int time);
 int taglib_read(const FILENAME_CHAR_T *filename, unsigned long id);
 char* taglib_version();
 int taglib_write_comment(const FILENAME_CHAR_T *filename, const char *comment);
+int taglib_write_fetched_metadata(const FILENAME_CHAR_T *filename, const char *album, const char *year, const char *genre, const char *recording_mbid, const char *release_mbid, const char *cover_path);
 
 #ifdef __cplusplus
 }

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -18,6 +18,7 @@ import (
 	"unicode"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/adapters/taglib"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -915,8 +916,55 @@ func (n *Router) addMusicBrainzMetadataRoute(r chi.Router) {
 				return
 			}
 
+			if err := n.saveFetchedMetadataToSongs(); err != nil {
+				log.Warn("Could not persist fetched metadata to song files", "err", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"status":"save_failed"}`))
+				return
+			}
+
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"status":"saved"}`))
 		})
 	})
+}
+
+func (n *Router) saveFetchedMetadataToSongs() error {
+	ctx := context.Background()
+	cursor, err := n.ds.MediaFile(ctx).GetCursor()
+	if err != nil {
+		return err
+	}
+
+	for mf, e := range cursor {
+		if e != nil {
+			return e
+		}
+
+		if strings.TrimSpace(mf.Path) == "" || strings.TrimSpace(mf.LibraryPath) == "" {
+			continue
+		}
+
+		coverFile := ""
+		if strings.HasPrefix(strings.TrimSpace(mf.CoverPath), coverCacheDirName+"/") {
+			coverFile = filepath.Join(conf.Server.DataFolder, filepath.FromSlash(mf.CoverPath))
+		}
+
+		if strings.TrimSpace(mf.Album) == "" && mf.Year == 0 && strings.TrimSpace(mf.Genre) == "" && strings.TrimSpace(mf.MbzRecordingID) == "" && strings.TrimSpace(mf.MbzReleaseID) == "" && coverFile == "" {
+			continue
+		}
+
+		if err := taglib.WriteFetchedMetadata(mf.AbsolutePath(), taglib.FetchedMetadata{
+			Album:         mf.Album,
+			Year:          mf.Year,
+			Genre:         mf.Genre,
+			RecordingMBID: mf.MbzRecordingID,
+			ReleaseMBID:   mf.MbzReleaseID,
+			CoverPath:     coverFile,
+		}); err != nil {
+			log.Warn(ctx, "Could not write fetched metadata to song", "songId", mf.ID, "path", mf.Path, "err", err)
+		}
+	}
+
+	return nil
 }

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -950,7 +950,8 @@ func (n *Router) saveFetchedMetadataToSongs() error {
 			coverFile = filepath.Join(conf.Server.DataFolder, filepath.FromSlash(mf.CoverPath))
 		}
 
-		if strings.TrimSpace(mf.Album) == "" && mf.Year == 0 && strings.TrimSpace(mf.Genre) == "" && strings.TrimSpace(mf.MbzRecordingID) == "" && strings.TrimSpace(mf.MbzReleaseID) == "" && coverFile == "" {
+		hasFetchedIDs := strings.TrimSpace(mf.MbzRecordingID) != "" || strings.TrimSpace(mf.MbzReleaseID) != ""
+		if !hasFetchedIDs && coverFile == "" {
 			continue
 		}
 

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -36,6 +36,7 @@ type metadataFieldProgress struct {
 
 type musicBrainzMetadataStatus struct {
 	Running       bool                  `json:"running"`
+	Saving        bool                  `json:"saving"`
 	StartedAt     *time.Time            `json:"startedAt,omitempty"`
 	FinishedAt    *time.Time            `json:"finishedAt,omitempty"`
 	LastError     string                `json:"lastError,omitempty"`
@@ -45,6 +46,7 @@ type musicBrainzMetadataStatus struct {
 	RecordingMBID metadataFieldProgress `json:"recordingMbid"`
 	ReleaseMBID   metadataFieldProgress `json:"releaseMbid"`
 	CoverArt      metadataFieldProgress `json:"coverArt"`
+	CoverArtSave  metadataFieldProgress `json:"coverArtSave"`
 }
 
 type musicBrainzMetadataJob struct {
@@ -410,6 +412,39 @@ func (j *musicBrainzMetadataJob) setError(err error) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	j.status.LastError = err.Error()
+}
+
+func (j *musicBrainzMetadataJob) setCoverArtSaveTotal(total int) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.status.CoverArtSave = metadataFieldProgress{Missing: total, Left: total}
+	j.status.Saving = total > 0
+}
+
+func (j *musicBrainzMetadataJob) beginCoverArtSave() {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.status.CoverArtSave.Fetching++
+}
+
+func (j *musicBrainzMetadataJob) finishCoverArtSave(saved bool) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.status.CoverArtSave.Fetching > 0 {
+		j.status.CoverArtSave.Fetching--
+	}
+	if j.status.CoverArtSave.Left > 0 {
+		j.status.CoverArtSave.Left--
+	}
+	if saved {
+		j.status.CoverArtSave.Fetched++
+		j.status.CoverArtSave.Updated++
+	} else {
+		j.status.CoverArtSave.CouldntFetch++
+	}
+	if j.status.CoverArtSave.Left == 0 && j.status.CoverArtSave.Fetching == 0 {
+		j.status.Saving = false
+	}
 }
 
 func (j *musicBrainzMetadataJob) ensureReleaseCover(ctx context.Context, releaseMBID string) (string, bool) {
@@ -936,6 +971,22 @@ func (n *Router) saveFetchedMetadataToSongs() error {
 		return err
 	}
 
+	totalCoverArtToSave := 0
+	for mf, e := range cursor {
+		if e != nil {
+			return e
+		}
+		if strings.HasPrefix(strings.TrimSpace(mf.CoverPath), coverCacheDirName+"/") {
+			totalCoverArtToSave++
+		}
+	}
+	n.metadataJob.setCoverArtSaveTotal(totalCoverArtToSave)
+
+	cursor, err = n.ds.MediaFile(ctx).GetCursor()
+	if err != nil {
+		return err
+	}
+
 	for mf, e := range cursor {
 		if e != nil {
 			return e
@@ -948,6 +999,7 @@ func (n *Router) saveFetchedMetadataToSongs() error {
 		coverFile := ""
 		if strings.HasPrefix(strings.TrimSpace(mf.CoverPath), coverCacheDirName+"/") {
 			coverFile = filepath.Join(conf.Server.DataFolder, filepath.FromSlash(mf.CoverPath))
+			n.metadataJob.beginCoverArtSave()
 		}
 
 		hasFetchedIDs := strings.TrimSpace(mf.MbzRecordingID) != "" || strings.TrimSpace(mf.MbzReleaseID) != ""
@@ -963,7 +1015,14 @@ func (n *Router) saveFetchedMetadataToSongs() error {
 			ReleaseMBID:   mf.MbzReleaseID,
 			CoverPath:     coverFile,
 		}); err != nil {
+			if coverFile != "" {
+				n.metadataJob.finishCoverArtSave(false)
+			}
 			log.Warn(ctx, "Could not write fetched metadata to song", "songId", mf.ID, "path", mf.Path, "err", err)
+			continue
+		}
+		if coverFile != "" {
+			n.metadataJob.finishCoverArtSave(true)
 		}
 	}
 

--- a/ui/src/layout/CoverArtPanel.jsx
+++ b/ui/src/layout/CoverArtPanel.jsx
@@ -99,6 +99,26 @@ const ProgressCard = ({ title, progress, translate, classes }) => (
   </Card>
 )
 
+const CoverArtSaveCard = ({ title, progress, classes }) => (
+  <Card variant="outlined" className={classes.progressCard}>
+    <CardContent>
+      <Typography variant="subtitle2">{title}</Typography>
+      <Box className={classes.row}>
+        <span>Saving</span>
+        <span>{progress.fetching || 0}</span>
+      </Box>
+      <Box className={classes.row}>
+        <span>Saved completed</span>
+        <span>{progress.updated || 0}</span>
+      </Box>
+      <Box className={classes.row}>
+        <span>Remaining</span>
+        <span>{progress.left || 0}</span>
+      </Box>
+    </CardContent>
+  </Card>
+)
+
 const CoverArtPanel = () => {
   const classes = useStyles()
   const translate = useTranslate()
@@ -112,6 +132,7 @@ const CoverArtPanel = () => {
     recordingMbid: emptyProgress,
     releaseMbid: emptyProgress,
     coverArt: emptyProgress,
+    coverArtSave: emptyProgress,
   })
 
   const open = Boolean(anchorEl)
@@ -128,6 +149,7 @@ const CoverArtPanel = () => {
             recordingMbid: emptyProgress,
             releaseMbid: emptyProgress,
             coverArt: emptyProgress,
+            coverArtSave: emptyProgress,
           },
         )
       })
@@ -166,6 +188,7 @@ const CoverArtPanel = () => {
       .then(({ status: code }) => {
         if (code === 200) {
           notify('activity.musicbrainz.saved', 'info')
+          loadStatus()
         } else {
           notify('activity.musicbrainz.saveFailed', 'warning')
         }
@@ -204,7 +227,7 @@ const CoverArtPanel = () => {
                   variant="contained"
                   startIcon={<MdSave />}
                   onClick={saveMetadata}
-                  disabled={status.running}
+                  disabled={status.running || status.saving}
                   data-testid="coverart-metadata-save-btn"
                 >
                   {translate('activity.musicbrainz.save')}
@@ -214,7 +237,7 @@ const CoverArtPanel = () => {
                   variant="contained"
                   startIcon={<BiDownload />}
                   onClick={startFetch}
-                  disabled={status.running}
+                  disabled={status.running || status.saving}
                   data-testid="coverart-metadata-fetch-btn"
                 >
                   {translate('activity.musicbrainz.fetch')}
@@ -227,6 +250,13 @@ const CoverArtPanel = () => {
                   title="Cover Art"
                   progress={status.coverArt || emptyProgress}
                   translate={translate}
+                  classes={classes}
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <CoverArtSaveCard
+                  title="Cover Art Save"
+                  progress={status.coverArtSave || emptyProgress}
                   classes={classes}
                 />
               </Grid>


### PR DESCRIPTION
### Motivation
- Enable the MusicBrainz "Save" action to persist fetched metadata (album/year/genre/MBIDs and cover art) back into the original media files so the fetched data is written permanently to the files.

### Description
- Added a native taglib C++ API `taglib_write_fetched_metadata` that writes album/year/genre, MusicBrainz IDs and embeds cached cover art into MP3 files (APIC front cover).
- Exposed a Go wrapper `WriteFetchedMetadata` and `FetchedMetadata` struct in `adapters/taglib` to call the native writer from Go code.
- Implemented `saveFetchedMetadataToSongs` and wired it into the `/api/metadata/musicbrainz/save` handler so the Save route iterates media files and calls `taglib.WriteFetchedMetadata` for each candidate, preserving existing behavior otherwise.
- The save flow only attempts embedding cover art when `MediaFile.CoverPath` references Navidrome's cover cache and logs per-file write failures without aborting the whole process.

### Testing
- Ran code formatting (`gofmt -w adapters/taglib/taglib_wrapper.go server/nativeapi/musicbrainz_metadata.go`) successfully.
- Attempted `go test` for the modified packages but tests could not run in this environment due to missing TagLib system dependency (pkg-config/taglib not found), so unit tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c5e0717408322a37a405c6c5690b3)