### PR TITLE
Reverse cover-art toggle to show missing artwork and rename label

### DIFF
--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -84,6 +84,7 @@ func NewMediaFileRepository(ctx context.Context, db dbx.Builder) model.MediaFile
 		"artist":         "order_artist_name, order_album_name, release_date, disc_number, track_number",
 		"album_artist":   "order_album_artist_name, order_album_name, release_date, disc_number, track_number",
 		"album":          "order_album_name, album_id, disc_number, track_number, order_artist_name, title",
+		"fetched":        "(media_file.has_cover_art or media_file.cover_path <> '')",
 		"random":         "random",
 		"created_at":     "media_file.created_at",
 		"recently_added": mediaFileRecentlyAddedSort(),
@@ -102,9 +103,15 @@ var mediaFileFilter = sync.OnceValue(func() map[string]filterFunc {
 		"genre_id":    tagIDFilter,
 		"missing":     booleanFilter,
 		"hascoverart": func(_ string, value any) Sqlizer { return booleanFilter("media_file.has_cover_art", value) },
-		"artists_id":  artistFilter,
-		"path":        containsFilter("media_file.path"),
-		"library_id":  libraryIdFilter,
+		"fetched": func(_ string, value any) Sqlizer {
+			if isTrue(value) {
+				return Or{Eq{"media_file.has_cover_art": true}, NotEq{"media_file.cover_path": ""}}
+			}
+			return And{Eq{"media_file.has_cover_art": false}, Eq{"media_file.cover_path": ""}}
+		},
+		"artists_id": artistFilter,
+		"path":       containsFilter("media_file.path"),
+		"library_id": libraryIdFilter,
 	}
 	// Add all album tags as filters
 	for tag := range model.TagMappings() {

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -76,6 +76,47 @@ var _ = Describe("MediaRepository", func() {
 		Expect(ids).ToNot(ContainElement(withCover.ID))
 	})
 
+	It("filters media files by fetched status in REST query options", func() {
+		withEmbeddedCover := model.MediaFile{ID: id.NewRandom(), LibraryID: 1, Path: "embedded-cover.mp3", HasCoverArt: true}
+		withFetchedCover := model.MediaFile{ID: id.NewRandom(), LibraryID: 1, Path: "fetched-cover.mp3", CoverPath: "covers/fetched-cover.jpg"}
+		withoutFetchedCover := model.MediaFile{ID: id.NewRandom(), LibraryID: 1, Path: "missing-cover.mp3", HasCoverArt: false, CoverPath: ""}
+		Expect(adminRepo.Put(&withEmbeddedCover)).To(Succeed())
+		Expect(adminRepo.Put(&withFetchedCover)).To(Succeed())
+		Expect(adminRepo.Put(&withoutFetchedCover)).To(Succeed())
+		DeferCleanup(func() {
+			_ = adminRepo.Delete(withEmbeddedCover.ID)
+			_ = adminRepo.Delete(withFetchedCover.ID)
+			_ = adminRepo.Delete(withoutFetchedCover.ID)
+		})
+
+		resourceRepo, ok := adminRepo.(model.ResourceRepository)
+		Expect(ok).To(BeTrue())
+
+		fetchedResult, err := resourceRepo.ReadAll(rest.QueryOptions{Filters: map[string]any{"fetched": "true"}})
+		Expect(err).ToNot(HaveOccurred())
+		fetchedFiles, ok := fetchedResult.(model.MediaFiles)
+		Expect(ok).To(BeTrue())
+		fetchedIDs := make([]string, 0, len(fetchedFiles))
+		for _, file := range fetchedFiles {
+			fetchedIDs = append(fetchedIDs, file.ID)
+		}
+		Expect(fetchedIDs).To(ContainElement(withEmbeddedCover.ID))
+		Expect(fetchedIDs).To(ContainElement(withFetchedCover.ID))
+		Expect(fetchedIDs).ToNot(ContainElement(withoutFetchedCover.ID))
+
+		notFetchedResult, err := resourceRepo.ReadAll(rest.QueryOptions{Filters: map[string]any{"fetched": "false"}})
+		Expect(err).ToNot(HaveOccurred())
+		notFetchedFiles, ok := notFetchedResult.(model.MediaFiles)
+		Expect(ok).To(BeTrue())
+		notFetchedIDs := make([]string, 0, len(notFetchedFiles))
+		for _, file := range notFetchedFiles {
+			notFetchedIDs = append(notFetchedIDs, file.ID)
+		}
+		Expect(notFetchedIDs).To(ContainElement(withoutFetchedCover.ID))
+		Expect(notFetchedIDs).ToNot(ContainElement(withEmbeddedCover.ID))
+		Expect(notFetchedIDs).ToNot(ContainElement(withFetchedCover.ID))
+	})
+
 	It("returns songs ordered by lyrics with a specific title/artist", func() {
 		// attempt to mimic filters.SongsByArtistTitleWithLyricsFirst, except we want all items
 		results, err := mr.GetAll(model.QueryOptions{

--- a/persistence/sql_restful.go
+++ b/persistence/sql_restful.go
@@ -97,15 +97,19 @@ func containsFilter(field string) func(string, any) Sqlizer {
 }
 
 func booleanFilter(field string, value any) Sqlizer {
+	return Eq{field: isTrue(value)}
+}
+
+func isTrue(value any) bool {
 	switch v := value.(type) {
 	case bool:
-		return Eq{field: v}
+		return v
 	case string:
 		v = strings.ToLower(v)
-		return Eq{field: v == "true"}
+		return v == "true"
 	default:
 		vStr := strings.ToLower(fmt.Sprintf("%v", v))
-		return Eq{field: vStr == "true"}
+		return vStr == "true"
 	}
 }
 

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -75,6 +75,7 @@ const CovertartList = (props) => {
     <List
       {...props}
       sort={{ field: 'title', order: 'ASC' }}
+      filter={{ hascoverart: false }}
       actions={<CovertartListActions />}
       filters={<CovertartFilter />}
       exporter={false}

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -1,4 +1,7 @@
 import React from 'react'
+import IconButton from '@material-ui/core/IconButton'
+import Tooltip from '@material-ui/core/Tooltip'
+import ImageOutlinedIcon from '@material-ui/icons/ImageOutlined'
 import {
   Datagrid,
   Filter,
@@ -6,9 +9,13 @@ import {
   List,
   SearchInput,
   TextField,
+  TopToolbar,
+  useListContext,
+  useTranslate,
 } from 'react-admin'
 import { makeStyles } from '@material-ui/core/styles'
 import { DurationField, Pagination } from '../common'
+import subsonic from '../subsonic'
 
 const useStyles = makeStyles({
   mbidText: {
@@ -16,6 +23,44 @@ const useStyles = makeStyles({
     fontSize: '0.75rem',
   },
 })
+
+const FetchedToggleButton = () => {
+  const translate = useTranslate()
+  const { filterValues, displayedFilters, setFilters } = useListContext()
+  const missingCoverArtOn =
+    filterValues?.fetched === false || filterValues?.fetched === 'false'
+
+  const toggleFetchedFilter = () => {
+    if (missingCoverArtOn) {
+      const { fetched, ...rest } = filterValues || {}
+      setFilters(rest, displayedFilters)
+      return
+    }
+    setFilters({ ...(filterValues || {}), fetched: false }, displayedFilters)
+  }
+
+  return (
+    <Tooltip
+      title={`${translate('resources.covertart.fields.missingCoverArt')}: ${
+        missingCoverArtOn ? 'On' : 'Off'
+      }`}
+    >
+      <IconButton
+        color={missingCoverArtOn ? 'primary' : 'default'}
+        aria-label={translate('resources.covertart.fields.missingCoverArt')}
+        onClick={toggleFetchedFilter}
+      >
+        <ImageOutlinedIcon />
+      </IconButton>
+    </Tooltip>
+  )
+}
+
+const CovertartListActions = (props) => (
+  <TopToolbar {...props}>
+    <FetchedToggleButton />
+  </TopToolbar>
+)
 
 const CovertartFilter = (props) => (
   <Filter {...props} variant={'outlined'}>
@@ -30,7 +75,7 @@ const CovertartList = (props) => {
     <List
       {...props}
       sort={{ field: 'title', order: 'ASC' }}
-      filter={{ hascoverart: false }}
+      actions={<CovertartListActions />}
       filters={<CovertartFilter />}
       exporter={false}
       bulkActionButtons={false}
@@ -42,9 +87,7 @@ const CovertartList = (props) => {
           label="Cover Art"
           sortable={false}
           render={(record) => {
-            const coverSrc = record?.mbzReleaseId
-              ? `/api/cover/${record.mbzReleaseId}`
-              : '/default-cover.png'
+            const coverSrc = subsonic.getCoverArtUrl(record, 50, true) || '/default-cover.png'
 
             return (
               <img
@@ -62,6 +105,13 @@ const CovertartList = (props) => {
         <TextField source="album" label="Album" />
         <TextField source="year" label="Release Year" />
         <TextField source="genre" label="Genre" />
+        <FunctionField
+          label="Fetched"
+          sortBy="fetched"
+          render={(record) =>
+            record?.hasCoverArt || Boolean(record?.coverPath) ? 'Yes' : 'No'
+          }
+        />
         <FunctionField
           label="Recording MBID"
           sortable={false}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -108,7 +108,11 @@
       }
     },
     "covertart": {
-      "name": "Cover Art |||| Cover Art"
+      "name": "Cover Art |||| Cover Art",
+      "fields": {
+        "fetched": "Fetched",
+        "missingCoverArt": "Missing CoverArt"
+      }
     },
     "artist": {
       "name": "Artist |||| Artists",


### PR DESCRIPTION
### Motivation
- The cover-art list toggle should highlight items missing cover art when active and show all items when off, and the UI label should reflect this as "Missing CoverArt".

### Description
- Reversed the toggle logic in `ui/src/covertart/CovertartList.jsx` so the active (pink) state applies `fetched: false` to show songs missing cover art and the inactive state removes the `fetched` filter to show all songs.
- Updated tooltip text and `aria-label` to use the new i18n key `resources.covertart.fields.missingCoverArt` and changed button color/active detection to `missingCoverArtOn`.
- Added the `missingCoverArt` translation entry in `ui/src/i18n/en.json` and preserved the existing `fetched` key for backward compatibility.

### Testing
- Ran lint on the modified UI file with `cd ui && npx eslint src/covertart/CovertartList.jsx`, which succeeded.
- Ran UI unit tests with `npm --prefix ui run test -- src/subsonic/index.test.js`, and all tests passed.
- Attempted a Playwright screenshot of `http://localhost:4533/#/covertart`, but the page was unreachable in this environment (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dbb67bffc832296987bd6a5226d2d)