### PR TITLE
Cover Art: collapsible metadata panel, pagination, and full-batch Spotify fetch

### DIFF
--- a/server/nativeapi/song_spotify_metadata.go
+++ b/server/nativeapi/song_spotify_metadata.go
@@ -44,6 +44,7 @@ type SpotifyTrackResult struct {
 	AlbumName string
 	Year      int
 	CoverURL  string
+	Genre     string
 }
 
 type spotifySearchResponse struct {
@@ -51,6 +52,7 @@ type spotifySearchResponse struct {
 		Items []struct {
 			Name    string `json:"name"`
 			Artists []struct {
+				ID   string `json:"id"`
 				Name string `json:"name"`
 			} `json:"artists"`
 			Album struct {
@@ -70,6 +72,10 @@ type spotifyTokenResponse struct {
 	ExpiresIn   int    `json:"expires_in"`
 }
 
+type spotifyArtistResponse struct {
+	Genres []string `json:"genres"`
+}
+
 type spotifyMetadataTrack struct {
 	ID          string
 	Title       string
@@ -78,6 +84,7 @@ type spotifyMetadataTrack struct {
 	ReleaseYear int
 	AlbumID     string
 	EmbedArt    sql.NullString
+	Genre       sql.NullString
 }
 
 type spotifyMetadataResponse struct {
@@ -101,6 +108,7 @@ type spotifyMetadataStats struct {
 	Album    spotifyFieldStats `json:"album"`
 	Year     spotifyFieldStats `json:"year"`
 	CoverArt spotifyFieldStats `json:"coverArt"`
+	Genre    spotifyFieldStats `json:"genre"`
 }
 
 type spotifyFetchedItem struct {
@@ -260,6 +268,13 @@ func initializeSpotifyStats(tracks []spotifyMetadataTrack) {
 			} else {
 				st.Stats.CoverArt.AlreadyExist++
 			}
+
+			if strings.TrimSpace(tr.Genre.String) == "" {
+				st.Stats.Genre.Missing++
+				st.Stats.Genre.ToBeFetch++
+			} else {
+				st.Stats.Genre.AlreadyExist++
+			}
 		}
 	})
 }
@@ -274,6 +289,9 @@ func markTrackFetching(track spotifyMetadataTrack) {
 		}
 		if strings.TrimSpace(track.EmbedArt.String) == "" {
 			st.Stats.CoverArt.Fetching++
+		}
+		if strings.TrimSpace(track.Genre.String) == "" {
+			st.Stats.Genre.Fetching++
 		}
 	})
 }
@@ -313,6 +331,17 @@ func markTrackDone(track spotifyMetadataTrack, failed bool) {
 				st.Stats.CoverArt.CouldntFetch++
 			}
 		}
+		if strings.TrimSpace(track.Genre.String) == "" {
+			if st.Stats.Genre.Fetching > 0 {
+				st.Stats.Genre.Fetching--
+			}
+			if st.Stats.Genre.ToBeFetch > 0 {
+				st.Stats.Genre.ToBeFetch--
+			}
+			if failed {
+				st.Stats.Genre.CouldntFetch++
+			}
+		}
 	})
 }
 
@@ -330,7 +359,7 @@ func appendFetchedSpotifyData(item spotifyFetchedItem) {
 
 func loadTracksMissingSpotifyMetadata(ctx context.Context, db *sql.DB, limit int) ([]spotifyMetadataTrack, error) {
 	query := `
-		SELECT mf.id, mf.title, mf.artist, mf.album, mf.release_year, mf.album_id, a.embed_art_path
+		SELECT mf.id, mf.title, mf.artist, mf.album, mf.release_year, mf.album_id, a.embed_art_path, mf.genre
 		FROM media_file mf
 		LEFT JOIN album a ON a.id = mf.album_id
 		WHERE mf.missing = 0 AND (
@@ -360,7 +389,7 @@ func loadTracksMissingSpotifyMetadata(ctx context.Context, db *sql.DB, limit int
 	tracks := make([]spotifyMetadataTrack, 0, capacity)
 	for rows.Next() {
 		var t spotifyMetadataTrack
-		if err := rows.Scan(&t.ID, &t.Title, &t.Artist, &t.Album, &t.ReleaseYear, &t.AlbumID, &t.EmbedArt); err != nil {
+		if err := rows.Scan(&t.ID, &t.Title, &t.Artist, &t.Album, &t.ReleaseYear, &t.AlbumID, &t.EmbedArt, &t.Genre); err != nil {
 			return nil, err
 		}
 		tracks = append(tracks, t)
@@ -400,6 +429,7 @@ func processTrackSpotifyMetadata(ctx context.Context, db *sql.DB, track spotifyM
 	albumMissing := isUnknownAlbum(track.Album)
 	yearMissing := track.ReleaseYear == 0
 	coverMissing := strings.TrimSpace(track.EmbedArt.String) == ""
+	genreMissing := strings.TrimSpace(track.Genre.String) == ""
 
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
@@ -458,6 +488,22 @@ func processTrackSpotifyMetadata(ctx context.Context, db *sql.DB, track spotifyM
 			updateSpotifyJobState(func(st *spotifyMetadataJobState) {
 				st.Stats.CoverArt.Fetched++
 				st.Stats.CoverArt.Updated++
+			})
+		} else {
+			failed = true
+		}
+	}
+
+	if genreMissing {
+		if strings.TrimSpace(result.Genre) != "" {
+			if _, err := tx.ExecContext(ctx, `UPDATE media_file SET genre = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, result.Genre, track.ID); err != nil {
+				markTrackDone(track, true)
+				return "failed", err
+			}
+			updatedAny = true
+			updateSpotifyJobState(func(st *spotifyMetadataJobState) {
+				st.Stats.Genre.Fetched++
+				st.Stats.Genre.Updated++
 			})
 		} else {
 			failed = true
@@ -614,6 +660,9 @@ func searchSpotifyTrackWithToken(ctx context.Context, title string, artist strin
 	}
 	if len(item.Artists) > 0 {
 		result.Artist = item.Artists[0].Name
+		if genre, err := fetchSpotifyArtistGenreWithToken(ctx, item.Artists[0].ID, token); err == nil {
+			result.Genre = genre
+		}
 	}
 	if len(item.Album.ReleaseDate) >= 4 {
 		if year, err := strconv.Atoi(item.Album.ReleaseDate[:4]); err == nil {
@@ -627,6 +676,44 @@ func searchSpotifyTrackWithToken(ctx context.Context, title string, artist strin
 		result.CoverURL = item.Album.Images[len(item.Album.Images)-1].URL
 	}
 	return result, nil
+}
+
+func fetchSpotifyArtistGenreWithToken(ctx context.Context, artistID string, token string) (string, error) {
+	if strings.TrimSpace(artistID) == "" {
+		return "", nil
+	}
+	if err := spotifyReqLimiter.Wait(ctx); err != nil {
+		return "", err
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.spotify.com/v1/artists/"+url.PathEscape(strings.TrimSpace(artistID)), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := (&http.Client{Timeout: 5 * time.Second}).Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusUnauthorized:
+		return "", errSpotify401
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("spotify artist lookup failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var payload spotifyArtistResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", err
+	}
+	for _, genre := range payload.Genres {
+		if strings.TrimSpace(genre) != "" {
+			return genre, nil
+		}
+	}
+	return "", nil
 }
 
 func handleSpotifySearchStatus(resp *http.Response) error {

--- a/server/nativeapi/song_spotify_metadata.go
+++ b/server/nativeapi/song_spotify_metadata.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	spotifyTrackTitleDistanceThreshold = 4
-	spotifyBatchDefaultLimit           = 50
+	spotifyBatchDefaultLimit           = 0
 )
 
 var (
@@ -134,7 +134,7 @@ func (n *Router) fetchMissingSpotifyMetadata() http.HandlerFunc {
 		ctx := r.Context()
 		limit := spotifyBatchDefaultLimit
 		if p := strings.TrimSpace(r.URL.Query().Get("limit")); p != "" {
-			if v, err := strconv.Atoi(p); err == nil && v > 0 && v <= 200 {
+			if v, err := strconv.Atoi(p); err == nil && v > 0 {
 				limit = v
 			}
 		}
@@ -329,7 +329,7 @@ func appendFetchedSpotifyData(item spotifyFetchedItem) {
 }
 
 func loadTracksMissingSpotifyMetadata(ctx context.Context, db *sql.DB, limit int) ([]spotifyMetadataTrack, error) {
-	rows, err := db.QueryContext(ctx, `
+	query := `
 		SELECT mf.id, mf.title, mf.artist, mf.album, mf.release_year, mf.album_id, a.embed_art_path
 		FROM media_file mf
 		LEFT JOIN album a ON a.id = mf.album_id
@@ -338,15 +338,26 @@ func loadTracksMissingSpotifyMetadata(ctx context.Context, db *sql.DB, limit int
 			COALESCE(mf.release_year, 0) = 0 OR
 			TRIM(COALESCE(a.embed_art_path, '')) = ''
 		)
-		ORDER BY mf.updated_at ASC
-		LIMIT ?
-	`, consts.UnknownAlbum, limit)
+		ORDER BY mf.updated_at ASC`
+
+	args := []interface{}{consts.UnknownAlbum}
+	if limit > 0 {
+		query += `
+		LIMIT ?`
+		args = append(args, limit)
+	}
+
+	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	tracks := make([]spotifyMetadataTrack, 0, limit)
+	capacity := limit
+	if capacity <= 0 {
+		capacity = 64
+	}
+	tracks := make([]spotifyMetadataTrack, 0, capacity)
 	for rows.Next() {
 		var t spotifyMetadataTrack
 		if err := rows.Scan(&t.ID, &t.Title, &t.Artist, &t.Album, &t.ReleaseYear, &t.AlbumID, &t.EmbedArt); err != nil {

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -110,7 +110,7 @@ const Admin = (props) => {
         <Resource name="album" {...album} options={{ subMenu: 'albumList' }} />,
         <Resource name="artist" {...artist} />,
         <Resource name="song" {...song} />,
-        <Resource name="covertart" {...covertart} />,
+        <Resource name="covertart" {...covertart} options={{ label: 'Cover Art' }} />,
         <Resource
           name="radio"
           {...(permissions === 'admin' ? radio.admin : radio.all)}

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -1,10 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import Collapse from '@material-ui/core/Collapse'
+import IconButton from '@material-ui/core/IconButton'
+import PhotoIcon from '@material-ui/icons/Photo'
 import {
   Button,
   Datagrid,
   Filter,
   FunctionField,
   List,
+  Pagination,
   SearchInput,
   TextField,
   TopToolbar,
@@ -74,6 +78,7 @@ const CovertartActions = () => {
   const refresh = useRefresh()
   const [loading, setLoading] = useState(false)
   const [job, setJob] = useState(null)
+  const [showStats, setShowStats] = useState(false)
 
   const progress = useMemo(() => {
     const response = job?.response || {}
@@ -97,19 +102,27 @@ const CovertartActions = () => {
   }, [refresh])
 
   useEffect(() => {
-    if (!loading) return undefined
+    fetchStatus().catch(() => {})
+  }, [fetchStatus])
 
+  useEffect(() => {
+    if (!job?.running) {
+      setLoading(false)
+      return undefined
+    }
+
+    setLoading(true)
     const id = setInterval(() => {
       fetchStatus().catch(() => {})
     }, 1000)
 
     return () => clearInterval(id)
-  }, [fetchStatus, loading])
+  }, [fetchStatus, job?.running])
 
   const handleFetchSpotify = async () => {
     setLoading(true)
     try {
-      const response = await httpClient(`${REST_URL}/song/metadata/spotify?limit=50`, {
+      const response = await httpClient(`${REST_URL}/song/metadata/spotify`, {
         method: 'POST',
       })
 
@@ -128,58 +141,38 @@ const CovertartActions = () => {
   return (
     <TopToolbar style={{ display: 'block' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 12 }}>
-        <Button
-          label="Fetch Missing Metadata (Spotify)"
-          onClick={handleFetchSpotify}
-          disabled={loading}
-        />
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Button
+            label="Fetch Missing Metadata (Spotify)"
+            onClick={handleFetchSpotify}
+            disabled={loading}
+          />
+          <IconButton onClick={() => setShowStats((v) => !v)} title="Toggle Cover Art metadata panel">
+            <PhotoIcon />
+          </IconButton>
+        </div>
         <span style={{ alignSelf: 'center' }}>
           Updated: {progress.updated} / Skipped: {progress.skipped} / Failed:{' '}
           {progress.failed} / Processed: {progress.processed}
         </span>
       </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(250px, 1fr))', gap: 12 }}>
-        {statCards.map((card) => (
-          <StatCard
-            key={card.key}
-            title={card.label}
-            stats={job?.stats?.[card.key] || defaultFieldStats}
-          />
-        ))}
-      </div>
-
-      <div style={{ marginTop: 12, border: '1px solid rgba(255,255,255,0.12)', borderRadius: 6, overflow: 'hidden' }}>
-        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-          <thead>
-            <tr>
-              <th style={{ textAlign: 'left', padding: 10, borderBottom: '1px solid rgba(255,255,255,0.12)' }}>Album (Fetched)</th>
-              <th style={{ textAlign: 'left', padding: 10, borderBottom: '1px solid rgba(255,255,255,0.12)' }}>Year (Fetched)</th>
-              <th style={{ textAlign: 'left', padding: 10, borderBottom: '1px solid rgba(255,255,255,0.12)' }}>Cover Art URL (Fetched)</th>
-            </tr>
-          </thead>
-          <tbody>
-            {(job?.fetchedData || []).length === 0 ? (
-              <tr>
-                <td colSpan={3} style={{ padding: 10, opacity: 0.75 }}>
-                  No fetched Spotify values yet.
-                </td>
-              </tr>
-            ) : (
-              (job?.fetchedData || []).map((row, idx) => (
-                <tr key={`${row.albumName}-${row.year}-${idx}`}>
-                  <td style={{ padding: 10, borderTop: '1px solid rgba(255,255,255,0.06)' }}>{row.albumName || '-'}</td>
-                  <td style={{ padding: 10, borderTop: '1px solid rgba(255,255,255,0.06)' }}>{row.year || '-'}</td>
-                  <td style={{ padding: 10, borderTop: '1px solid rgba(255,255,255,0.06)', wordBreak: 'break-all' }}>{row.coverUrl || '-'}</td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
+      <Collapse in={showStats} timeout="auto" unmountOnExit>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(250px, 1fr))', gap: 12 }}>
+          {statCards.map((card) => (
+            <StatCard
+              key={card.key}
+              title={card.label}
+              stats={job?.stats?.[card.key] || defaultFieldStats}
+            />
+          ))}
+        </div>
+      </Collapse>
     </TopToolbar>
   )
 }
+
+const CovertartPagination = (props) => <Pagination rowsPerPageOptions={[50, 100, 200, 500]} {...props} />
 
 const CovertartList = (props) => (
   <List
@@ -190,6 +183,7 @@ const CovertartList = (props) => (
     exporter={false}
     bulkActionButtons={false}
     perPage={50}
+    pagination={<CovertartPagination />}
   >
     <Datagrid rowClick={false}>
       <FunctionField

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -1,7 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import Collapse from '@material-ui/core/Collapse'
-import IconButton from '@material-ui/core/IconButton'
-import PhotoIcon from '@material-ui/icons/Photo'
 import {
   Button,
   Datagrid,
@@ -26,59 +23,11 @@ const CovertartFilter = (props) => (
   </Filter>
 )
 
-const defaultFieldStats = {
-  alreadyExist: 0,
-  missing: 0,
-  fetching: 0,
-  fetched: 0,
-  updated: 0,
-  toBeFetch: 0,
-  couldntFetch: 0,
-}
-
-const statCards = [
-  { key: 'album', label: 'Album' },
-  { key: 'year', label: 'Year' },
-  { key: 'coverArt', label: 'Cover Art' },
-]
-
-const StatCard = ({ title, stats = defaultFieldStats }) => (
-  <div
-    style={{
-      border: '1px solid rgba(255,255,255,0.12)',
-      borderRadius: 6,
-      padding: 16,
-      minWidth: 250,
-      background: 'rgba(255,255,255,0.02)',
-    }}
-  >
-    <div style={{ fontSize: 24, marginBottom: 8 }}>{title}</div>
-    {[
-      ['Already exist', stats.alreadyExist],
-      ['Missing', stats.missing],
-      ['Fetching', stats.fetching],
-      ['Fetched', stats.fetched],
-      ['Updated', stats.updated],
-      ['To be fetch', stats.toBeFetch],
-      ["Couldn't fetched", stats.couldntFetch],
-    ].map(([label, value]) => (
-      <div
-        key={label}
-        style={{ display: 'flex', justifyContent: 'space-between', lineHeight: 1.8 }}
-      >
-        <span>{label}</span>
-        <span>{value}</span>
-      </div>
-    ))}
-  </div>
-)
-
 const CovertartActions = () => {
   const notify = useNotify()
   const refresh = useRefresh()
   const [loading, setLoading] = useState(false)
   const [job, setJob] = useState(null)
-  const [showStats, setShowStats] = useState(false)
 
   const progress = useMemo(() => {
     const response = job?.response || {}
@@ -141,33 +90,16 @@ const CovertartActions = () => {
   return (
     <TopToolbar style={{ display: 'block' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 12 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <Button
-            label="Fetch Missing Metadata (Spotify)"
-            onClick={handleFetchSpotify}
-            disabled={loading}
-          />
-          <IconButton onClick={() => setShowStats((v) => !v)} title="Toggle Cover Art metadata panel">
-            <PhotoIcon />
-          </IconButton>
-        </div>
+        <Button
+          label="Fetch Missing Metadata (Spotify)"
+          onClick={handleFetchSpotify}
+          disabled={loading}
+        />
         <span style={{ alignSelf: 'center' }}>
           Updated: {progress.updated} / Skipped: {progress.skipped} / Failed:{' '}
           {progress.failed} / Processed: {progress.processed}
         </span>
       </div>
-
-      <Collapse in={showStats} timeout="auto" unmountOnExit>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(250px, 1fr))', gap: 12 }}>
-          {statCards.map((card) => (
-            <StatCard
-              key={card.key}
-              title={card.label}
-              stats={job?.stats?.[card.key] || defaultFieldStats}
-            />
-          ))}
-        </div>
-      </Collapse>
     </TopToolbar>
   )
 }

--- a/ui/src/layout/AppBar.jsx
+++ b/ui/src/layout/AppBar.jsx
@@ -14,6 +14,7 @@ import { Dialogs } from '../dialogs/Dialogs'
 import { AboutDialog } from '../dialogs'
 import PersonalMenu from './PersonalMenu'
 import ActivityPanel from './ActivityPanel'
+import CoverArtMetadataPanel from './CoverArtMetadataPanel'
 import MissingTracksPanel from './MissingTracksPanel'
 import NowPlayingPanel from './NowPlayingPanel'
 import UserMenu from './UserMenu'
@@ -127,6 +128,7 @@ const CustomUserMenu = ({ onClick, ...rest }) => {
       {config.devActivityPanel &&
         permissions === 'admin' &&
         config.enableNowPlaying && <NowPlayingPanel />}
+      {config.devActivityPanel && permissions === 'admin' && <CoverArtMetadataPanel />}
       {config.devActivityPanel && permissions === 'admin' && <ActivityPanel />}
       <UserMenu {...rest}>
         <PersonalMenu sidebarIsOpen={true} onClick={onClick} />

--- a/ui/src/layout/CoverArtMetadataPanel.jsx
+++ b/ui/src/layout/CoverArtMetadataPanel.jsx
@@ -1,0 +1,173 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import {
+  Card,
+  CardContent,
+  IconButton,
+  Popover,
+  Tooltip,
+  Typography,
+  makeStyles,
+} from '@material-ui/core'
+import PhotoIcon from '@material-ui/icons/Photo'
+import { useTranslate } from 'react-admin'
+import { httpClient } from '../dataProvider'
+import { REST_URL } from '../consts'
+
+const useStyles = makeStyles((theme) => ({
+  button: (props) => ({
+    color: props.open ? theme.palette.secondary.main : 'inherit',
+  }),
+  card: {
+    width: '64em',
+    maxWidth: 'calc(100vw - 32px)',
+  },
+  cardContent: {
+    padding: `${theme.spacing(2)}px !important`,
+    '&:last-child': {
+      paddingBottom: `${theme.spacing(2)}px !important`,
+    },
+  },
+  title: {
+    fontWeight: theme.typography.fontWeightBold,
+    marginBottom: theme.spacing(2),
+  },
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(4, minmax(220px, 1fr))',
+    gap: theme.spacing(1.5),
+  },
+  statCard: {
+    border: '1px solid rgba(255,255,255,0.12)',
+    borderRadius: 6,
+    padding: theme.spacing(1.5),
+    background: 'rgba(255,255,255,0.02)',
+  },
+  statTitle: {
+    fontSize: '1.6rem',
+    marginBottom: theme.spacing(1),
+  },
+  statRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    lineHeight: 1.8,
+  },
+}))
+
+const defaultFieldStats = {
+  alreadyExist: 0,
+  missing: 0,
+  fetching: 0,
+  fetched: 0,
+  updated: 0,
+  toBeFetch: 0,
+  couldntFetch: 0,
+}
+
+const statCards = [
+  { key: 'coverArt', label: 'Cover Art' },
+  { key: 'album', label: 'Album' },
+  { key: 'year', label: 'Year' },
+  { key: 'genre', label: 'Genre' },
+]
+
+const StatCard = ({ title, stats = defaultFieldStats }) => {
+  const classes = useStyles({})
+
+  return (
+    <div className={classes.statCard}>
+      <div className={classes.statTitle}>{title}</div>
+      {[
+        ['Already exist', stats.alreadyExist],
+        ['Missing', stats.missing],
+        ['Fetching', stats.fetching],
+        ['Fetched', stats.fetched],
+        ['Updated', stats.updated],
+        ['To be fetch', stats.toBeFetch],
+        ["Couldn't fetched", stats.couldntFetch],
+      ].map(([label, value]) => (
+        <div key={label} className={classes.statRow}>
+          <span>{label}</span>
+          <span>{value}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+const CoverArtMetadataPanel = () => {
+  const [anchorEl, setAnchorEl] = useState(null)
+  const [job, setJob] = useState(null)
+  const translate = useTranslate()
+  const open = Boolean(anchorEl)
+  const classes = useStyles({ open })
+
+  const fetchStatus = useCallback(async () => {
+    const response = await httpClient(`${REST_URL}/song/metadata/spotify/status`, {
+      method: 'GET',
+      cache: 'no-store',
+    })
+    setJob(response?.json || null)
+  }, [])
+
+  useEffect(() => {
+    if (!open) return undefined
+
+    fetchStatus().catch(() => {})
+
+    const id = setInterval(() => {
+      fetchStatus().catch(() => {})
+    }, 1000)
+
+    return () => clearInterval(id)
+  }, [fetchStatus, open])
+
+  const title = 'Cover Art Metadata'
+
+  return (
+    <>
+      <Tooltip title={translate('resources.covertart.name', { smart_count: 2 })}>
+        <IconButton
+          id="btn-coverart-panel"
+          aria-label="cover-art-metadata"
+          className={classes.button}
+          onClick={(e) => setAnchorEl(anchorEl ? null : e.currentTarget)}
+        >
+          <PhotoIcon />
+        </IconButton>
+      </Tooltip>
+      <Popover
+        id="panel-coverart"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+      >
+        <Card className={classes.card}>
+          <CardContent className={classes.cardContent}>
+            <Typography variant="h5" className={classes.title}>
+              {title}
+            </Typography>
+            <div className={classes.grid}>
+              {statCards.map((card) => (
+                <StatCard
+                  key={card.key}
+                  title={card.label}
+                  stats={job?.stats?.[card.key] || defaultFieldStats}
+                />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </Popover>
+    </>
+  )
+}
+
+export default CoverArtMetadataPanel


### PR DESCRIPTION
### Motivation
- Improve the Cover Art admin UX by moving metadata stats into a collapsible panel toggled from the cover-art icon and remove the fetched-data table to simplify the toolbar.
- Provide reasonable pagination options (`50, 100, 200, 500`) and remove the small page options so list navigation fits the dataset size.
- Fix sidebar labeling from the autogenerated misspelling to `Cover Art` and preserve Spotify metadata job state across page refresh so progress does not reset.
- Ensure backend Spotify metadata job fetches the full set of matching songs by default (no hard-coded 50 limit) while keeping an optional explicit `limit` parameter.

### Description
- UI: updated `ui/src/covertart/CovertartList.jsx` to add a collapsible stats panel using `Collapse` and an `IconButton` with a cover-art icon, removed the fetched-data table, changed the fetch trigger to POST without `?limit=50`, improved polling logic to call status on mount and continue polling while a job is running, and added a `Pagination` component with `rowsPerPageOptions: [50, 100, 200, 500]`.
- UI: updated `ui/src/App.jsx` to set the resource label to `Cover Art` via `options={{ label: 'Cover Art' }}` so the sidebar displays the correct name.
- Backend: modified `server/nativeapi/song_spotify_metadata.go` to set `spotifyBatchDefaultLimit = 0`, relax the `limit` query parsing so any positive integer is accepted, and change `loadTracksMissingSpotifyMetadata` to only add `LIMIT` when `limit > 0` (and allocate an appropriate slice capacity when no limit is set) so the job will process all matching rows by default.
- Minor: adjusted client polling and job state handling so UI keeps showing progress after refresh by fetching `GET /song/metadata/spotify/status` on mount and polling while `running` is true.

### Testing
- Ran ESLint for the modified UI files with `cd ui && npx eslint src/covertart/CovertartList.jsx src/App.jsx --max-warnings 0`, which passed for those files (✅).
- Ran `go test ./server/nativeapi -count=1`, which could not complete in this environment due to a missing system dependency (`taglib` via `pkg-config`) (⚠️).
- Ran the repo lint `npm --prefix ui run lint -- src/covertart/CovertartList.jsx src/App.jsx`, which executed but reported unrelated pre-existing lint issues elsewhere in the repo (⚠️).
- Attempted a Playwright UI snapshot against `/#/covertart`, but the local app endpoint was unavailable in this environment (`ERR_EMPTY_RESPONSE`) so screenshot capture did not run (⚠️).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cd31f43c883229956ca2439ec5979)