### PR TITLE
Fix inverted 'Fetched' filter for Cover Art list

### DIFF
--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -94,6 +94,9 @@ const mapResource = (resource, params) => {
       params = applyLibraryFilter(resource, params)
 
       if (resource === 'covertart') {
+        if (typeof params.filter.hascoverart === 'boolean') {
+          params.filter.hascoverart = !params.filter.hascoverart
+        }
         return ['song', params]
       }
 


### PR DESCRIPTION
### Motivation
- The Cover Art list showed items under the opposite fetched state because the `covertart` resource is proxied to the `song` endpoint and the `hascoverart` boolean filter polarity didn't match what users expect.

### Description
- In `ui/src/dataProvider/wrapperDataProvider.js` inside `mapResource`, invert `params.filter.hascoverart` when `resource === 'covertart'` so the UI `Fetched` selector maps correctly before returning `['song', params]`.

### Testing
- Ran `cd ui && npx eslint src/dataProvider/wrapperDataProvider.js` which succeeded; ran `cd ui && npm run lint` which failed due to unrelated pre-existing lint errors in other files; attempted a Playwright navigation to `/#/covertart` for visual validation which failed with `net::ERR_EMPTY_RESPONSE` because the app was not reachable in the test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc59c14c083228b1f4ca4e98509c5)