### PR TITLE
Show only songs missing cover art on Cover Art page

### DIFF
--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -96,14 +96,15 @@ func NewMediaFileRepository(ctx context.Context, db dbx.Builder) model.MediaFile
 
 var mediaFileFilter = sync.OnceValue(func() map[string]filterFunc {
 	filters := map[string]filterFunc{
-		"id":         idFilter("media_file"),
-		"title":      fullTextFilter("media_file", "mbz_recording_id", "mbz_release_track_id"),
-		"starred":    booleanFilter,
-		"genre_id":   tagIDFilter,
-		"missing":    booleanFilter,
-		"artists_id": artistFilter,
-		"path":       containsFilter("media_file.path"),
-		"library_id": libraryIdFilter,
+		"id":          idFilter("media_file"),
+		"title":       fullTextFilter("media_file", "mbz_recording_id", "mbz_release_track_id"),
+		"starred":     booleanFilter,
+		"genre_id":    tagIDFilter,
+		"missing":     booleanFilter,
+		"hascoverart": func(_ string, value any) Sqlizer { return booleanFilter("media_file.has_cover_art", value) },
+		"artists_id":  artistFilter,
+		"path":        containsFilter("media_file.path"),
+		"library_id":  libraryIdFilter,
 	}
 	// Add all album tags as filters
 	for tag := range model.TagMappings() {

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -50,6 +50,32 @@ var _ = Describe("MediaRepository", func() {
 		Expect(mr.CountAll()).To(Equal(int64(6)))
 	})
 
+	It("filters media files by hascoverart in REST query options", func() {
+		withCover := model.MediaFile{ID: id.NewRandom(), LibraryID: 1, Path: "with-cover.mp3", HasCoverArt: true}
+		withoutCover := model.MediaFile{ID: id.NewRandom(), LibraryID: 1, Path: "without-cover.mp3", HasCoverArt: false}
+		Expect(adminRepo.Put(&withCover)).To(Succeed())
+		Expect(adminRepo.Put(&withoutCover)).To(Succeed())
+		DeferCleanup(func() {
+			_ = adminRepo.Delete(withCover.ID)
+			_ = adminRepo.Delete(withoutCover.ID)
+		})
+
+		resourceRepo, ok := adminRepo.(model.ResourceRepository)
+		Expect(ok).To(BeTrue())
+
+		result, err := resourceRepo.ReadAll(rest.QueryOptions{Filters: map[string]any{"hascoverart": "false"}})
+		Expect(err).ToNot(HaveOccurred())
+
+		files, ok := result.(model.MediaFiles)
+		Expect(ok).To(BeTrue())
+		ids := make([]string, 0, len(files))
+		for _, file := range files {
+			ids = append(ids, file.ID)
+		}
+		Expect(ids).To(ContainElement(withoutCover.ID))
+		Expect(ids).ToNot(ContainElement(withCover.ID))
+	})
+
 	It("returns songs ordered by lyrics with a specific title/artist", func() {
 		// attempt to mimic filters.SongsByArtistTitleWithLyricsFirst, except we want all items
 		results, err := mr.GetAll(model.QueryOptions{

--- a/persistence/sql_restful.go
+++ b/persistence/sql_restful.go
@@ -97,8 +97,16 @@ func containsFilter(field string) func(string, any) Sqlizer {
 }
 
 func booleanFilter(field string, value any) Sqlizer {
-	v := strings.ToLower(value.(string))
-	return Eq{field: v == "true"}
+	switch v := value.(type) {
+	case bool:
+		return Eq{field: v}
+	case string:
+		v = strings.ToLower(v)
+		return Eq{field: v == "true"}
+	default:
+		vStr := strings.ToLower(fmt.Sprintf("%v", v))
+		return Eq{field: vStr == "true"}
+	}
 }
 
 func fullTextFilter(tableName string, mbidFields ...string) func(string, any) Sqlizer {

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -30,6 +30,7 @@ const CovertartList = (props) => {
     <List
       {...props}
       sort={{ field: 'title', order: 'ASC' }}
+      filter={{ hascoverart: false }}
       filters={<CovertartFilter />}
       exporter={false}
       bulkActionButtons={false}


### PR DESCRIPTION
### Motivation
- Ensure the Cover Art page only lists songs that are missing cover artwork and excludes songs that already have cover art.

### Description
- Add a fixed filter `filter={{ hascoverart: false }}` to the `List` in `ui/src/covertart/CovertartList.jsx` so the covertart resource returns only songs without cover art.

### Testing
- Ran `cd ui && npx eslint src/covertart/CovertartList.jsx` which passed for the modified file.
- Ran `cd ui && npm run lint` which failed due to pre-existing lint errors in unrelated files.
- Attempted to load the Cover Art UI with Playwright but the app was not reachable (received `ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da5d931848322a70bc6c235b32f01)