### PR TITLE
Add column display toggles for all existing Cover Art columns

### DIFF
--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -15,7 +15,7 @@ import {
   useTranslate,
 } from 'react-admin'
 import { makeStyles } from '@material-ui/core/styles'
-import { DurationField, Pagination } from '../common'
+import { DurationField, Pagination, ToggleFieldsMenu, useSelectedFields } from '../common'
 import { httpClient } from '../dataProvider'
 import subsonic from '../subsonic'
 import CovertartSongBulkActions from './CovertartSongBulkActions'
@@ -62,6 +62,7 @@ const FetchedToggleButton = () => {
 const CovertartListActions = (props) => (
   <TopToolbar {...props}>
     <FetchedToggleButton />
+    <ToggleFieldsMenu resource="covertart" />
   </TopToolbar>
 )
 
@@ -91,23 +92,15 @@ const CovertartList = (props) => {
     return map
   }, [confidenceEntries])
 
-  return (
-    <List
-      {...props}
-      sort={{ field: 'title', order: 'ASC' }}
-      filter={{ hascoverart: false }}
-      actions={<CovertartListActions />}
-      filters={<CovertartFilter />}
-      exporter={false}
-      perPage={50}
-      pagination={<Pagination />}
-    >
-      <Datagrid rowClick={false} bulkActionButtons={<CovertartSongBulkActions />}>
+  const toggleableFields = useMemo(
+    () => ({
+      coverArt: (
         <FunctionField
           label="Cover Art"
           sortBy="title"
           render={(record) => {
-            const coverSrc = subsonic.getCoverArtUrl(record, 50, true) || '/default-cover.png'
+            const coverSrc =
+              subsonic.getCoverArtUrl(record, 50, true) || '/default-cover.png'
 
             return (
               <img
@@ -120,12 +113,14 @@ const CovertartList = (props) => {
             )
           }}
         />
-        <TextField source="title" />
-        <TextField source="artist" label="Artist" />
-        <TextField source="album" label="Album" />
-        <DateField source="createdAt" sortBy="recently_added" showTime />
-        <TextField source="year" label="Release Year" />
-        <TextField source="genre" label="Genre" />
+      ),
+      title: <TextField source="title" />,
+      artist: <TextField source="artist" label="Artist" />,
+      album: <TextField source="album" label="Album" />,
+      createdAt: <DateField source="createdAt" sortBy="recently_added" showTime />,
+      year: <TextField source="year" label="Release Year" />,
+      genre: <TextField source="genre" label="Genre" />,
+      fetched: (
         <FunctionField
           label="Fetched"
           sortBy="fetched"
@@ -133,6 +128,8 @@ const CovertartList = (props) => {
             record?.hasCoverArt || Boolean(record?.coverPath) ? 'Yes' : 'No'
           }
         />
+      ),
+      confidence: (
         <FunctionField
           label="Confidence"
           sortBy="title"
@@ -144,6 +141,8 @@ const CovertartList = (props) => {
             return value.toFixed(3)
           }}
         />
+      ),
+      spotifyMatch: (
         <FunctionField
           label="Spotify Match"
           sortBy="title"
@@ -158,6 +157,8 @@ const CovertartList = (props) => {
             return `${entry.spotifyMatch} - ${entry.spotifyArtist}`
           }}
         />
+      ),
+      recordingMbid: (
         <FunctionField
           label="Recording MBID"
           sortBy="mbzRecordingID"
@@ -180,6 +181,8 @@ const CovertartList = (props) => {
             )
           }}
         />
+      ),
+      releaseMbid: (
         <FunctionField
           label="Release MBID"
           sortBy="mbzReleaseId"
@@ -202,7 +205,30 @@ const CovertartList = (props) => {
             )
           }}
         />
-        <DurationField source="duration" />
+      ),
+      duration: <DurationField source="duration" />,
+    }),
+    [classes.mbidText, confidenceBySong],
+  )
+
+  const columns = useSelectedFields({
+    resource: 'covertart',
+    columns: toggleableFields,
+  })
+
+  return (
+    <List
+      {...props}
+      sort={{ field: 'title', order: 'ASC' }}
+      filter={{ hascoverart: false }}
+      actions={<CovertartListActions />}
+      filters={<CovertartFilter />}
+      exporter={false}
+      perPage={50}
+      pagination={<Pagination />}
+    >
+      <Datagrid rowClick={false} bulkActionButtons={<CovertartSongBulkActions />}>
+        {columns}
       </Datagrid>
     </List>
   )

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -110,8 +110,19 @@
     "covertart": {
       "name": "Cover Art |||| Cover Art",
       "fields": {
+        "coverArt": "Cover Art",
+        "title": "Title",
+        "artist": "Artist",
+        "album": "Album",
         "createdAt": "Date added",
+        "year": "Release Year",
+        "genre": "Genre",
         "fetched": "Fetched",
+        "confidence": "Confidence",
+        "spotifyMatch": "Spotify Match",
+        "recordingMbid": "Recording MBID",
+        "releaseMbid": "Release MBID",
+        "duration": "Time",
         "missingCoverArt": "Missing CoverArt"
       }
     },


### PR DESCRIPTION
### Motivation
- Provide the same "Columns To Display" picker for the Cover Art list so users can hide/show and reorder every existing Cover Art column without removing or changing any column definitions.

### Description
- Add `ToggleFieldsMenu` to the Cover Art list toolbar (`CovertartListActions`) to expose the column picker UI for `covertart`.
- Refactor the Cover Art datagrid into a `toggleableFields` map and render it via `useSelectedFields` so all existing columns (cover image, title, artist, album, date, year, genre, fetched, confidence, Spotify match, recording MBID, release MBID, duration) are available for toggling and ordering.  
- Keep all original column render logic intact while moving them into the `toggleableFields` map and rendering `{columns}` inside the `Datagrid`.
- Add missing English i18n labels for the new `covertart` field keys so the column picker shows readable names.

### Testing
- Ran `cd ui && npm run lint` which failed due to pre-existing repository lint errors unrelated to this change.  
- Ran `cd ui && npx eslint src/covertart/CovertartList.jsx src/i18n/en.json` which succeeded for the modified files.  
- Started the dev server via `cd ui && npm run start` which launched Vite, but the runtime reported a dependency resolution warning for `@dnd-kit/core` in this environment (external dependency resolution issue, not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b0e2be188322a45d2b0ec84263ce)