### PR TITLE
Only process MusicBrainz metadata for songs missing cover art

### DIFF
--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -305,8 +305,13 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 			genre:         strings.TrimSpace(mf.Genre) == "",
 			recordingMBID: strings.TrimSpace(mf.MbzRecordingID) == "",
 			releaseMBID:   strings.TrimSpace(mf.MbzReleaseID) == "",
-			coverArt:      !mf.HasCoverArt && strings.TrimSpace(mf.CoverPath) == "",
+			coverArt:      hasMissingCoverArt(mf),
 		}
+
+		if !flags.coverArt {
+			continue
+		}
+
 		j.incrementExisting(flags)
 		if !flags.album && !flags.year && !flags.genre && !flags.recordingMBID && !flags.releaseMBID && !flags.coverArt {
 			continue
@@ -316,6 +321,10 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 		j.incrementMissing(flags)
 	}
 	return res, nil
+}
+
+func hasMissingCoverArt(mf model.MediaFile) bool {
+	return !mf.HasCoverArt && strings.TrimSpace(mf.CoverPath) == ""
 }
 
 func (j *musicBrainzMetadataJob) incrementExisting(flags missingFlags) {

--- a/server/nativeapi/musicbrainz_metadata_test.go
+++ b/server/nativeapi/musicbrainz_metadata_test.go
@@ -1,6 +1,10 @@
 package nativeapi
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/navidrome/navidrome/model"
+)
 
 func TestNormalizeMBString(t *testing.T) {
 	got := normalizeMBString("  AC/DC - Live!  ")
@@ -110,5 +114,41 @@ func TestSelectBestReleaseCandidatePrefersEarliestThenUS(t *testing.T) {
 	}
 	if rel.release.ID != "c" {
 		t.Fatalf("expected earliest release when no cover exists, got %q", rel.release.ID)
+	}
+}
+
+func TestHasMissingCoverArt(t *testing.T) {
+	tests := []struct {
+		name string
+		mf   model.MediaFile
+		want bool
+	}{
+		{
+			name: "missing when embedded and external cover are absent",
+			mf:   model.MediaFile{},
+			want: true,
+		},
+		{
+			name: "not missing when embedded cover exists",
+			mf: model.MediaFile{
+				HasCoverArt: true,
+			},
+			want: false,
+		},
+		{
+			name: "not missing when external cover path exists",
+			mf: model.MediaFile{
+				CoverPath: "covers/release.jpg",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasMissingCoverArt(tt.mf); got != tt.want {
+				t.Fatalf("hasMissingCoverArt() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Motivation
- Ensure bulk metadata fetches (MusicBrainz/Spotify) don't touch or count tracks that already have cover art, so selecting large sets or folders only affects tracks missing cover art.

### Description
- Restrict candidate selection in `collectCandidates` to only include tracks with missing cover art by checking `hasMissingCoverArt(mf)` instead of inlining the condition. (modified `server/nativeapi/musicbrainz_metadata.go`).
- Early-skip tracks that already have cover art so they are excluded before status counters are incremented and before any metadata fetch is attempted. (modified `server/nativeapi/musicbrainz_metadata.go`).
- Add helper `hasMissingCoverArt(mf model.MediaFile) bool` to encapsulate the missing-cover check for clarity and testability. (added to `server/nativeapi/musicbrainz_metadata.go`).
- Add unit test `TestHasMissingCoverArt` to validate the helper for embedded cover, external `CoverPath`, and missing scenarios. (added to `server/nativeapi/musicbrainz_metadata_test.go`).

### Testing
- Ran `gofmt -w server/nativeapi/musicbrainz_metadata.go server/nativeapi/musicbrainz_metadata_test.go` to format the changes successfully. 
- Added unit test `TestHasMissingCoverArt` to cover the new helper `hasMissingCoverArt`. 
- Attempted `go test ./server/nativeapi -run TestHasMissingCoverArt -count=1`, but the test run could not complete in this environment due to missing native `taglib` and CGO sqlite dependencies required to build the package; the change and the focused unit test are small and should run in a normal development environment where those native dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49865153083228584757d9fefda47)