### PR TITLE
Filter Cover Art list to exclude songs that already have artwork

### DIFF
--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -88,6 +88,11 @@ const mapResource = (resource, params) => {
     case 'artist':
     case 'tag': {
       params.filter = params.filter || {}
+
+      if (resource === 'covertart') {
+        params.filter.hascoverart = false
+      }
+
       if (!isAdmin()) {
         params.filter.missing = false
       }


### PR DESCRIPTION
### Motivation
- The Cover Art admin page was listing songs that already have artwork because the UI reused the `song` endpoint without restricting results to tracks missing cover images, so the page must only request songs without cover art.

### Description
- Add `params.filter.hascoverart = false` for `resource === 'covertart'` in `ui/src/dataProvider/wrapperDataProvider.js` so the `covertart` mapping queries the `song` endpoint only for tracks without cover art.

### Testing
- Ran the focused unit tests with `npm --prefix ui test -- src/subsonic/index.test.js` and they passed.
- Ran the full UI test suite with `npm --prefix ui test` which executed many tests but reported pre-existing unrelated failures in `src/audioplayer/PlayerToolbar.test.jsx` (not caused by this change).
- Ran linter with `npm --prefix ui run lint -- src/dataProvider/wrapperDataProvider.js` which failed due to unrelated `no-console` lint errors in other files.
- Attempted an automated Playwright navigation to `http://localhost:4533/#/covertart` which failed with `ERR_EMPTY_RESPONSE`, so no UI screenshot could be captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da900d9248322a5ef838418c8219f)