### PR TITLE
Fix cover art preview fallback for songs

### DIFF
--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -9,6 +9,7 @@ import {
 } from 'react-admin'
 import { makeStyles } from '@material-ui/core/styles'
 import { DurationField, Pagination } from '../common'
+import subsonic from '../subsonic'
 
 const useStyles = makeStyles({
   mbidText: {
@@ -41,12 +42,18 @@ const CovertartList = (props) => {
           label="Cover Art"
           sortable={false}
           render={(record) => {
-            const coverSrc =
-              record?.artworkUrl ||
-              record?.cover_art_url ||
-              (record?.mbzReleaseId
-                ? `/api/cover/${record.mbzReleaseId}`
-                : '/default-cover.png')
+            const hasSongCoverArt = Boolean(
+              record?.hasCoverArt ||
+                record?.artworkId ||
+                record?.artworkUrl ||
+                record?.cover_art_url,
+            )
+            const mbzCoverSrc = record?.mbzReleaseId
+              ? `/api/cover/${record.mbzReleaseId}`
+              : '/default-cover.png'
+            const coverSrc = hasSongCoverArt
+              ? subsonic.getCoverArtUrl(record, 50, true)
+              : mbzCoverSrc
 
             return (
               <img
@@ -55,6 +62,16 @@ const CovertartList = (props) => {
                 width="50"
                 height="50"
                 loading="lazy"
+                onError={(event) => {
+                  const image = event.currentTarget
+                  if (image.dataset.mbzFallbackApplied !== 'true') {
+                    image.dataset.mbzFallbackApplied = 'true'
+                    image.src = mbzCoverSrc
+                    return
+                  }
+                  image.onerror = null
+                  image.src = '/default-cover.png'
+                }}
               />
             )
           }}

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -11,6 +11,55 @@ import { makeStyles } from '@material-ui/core/styles'
 import { DurationField, Pagination } from '../common'
 import subsonic from '../subsonic'
 
+const fallbackCoverSrc = '/default-cover.png'
+
+const CoverArtThumbnail = ({ record }) => {
+  const hasSongCoverArt = Boolean(
+    record?.hasCoverArt ||
+      record?.artworkId ||
+      record?.artworkUrl ||
+      record?.cover_art_url,
+  )
+  const mbzCoverSrc = record?.mbzReleaseId
+    ? `/api/cover/${record.mbzReleaseId}`
+    : fallbackCoverSrc
+  const primaryCoverSrc = hasSongCoverArt
+    ? subsonic.getCoverArtUrl(record, 50, true)
+    : mbzCoverSrc
+  const fallbackSources = [mbzCoverSrc, fallbackCoverSrc].filter(
+    (src, index, arr) => src && arr.indexOf(src) === index,
+  )
+
+  const [src, setSrc] = React.useState(primaryCoverSrc)
+  const [fallbackIndex, setFallbackIndex] = React.useState(0)
+
+  React.useEffect(() => {
+    setSrc(primaryCoverSrc)
+    setFallbackIndex(0)
+  }, [primaryCoverSrc])
+
+  const onError = React.useCallback(() => {
+    const nextFallbackSrc = fallbackSources[fallbackIndex]
+    if (!nextFallbackSrc || nextFallbackSrc === src) {
+      return
+    }
+
+    setSrc(nextFallbackSrc)
+    setFallbackIndex((index) => index + 1)
+  }, [fallbackIndex, fallbackSources, src])
+
+  return (
+    <img
+      src={src}
+      alt={record?.title || 'cover art'}
+      width="50"
+      height="50"
+      loading="lazy"
+      onError={onError}
+    />
+  )
+}
+
 const useStyles = makeStyles({
   mbidText: {
     fontFamily: 'monospace',
@@ -41,40 +90,7 @@ const CovertartList = (props) => {
         <FunctionField
           label="Cover Art"
           sortable={false}
-          render={(record) => {
-            const hasSongCoverArt = Boolean(
-              record?.hasCoverArt ||
-                record?.artworkId ||
-                record?.artworkUrl ||
-                record?.cover_art_url,
-            )
-            const mbzCoverSrc = record?.mbzReleaseId
-              ? `/api/cover/${record.mbzReleaseId}`
-              : '/default-cover.png'
-            const coverSrc = hasSongCoverArt
-              ? subsonic.getCoverArtUrl(record, 50, true)
-              : mbzCoverSrc
-
-            return (
-              <img
-                src={coverSrc}
-                alt={record.title || 'cover art'}
-                width="50"
-                height="50"
-                loading="lazy"
-                onError={(event) => {
-                  const image = event.currentTarget
-                  if (image.dataset.mbzFallbackApplied !== 'true') {
-                    image.dataset.mbzFallbackApplied = 'true'
-                    image.src = mbzCoverSrc
-                    return
-                  }
-                  image.onerror = null
-                  image.src = '/default-cover.png'
-                }}
-              />
-            )
-          }}
+          render={(record) => <CoverArtThumbnail record={record} />}
         />
         <TextField source="title" />
         <TextField source="artist" label="Artist" />

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -41,9 +41,12 @@ const CovertartList = (props) => {
           label="Cover Art"
           sortable={false}
           render={(record) => {
-            const coverSrc = record?.mbzReleaseId
-              ? `/api/cover/${record.mbzReleaseId}`
-              : '/default-cover.png'
+            const coverSrc =
+              record?.artworkUrl ||
+              record?.cover_art_url ||
+              (record?.mbzReleaseId
+                ? `/api/cover/${record.mbzReleaseId}`
+                : '/default-cover.png')
 
             return (
               <img


### PR DESCRIPTION
### Motivation
- Songs with embedded or previously-resolved artwork were not showing thumbnails because the Cover Art list only used the MusicBrainz release lookup and a default placeholder.

### Description
- Updated `ui/src/covertart/CovertartList.jsx` to prefer `record.artworkUrl` and `record.cover_art_url` before falling back to the `/api/cover/{mbzReleaseId}` MusicBrainz cached endpoint and then to the default placeholder.

### Testing
- Ran `npx eslint ui/src/covertart/CovertartList.jsx` which succeeded for the modified file.
- Ran `cd ui && npm run lint -- src/covertart/CovertartList.jsx` which failed due to unrelated existing lint errors in other UI files.
- Started the dev server with `cd ui && npm start -- --host 0.0.0.0 --port 4173` and captured a screenshot with a Playwright script (`artifacts/coverart-fix.png`); the screenshot was produced but Vite reported an unrelated dependency resolution error for `@dnd-kit/core` that prevented a full UI load for manual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da579c7bc83228485d76b2a1bf855)