### PR TITLE
Add selected-song metadata fetch to Cover Art list

### DIFF
--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -66,7 +66,7 @@ func (j *musicBrainzMetadataJob) getStatus() musicBrainzMetadataStatus {
 	return j.status
 }
 
-func (j *musicBrainzMetadataJob) start(ds model.DataStore) bool {
+func (j *musicBrainzMetadataJob) start(ds model.DataStore, songIDs []string) bool {
 	j.mu.Lock()
 	if j.status.Running {
 		j.mu.Unlock()
@@ -76,8 +76,29 @@ func (j *musicBrainzMetadataJob) start(ds model.DataStore) bool {
 	j.status = musicBrainzMetadataStatus{Running: true, StartedAt: &now}
 	j.mu.Unlock()
 
-	go j.run(ds)
+	go j.run(ds, makeSongIDSet(songIDs))
 	return true
+}
+
+func makeSongIDSet(songIDs []string) map[string]struct{} {
+	if len(songIDs) == 0 {
+		return nil
+	}
+
+	res := make(map[string]struct{}, len(songIDs))
+	for _, id := range songIDs {
+		trimmed := strings.TrimSpace(id)
+		if trimmed == "" {
+			continue
+		}
+		res[trimmed] = struct{}{}
+	}
+
+	if len(res) == 0 {
+		return nil
+	}
+
+	return res
 }
 
 type missingFlags struct {
@@ -102,7 +123,7 @@ type metadataResult struct {
 	ReleaseMBID   string
 }
 
-func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
+func (j *musicBrainzMetadataJob) run(ds model.DataStore, songIDSet map[string]struct{}) {
 	ctx := context.Background()
 	defer func() {
 		j.mu.Lock()
@@ -112,7 +133,7 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 		j.mu.Unlock()
 	}()
 
-	candidates, err := j.collectCandidates(ctx, ds)
+	candidates, err := j.collectCandidates(ctx, ds, songIDSet)
 	if err != nil {
 		j.setError(err)
 		return
@@ -210,7 +231,7 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 	)
 }
 
-func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model.DataStore) ([]mbMetadataCandidate, error) {
+func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model.DataStore, songIDSet map[string]struct{}) ([]mbMetadataCandidate, error) {
 	cursor, err := ds.MediaFile(ctx).GetCursor()
 	if err != nil {
 		return nil, err
@@ -221,6 +242,12 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 		if e != nil {
 			return nil, e
 		}
+		if len(songIDSet) > 0 {
+			if _, ok := songIDSet[mf.ID]; !ok {
+				continue
+			}
+		}
+
 		if strings.TrimSpace(mf.Title) == "" || strings.TrimSpace(mf.Artist) == "" {
 			continue
 		}
@@ -899,8 +926,24 @@ func (n *Router) addMusicBrainzMetadataRoute(r chi.Router) {
 		r.Get("/status", func(w http.ResponseWriter, _ *http.Request) {
 			_ = json.NewEncoder(w).Encode(n.metadataJob.getStatus())
 		})
-		r.Post("/fetch", func(w http.ResponseWriter, _ *http.Request) {
-			if n.metadataJob.start(n.ds) {
+		type fetchMusicBrainzRequest struct {
+			SongIDs []string `json:"songIds"`
+		}
+
+		r.Post("/fetch", func(w http.ResponseWriter, req *http.Request) {
+			var payload fetchMusicBrainzRequest
+			if req.Body != nil {
+				defer req.Body.Close()
+				if body, err := io.ReadAll(req.Body); err == nil && len(strings.TrimSpace(string(body))) > 0 {
+					if err := json.Unmarshal(body, &payload); err != nil {
+						w.WriteHeader(http.StatusBadRequest)
+						_, _ = w.Write([]byte(`{"status":"invalid_request"}`))
+						return
+					}
+				}
+			}
+
+			if n.metadataJob.start(n.ds, payload.SongIDs) {
 				w.WriteHeader(http.StatusAccepted)
 				_, _ = w.Write([]byte(`{"status":"started"}`))
 				return

--- a/ui/src/covertart/CovertartBulkActions.jsx
+++ b/ui/src/covertart/CovertartBulkActions.jsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react'
+import { useNotify, useUnselectAll } from 'react-admin'
+import { Button } from '@material-ui/core'
+import { BiDownload } from 'react-icons/bi'
+import { httpClient } from '../dataProvider'
+
+const CovertartBulkActions = ({ selectedIds = [] }) => {
+  const notify = useNotify()
+  const unselectAll = useUnselectAll()
+  const [loading, setLoading] = useState(false)
+
+  const handleFetchSelected = () => {
+    if (!selectedIds.length) {
+      return
+    }
+
+    setLoading(true)
+    httpClient('/api/metadata/musicbrainz/fetch', {
+      method: 'POST',
+      body: JSON.stringify({ songIds: selectedIds }),
+    })
+      .then(({ status }) => {
+        if (status === 202) {
+          notify('activity.musicbrainz.started', 'info')
+        } else {
+          notify('activity.musicbrainz.alreadyRunning', 'warning')
+        }
+      })
+      .catch(() => notify('activity.musicbrainz.failed', 'warning'))
+      .finally(() => {
+        setLoading(false)
+        unselectAll('covertart')
+      })
+  }
+
+  return (
+    <Button
+      color="primary"
+      startIcon={<BiDownload />}
+      onClick={handleFetchSelected}
+      disabled={loading || selectedIds.length === 0}
+      aria-label="Fetch metadata for selected songs"
+    >
+      Fetch Selected Metadata
+    </Button>
+  )
+}
+
+export default CovertartBulkActions

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -16,6 +16,7 @@ import {
 import { makeStyles } from '@material-ui/core/styles'
 import { DurationField, Pagination } from '../common'
 import subsonic from '../subsonic'
+import CovertartBulkActions from './CovertartBulkActions'
 
 const useStyles = makeStyles({
   mbidText: {
@@ -79,7 +80,7 @@ const CovertartList = (props) => {
       actions={<CovertartListActions />}
       filters={<CovertartFilter />}
       exporter={false}
-      bulkActionButtons={false}
+      bulkActionButtons={<CovertartBulkActions />}
       perPage={50}
       pagination={<Pagination />}
     >


### PR DESCRIPTION
### Motivation

- Allow users to select specific songs in the Cover Art list and fetch only their MusicBrainz metadata instead of always running a full-library fetch. 

### Description

- Add a new UI bulk action `CovertartBulkActions` (`ui/src/covertart/CovertartBulkActions.jsx`) and wire it into the Cover Art list via `bulkActionButtons` so users can select rows and click `Fetch Selected Metadata`. 
- Extend the native API `POST /api/metadata/musicbrainz/fetch` to accept an optional `songIds` JSON payload and pass those IDs to the metadata job so it only processes the selected songs. 
- Implement `makeSongIDSet` helper and update `musicBrainzMetadataJob.start`, `run`, and `collectCandidates` to accept and honor the optional song ID set while preserving existing behavior when no IDs are provided. 
- Keep previous behavior intact: calling fetch without a payload still starts a full-library fetch.

### Testing

- Ran lint on the modified UI files with `npx eslint src/covertart/CovertartList.jsx src/covertart/CovertartBulkActions.jsx`, which completed for the targeted files. 
- Ran type checks with `npm run type-check` which succeeded. 
- Attempted to run UI tests with `npm run test` (Vitest) but no relevant test files were found for the Cover Art changes. 
- Attempted `go test ./server/nativeapi/...` but execution in this environment failed due to a missing system `taglib` pkg-config dependency, so backend unit tests could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f443290608322812ab8d365f11fca)