### PR TITLE
Fix metadata fetch regression while keeping Cover Art missing-only filtering

### DIFF
--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -96,14 +96,15 @@ func NewMediaFileRepository(ctx context.Context, db dbx.Builder) model.MediaFile
 
 var mediaFileFilter = sync.OnceValue(func() map[string]filterFunc {
 	filters := map[string]filterFunc{
-		"id":         idFilter("media_file"),
-		"title":      fullTextFilter("media_file", "mbz_recording_id", "mbz_release_track_id"),
-		"starred":    booleanFilter,
-		"genre_id":   tagIDFilter,
-		"missing":    booleanFilter,
-		"artists_id": artistFilter,
-		"path":       containsFilter("media_file.path"),
-		"library_id": libraryIdFilter,
+		"id":          idFilter("media_file"),
+		"title":       fullTextFilter("media_file", "mbz_recording_id", "mbz_release_track_id"),
+		"starred":     booleanFilter,
+		"genre_id":    tagIDFilter,
+		"missing":     booleanFilter,
+		"hascoverart": coverArtFilter,
+		"artists_id":  artistFilter,
+		"path":        containsFilter("media_file.path"),
+		"library_id":  libraryIdFilter,
 	}
 	// Add all album tags as filters
 	for tag := range model.TagMappings() {
@@ -113,6 +114,21 @@ var mediaFileFilter = sync.OnceValue(func() map[string]filterFunc {
 	}
 	return filters
 })
+
+func coverArtFilter(_ string, value any) Sqlizer {
+	switch v := value.(type) {
+	case string:
+		return booleanFilter("media_file.has_cover_art", v)
+	case bool:
+		if v {
+			return Eq{"media_file.has_cover_art": true}
+		}
+		return Eq{"media_file.has_cover_art": false}
+	default:
+		vStr := strings.ToLower(strings.TrimSpace(fmt.Sprintf("%v", v)))
+		return Eq{"media_file.has_cover_art": vStr == "true"}
+	}
+}
 
 func mediaFileRecentlyAddedSort() string {
 	if conf.Server.RecentlyAddedByModTime {

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -50,6 +50,44 @@ var _ = Describe("MediaRepository", func() {
 		Expect(mr.CountAll()).To(Equal(int64(6)))
 	})
 
+	It("filters media files by hascoverart in REST query options", func() {
+		withCover := model.MediaFile{ID: id.NewRandom(), LibraryID: 1, Path: "with-cover.mp3", HasCoverArt: true}
+		withoutCover := model.MediaFile{ID: id.NewRandom(), LibraryID: 1, Path: "without-cover.mp3", HasCoverArt: false}
+		Expect(adminRepo.Put(&withCover)).To(Succeed())
+		Expect(adminRepo.Put(&withoutCover)).To(Succeed())
+		DeferCleanup(func() {
+			_ = adminRepo.Delete(withCover.ID)
+			_ = adminRepo.Delete(withoutCover.ID)
+		})
+
+		resourceRepo, ok := adminRepo.(model.ResourceRepository)
+		Expect(ok).To(BeTrue())
+
+		result, err := resourceRepo.ReadAll(rest.QueryOptions{Filters: map[string]any{"hascoverart": "false"}})
+		Expect(err).ToNot(HaveOccurred())
+
+		resultBool, err := resourceRepo.ReadAll(rest.QueryOptions{Filters: map[string]any{"hascoverart": false}})
+		Expect(err).ToNot(HaveOccurred())
+
+		files, ok := result.(model.MediaFiles)
+		Expect(ok).To(BeTrue())
+		ids := make([]string, 0, len(files))
+		for _, file := range files {
+			ids = append(ids, file.ID)
+		}
+		Expect(ids).To(ContainElement(withoutCover.ID))
+		Expect(ids).ToNot(ContainElement(withCover.ID))
+
+		filesBool, ok := resultBool.(model.MediaFiles)
+		Expect(ok).To(BeTrue())
+		idsBool := make([]string, 0, len(filesBool))
+		for _, file := range filesBool {
+			idsBool = append(idsBool, file.ID)
+		}
+		Expect(idsBool).To(ContainElement(withoutCover.ID))
+		Expect(idsBool).ToNot(ContainElement(withCover.ID))
+	})
+
 	It("returns songs ordered by lyrics with a specific title/artist", func() {
 		// attempt to mimic filters.SongsByArtistTitleWithLyricsFirst, except we want all items
 		results, err := mr.GetAll(model.QueryOptions{

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -30,6 +30,7 @@ const CovertartList = (props) => {
     <List
       {...props}
       sort={{ field: 'title', order: 'ASC' }}
+      filter={{ hascoverart: false }}
       filters={<CovertartFilter />}
       exporter={false}
       bulkActionButtons={false}


### PR DESCRIPTION
### Motivation
- A previous broad change hardened `booleanFilter` globally and caused metadata-fetching flows to misinterpret boolean REST filters, breaking metadata fetch/save behavior. 
- The Cover Art UI still needs to filter out files that already have artwork, so the `hascoverart` REST filter must work without affecting metadata jobs.

### Description
- Reverted `booleanFilter` in `persistence/sql_restful.go` to its string-based behavior and comparison to "true". 
- Added a dedicated `coverArtFilter` in `persistence/mediafile_repository.go` mapped to `hascoverart` that accepts `string`, `bool`, and other types and translates them to `media_file.has_cover_art` SQL conditions. 
- Updated the media-file filter map to use `coverArtFilter` for `hascoverart`. 
- Extended `persistence/mediafile_repository_test.go` to assert that `hascoverart=false` works for both the string and boolean forms.

### Testing
- Ran `cd ui && npx eslint src/covertart/CovertartList.jsx`, which completed successfully. 
- Ran `gofmt -w` on the modified Go files to ensure formatting consistency. 
- Attempted `go test ./persistence -ginkgo.focus="hascoverart in REST query options"`, but the test run was blocked by a missing native `taglib` pkg-config dependency in the environment so it could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da5d931848322a70bc6c235b32f01)