### PR TITLE
Limit MusicBrainz metadata fetch to tracks missing cover art

### DIFF
--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -233,8 +233,14 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 			releaseMBID:   strings.TrimSpace(mf.MbzReleaseID) == "",
 			coverArt:      !mf.HasCoverArt && strings.TrimSpace(mf.CoverPath) == "",
 		}
+
+		if !flags.coverArt {
+			j.incrementCoverArtExisting()
+			continue
+		}
+
 		j.incrementExisting(flags)
-		if !flags.album && !flags.year && !flags.genre && !flags.recordingMBID && !flags.releaseMBID && !flags.coverArt {
+		if !flags.album && !flags.year && !flags.genre && !flags.recordingMBID && !flags.releaseMBID {
 			continue
 		}
 
@@ -242,6 +248,12 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 		j.incrementMissing(flags)
 	}
 	return res, nil
+}
+
+func (j *musicBrainzMetadataJob) incrementCoverArtExisting() {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.status.CoverArt.Existing++
 }
 
 func (j *musicBrainzMetadataJob) incrementExisting(flags missingFlags) {


### PR DESCRIPTION
### Motivation
- Avoid fetching MusicBrainz metadata for tracks that already have cover art so only the  files missing cover art are processed.

### Description
- In `collectCandidates` skip files that have cover art early so they are not enqueued for MusicBrainz fetches, and update the candidate-filter condition accordingly (`server/nativeapi/musicbrainz_metadata.go`).
- Add `incrementCoverArtExisting()` to keep the Cover Art "Existing" counter accurate for skipped tracks.

### Testing
- Attempted `go test ./server/nativeapi -count=1`, but tests could not run to completion in this environment due to a missing system dependency (`taglib` via `pkg-config`), so no passing test run is available here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e17928fa88322b33abec18e4d72b4)