### PR TITLE
Fetch MusicBrainz metadata only for tracks missing cover art

### DIFF
--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -233,6 +233,11 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 			releaseMBID:   strings.TrimSpace(mf.MbzReleaseID) == "",
 			coverArt:      !mf.HasCoverArt && strings.TrimSpace(mf.CoverPath) == "",
 		}
+		if !flags.coverArt {
+			// Ignore tracks that already have cover art. Metadata enrichment should only
+			// run for tracks still missing cover art.
+			continue
+		}
 		j.incrementExisting(flags)
 		if !flags.album && !flags.year && !flags.genre && !flags.recordingMBID && !flags.releaseMBID && !flags.coverArt {
 			continue


### PR DESCRIPTION
### Motivation
- Only enrich metadata (album/year/genre/MBIDs/cover) for tracks that are missing cover art so tracks that already have cover art are ignored completely and not queried or modified.

### Description
- In `server/nativeapi/musicbrainz_metadata.go` the candidate collection now immediately skips any media file where `!mf.HasCoverArt && strings.TrimSpace(mf.CoverPath) != ""` is false, ensuring tracks with existing cover art are not considered for MusicBrainz queries and their album/year/genre/recordingMBID/releaseMBID are left untouched.

### Testing
- Ran `go test ./server/nativeapi`, which could not complete in this environment because the native `taglib` development package is missing from the `pkg-config` path and the package fails to compile.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dbbc2c4a8832292bf108eeee1bd25)