### PR TITLE
Limit MusicBrainz metadata fetch to tracks missing cover art

### DIFF
--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -273,12 +273,12 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 			releaseMBID:   strings.TrimSpace(mf.MbzReleaseID) == "",
 			coverArt:      !mf.HasCoverArt && strings.TrimSpace(mf.CoverPath) == "",
 		}
-		j.incrementExisting(flags)
 		if !flags.coverArt {
 			// Only process metadata for tracks with missing cover art.
 			continue
 		}
 
+		j.incrementExisting(flags)
 		res = append(res, mbMetadataCandidate{mf: mf, flags: flags})
 		j.incrementMissing(flags)
 	}

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -274,7 +274,8 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 			coverArt:      !mf.HasCoverArt && strings.TrimSpace(mf.CoverPath) == "",
 		}
 		j.incrementExisting(flags)
-		if !flags.album && !flags.year && !flags.genre && !flags.recordingMBID && !flags.releaseMBID && !flags.coverArt {
+		if !flags.coverArt {
+			// Only process metadata for tracks with missing cover art.
 			continue
 		}
 


### PR DESCRIPTION
### Motivation
- Prevent the MusicBrainz metadata job from fetching album/year/MBID data for tracks that already have cover art and only process the subset of tracks whose cover art is missing.

### Description
- Change the candidate selection in `server/nativeapi/musicbrainz_metadata.go` so `collectCandidates` skips any media file where `!flags.coverArt` (added `if !flags.coverArt { continue }`), thereby only enqueuing tracks with missing cover art.

### Testing
- Ran `gofmt -w server/nativeapi/musicbrainz_metadata.go` successfully, and attempted `go test ./server/nativeapi -run TestDoesNotExist` which could not complete in this environment due to a missing system `taglib` pkg-config dependency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49324a3608322aacfc381820c3c8d)