### PR TITLE
Add coverart bulk selection metadata fetch support

### DIFF
--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -68,7 +68,7 @@ func (j *musicBrainzMetadataJob) getStatus() musicBrainzMetadataStatus {
 	return j.status
 }
 
-func (j *musicBrainzMetadataJob) start(ds model.DataStore) bool {
+func (j *musicBrainzMetadataJob) start(ds model.DataStore, songIDs []string) bool {
 	j.mu.Lock()
 	if j.status.Running {
 		j.mu.Unlock()
@@ -78,7 +78,7 @@ func (j *musicBrainzMetadataJob) start(ds model.DataStore) bool {
 	j.status = musicBrainzMetadataStatus{Running: true, StartedAt: &now}
 	j.mu.Unlock()
 
-	go j.run(ds)
+	go j.run(ds, songIDs)
 	return true
 }
 
@@ -133,6 +133,26 @@ type spotifyMetadataJob struct {
 	coverMisses sync.Map
 }
 
+type selectedSongsPayload struct {
+	SongIDs []string `json:"songIds"`
+}
+
+func decodeSelectedSongIDs(r *http.Request) ([]string, error) {
+	if r == nil || r.Body == nil {
+		return nil, nil
+	}
+
+	payload := selectedSongsPayload{}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		if err == io.EOF {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return payload.SongIDs, nil
+}
+
 func newSpotifyMetadataJob() *spotifyMetadataJob {
 	return &spotifyMetadataJob{
 		client:  &http.Client{Timeout: 15 * time.Second},
@@ -142,7 +162,7 @@ func newSpotifyMetadataJob() *spotifyMetadataJob {
 
 const spotifyMinScore = 0.69
 
-func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
+func (j *musicBrainzMetadataJob) run(ds model.DataStore, songIDs []string) {
 	ctx := context.Background()
 	defer func() {
 		j.mu.Lock()
@@ -152,7 +172,7 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 		j.mu.Unlock()
 	}()
 
-	candidates, err := j.collectCandidates(ctx, ds)
+	candidates, err := j.collectCandidates(ctx, ds, songIDs)
 	if err != nil {
 		j.setError(err)
 		return
@@ -250,11 +270,20 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore) {
 	)
 }
 
-func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model.DataStore) ([]mbMetadataCandidate, error) {
+func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model.DataStore, songIDs []string) ([]mbMetadataCandidate, error) {
 	cursor, err := ds.MediaFile(ctx).GetCursor()
 	if err != nil {
 		return nil, err
 	}
+
+	allowedSongs := make(map[string]struct{}, len(songIDs))
+	for _, id := range songIDs {
+		trimmed := strings.TrimSpace(id)
+		if trimmed != "" {
+			allowedSongs[trimmed] = struct{}{}
+		}
+	}
+	filterBySongIDs := len(allowedSongs) > 0
 
 	res := make([]mbMetadataCandidate, 0)
 	for mf, e := range cursor {
@@ -263,6 +292,11 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 		}
 		if strings.TrimSpace(mf.Title) == "" || strings.TrimSpace(mf.Artist) == "" {
 			continue
+		}
+		if filterBySongIDs {
+			if _, ok := allowedSongs[mf.ID]; !ok {
+				continue
+			}
 		}
 
 		flags := missingFlags{
@@ -981,7 +1015,7 @@ func (j *spotifyMetadataJob) getConfidenceEntries() []spotifyConfidenceEntry {
 	return res
 }
 
-func (j *spotifyMetadataJob) start(ds model.DataStore) bool {
+func (j *spotifyMetadataJob) start(ds model.DataStore, songIDs []string) bool {
 	j.mu.Lock()
 	if j.status.Running {
 		j.mu.Unlock()
@@ -992,11 +1026,11 @@ func (j *spotifyMetadataJob) start(ds model.DataStore) bool {
 	j.entries = map[string]spotifyConfidenceEntry{}
 	j.mu.Unlock()
 
-	go j.run(ds)
+	go j.run(ds, songIDs)
 	return true
 }
 
-func (j *spotifyMetadataJob) run(ds model.DataStore) {
+func (j *spotifyMetadataJob) run(ds model.DataStore, songIDs []string) {
 	ctx := context.Background()
 	defer func() {
 		j.mu.Lock()
@@ -1018,6 +1052,15 @@ func (j *spotifyMetadataJob) run(ds model.DataStore) {
 		return
 	}
 
+	allowedSongs := make(map[string]struct{}, len(songIDs))
+	for _, id := range songIDs {
+		trimmed := strings.TrimSpace(id)
+		if trimmed != "" {
+			allowedSongs[trimmed] = struct{}{}
+		}
+	}
+	filterBySongIDs := len(allowedSongs) > 0
+
 	candidates := make([]model.MediaFile, 0)
 	for mf, e := range cursor {
 		if e != nil {
@@ -1026,6 +1069,11 @@ func (j *spotifyMetadataJob) run(ds model.DataStore) {
 		}
 		if strings.TrimSpace(mf.Title) == "" || strings.TrimSpace(mf.Artist) == "" {
 			continue
+		}
+		if filterBySongIDs {
+			if _, ok := allowedSongs[mf.ID]; !ok {
+				continue
+			}
 		}
 		missingCover := !mf.HasCoverArt && strings.TrimSpace(mf.CoverPath) == ""
 		if !missingCover {
@@ -1359,8 +1407,15 @@ func (n *Router) addMusicBrainzMetadataRoute(r chi.Router) {
 		r.Get("/status", func(w http.ResponseWriter, _ *http.Request) {
 			_ = json.NewEncoder(w).Encode(n.metadataJob.getStatus())
 		})
-		r.Post("/fetch", func(w http.ResponseWriter, _ *http.Request) {
-			if n.metadataJob.start(n.ds) {
+		r.Post("/fetch", func(w http.ResponseWriter, r *http.Request) {
+			songIDs, err := decodeSelectedSongIDs(r)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"status":"invalid_payload"}`))
+				return
+			}
+
+			if n.metadataJob.start(n.ds, songIDs) {
 				w.WriteHeader(http.StatusAccepted)
 				_, _ = w.Write([]byte(`{"status":"started"}`))
 				return
@@ -1374,8 +1429,15 @@ func (n *Router) addMusicBrainzMetadataRoute(r chi.Router) {
 		r.Get("/spotify/confidence", func(w http.ResponseWriter, _ *http.Request) {
 			_ = json.NewEncoder(w).Encode(map[string]any{"items": n.spotifyJob.getConfidenceEntries()})
 		})
-		r.Post("/spotify/fetch", func(w http.ResponseWriter, _ *http.Request) {
-			if n.spotifyJob.start(n.ds) {
+		r.Post("/spotify/fetch", func(w http.ResponseWriter, r *http.Request) {
+			songIDs, err := decodeSelectedSongIDs(r)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"status":"invalid_payload"}`))
+				return
+			}
+
+			if n.spotifyJob.start(n.ds, songIDs) {
 				w.WriteHeader(http.StatusAccepted)
 				_, _ = w.Write([]byte(`{"status":"started"}`))
 				return

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -17,6 +17,7 @@ import { makeStyles } from '@material-ui/core/styles'
 import { DurationField, Pagination } from '../common'
 import { httpClient } from '../dataProvider'
 import subsonic from '../subsonic'
+import CovertartSongBulkActions from './CovertartSongBulkActions'
 
 const useStyles = makeStyles({
   mbidText: {
@@ -97,11 +98,10 @@ const CovertartList = (props) => {
       actions={<CovertartListActions />}
       filters={<CovertartFilter />}
       exporter={false}
-      bulkActionButtons={false}
       perPage={50}
       pagination={<Pagination />}
     >
-      <Datagrid rowClick={false}>
+      <Datagrid rowClick={false} bulkActionButtons={<CovertartSongBulkActions />}>
         <FunctionField
           label="Cover Art"
           sortable={false}

--- a/ui/src/covertart/CovertartSongBulkActions.jsx
+++ b/ui/src/covertart/CovertartSongBulkActions.jsx
@@ -1,0 +1,86 @@
+import React, { useMemo, useState } from 'react'
+import { Button } from '@material-ui/core'
+import { BiDownload } from 'react-icons/bi'
+import { useListContext, useNotify, useTranslate } from 'react-admin'
+import { makeStyles } from '@material-ui/core/styles'
+import { httpClient } from '../dataProvider'
+
+const useStyles = makeStyles((theme) => ({
+  button: {
+    color: theme.palette.type === 'dark' ? 'white' : undefined,
+  },
+}))
+
+const CovertartSongBulkActions = ({ onUnselectItems }) => {
+  const classes = useStyles()
+  const notify = useNotify()
+  const translate = useTranslate()
+  const { selectedIds = [] } = useListContext()
+  const [isLoadingMusicBrainz, setIsLoadingMusicBrainz] = useState(false)
+  const [isLoadingSpotify, setIsLoadingSpotify] = useState(false)
+
+  const payload = useMemo(
+    () => ({ songIds: selectedIds.map((id) => String(id)) }),
+    [selectedIds],
+  )
+
+  const startFetch = (url, setLoading, successKey) => {
+    setLoading(true)
+    httpClient(url, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+    })
+      .then(({ status }) => {
+        if (status === 202) {
+          notify(successKey, 'info')
+          onUnselectItems()
+          return
+        }
+
+        if (status === 409) {
+          notify('activity.musicbrainz.alreadyRunning', 'warning')
+          return
+        }
+
+        notify('activity.musicbrainz.failed', 'warning')
+      })
+      .catch(() => notify('activity.musicbrainz.failed', 'warning'))
+      .finally(() => setLoading(false))
+  }
+
+  return (
+    <>
+      <Button
+        className={classes.button}
+        startIcon={<BiDownload />}
+        disabled={selectedIds.length === 0 || isLoadingMusicBrainz || isLoadingSpotify}
+        onClick={() =>
+          startFetch(
+            '/api/metadata/musicbrainz/fetch',
+            setIsLoadingMusicBrainz,
+            'activity.musicbrainz.started',
+          )
+        }
+      >
+        {translate('activity.musicbrainz.fetch')}
+      </Button>
+      <Button
+        className={classes.button}
+        startIcon={<BiDownload />}
+        disabled={selectedIds.length === 0 || isLoadingMusicBrainz || isLoadingSpotify}
+        onClick={() =>
+          startFetch(
+            '/api/metadata/musicbrainz/spotify/fetch',
+            setIsLoadingSpotify,
+            'activity.musicbrainz.spotifyStarted',
+          )
+        }
+      >
+        {translate('activity.musicbrainz.fetchSpotify')}
+      </Button>
+    </>
+  )
+}
+
+export default CovertartSongBulkActions

--- a/ui/src/layout/CoverArtPanel.jsx
+++ b/ui/src/layout/CoverArtPanel.jsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect, useState } from 'react'
-import { useNotify, useTranslate } from 'react-admin'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { useNotify, useTranslate, useUnselectAll } from 'react-admin'
 import {
   Popover,
   Button,
@@ -15,6 +15,7 @@ import {
 import ImageOutlinedIcon from '@material-ui/icons/ImageOutlined'
 import { BiDownload } from 'react-icons/bi'
 import { MdSave } from 'react-icons/md'
+import { useSelector } from 'react-redux'
 import { httpClient } from '../dataProvider'
 
 const emptyProgress = {
@@ -126,6 +127,15 @@ const CoverArtPanel = () => {
     coverArt: emptyProgress,
   })
 
+  const unselectAll = useUnselectAll()
+  const selectedCoverArtIds = useSelector(
+    (state) => state?.admin?.resources?.covertart?.list?.selectedIds || [],
+  )
+  const selectedSongIDs = useMemo(
+    () => selectedCoverArtIds.map((id) => String(id)),
+    [selectedCoverArtIds],
+  )
+
   const open = Boolean(anchorEl)
 
   const loadStatus = useCallback(() => {
@@ -172,17 +182,31 @@ const CoverArtPanel = () => {
     return () => clearInterval(interval)
   }, [open, status.running, spotifyStatus.running, loadStatus])
 
-  const startFetch = () => {
-    httpClient('/api/metadata/musicbrainz/fetch', { method: 'POST' })
+  const postFetch = (url, startedMessage) => {
+    const options = { method: 'POST' }
+
+    if (selectedSongIDs.length > 0) {
+      options.body = JSON.stringify({ songIds: selectedSongIDs })
+      options.headers = new Headers({ 'Content-Type': 'application/json' })
+    }
+
+    httpClient(url, options)
       .then(({ status: code }) => {
         if (code === 202) {
-          notify('activity.musicbrainz.started', 'info')
+          notify(startedMessage, 'info')
+          if (selectedSongIDs.length > 0) {
+            unselectAll('covertart')
+          }
         } else {
           notify('activity.musicbrainz.alreadyRunning', 'warning')
         }
         loadStatus()
       })
       .catch(() => notify('activity.musicbrainz.failed', 'warning'))
+  }
+
+  const startFetch = () => {
+    postFetch('/api/metadata/musicbrainz/fetch', 'activity.musicbrainz.started')
   }
 
   const saveMetadata = () => {
@@ -198,16 +222,10 @@ const CoverArtPanel = () => {
   }
 
   const startSpotifyFetch = () => {
-    httpClient('/api/metadata/musicbrainz/spotify/fetch', { method: 'POST' })
-      .then(({ status: code }) => {
-        if (code === 202) {
-          notify('activity.musicbrainz.spotifyStarted', 'info')
-        } else {
-          notify('activity.musicbrainz.alreadyRunning', 'warning')
-        }
-        loadStatus()
-      })
-      .catch(() => notify('activity.musicbrainz.failed', 'warning'))
+    postFetch(
+      '/api/metadata/musicbrainz/spotify/fetch',
+      'activity.musicbrainz.spotifyStarted',
+    )
   }
 
   return (


### PR DESCRIPTION
### Motivation

- Allow users to select subsets of songs from the Cover Art list and fetch/persist metadata only for those selections, matching the existing playlist selection UX.

### Description

- Added a new frontend bulk-actions component `ui/src/covertart/CovertartSongBulkActions.jsx` that posts selected `songIds` to metadata endpoints and shows notifications. 
- Enabled bulk actions on the CoverArt list by wiring `CovertartSongBulkActions` into `ui/src/covertart/CovertartList.jsx` via the `Datagrid` `bulkActionButtons` prop. 
- Extended backend metadata routes and jobs in `server/nativeapi/musicbrainz_metadata.go` to accept an optional `songIds` JSON payload and to scope `musicBrainzMetadataJob` and `spotifyMetadataJob` runs to the provided IDs when present. 
- Added request payload decoding and validation helper `decodeSelectedSongIDs` and guarded candidate collection logic to filter by allowed song IDs. 

### Testing

- Ran `cd ui && npx eslint src/covertart/CovertartList.jsx src/covertart/CovertartSongBulkActions.jsx` which completed for the changed files (no blocking lint errors on those files). 
- Attempted `go test ./server/nativeapi` but tests cannot complete in this environment due to a missing system dependency (`taglib` via pkg-config), so server-side tests did not fully run. 
- Started the UI dev server (`cd ui && npm run start`) and captured a rendering attempt, but runtime failed in this environment because the dependency `@dnd-kit/core` could not be resolved, so full end-to-end UI validation was not possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4908074d4832289cceadae221a435)