### PR TITLE
Fix retail player artwork updates from realtime payload

### DIFF
--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -1049,7 +1049,7 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
         device: mergedDevice,
         status: mergedDevice.status || {},
         streamMetadata: mergedStreamMetadata,
-        artwork: mergedDevice.artwork || payload.artwork,
+        artwork: payload.artwork || mergedDevice.artwork,
       }
 
       setStatusState({


### PR DESCRIPTION
### Motivation
- Incoming realtime `payload.artwork` could be ignored when `mergedDevice.artwork` was present, causing freshly fetched cover art to be lost and the UI to show stale or missing images.

### Description
- Prefer the realtime artwork by changing the status merge in `ui/src/retailPlayer/useRetailPlayerDeviceStatus.js` from `artwork: mergedDevice.artwork || payload.artwork` to `artwork: payload.artwork || mergedDevice.artwork` so the incoming `payload.artwork` takes precedence.

### Testing
- Ran `npx eslint src/retailPlayer/useRetailPlayerDeviceStatus.js`, which succeeded for the modified file; a project-wide `npm run -s lint` invocation reported unrelated lint issues in other files and did not block this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cc6fafcf88322b3076032d38624a7)