### PR TITLE
Improve MusicBrainz recording MBID selection

### DIFF
--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -556,7 +556,7 @@ func valueOrNil(v string) *string {
 
 func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string, localDuration float32) (metadataResult, error) {
 	query := fmt.Sprintf("recording:\"%s\" AND artist:\"%s\"", title, artist)
-	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json&inc=releases+release-groups"
+	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json&limit=100&inc=releases+release-groups"
 	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return metadataResult{}, err
@@ -590,7 +590,7 @@ func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string, localDurati
 		return metadataResult{RecordingMBID: strings.TrimSpace(bestRecording.ID)}, nil
 	}
 
-	bestRelease := selectBestReleaseFromRecording(details.Releases, []string{"US", "USA"})
+	bestRelease := selectBestReleaseFromRecording(details.Releases)
 	if bestRelease == nil {
 		return metadataResult{RecordingMBID: strings.TrimSpace(bestRecording.ID)}, nil
 	}
@@ -643,21 +643,20 @@ func selectBestRecording(recordings []mbRecording, artist string, localDuration 
 	normalizedArtist := normalizeMBString(artist)
 
 	type recCandidate struct {
-		rec              *mbRecording
-		score            int
-		releases         int
-		hasAlbum         bool
-		hasOfficial      bool
-		earliest         int
-		durationDeltaMS  int
-		durationInWindow bool
+		rec             *mbRecording
+		score           int
+		releases        int
+		hasAlbum        bool
+		hasOfficial     bool
+		earliest        int
+		durationDeltaMS int
 	}
 
 	candidates := make([]recCandidate, 0, len(recordings))
 	for i := range recordings {
 		rec := &recordings[i]
 		score := rec.Score.Int()
-		if score < 80 {
+		if score != 100 {
 			continue
 		}
 		if !artistCreditMatches(rec.ArtistCredit, normalizedArtist) {
@@ -686,13 +685,11 @@ func selectBestRecording(recordings []mbRecording, artist string, localDuration 
 		}
 
 		delta := int(^uint(0) >> 1)
-		durationInWindow := false
 		if localDuration > 0 && rec.Length > 0 {
 			delta = absInt(rec.Length - int(localDuration*1000))
-			durationInWindow = delta <= 3000
 		}
 
-		candidates = append(candidates, recCandidate{rec: rec, score: score, releases: len(rec.Releases), hasAlbum: hasAlbum, hasOfficial: hasOfficial, earliest: earliest, durationDeltaMS: delta, durationInWindow: durationInWindow})
+		candidates = append(candidates, recCandidate{rec: rec, score: score, releases: len(rec.Releases), hasAlbum: hasAlbum, hasOfficial: hasOfficial, earliest: earliest, durationDeltaMS: delta})
 	}
 	if len(candidates) == 0 {
 		return nil
@@ -714,7 +711,7 @@ func selectBestRecording(recordings []mbRecording, artist string, localDuration 
 		if a.score != b.score {
 			return b.score - a.score
 		}
-		if a.durationInWindow && b.durationInWindow && a.durationDeltaMS != b.durationDeltaMS {
+		if localDuration > 0 && a.durationDeltaMS != b.durationDeltaMS {
 			return a.durationDeltaMS - b.durationDeltaMS
 		}
 		if a.hasAlbum && !b.hasAlbum {
@@ -746,7 +743,7 @@ func artistCreditMatches(credits []struct {
 	return false
 }
 
-func selectBestReleaseFromRecording(releases []mbRelease, preferredCountries []string) *mbRelease {
+func selectBestReleaseFromRecording(releases []mbRelease) *mbRelease {
 	filtered := make([]*mbRelease, 0, len(releases))
 	for i := range releases {
 		release := &releases[i]
@@ -787,14 +784,6 @@ func selectBestReleaseFromRecording(releases []mbRelease, preferredCountries []s
 			return aYear - bYear
 		}
 
-		aCountry := countryPreferred(a.Country, preferredCountries)
-		bCountry := countryPreferred(b.Country, preferredCountries)
-		if aCountry && !bCountry {
-			return -1
-		}
-		if !aCountry && bCountry {
-			return 1
-		}
 		return 0
 	})
 
@@ -812,16 +801,6 @@ func releasePrimaryTypeRank(primaryType string) int {
 	default:
 		return 3
 	}
-}
-
-func countryPreferred(country string, preferredCountries []string) bool {
-	country = normalizeMBString(country)
-	for _, c := range preferredCountries {
-		if country == normalizeMBString(c) {
-			return true
-		}
-	}
-	return false
 }
 
 func hasExcludedSecondaryType(release mbRelease) bool {

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -555,32 +555,23 @@ func valueOrNil(v string) *string {
 }
 
 func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string, localDuration float32) (metadataResult, error) {
-	query := fmt.Sprintf("recording:\"%s\" AND artist:\"%s\"", title, artist)
-	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json&limit=100&inc=releases+release-groups"
-	req, err := http.NewRequest(http.MethodGet, u, nil)
-	if err != nil {
-		return metadataResult{}, err
-	}
-	req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
-
-	resp, err := j.client.Do(req)
-	if err != nil {
-		return metadataResult{}, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return metadataResult{}, fmt.Errorf("musicbrainz status %d", resp.StatusCode)
+	queries := []string{
+		fmt.Sprintf("recording:\"%s\" AND artist:\"%s\"", title, artist),
+		fmt.Sprintf("recording:%s AND artist:%s", title, artist),
+		fmt.Sprintf("recording:\"%s\"", title),
 	}
 
-	var payload mbSearchResponse
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return metadataResult{}, err
+	var bestRecording *mbRecording
+	for _, query := range queries {
+		recordings, err := j.searchRecordings(query)
+		if err != nil {
+			continue
+		}
+		bestRecording = selectBestRecording(recordings, artist, localDuration)
+		if bestRecording != nil {
+			break
+		}
 	}
-	if len(payload.Recordings) == 0 {
-		return metadataResult{}, nil
-	}
-
-	bestRecording := selectBestRecording(payload.Recordings, artist, localDuration)
 	if bestRecording == nil {
 		return metadataResult{}, nil
 	}
@@ -608,6 +599,30 @@ func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string, localDurati
 		RecordingMBID: strings.TrimSpace(bestRecording.ID),
 		ReleaseMBID:   strings.TrimSpace(bestRelease.ID),
 	}, nil
+}
+
+func (j *musicBrainzMetadataJob) searchRecordings(query string) ([]mbRecording, error) {
+	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json&limit=100&inc=releases+release-groups"
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
+
+	resp, err := j.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("musicbrainz status %d", resp.StatusCode)
+	}
+
+	var payload mbSearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+	return payload.Recordings, nil
 }
 
 func (j *musicBrainzMetadataJob) fetchRecordingDetails(recordingID string) (mbRecording, error) {
@@ -656,10 +671,10 @@ func selectBestRecording(recordings []mbRecording, artist string, localDuration 
 	for i := range recordings {
 		rec := &recordings[i]
 		score := rec.Score.Int()
-		if score != 100 {
+		if score < 60 {
 			continue
 		}
-		if !artistCreditMatches(rec.ArtistCredit, normalizedArtist) {
+		if !artistCreditMatches(rec.ArtistCredit, normalizedArtist) && !artistCreditLooselyMatches(rec.ArtistCredit, normalizedArtist) {
 			continue
 		}
 		if isExcludedRecording(*rec) {
@@ -738,6 +753,33 @@ func artistCreditMatches(credits []struct {
 	for _, credit := range credits {
 		if normalizeMBString(credit.Name) == normalizedArtist {
 			return true
+		}
+	}
+	return false
+}
+
+func artistCreditLooselyMatches(credits []struct {
+	Name string `json:"name"`
+}, normalizedArtist string) bool {
+	if normalizedArtist == "" {
+		return false
+	}
+	artistTokens := strings.Fields(normalizedArtist)
+	if len(artistTokens) == 0 {
+		return false
+	}
+	for _, credit := range credits {
+		n := normalizeMBString(credit.Name)
+		if n == "" {
+			continue
+		}
+		if strings.Contains(n, normalizedArtist) || strings.Contains(normalizedArtist, n) {
+			return true
+		}
+		for _, tok := range artistTokens {
+			if tok != "" && strings.Contains(n, tok) {
+				return true
+			}
 		}
 	}
 	return false

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -497,14 +497,19 @@ type mbRecording struct {
 }
 
 type mbRelease struct {
-	ID           string   `json:"id"`
-	Title        string   `json:"title"`
-	Date         string   `json:"date"`
-	Status       string   `json:"status"`
-	Country      string   `json:"country"`
-	ReleaseGroup mbGroup  `json:"release-group"`
-	Tags         []mbName `json:"tags"`
-	Genres       []mbName `json:"genres"`
+	ID           string     `json:"id"`
+	Title        string     `json:"title"`
+	Date         string     `json:"date"`
+	Status       string     `json:"status"`
+	Country      string     `json:"country"`
+	ReleaseGroup mbGroup    `json:"release-group"`
+	Media        []mbMedium `json:"media"`
+	Tags         []mbName   `json:"tags"`
+	Genres       []mbName   `json:"genres"`
+}
+
+type mbMedium struct {
+	Format string `json:"format"`
 }
 
 type mbScore string
@@ -575,65 +580,63 @@ func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string, localDurati
 		return metadataResult{}, nil
 	}
 
-	bestCandidates := collectReleaseCandidates(payload.Recordings, artist, localDuration)
-	if len(bestCandidates) == 0 {
+	bestRecording := selectBestRecording(payload.Recordings, artist, localDuration)
+	if bestRecording == nil {
 		return metadataResult{}, nil
 	}
 
-	coverCache := make(map[string]bool, len(bestCandidates))
-	best := selectBestReleaseCandidate(bestCandidates, func(releaseID string) bool {
-		return j.releaseHasCover(releaseID, coverCache)
-	})
-	if best == nil {
-		return metadataResult{}, nil
+	details, err := j.fetchRecordingDetails(bestRecording.ID)
+	if err != nil {
+		return metadataResult{RecordingMBID: strings.TrimSpace(bestRecording.ID)}, nil
 	}
 
-	album := strings.TrimSpace(best.release.Title)
-	year := yearFromDate(best.release.Date)
+	bestRelease := selectBestReleaseFromRecording(details.Releases, []string{"US", "USA"})
+	if bestRelease == nil {
+		return metadataResult{RecordingMBID: strings.TrimSpace(bestRecording.ID)}, nil
+	}
+
+	album := strings.TrimSpace(bestRelease.Title)
+	year := yearFromDate(bestRelease.Date)
 	if year == 0 {
-		year = yearFromDate(best.recording.FirstReleaseDate)
+		year = yearFromDate(bestRecording.FirstReleaseDate)
 	}
-	genre := collectGenre(*best.recording, *best.release)
+	genre := collectGenre(*bestRecording, *bestRelease)
 	return metadataResult{
 		Album:         album,
 		Year:          year,
 		Genre:         genre,
-		RecordingMBID: strings.TrimSpace(best.recording.ID),
-		ReleaseMBID:   strings.TrimSpace(best.release.ID),
+		RecordingMBID: strings.TrimSpace(bestRecording.ID),
+		ReleaseMBID:   strings.TrimSpace(bestRelease.ID),
 	}, nil
 }
 
-func (j *musicBrainzMetadataJob) releaseHasCover(releaseID string, cache map[string]bool) bool {
-	releaseID = strings.TrimSpace(releaseID)
-	if releaseID == "" {
-		return false
-	}
-	if cached, ok := cache[releaseID]; ok {
-		return cached
+func (j *musicBrainzMetadataJob) fetchRecordingDetails(recordingID string) (mbRecording, error) {
+	recordingID = strings.TrimSpace(recordingID)
+	if recordingID == "" {
+		return mbRecording{}, nil
 	}
 
-	u := "https://coverartarchive.org/release/" + url.PathEscape(releaseID)
-	req, err := http.NewRequest(http.MethodHead, u, nil)
+	u := "https://musicbrainz.org/ws/2/recording/" + url.PathEscape(recordingID) + "?inc=releases+release-groups&fmt=json"
+	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
-		cache[releaseID] = false
-		return false
+		return mbRecording{}, err
 	}
 	req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	req = req.WithContext(ctx)
-
 	resp, err := j.client.Do(req)
 	if err != nil {
-		cache[releaseID] = false
-		return false
+		return mbRecording{}, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return mbRecording{}, fmt.Errorf("musicbrainz status %d", resp.StatusCode)
+	}
 
-	hasCover := resp.StatusCode == http.StatusOK
-	cache[releaseID] = hasCover
-	return hasCover
+	var details mbRecording
+	if err := json.NewDecoder(resp.Body).Decode(&details); err != nil {
+		return mbRecording{}, err
+	}
+	return details, nil
 }
 
 func selectBestRecording(recordings []mbRecording, artist string, localDuration float32) *mbRecording {
@@ -743,90 +746,102 @@ func artistCreditMatches(credits []struct {
 	return false
 }
 
-type releaseCandidate struct {
-	recording *mbRecording
-	release   *mbRelease
-}
-
-func collectReleaseCandidates(recordings []mbRecording, artist string, localDuration float32) []releaseCandidate {
-	bestRecording := selectBestRecording(recordings, artist, localDuration)
-	if bestRecording == nil {
-		return nil
-	}
-
-	matches := make([]releaseCandidate, 0, len(bestRecording.Releases))
-	fallback := make([]releaseCandidate, 0, len(bestRecording.Releases))
-	for i := range bestRecording.Releases {
-		release := &bestRecording.Releases[i]
+func selectBestReleaseFromRecording(releases []mbRelease, preferredCountries []string) *mbRelease {
+	filtered := make([]*mbRelease, 0, len(releases))
+	for i := range releases {
+		release := &releases[i]
 		if !isValidRelease(*release) {
 			continue
 		}
 		if !strings.EqualFold(strings.TrimSpace(release.Status), "Official") {
 			continue
 		}
-
-		candidate := releaseCandidate{recording: bestRecording, release: release}
-		fallback = append(fallback, candidate)
-		if isAlbumRelease(*release) && !hasDiscouragedSecondaryType(*release) {
-			matches = append(matches, candidate)
+		if hasExcludedSecondaryType(*release) {
+			continue
 		}
+		if hasExcludedMediaFormat(*release) {
+			continue
+		}
+		filtered = append(filtered, release)
 	}
-
-	if len(matches) > 0 {
-		return matches
-	}
-	return fallback
-}
-
-func selectBestReleaseCandidate(candidates []releaseCandidate, hasCover func(releaseID string) bool) *releaseCandidate {
-	type relCandidate struct {
-		candidate *releaseCandidate
-		hasCover  bool
-		usCountry bool
-		year      int
-	}
-
-	sortedCandidates := make([]relCandidate, 0, len(candidates))
-	for i := range candidates {
-		candidate := &candidates[i]
-		releaseID := strings.TrimSpace(candidate.release.ID)
-		sortedCandidates = append(sortedCandidates, relCandidate{
-			candidate: candidate,
-			hasCover:  hasCover(releaseID),
-			usCountry: strings.EqualFold(strings.TrimSpace(candidate.release.Country), "US"),
-			year:      yearFromDate(candidate.release.Date),
-		})
-	}
-	if len(sortedCandidates) == 0 {
+	if len(filtered) == 0 {
 		return nil
 	}
 
-	slices.SortFunc(sortedCandidates, func(a, b relCandidate) int {
-		if a.hasCover && !b.hasCover {
-			return -1
+	slices.SortFunc(filtered, func(a, b *mbRelease) int {
+		aRank := releasePrimaryTypeRank(a.ReleaseGroup.PrimaryType)
+		bRank := releasePrimaryTypeRank(b.ReleaseGroup.PrimaryType)
+		if aRank != bRank {
+			return aRank - bRank
 		}
-		if !a.hasCover && b.hasCover {
+
+		aYear := yearFromDate(a.Date)
+		bYear := yearFromDate(b.Date)
+		if aYear == 0 && bYear > 0 {
 			return 1
 		}
-		if a.year == 0 && b.year > 0 {
-			return 1
-		}
-		if b.year == 0 && a.year > 0 {
+		if bYear == 0 && aYear > 0 {
 			return -1
 		}
-		if a.year != b.year {
-			return a.year - b.year
+		if aYear != bYear {
+			return aYear - bYear
 		}
-		if a.usCountry && !b.usCountry {
+
+		aCountry := countryPreferred(a.Country, preferredCountries)
+		bCountry := countryPreferred(b.Country, preferredCountries)
+		if aCountry && !bCountry {
 			return -1
 		}
-		if !a.usCountry && b.usCountry {
+		if !aCountry && bCountry {
 			return 1
 		}
 		return 0
 	})
 
-	return sortedCandidates[0].candidate
+	return filtered[0]
+}
+
+func releasePrimaryTypeRank(primaryType string) int {
+	switch normalizeMBString(primaryType) {
+	case "single":
+		return 0
+	case "album":
+		return 1
+	case "ep":
+		return 2
+	default:
+		return 3
+	}
+}
+
+func countryPreferred(country string, preferredCountries []string) bool {
+	country = normalizeMBString(country)
+	for _, c := range preferredCountries {
+		if country == normalizeMBString(c) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasExcludedSecondaryType(release mbRelease) bool {
+	for _, t := range release.ReleaseGroup.SecondaryType {
+		n := normalizeMBString(t)
+		if n == "compilation" || n == "remix" || n == "soundtrack" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasExcludedMediaFormat(release mbRelease) bool {
+	for _, media := range release.Media {
+		format := normalizeMBString(media.Format)
+		if strings.Contains(format, "dvd") || strings.Contains(format, "video") {
+			return true
+		}
+	}
+	return false
 }
 
 func isValidRelease(release mbRelease) bool {
@@ -840,16 +855,6 @@ func isValidRelease(release mbRelease) bool {
 		}
 	}
 	return true
-}
-
-func hasDiscouragedSecondaryType(release mbRelease) bool {
-	for _, t := range release.ReleaseGroup.SecondaryType {
-		n := normalizeMBString(t)
-		if n == "compilation" || n == "live" {
-			return true
-		}
-	}
-	return false
 }
 
 func isExcludedRecording(rec mbRecording) bool {

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -581,7 +581,10 @@ func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string, localDurati
 		return metadataResult{RecordingMBID: strings.TrimSpace(bestRecording.ID)}, nil
 	}
 
-	bestRelease := selectBestReleaseFromRecording(details.Releases)
+	coverCache := make(map[string]bool)
+	bestRelease := selectBestReleaseFromRecording(details.Releases, func(releaseID string) bool {
+		return j.releaseHasCover(releaseID, coverCache)
+	})
 	if bestRelease == nil {
 		return metadataResult{RecordingMBID: strings.TrimSpace(bestRecording.ID)}, nil
 	}
@@ -623,6 +626,36 @@ func (j *musicBrainzMetadataJob) searchRecordings(query string) ([]mbRecording, 
 		return nil, err
 	}
 	return payload.Recordings, nil
+}
+
+func (j *musicBrainzMetadataJob) releaseHasCover(releaseID string, cache map[string]bool) bool {
+	releaseID = strings.TrimSpace(releaseID)
+	if releaseID == "" {
+		return false
+	}
+	if v, ok := cache[releaseID]; ok {
+		return v
+	}
+
+	req, err := http.NewRequest(http.MethodHead, "https://coverartarchive.org/release/"+url.PathEscape(releaseID), nil)
+	if err != nil {
+		cache[releaseID] = false
+		return false
+	}
+	req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	resp, err := j.client.Do(req.WithContext(ctx))
+	if err != nil {
+		cache[releaseID] = false
+		return false
+	}
+	defer resp.Body.Close()
+
+	hasCover := resp.StatusCode == http.StatusOK
+	cache[releaseID] = hasCover
+	return hasCover
 }
 
 func (j *musicBrainzMetadataJob) fetchRecordingDetails(recordingID string) (mbRecording, error) {
@@ -785,7 +818,25 @@ func artistCreditLooselyMatches(credits []struct {
 	return false
 }
 
-func selectBestReleaseFromRecording(releases []mbRelease) *mbRelease {
+func selectBestReleaseFromRecording(releases []mbRelease, hasCover func(releaseID string) bool) *mbRelease {
+	ordered := rankReleases(releases, false)
+	for _, release := range ordered {
+		if hasCover == nil || hasCover(release.ID) {
+			return release
+		}
+	}
+
+	fallbackOrdered := rankReleases(releases, true)
+	for _, release := range fallbackOrdered {
+		if hasCover == nil || hasCover(release.ID) {
+			return release
+		}
+	}
+
+	return nil
+}
+
+func rankReleases(releases []mbRelease, includeExcluded bool) []*mbRelease {
 	filtered := make([]*mbRelease, 0, len(releases))
 	for i := range releases {
 		release := &releases[i]
@@ -795,11 +846,13 @@ func selectBestReleaseFromRecording(releases []mbRelease) *mbRelease {
 		if !strings.EqualFold(strings.TrimSpace(release.Status), "Official") {
 			continue
 		}
-		if hasExcludedSecondaryType(*release) {
-			continue
-		}
-		if hasExcludedMediaFormat(*release) {
-			continue
+		if !includeExcluded {
+			if hasExcludedSecondaryType(*release) {
+				continue
+			}
+			if hasExcludedMediaFormat(*release) {
+				continue
+			}
 		}
 		filtered = append(filtered, release)
 	}
@@ -825,11 +878,10 @@ func selectBestReleaseFromRecording(releases []mbRelease) *mbRelease {
 		if aYear != bYear {
 			return aYear - bYear
 		}
-
 		return 0
 	})
 
-	return filtered[0]
+	return filtered
 }
 
 func releasePrimaryTypeRank(primaryType string) int {

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -480,6 +480,12 @@ type mbSearchResponse struct {
 	Recordings []mbRecording `json:"recordings"`
 }
 
+type mbReleaseSearchResponse struct {
+	Count    int         `json:"count"`
+	Offset   int         `json:"offset"`
+	Releases []mbRelease `json:"releases"`
+}
+
 type mbRecording struct {
 	ID               string  `json:"id"`
 	Title            string  `json:"title"`
@@ -581,8 +587,13 @@ func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string, localDurati
 		return metadataResult{RecordingMBID: strings.TrimSpace(bestRecording.ID)}, nil
 	}
 
+	allReleases := details.Releases
+	if extraReleases, err := j.searchReleasesByRecording(bestRecording.ID); err == nil {
+		allReleases = mergeUniqueReleases(allReleases, extraReleases)
+	}
+
 	coverCache := make(map[string]bool)
-	bestRelease := selectBestReleaseFromRecording(details.Releases, func(releaseID string) bool {
+	bestRelease := selectBestReleaseFromRecording(allReleases, func(releaseID string) bool {
 		return j.releaseHasCover(releaseID, coverCache)
 	})
 	if bestRelease == nil {
@@ -628,6 +639,67 @@ func (j *musicBrainzMetadataJob) searchRecordings(query string) ([]mbRecording, 
 	return payload.Recordings, nil
 }
 
+func (j *musicBrainzMetadataJob) searchReleasesByRecording(recordingID string) ([]mbRelease, error) {
+	recordingID = strings.TrimSpace(recordingID)
+	if recordingID == "" {
+		return nil, nil
+	}
+
+	all := make([]mbRelease, 0, 32)
+	for offset := 0; ; offset += 100 {
+		u := "https://musicbrainz.org/ws/2/release/?recording=" + url.QueryEscape(recordingID) + "&fmt=json&limit=100&offset=" + strconv.Itoa(offset) + "&inc=release-groups+media"
+		req, err := http.NewRequest(http.MethodGet, u, nil)
+		if err != nil {
+			return all, err
+		}
+		req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
+
+		resp, err := j.client.Do(req)
+		if err != nil {
+			return all, err
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			resp.Body.Close()
+			return all, fmt.Errorf("musicbrainz status %d", resp.StatusCode)
+		}
+
+		var payload mbReleaseSearchResponse
+		err = json.NewDecoder(resp.Body).Decode(&payload)
+		resp.Body.Close()
+		if err != nil {
+			return all, err
+		}
+
+		all = append(all, payload.Releases...)
+		if len(payload.Releases) == 0 || len(all) >= payload.Count {
+			break
+		}
+	}
+	return all, nil
+}
+
+func mergeUniqueReleases(base, extra []mbRelease) []mbRelease {
+	seen := make(map[string]bool, len(base)+len(extra))
+	out := make([]mbRelease, 0, len(base)+len(extra))
+	for _, rel := range base {
+		id := strings.TrimSpace(rel.ID)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, rel)
+	}
+	for _, rel := range extra {
+		id := strings.TrimSpace(rel.ID)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, rel)
+	}
+	return out
+}
+
 func (j *musicBrainzMetadataJob) releaseHasCover(releaseID string, cache map[string]bool) bool {
 	releaseID = strings.TrimSpace(releaseID)
 	if releaseID == "" {
@@ -637,25 +709,39 @@ func (j *musicBrainzMetadataJob) releaseHasCover(releaseID string, cache map[str
 		return v
 	}
 
-	req, err := http.NewRequest(http.MethodHead, "https://coverartarchive.org/release/"+url.PathEscape(releaseID), nil)
-	if err != nil {
-		cache[releaseID] = false
-		return false
+	check := func(method, urlStr string) (bool, bool) {
+		req, err := http.NewRequest(method, urlStr, nil)
+		if err != nil {
+			return false, false
+		}
+		req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		resp, err := j.client.Do(req.WithContext(ctx))
+		if err != nil {
+			return false, false
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			return true, true
+		}
+		if resp.StatusCode == http.StatusNotFound {
+			return false, true
+		}
+		return false, false
 	}
-	req.Header.Set("User-Agent", "Navidrome/metadata-fetcher (https://www.navidrome.org)")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	resp, err := j.client.Do(req.WithContext(ctx))
-	if err != nil {
-		cache[releaseID] = false
-		return false
+	apiURL := "https://coverartarchive.org/release/" + url.PathEscape(releaseID)
+	if has, done := check(http.MethodHead, apiURL); done {
+		cache[releaseID] = has
+		return has
 	}
-	defer resp.Body.Close()
-
-	hasCover := resp.StatusCode == http.StatusOK
-	cache[releaseID] = hasCover
-	return hasCover
+	if has, done := check(http.MethodGet, apiURL); done {
+		cache[releaseID] = has
+		return has
+	}
+	cache[releaseID] = false
+	return false
 }
 
 func (j *musicBrainzMetadataJob) fetchRecordingDetails(recordingID string) (mbRecording, error) {

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -139,7 +139,7 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 		}
 		j.setFetching(c.flags, 1)
 
-		metadata, fetchErr := j.fetchMetadata(c.mf.Title, c.mf.Artist)
+		metadata, fetchErr := j.fetchMetadata(c.mf.Title, c.mf.Artist, c.mf.Duration)
 		if fetchErr != nil {
 			failed++
 			log.Warn(ctx, "Could not fetch metadata from MusicBrainz", "songId", c.mf.ID, "title", c.mf.Title, "artist", c.mf.Artist, fetchErr)
@@ -483,6 +483,9 @@ type mbSearchResponse struct {
 type mbRecording struct {
 	ID               string  `json:"id"`
 	Score            mbScore `json:"score"`
+	Length           int     `json:"length"`
+	Video            bool    `json:"video"`
+	Disambiguation   string  `json:"disambiguation"`
 	FirstReleaseDate string  `json:"first-release-date"`
 	ArtistCredit     []struct {
 		Name string `json:"name"`
@@ -545,8 +548,8 @@ func valueOrNil(v string) *string {
 	return &v
 }
 
-func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (metadataResult, error) {
-	query := fmt.Sprintf("artist:%s AND recording:%s", artist, title)
+func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string, localDuration float32) (metadataResult, error) {
+	query := fmt.Sprintf("recording:\"%s\" AND artist:\"%s\"", title, artist)
 	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json&inc=releases+release-groups"
 	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
@@ -571,7 +574,7 @@ func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (metadataRe
 		return metadataResult{}, nil
 	}
 
-	bestCandidates := collectReleaseCandidates(payload.Recordings, artist)
+	bestCandidates := collectReleaseCandidates(payload.Recordings, artist, localDuration)
 	if len(bestCandidates) == 0 {
 		return metadataResult{}, nil
 	}
@@ -632,15 +635,18 @@ func (j *musicBrainzMetadataJob) releaseHasCover(releaseID string, cache map[str
 	return hasCover
 }
 
-func selectBestRecording(recordings []mbRecording, artist string) *mbRecording {
+func selectBestRecording(recordings []mbRecording, artist string, localDuration float32) *mbRecording {
 	normalizedArtist := normalizeMBString(artist)
 
 	type recCandidate struct {
-		rec      *mbRecording
-		score    int
-		releases int
-		hasAlbum bool
-		earliest int
+		rec              *mbRecording
+		score            int
+		releases         int
+		hasAlbum         bool
+		hasOfficial      bool
+		earliest         int
+		durationDeltaMS  int
+		durationInWindow bool
 	}
 
 	candidates := make([]recCandidate, 0, len(recordings))
@@ -653,12 +659,19 @@ func selectBestRecording(recordings []mbRecording, artist string) *mbRecording {
 		if !artistCreditMatches(rec.ArtistCredit, normalizedArtist) {
 			continue
 		}
+		if isExcludedRecording(*rec) {
+			continue
+		}
 
 		hasAlbum := false
+		hasOfficial := false
 		earliest := 9999
 		for _, rel := range rec.Releases {
 			if !isValidRelease(rel) {
 				continue
+			}
+			if strings.EqualFold(strings.TrimSpace(rel.Status), "Official") {
+				hasOfficial = true
 			}
 			if isAlbumRelease(rel) {
 				hasAlbum = true
@@ -667,13 +680,27 @@ func selectBestRecording(recordings []mbRecording, artist string) *mbRecording {
 				earliest = y
 			}
 		}
-		candidates = append(candidates, recCandidate{rec: rec, score: score, releases: len(rec.Releases), hasAlbum: hasAlbum, earliest: earliest})
+
+		delta := int(^uint(0) >> 1)
+		durationInWindow := false
+		if localDuration > 0 && rec.Length > 0 {
+			delta = absInt(rec.Length - int(localDuration*1000))
+			durationInWindow = delta <= 3000
+		}
+
+		candidates = append(candidates, recCandidate{rec: rec, score: score, releases: len(rec.Releases), hasAlbum: hasAlbum, hasOfficial: hasOfficial, earliest: earliest, durationDeltaMS: delta, durationInWindow: durationInWindow})
 	}
 	if len(candidates) == 0 {
 		return nil
 	}
 
 	slices.SortFunc(candidates, func(a, b recCandidate) int {
+		if a.hasOfficial && !b.hasOfficial {
+			return -1
+		}
+		if !a.hasOfficial && b.hasOfficial {
+			return 1
+		}
 		if a.releases > 0 && b.releases == 0 {
 			return -1
 		}
@@ -682,6 +709,9 @@ func selectBestRecording(recordings []mbRecording, artist string) *mbRecording {
 		}
 		if a.score != b.score {
 			return b.score - a.score
+		}
+		if a.durationInWindow && b.durationInWindow && a.durationDeltaMS != b.durationDeltaMS {
+			return a.durationDeltaMS - b.durationDeltaMS
 		}
 		if a.hasAlbum && !b.hasAlbum {
 			return -1
@@ -717,8 +747,8 @@ type releaseCandidate struct {
 	release   *mbRelease
 }
 
-func collectReleaseCandidates(recordings []mbRecording, artist string) []releaseCandidate {
-	bestRecording := selectBestRecording(recordings, artist)
+func collectReleaseCandidates(recordings []mbRecording, artist string, localDuration float32) []releaseCandidate {
+	bestRecording := selectBestRecording(recordings, artist, localDuration)
 	if bestRecording == nil {
 		return nil
 	}
@@ -819,6 +849,34 @@ func hasDiscouragedSecondaryType(release mbRelease) bool {
 		}
 	}
 	return false
+}
+
+func isExcludedRecording(rec mbRecording) bool {
+	if rec.Video {
+		return true
+	}
+	for _, marker := range []string{"live", "remix", "acoustic", "demo", "instrumental", "video"} {
+		if hasMarker(rec.Title, marker) || hasMarker(rec.Disambiguation, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasMarker(value, marker string) bool {
+	for _, token := range strings.Fields(normalizeMBString(value)) {
+		if token == marker {
+			return true
+		}
+	}
+	return false
+}
+
+func absInt(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
 }
 
 func isAlbumRelease(release mbRelease) bool {

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -482,6 +482,7 @@ type mbSearchResponse struct {
 
 type mbRecording struct {
 	ID               string  `json:"id"`
+	Title            string  `json:"title"`
 	Score            mbScore `json:"score"`
 	Length           int     `json:"length"`
 	Video            bool    `json:"video"`

--- a/server/nativeapi/musicbrainz_metadata_test.go
+++ b/server/nativeapi/musicbrainz_metadata_test.go
@@ -124,15 +124,25 @@ func TestSelectBestRecordingPrefersClosestDurationWhenProvided(t *testing.T) {
 	}
 }
 
-func TestSelectBestRecordingRequiresPerfectScore(t *testing.T) {
+func TestSelectBestRecordingRejectsVeryLowScore(t *testing.T) {
 	recordings := []mbRecording{
-		{ID: "almost", Score: "99", ArtistCredit: []struct {
+		{ID: "low", Score: "50", ArtistCredit: []struct {
 			Name string `json:"name"`
 		}{{Name: "The Artist"}}, Releases: []mbRelease{{Title: "Album", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}}},
 	}
 
 	rec := selectBestRecording(recordings, "the artist", 0)
 	if rec != nil {
-		t.Fatalf("expected no recording for non-100 score, got %q", rec.ID)
+		t.Fatalf("expected no recording for very low score, got %q", rec.ID)
+	}
+}
+
+func TestArtistCreditLooselyMatches(t *testing.T) {
+	credits := []struct {
+		Name string `json:"name"`
+	}{{Name: "Edward Sharpe & the Magnetic Zeros"}}
+
+	if !artistCreditLooselyMatches(credits, normalizeMBString("Edward Sharpe and the Magnetic Zeros")) {
+		t.Fatal("expected loose artist matching to succeed")
 	}
 }

--- a/server/nativeapi/musicbrainz_metadata_test.go
+++ b/server/nativeapi/musicbrainz_metadata_test.go
@@ -42,74 +42,39 @@ func TestSelectBestRecording(t *testing.T) {
 	}
 }
 
-func TestCollectReleaseCandidates(t *testing.T) {
-	recordings := []mbRecording{{
-		Score: "95",
-		ArtistCredit: []struct {
-			Name string `json:"name"`
-		}{{Name: "The Artist"}},
-		Releases: []mbRelease{
-			{ID: "live", Title: "Live Cut", Date: "1990", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album", SecondaryType: []string{"Live"}}},
-			{ID: "comp", Title: "Compilation", Date: "1992", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album", SecondaryType: []string{"Compilation"}}},
-			{ID: "album", Title: "Studio Album", Date: "2001", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
-		},
-	}}
-
-	candidates := collectReleaseCandidates(recordings, "the artist", 0)
-	if len(candidates) != 1 {
-		t.Fatalf("expected 1 preferred candidate, got %d", len(candidates))
+func TestSelectBestReleaseFromRecording(t *testing.T) {
+	releases := []mbRelease{
+		{ID: "bootleg", Title: "Bootleg", Status: "Bootleg", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
+		{ID: "comp", Title: "Compilation", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album", SecondaryType: []string{"Compilation"}}},
+		{ID: "remix", Title: "Remix", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album", SecondaryType: []string{"Remix"}}},
+		{ID: "video", Title: "Video", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Single"}, Media: []mbMedium{{Format: "DVD-Video"}}},
+		{ID: "ep", Title: "EP", Status: "Official", Date: "2010-01-01", ReleaseGroup: mbGroup{PrimaryType: "EP"}},
+		{ID: "album", Title: "Album", Status: "Official", Date: "2010-01-01", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
+		{ID: "single", Title: "Single", Status: "Official", Date: "2010-01-01", ReleaseGroup: mbGroup{PrimaryType: "Single"}},
 	}
-	if candidates[0].release.ID != "album" {
-		t.Fatalf("expected album candidate, got %q", candidates[0].release.ID)
+
+	best := selectBestReleaseFromRecording(releases, []string{"US", "USA"})
+	if best == nil {
+		t.Fatal("expected a release")
+	}
+	if best.ID != "single" {
+		t.Fatalf("expected single to be prioritized, got %q", best.ID)
 	}
 }
 
-func TestCollectReleaseCandidatesFallsBackToOfficial(t *testing.T) {
-	recordings := []mbRecording{{
-		Score: "95",
-		ArtistCredit: []struct {
-			Name string `json:"name"`
-		}{{Name: "The Artist"}},
-		Releases: []mbRelease{
-			{ID: "live", Title: "Live Cut", Date: "1990", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album", SecondaryType: []string{"Live"}}},
-			{ID: "single", Title: "Official Single", Date: "1991", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Single"}},
-		},
-	}}
-
-	candidates := collectReleaseCandidates(recordings, "the artist", 0)
-	if len(candidates) != 2 {
-		t.Fatalf("expected official fallback candidates, got %d", len(candidates))
-	}
-}
-
-func TestSelectBestReleaseCandidatePrefersCover(t *testing.T) {
-	candidates := []releaseCandidate{
-		{release: &mbRelease{ID: "a", Title: "No Cover", Date: "1980", Country: "US"}},
-		{release: &mbRelease{ID: "b", Title: "Has Cover", Date: "2001", Country: "GB"}},
+func TestSelectBestReleaseFromRecordingPrefersEarliestThenUS(t *testing.T) {
+	releases := []mbRelease{
+		{ID: "later-us", Title: "Later US", Status: "Official", Country: "US", Date: "2011-01-01", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
+		{ID: "earlier-gb", Title: "Earlier GB", Status: "Official", Country: "GB", Date: "2010-01-01", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
+		{ID: "earlier-us", Title: "Earlier US", Status: "Official", Country: "USA", Date: "2010-01-01", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
 	}
 
-	rel := selectBestReleaseCandidate(candidates, func(releaseID string) bool { return releaseID == "b" })
-	if rel == nil {
-		t.Fatal("expected release")
+	best := selectBestReleaseFromRecording(releases, []string{"US", "USA"})
+	if best == nil {
+		t.Fatal("expected a release")
 	}
-	if rel.release.ID != "b" {
-		t.Fatalf("expected release with cover, got %q", rel.release.ID)
-	}
-}
-
-func TestSelectBestReleaseCandidatePrefersEarliestThenUS(t *testing.T) {
-	candidates := []releaseCandidate{
-		{release: &mbRelease{ID: "a", Title: "Album A", Date: "2001", Country: "GB"}},
-		{release: &mbRelease{ID: "b", Title: "Album B", Date: "2001", Country: "US"}},
-		{release: &mbRelease{ID: "c", Title: "Album C", Date: "1999", Country: "GB"}},
-	}
-
-	rel := selectBestReleaseCandidate(candidates, func(string) bool { return false })
-	if rel == nil {
-		t.Fatal("expected release")
-	}
-	if rel.release.ID != "c" {
-		t.Fatalf("expected earliest release when no cover exists, got %q", rel.release.ID)
+	if best.ID != "earlier-us" {
+		t.Fatalf("expected earliest date then preferred country, got %q", best.ID)
 	}
 }
 

--- a/server/nativeapi/musicbrainz_metadata_test.go
+++ b/server/nativeapi/musicbrainz_metadata_test.go
@@ -161,3 +161,30 @@ func TestSelectBestReleaseFromRecordingSkipsNoCover(t *testing.T) {
 		t.Fatalf("expected first release with cover, got %q", best.ID)
 	}
 }
+
+func TestMergeUniqueReleases(t *testing.T) {
+	base := []mbRelease{{ID: "a", Title: "A"}, {ID: "b", Title: "B"}}
+	extra := []mbRelease{{ID: "b", Title: "B2"}, {ID: "c", Title: "C"}}
+	merged := mergeUniqueReleases(base, extra)
+	if len(merged) != 3 {
+		t.Fatalf("expected 3 unique releases, got %d", len(merged))
+	}
+	if merged[0].ID != "a" || merged[1].ID != "b" || merged[2].ID != "c" {
+		t.Fatalf("unexpected merge order: %#v", merged)
+	}
+}
+
+func TestSelectBestReleaseFromRecordingFallsBackToBroaderSetForCover(t *testing.T) {
+	releases := []mbRelease{
+		{ID: "single-no-cover", Title: "Single", Status: "Official", Date: "2010-01-01", ReleaseGroup: mbGroup{PrimaryType: "Single"}},
+		{ID: "comp-cover", Title: "Comp", Status: "Official", Date: "2009-01-01", ReleaseGroup: mbGroup{PrimaryType: "Album", SecondaryType: []string{"Compilation"}}},
+	}
+
+	best := selectBestReleaseFromRecording(releases, func(id string) bool { return id == "comp-cover" })
+	if best == nil {
+		t.Fatal("expected a release")
+	}
+	if best.ID != "comp-cover" {
+		t.Fatalf("expected broader fallback to pick covered release, got %q", best.ID)
+	}
+}

--- a/server/nativeapi/musicbrainz_metadata_test.go
+++ b/server/nativeapi/musicbrainz_metadata_test.go
@@ -19,7 +19,7 @@ func TestSelectBestRecording(t *testing.T) {
 			Releases: []mbRelease{{Title: "Wrong Album", Date: "2010-01-01", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}},
 		},
 		{
-			Score: "92",
+			Score: "100",
 			ArtistCredit: []struct {
 				Name string `json:"name"`
 			}{{Name: "The Artist"}},
@@ -53,7 +53,7 @@ func TestSelectBestReleaseFromRecording(t *testing.T) {
 		{ID: "single", Title: "Single", Status: "Official", Date: "2010-01-01", ReleaseGroup: mbGroup{PrimaryType: "Single"}},
 	}
 
-	best := selectBestReleaseFromRecording(releases, []string{"US", "USA"})
+	best := selectBestReleaseFromRecording(releases)
 	if best == nil {
 		t.Fatal("expected a release")
 	}
@@ -62,19 +62,18 @@ func TestSelectBestReleaseFromRecording(t *testing.T) {
 	}
 }
 
-func TestSelectBestReleaseFromRecordingPrefersEarliestThenUS(t *testing.T) {
+func TestSelectBestReleaseFromRecordingPrefersEarliestDate(t *testing.T) {
 	releases := []mbRelease{
-		{ID: "later-us", Title: "Later US", Status: "Official", Country: "US", Date: "2011-01-01", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
-		{ID: "earlier-gb", Title: "Earlier GB", Status: "Official", Country: "GB", Date: "2010-01-01", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
-		{ID: "earlier-us", Title: "Earlier US", Status: "Official", Country: "USA", Date: "2010-01-01", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
+		{ID: "later", Title: "Later", Status: "Official", Country: "US", Date: "2011-01-01", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
+		{ID: "earlier", Title: "Earlier", Status: "Official", Country: "GB", Date: "2010-01-01", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
 	}
 
-	best := selectBestReleaseFromRecording(releases, []string{"US", "USA"})
+	best := selectBestReleaseFromRecording(releases)
 	if best == nil {
 		t.Fatal("expected a release")
 	}
-	if best.ID != "earlier-us" {
-		t.Fatalf("expected earliest date then preferred country, got %q", best.ID)
+	if best.ID != "earlier" {
+		t.Fatalf("expected earliest date to be preferred, got %q", best.ID)
 	}
 }
 
@@ -92,7 +91,7 @@ func TestSelectBestRecordingFiltersExcludedAndPrefersOfficial(t *testing.T) {
 		{ID: "non-official", Score: "100", ArtistCredit: []struct {
 			Name string `json:"name"`
 		}{{Name: "The Artist"}}, Releases: []mbRelease{{Title: "Unofficial", Status: "Bootleg", ReleaseGroup: mbGroup{PrimaryType: "Album"}}}},
-		{ID: "official", Score: "99", ArtistCredit: []struct {
+		{ID: "official", Score: "100", ArtistCredit: []struct {
 			Name string `json:"name"`
 		}{{Name: "The Artist"}}, Releases: []mbRelease{{Title: "Official", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}}},
 	}
@@ -106,7 +105,7 @@ func TestSelectBestRecordingFiltersExcludedAndPrefersOfficial(t *testing.T) {
 	}
 }
 
-func TestSelectBestRecordingPrefersClosestDurationWithinWindow(t *testing.T) {
+func TestSelectBestRecordingPrefersClosestDurationWhenProvided(t *testing.T) {
 	recordings := []mbRecording{
 		{ID: "far", Score: "100", Length: 211000, ArtistCredit: []struct {
 			Name string `json:"name"`
@@ -122,5 +121,18 @@ func TestSelectBestRecordingPrefersClosestDurationWithinWindow(t *testing.T) {
 	}
 	if rec.ID != "close" {
 		t.Fatalf("expected closest duration recording, got %q", rec.ID)
+	}
+}
+
+func TestSelectBestRecordingRequiresPerfectScore(t *testing.T) {
+	recordings := []mbRecording{
+		{ID: "almost", Score: "99", ArtistCredit: []struct {
+			Name string `json:"name"`
+		}{{Name: "The Artist"}}, Releases: []mbRelease{{Title: "Album", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}}},
+	}
+
+	rec := selectBestRecording(recordings, "the artist", 0)
+	if rec != nil {
+		t.Fatalf("expected no recording for non-100 score, got %q", rec.ID)
 	}
 }

--- a/server/nativeapi/musicbrainz_metadata_test.go
+++ b/server/nativeapi/musicbrainz_metadata_test.go
@@ -53,7 +53,7 @@ func TestSelectBestReleaseFromRecording(t *testing.T) {
 		{ID: "single", Title: "Single", Status: "Official", Date: "2010-01-01", ReleaseGroup: mbGroup{PrimaryType: "Single"}},
 	}
 
-	best := selectBestReleaseFromRecording(releases)
+	best := selectBestReleaseFromRecording(releases, func(id string) bool { return id != "album" })
 	if best == nil {
 		t.Fatal("expected a release")
 	}
@@ -68,7 +68,7 @@ func TestSelectBestReleaseFromRecordingPrefersEarliestDate(t *testing.T) {
 		{ID: "earlier", Title: "Earlier", Status: "Official", Country: "GB", Date: "2010-01-01", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
 	}
 
-	best := selectBestReleaseFromRecording(releases)
+	best := selectBestReleaseFromRecording(releases, func(string) bool { return true })
 	if best == nil {
 		t.Fatal("expected a release")
 	}
@@ -144,5 +144,20 @@ func TestArtistCreditLooselyMatches(t *testing.T) {
 
 	if !artistCreditLooselyMatches(credits, normalizeMBString("Edward Sharpe and the Magnetic Zeros")) {
 		t.Fatal("expected loose artist matching to succeed")
+	}
+}
+
+func TestSelectBestReleaseFromRecordingSkipsNoCover(t *testing.T) {
+	releases := []mbRelease{
+		{ID: "single-no-cover", Title: "Single", Status: "Official", Date: "2010-01-01", ReleaseGroup: mbGroup{PrimaryType: "Single"}},
+		{ID: "album-cover", Title: "Album", Status: "Official", Date: "2010-01-01", ReleaseGroup: mbGroup{PrimaryType: "Album"}},
+	}
+
+	best := selectBestReleaseFromRecording(releases, func(id string) bool { return id == "album-cover" })
+	if best == nil {
+		t.Fatal("expected a release")
+	}
+	if best.ID != "album-cover" {
+		t.Fatalf("expected first release with cover, got %q", best.ID)
 	}
 }

--- a/server/nativeapi/musicbrainz_metadata_test.go
+++ b/server/nativeapi/musicbrainz_metadata_test.go
@@ -33,7 +33,7 @@ func TestSelectBestRecording(t *testing.T) {
 		},
 	}}
 
-	rec := selectBestRecording(payload.Recordings, "the artist")
+	rec := selectBestRecording(payload.Recordings, "the artist", 0)
 	if rec == nil {
 		t.Fatal("expected a recording")
 	}
@@ -55,7 +55,7 @@ func TestCollectReleaseCandidates(t *testing.T) {
 		},
 	}}
 
-	candidates := collectReleaseCandidates(recordings, "the artist")
+	candidates := collectReleaseCandidates(recordings, "the artist", 0)
 	if len(candidates) != 1 {
 		t.Fatalf("expected 1 preferred candidate, got %d", len(candidates))
 	}
@@ -76,7 +76,7 @@ func TestCollectReleaseCandidatesFallsBackToOfficial(t *testing.T) {
 		},
 	}}
 
-	candidates := collectReleaseCandidates(recordings, "the artist")
+	candidates := collectReleaseCandidates(recordings, "the artist", 0)
 	if len(candidates) != 2 {
 		t.Fatalf("expected official fallback candidates, got %d", len(candidates))
 	}
@@ -110,5 +110,52 @@ func TestSelectBestReleaseCandidatePrefersEarliestThenUS(t *testing.T) {
 	}
 	if rel.release.ID != "c" {
 		t.Fatalf("expected earliest release when no cover exists, got %q", rel.release.ID)
+	}
+}
+
+func TestSelectBestRecordingFiltersExcludedAndPrefersOfficial(t *testing.T) {
+	recordings := []mbRecording{
+		{ID: "video", Score: "100", Video: true, ArtistCredit: []struct {
+			Name string `json:"name"`
+		}{{Name: "The Artist"}}, Releases: []mbRelease{{Title: "Video Album", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}}},
+		{ID: "acoustic", Score: "100", Disambiguation: "acoustic", ArtistCredit: []struct {
+			Name string `json:"name"`
+		}{{Name: "The Artist"}}, Releases: []mbRelease{{Title: "Acoustic Album", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}}},
+		{ID: "demo", Title: "Song (demo)", Score: "100", ArtistCredit: []struct {
+			Name string `json:"name"`
+		}{{Name: "The Artist"}}, Releases: []mbRelease{{Title: "Demo Album", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}}},
+		{ID: "non-official", Score: "100", ArtistCredit: []struct {
+			Name string `json:"name"`
+		}{{Name: "The Artist"}}, Releases: []mbRelease{{Title: "Unofficial", Status: "Bootleg", ReleaseGroup: mbGroup{PrimaryType: "Album"}}}},
+		{ID: "official", Score: "99", ArtistCredit: []struct {
+			Name string `json:"name"`
+		}{{Name: "The Artist"}}, Releases: []mbRelease{{Title: "Official", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}}},
+	}
+
+	rec := selectBestRecording(recordings, "the artist", 0)
+	if rec == nil {
+		t.Fatal("expected recording")
+	}
+	if rec.ID != "official" {
+		t.Fatalf("expected official recording, got %q", rec.ID)
+	}
+}
+
+func TestSelectBestRecordingPrefersClosestDurationWithinWindow(t *testing.T) {
+	recordings := []mbRecording{
+		{ID: "far", Score: "100", Length: 211000, ArtistCredit: []struct {
+			Name string `json:"name"`
+		}{{Name: "The Artist"}}, Releases: []mbRelease{{Title: "Album", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}}},
+		{ID: "close", Score: "100", Length: 212500, ArtistCredit: []struct {
+			Name string `json:"name"`
+		}{{Name: "The Artist"}}, Releases: []mbRelease{{Title: "Album", Status: "Official", ReleaseGroup: mbGroup{PrimaryType: "Album"}}}},
+	}
+
+	rec := selectBestRecording(recordings, "the artist", 213)
+	if rec == nil {
+		t.Fatal("expected recording")
+	}
+	if rec.ID != "close" {
+		t.Fatalf("expected closest duration recording, got %q", rec.ID)
 	}
 }


### PR DESCRIPTION
### Motivation
- Improve accuracy when resolving a MusicBrainz recording MBID for a local file by using a stricter search query and smarter candidate selection. 
- Avoid matching live/remix/acoustic/demo/instrumental/video variants and prefer official-release recordings, and use local duration to disambiguate close candidates.

### Description
- Switch the MusicBrainz search query to the strict format `recording:"{title}" AND artist:"{artist}"` and pass the local file duration into the metadata fetcher via `fetchMetadata(..., localDuration)`. 
- Parse and use additional recording fields (`length`, `video`, `disambiguation`) by extending `mbRecording` and filter out excluded recordings with `isExcludedRecording`. 
- Prefer recordings attached to official releases during ranking, and when durations are available prefer the recording whose length is closest to the local duration (within ±3s) while still honoring `score` as the primary filter. 
- Update `collectReleaseCandidates`/`selectBestRecording` signatures and behavior to be duration-aware and add helper functions (`hasMarker`, `absInt`) and unit tests covering exclusion, official preference, and duration proximity; changes are in `server/nativeapi/musicbrainz_metadata.go` and `server/nativeapi/musicbrainz_metadata_test.go`.

### Testing
- Ran formatter: `gofmt -w server/nativeapi/musicbrainz_metadata.go server/nativeapi/musicbrainz_metadata_test.go` which completed successfully. 
- Attempted to run unit tests: `go test -v ./server/nativeapi -run 'Test(SelectBestRecording|CollectReleaseCandidates|SelectBestReleaseCandidate|NormalizeMBString)'` but the run failed in this environment due to missing system `taglib` (pkg-config) dependency. 
- Attempted `CGO_ENABLED=0 go test ...` to work around cgo but it also failed in this environment due to a sqlite backup API difference without cgo, so the new unit tests were added but could not be executed successfully here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e1250a1d48322814b74c6a18b2a7d)