### PR TITLE
Show Spotify match in Coverart UI and align metadata matching with fetch script; add configurable Spotify token

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -177,6 +177,7 @@ type lastfmOptions struct {
 type spotifyOptions struct {
 	ID     string
 	Secret string
+	Token  string
 }
 
 type deezerOptions struct {
@@ -441,6 +442,7 @@ func disableExternalServices() {
 	Server.EnableInsightsCollector = false
 	Server.LastFM.Enabled = false
 	Server.Spotify.ID = ""
+	Server.Spotify.Token = ""
 	Server.Deezer.Enabled = false
 	Server.ListenBrainz.Enabled = false
 	Server.Agents = ""
@@ -625,6 +627,7 @@ func setViperDefaults() {
 	viper.SetDefault("lastfm.scrobblefirstartistonly", false)
 	viper.SetDefault("spotify.id", "")
 	viper.SetDefault("spotify.secret", "")
+	viper.SetDefault("spotify.token", "")
 	viper.SetDefault("deezer.enabled", true)
 	viper.SetDefault("listenbrainz.enabled", true)
 	viper.SetDefault("listenbrainz.baseurl", "https://api.listenbrainz.org/1/")

--- a/server/nativeapi/config.go
+++ b/server/nativeapi/config.go
@@ -22,6 +22,7 @@ var sensitiveFieldsPartialMask = []string{
 	"Prometheus.MetricsPath",
 	"Spotify.ID",
 	"Spotify.Secret",
+	"Spotify.Token",
 	"DevAutoLoginUsername",
 }
 

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -114,13 +114,15 @@ type spotifyMetadataStatus struct {
 }
 
 type spotifyConfidenceEntry struct {
-	SongID     string  `json:"songId"`
-	Title      string  `json:"title"`
-	Artist     string  `json:"artist"`
-	Confidence float64 `json:"confidence"`
-	Album      string  `json:"album"`
-	CoverURL   string  `json:"coverUrl,omitempty"`
-	Downloaded bool    `json:"downloaded"`
+	SongID        string  `json:"songId"`
+	Title         string  `json:"title"`
+	Artist        string  `json:"artist"`
+	Confidence    float64 `json:"confidence"`
+	Album         string  `json:"album"`
+	SpotifyMatch  string  `json:"spotifyMatch,omitempty"`
+	SpotifyArtist string  `json:"spotifyArtist,omitempty"`
+	CoverURL      string  `json:"coverUrl,omitempty"`
+	Downloaded    bool    `json:"downloaded"`
 }
 
 type spotifyMetadataJob struct {
@@ -138,11 +140,7 @@ func newSpotifyMetadataJob() *spotifyMetadataJob {
 	}
 }
 
-const (
-	spotifyClientID     = "887b8e46cce74eb3ad69f00c6fdf668e"
-	spotifyClientSecret = "faa6959477ff44bbbc8c71eb97210c98"
-	spotifyMinScore     = 0.69
-)
+const spotifyMinScore = 0.69
 
 func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 	ctx := context.Background()
@@ -938,6 +936,21 @@ func normalizeSpotifyString(v string) string {
 	return strings.TrimSpace(v)
 }
 
+func parseSpotifyFilename(filePath string) (artist, title string) {
+	name := strings.TrimSpace(filepath.Base(filePath))
+	if strings.HasSuffix(strings.ToLower(name), ".mp3") {
+		name = name[:len(name)-4]
+	}
+	if !strings.Contains(name, " - ") {
+		return "", ""
+	}
+	parts := strings.SplitN(name, " - ", 2)
+	if len(parts) != 2 {
+		return "", ""
+	}
+	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+}
+
 func yearFromDate(date string) int {
 	if len(date) < 4 {
 		return 0
@@ -1074,13 +1087,15 @@ func (j *spotifyMetadataJob) run(ds model.DataStore) {
 		}
 
 		j.storeEntry(spotifyConfidenceEntry{
-			SongID:     mf.ID,
-			Title:      mf.Title,
-			Artist:     mf.Artist,
-			Confidence: confidence,
-			Album:      albumName,
-			CoverURL:   coverURL,
-			Downloaded: downloaded,
+			SongID:        mf.ID,
+			Title:         mf.Title,
+			Artist:        mf.Artist,
+			Confidence:    confidence,
+			Album:         albumName,
+			SpotifyMatch:  strings.TrimSpace(track.Name),
+			SpotifyArtist: strings.TrimSpace(track.Artists[0].Name),
+			CoverURL:      coverURL,
+			Downloaded:    downloaded,
 		})
 
 		j.finishFetch(downloaded || coverURL != "", isMissingAlbum(mf.Album), setAlbum || albumName != "", downloaded)
@@ -1143,13 +1158,18 @@ func (j *spotifyMetadataJob) storeEntry(entry spotifyConfidenceEntry) {
 }
 
 func (j *spotifyMetadataJob) getToken(ctx context.Context) (string, error) {
+	token := strings.TrimSpace(conf.Server.Spotify.Token)
+	if token != "" {
+		return token, nil
+	}
+
 	form := url.Values{}
 	form.Set("grant_type", "client_credentials")
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://accounts.spotify.com/api/token", strings.NewReader(form.Encode()))
 	if err != nil {
 		return "", err
 	}
-	basic := base64.StdEncoding.EncodeToString([]byte(spotifyClientID + ":" + spotifyClientSecret))
+	basic := base64.StdEncoding.EncodeToString([]byte(conf.Server.Spotify.ID + ":" + conf.Server.Spotify.Secret))
 	req.Header.Set("Authorization", "Basic "+basic)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -1196,7 +1216,12 @@ type spotifyTrack struct {
 }
 
 func (j *spotifyMetadataJob) searchBestTrack(ctx context.Context, token string, mf model.MediaFile) (*spotifyTrack, float64, error) {
-	q := strings.TrimSpace(mf.Title + " " + mf.Artist)
+	localArtist, localTitle := parseSpotifyFilename(mf.Path)
+	if localArtist == "" || localTitle == "" {
+		return nil, 0, nil
+	}
+
+	q := strings.TrimSpace(localTitle + " " + localArtist)
 	if q == "" {
 		return nil, 0, nil
 	}
@@ -1229,8 +1254,8 @@ func (j *spotifyMetadataJob) searchBestTrack(ctx context.Context, token string, 
 		return nil, 0, nil
 	}
 
-	localTitle := normalizeSpotifyString(mf.Title)
-	localArtist := normalizeSpotifyString(mf.Artist)
+	localTitleNorm := normalizeSpotifyString(localTitle)
+	localArtistNorm := normalizeSpotifyString(localArtist)
 	localDuration := int(mf.Duration)
 
 	var best *spotifyTrack
@@ -1240,8 +1265,8 @@ func (j *spotifyMetadataJob) searchBestTrack(ctx context.Context, token string, 
 		if len(candidate.Artists) == 0 {
 			continue
 		}
-		titleScore := stringSimilarity(localTitle, normalizeSpotifyString(candidate.Name))
-		artistScore := stringSimilarity(localArtist, normalizeSpotifyString(candidate.Artists[0].Name))
+		titleScore := stringSimilarity(localTitleNorm, normalizeSpotifyString(candidate.Name))
+		artistScore := stringSimilarity(localArtistNorm, normalizeSpotifyString(candidate.Artists[0].Name))
 		durationScore := 0.0
 		if localDuration > 0 {
 			diff := localDuration - (candidate.DurationMS / 1000)

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -143,6 +143,20 @@ const CovertartList = (props) => {
           }}
         />
         <FunctionField
+          label="Spotify Match"
+          sortable={false}
+          render={(record) => {
+            const entry = confidenceBySong.get(record.id)
+            if (!entry?.spotifyMatch) {
+              return ''
+            }
+            if (!entry?.spotifyArtist) {
+              return entry.spotifyMatch
+            }
+            return `${entry.spotifyMatch} - ${entry.spotifyArtist}`
+          }}
+        />
+        <FunctionField
           label="Recording MBID"
           sortable={false}
           render={(record) => {


### PR DESCRIPTION
### Motivation
- Make Navidrome's Spotify metadata matching behave like the provided Python fetch script by using the same filename parsing and normalization/scoring so confidence values match. 
- Expose the actual Spotify track match (name + artist) returned by the search in the Cover Art UI so users can see what was matched. 
- Allow providing a manual Spotify bearer token from configuration so the token can be updated without changing code.

### Description
- Added `Spotify.Token` to `conf/configuration.go` with a default and cleared it when external services are disabled, and added the default `spotify.token` viper entry. 
- Marked `Spotify.Token` as sensitive in `server/nativeapi/config.go` so it is redacted by the config API. 
- Extended `spotifyConfidenceEntry` in `server/nativeapi/musicbrainz_metadata.go` to include `spotifyMatch` and `spotifyArtist`, and populate them with the matched track name and artist from Spotify. 
- Changed token retrieval in `getToken` to use `conf.Server.Spotify.Token` first (manual bearer token) and fall back to client-credentials using `Spotify.ID`/`Spotify.Secret`. 
- Aligned search input and scoring with the script by adding `parseSpotifyFilename` (parses `artist - title` from `mf.Path`) and using the parsed/normalized artist and title for query and similarity calculations. 
- Removed hardcoded spotify client constants from the metadata job path and switched to using configuration values. 
- Added a new `Spotify Match` column to the coverart list in `ui/src/covertart/CovertartList.jsx` that displays the matched Spotify track and artist from the confidence endpoint. 
- Ran `gofmt` over modified Go files.

### Testing
- Ran `gofmt -w` on modified files which completed successfully. 
- Attempted `go test ./server/nativeapi ./conf`, which failed to build `server/nativeapi` in this environment due to missing system dependencies (`taglib` / pkg-config and other CGO-related build issues). 
- Ran `CGO_ENABLED=0 go test ./server/nativeapi ./conf` where `./conf` tests passed but `server/nativeapi` still failed to build because the repository has components that need native libraries in this environment. 
- Tried to capture a UI screenshot via Playwright of `http://127.0.0.1:4533/app/#/covertart`, but the app was not reachable (`ERR_EMPTY_RESPONSE`) so no screenshot could be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fa6aa5964832289800227c009d1a6)