### PR TITLE
Add cover-art availability filter to Songs list

### DIFF
--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -36,7 +36,15 @@
         "tags": "Additional Tags",
         "mappedTags": "Mapped tags",
         "rawTags": "Raw tags",
-        "missing": "Missing"
+        "missing": "Missing",
+        "coverArt": "Cover Art"
+      },
+      "filters": {
+        "coverArt": {
+          "noFilter": "No Filter",
+          "existing": "Existing Cover Art",
+          "missing": "Missing Cover Art"
+        }
       },
       "actions": {
         "addToQueue": "Play Later",

--- a/ui/src/song/ReorderableSongList.jsx
+++ b/ui/src/song/ReorderableSongList.jsx
@@ -12,6 +12,7 @@ import {
   NumberField,
   ReferenceArrayInput,
   SearchInput,
+  SelectInput,
   TextField,
   useTranslate,
   NullableBooleanInput,
@@ -101,9 +102,43 @@ const SongFilter = (props) => {
   const translate = useTranslate()
   const { permissions } = usePermissions()
   const isAdmin = permissions === 'admin'
+  const coverArtFilterChoices = [
+    {
+      id: '',
+      name: translate('resources.song.filters.coverArt.noFilter'),
+    },
+    {
+      id: 'true',
+      name: translate('resources.song.filters.coverArt.existing'),
+    },
+    {
+      id: 'false',
+      name: translate('resources.song.filters.coverArt.missing'),
+    },
+  ]
+
+  const parseCoverArtFilter = (value) => {
+    if (value === 'true') return true
+    if (value === 'false') return false
+    return undefined
+  }
+
+  const formatCoverArtFilter = (value) => {
+    if (value === true) return 'true'
+    if (value === false) return 'false'
+    return ''
+  }
+
   return (
     <Filter {...props} variant={'outlined'}>
       <SearchInput source="title" alwaysOn />
+      <SelectInput
+        source="hascoverart"
+        label={translate('resources.song.fields.coverArt')}
+        choices={coverArtFilterChoices}
+        parse={parseCoverArtFilter}
+        format={formatCoverArtFilter}
+      />
       <ReferenceArrayInput
         label={translate('resources.song.fields.genre')}
         source="genre_id"

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -6,6 +6,7 @@ import {
   NumberField,
   ReferenceArrayInput,
   SearchInput,
+  SelectInput,
   TextField,
   useTranslate,
   NullableBooleanInput,
@@ -70,9 +71,43 @@ const SongFilter = (props) => {
   const translate = useTranslate()
   const { permissions } = usePermissions()
   const isAdmin = permissions === 'admin'
+  const coverArtFilterChoices = [
+    {
+      id: '',
+      name: translate('resources.song.filters.coverArt.noFilter'),
+    },
+    {
+      id: 'true',
+      name: translate('resources.song.filters.coverArt.existing'),
+    },
+    {
+      id: 'false',
+      name: translate('resources.song.filters.coverArt.missing'),
+    },
+  ]
+
+  const parseCoverArtFilter = (value) => {
+    if (value === 'true') return true
+    if (value === 'false') return false
+    return undefined
+  }
+
+  const formatCoverArtFilter = (value) => {
+    if (value === true) return 'true'
+    if (value === false) return 'false'
+    return ''
+  }
+
   return (
     <Filter {...props} variant={'outlined'}>
       <SearchInput source="title" alwaysOn />
+      <SelectInput
+        source="hascoverart"
+        label={translate('resources.song.fields.coverArt')}
+        choices={coverArtFilterChoices}
+        parse={parseCoverArtFilter}
+        format={formatCoverArtFilter}
+      />
       <ReferenceArrayInput
         label={translate('resources.song.fields.genre')}
         source="genre_id"


### PR DESCRIPTION
### Motivation
- Provide a way to filter songs by whether cover art has been fetched so users can view only tracks with existing art, only tracks without art, or keep no filter.

### Description
- Added a `SelectInput` with `source="hascoverart"` to the Songs filter in `ui/src/song/SongList.jsx` and `ui/src/song/ReorderableSongList.jsx` to surface a three-option dropdown (No Filter / Existing Cover Art / Missing Cover Art).
- Implemented `choices` plus `parse` and `format` helpers so the control sends boolean `true`/`false` to the API and omits the filter when “No Filter” is selected.
- Added English i18n strings for the new `coverArt` field and filter labels in `ui/src/i18n/en.json`.

### Testing
- Ran ESLint on the modified files with `cd ui && npx eslint src/song/SongList.jsx src/song/ReorderableSongList.jsx`, which completed successfully for the changed files.
- Ran the project-level linter with `cd ui && npm run lint -- src/song/SongList.jsx src/song/ReorderableSongList.jsx src/i18n/en.json`, which failed due to pre-existing unrelated lint errors in other UI files and not because of the changes in this PR.
- Started the dev server with `cd ui && npm run start` and attempted a Playwright screenshot to validate the UI rendering, but the running app reported a pre-existing module-resolution error for `@dnd-kit/core` (unrelated to this change); a screenshot artifact was still produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc868f7d48322b6d6772621020c31)