### PR TITLE
Add MB-Genre column and store MusicBrainz genres separately

### DIFF
--- a/db/migrations/20260301010101_add_mb_genre_to_media_file.go
+++ b/db/migrations/20260301010101_add_mb_genre_to_media_file.go
@@ -1,0 +1,47 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upAddMBGenreToMediaFile, downAddMBGenreToMediaFile)
+}
+
+func upAddMBGenreToMediaFile(_ context.Context, tx *sql.Tx) error {
+	rows, err := tx.Query(`pragma table_info(media_file)`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			cid       int
+			name      string
+			ctype     string
+			notnull   int
+			dfltValue sql.NullString
+			pk        int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dfltValue, &pk); err != nil {
+			return err
+		}
+		if name == "mb_genre" {
+			return nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	_, err = tx.Exec(`alter table media_file add mb_genre text not null default ''`)
+	return err
+}
+
+func downAddMBGenreToMediaFile(_ context.Context, _ *sql.Tx) error {
+	return nil
+}

--- a/db/migrations/20260302010101_add_new_mb_genre_to_media_file.go
+++ b/db/migrations/20260302010101_add_new_mb_genre_to_media_file.go
@@ -1,0 +1,68 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upAddNewMBGenreToMediaFile, downAddNewMBGenreToMediaFile)
+}
+
+func upAddNewMBGenreToMediaFile(_ context.Context, tx *sql.Tx) error {
+	rows, err := tx.Query(`pragma table_info(media_file)`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	hasNewMBGenre := false
+	hasLegacyMBGenre := false
+	for rows.Next() {
+		var (
+			cid       int
+			name      string
+			ctype     string
+			notnull   int
+			dfltValue sql.NullString
+			pk        int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dfltValue, &pk); err != nil {
+			return err
+		}
+		if name == "new_mb_genre" {
+			hasNewMBGenre = true
+		}
+		if name == "mb_genre" {
+			hasLegacyMBGenre = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	if !hasNewMBGenre {
+		if _, err := tx.Exec(`alter table media_file add new_mb_genre text not null default ''`); err != nil {
+			return err
+		}
+	}
+
+	if hasLegacyMBGenre {
+		_, err = tx.Exec(`
+			update media_file
+			set new_mb_genre = mb_genre
+			where trim(ifnull(new_mb_genre, '')) = '' and trim(ifnull(mb_genre, '')) <> ''
+		`)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func downAddNewMBGenreToMediaFile(_ context.Context, _ *sql.Tx) error {
+	return nil
+}

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -61,7 +61,7 @@ type MediaFile struct {
 	BitDepth             int      `structs:"bit_depth" json:"bitDepth"`
 	Channels             int      `structs:"channels" json:"channels"`
 	Genre                string   `structs:"genre" json:"genre"`
-	MBGenre              string   `structs:"mb_genre" json:"mbGenre,omitempty"`
+	NewMBGenre           string   `structs:"new_mb_genre" json:"newMbGenre,omitempty"`
 	Genres               Genres   `structs:"-" json:"genres,omitempty"`
 	SortTitle            string   `structs:"sort_title" json:"sortTitle,omitempty"`
 	SortAlbumName        string   `structs:"sort_album_name" json:"sortAlbumName,omitempty"`
@@ -363,7 +363,7 @@ type MediaFileRepository interface {
 	DeleteAllMissing() (int64, error)
 	FindByPaths(paths []string) (MediaFiles, error)
 	UpdateComment(ids []string, comment string) error
-	UpdateMissingMetadata(id string, album *string, year *int, genre *string, mbGenre *string, mbzRecordingID *string, mbzReleaseID *string) error
+	UpdateMissingMetadata(id string, album *string, year *int, genre *string, newMBGenre *string, mbzRecordingID *string, mbzReleaseID *string) error
 	UpdateCoverPath(id string, coverPath string) error
 
 	// The following methods are used exclusively by the scanner:

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -61,6 +61,7 @@ type MediaFile struct {
 	BitDepth             int      `structs:"bit_depth" json:"bitDepth"`
 	Channels             int      `structs:"channels" json:"channels"`
 	Genre                string   `structs:"genre" json:"genre"`
+	MBGenre              string   `structs:"mb_genre" json:"mbGenre,omitempty"`
 	Genres               Genres   `structs:"-" json:"genres,omitempty"`
 	SortTitle            string   `structs:"sort_title" json:"sortTitle,omitempty"`
 	SortAlbumName        string   `structs:"sort_album_name" json:"sortAlbumName,omitempty"`
@@ -362,7 +363,7 @@ type MediaFileRepository interface {
 	DeleteAllMissing() (int64, error)
 	FindByPaths(paths []string) (MediaFiles, error)
 	UpdateComment(ids []string, comment string) error
-	UpdateMissingMetadata(id string, album *string, year *int, genre *string, mbzRecordingID *string, mbzReleaseID *string) error
+	UpdateMissingMetadata(id string, album *string, year *int, genre *string, mbGenre *string, mbzRecordingID *string, mbzReleaseID *string) error
 	UpdateCoverPath(id string, coverPath string) error
 
 	// The following methods are used exclusively by the scanner:

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -284,8 +284,8 @@ func (r *mediaFileRepository) UpdateComment(ids []string, comment string) error 
 	return nil
 }
 
-func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, year *int, genre *string, mbzRecordingID *string, mbzReleaseID *string) error {
-	if album == nil && year == nil && genre == nil && mbzRecordingID == nil && mbzReleaseID == nil {
+func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, year *int, genre *string, mbGenre *string, mbzRecordingID *string, mbzReleaseID *string) error {
+	if album == nil && year == nil && genre == nil && mbGenre == nil && mbzRecordingID == nil && mbzReleaseID == nil {
 		return nil
 	}
 
@@ -299,6 +299,9 @@ func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, ye
 	}
 	if genre != nil {
 		up = up.Set("genre", Expr("case when trim(ifnull(genre, '')) = '' then ? else genre end", *genre))
+	}
+	if mbGenre != nil {
+		up = up.Set("mb_genre", Expr("case when trim(ifnull(mb_genre, '')) = '' then ? else mb_genre end", *mbGenre))
 	}
 	if mbzRecordingID != nil {
 		up = up.Set("mbz_recording_id", Expr("case when trim(ifnull(mbz_recording_id, '')) = '' then ? else mbz_recording_id end", *mbzRecordingID))

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -284,8 +284,8 @@ func (r *mediaFileRepository) UpdateComment(ids []string, comment string) error 
 	return nil
 }
 
-func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, year *int, genre *string, mbGenre *string, mbzRecordingID *string, mbzReleaseID *string) error {
-	if album == nil && year == nil && genre == nil && mbGenre == nil && mbzRecordingID == nil && mbzReleaseID == nil {
+func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, year *int, genre *string, newMBGenre *string, mbzRecordingID *string, mbzReleaseID *string) error {
+	if album == nil && year == nil && genre == nil && newMBGenre == nil && mbzRecordingID == nil && mbzReleaseID == nil {
 		return nil
 	}
 
@@ -300,8 +300,8 @@ func (r *mediaFileRepository) UpdateMissingMetadata(id string, album *string, ye
 	if genre != nil {
 		up = up.Set("genre", Expr("case when trim(ifnull(genre, '')) = '' then ? else genre end", *genre))
 	}
-	if mbGenre != nil {
-		up = up.Set("mb_genre", Expr("case when trim(ifnull(mb_genre, '')) = '' then ? else mb_genre end", *mbGenre))
+	if newMBGenre != nil {
+		up = up.Set("new_mb_genre", Expr("case when trim(ifnull(new_mb_genre, '')) = '' then ? else new_mb_genre end", *newMBGenre))
 	}
 	if mbzRecordingID != nil {
 		up = up.Set("mbz_recording_id", Expr("case when trim(ifnull(mbz_recording_id, '')) = '' then ? else mbz_recording_id end", *mbzRecordingID))

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -543,17 +543,17 @@ var _ = Describe("MediaRepository", func() {
 			Expect(updated.Genre).To(Equal("Rock"))
 		})
 
-		It("updates MB genre without touching regular genre", func() {
+		It("updates new MB genre without touching regular genre", func() {
 			mf := model.MediaFile{ID: id.NewRandom(), LibraryID: 1, Title: "Song", Album: "Album", Year: 2001, Genre: "Electronic"}
 			Expect(mr.Put(&mf)).To(Succeed())
 
-			mbGenre := "House"
-			Expect(mr.UpdateMissingMetadata(mf.ID, nil, nil, nil, &mbGenre, nil, nil)).To(Succeed())
+			newMBGenre := "House"
+			Expect(mr.UpdateMissingMetadata(mf.ID, nil, nil, nil, &newMBGenre, nil, nil)).To(Succeed())
 
 			updated, err := mr.Get(mf.ID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updated.Genre).To(Equal("Electronic"))
-			Expect(updated.MBGenre).To(Equal("House"))
+			Expect(updated.NewMBGenre).To(Equal("House"))
 		})
 	})
 

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -534,13 +534,26 @@ var _ = Describe("MediaRepository", func() {
 			album := "Real Album"
 			year := 2014
 			genre := "Rock"
-			Expect(mr.UpdateMissingMetadata(mf.ID, &album, &year, &genre, nil, nil)).To(Succeed())
+			Expect(mr.UpdateMissingMetadata(mf.ID, &album, &year, &genre, nil, nil, nil)).To(Succeed())
 
 			updated, err := mr.Get(mf.ID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updated.Album).To(Equal("Real Album"))
 			Expect(updated.Year).To(Equal(2014))
 			Expect(updated.Genre).To(Equal("Rock"))
+		})
+
+		It("updates MB genre without touching regular genre", func() {
+			mf := model.MediaFile{ID: id.NewRandom(), LibraryID: 1, Title: "Song", Album: "Album", Year: 2001, Genre: "Electronic"}
+			Expect(mr.Put(&mf)).To(Succeed())
+
+			mbGenre := "House"
+			Expect(mr.UpdateMissingMetadata(mf.ID, nil, nil, nil, &mbGenre, nil, nil)).To(Succeed())
+
+			updated, err := mr.Get(mf.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated.Genre).To(Equal("Electronic"))
+			Expect(updated.MBGenre).To(Equal("House"))
 		})
 	})
 

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -43,7 +43,7 @@ type musicBrainzMetadataStatus struct {
 	LastError     string                `json:"lastError,omitempty"`
 	Album         metadataFieldProgress `json:"album"`
 	Year          metadataFieldProgress `json:"year"`
-	Genre         metadataFieldProgress `json:"genre"`
+	NewMBGenre    metadataFieldProgress `json:"newMbGenre"`
 	RecordingMBID metadataFieldProgress `json:"recordingMbid"`
 	ReleaseMBID   metadataFieldProgress `json:"releaseMbid"`
 	CoverArt      metadataFieldProgress `json:"coverArt"`
@@ -85,7 +85,7 @@ func (j *musicBrainzMetadataJob) start(ds model.DataStore, songIDs []string) boo
 type missingFlags struct {
 	album         bool
 	year          bool
-	genre         bool
+	newMBGenre    bool
 	recordingMBID bool
 	releaseMBID   bool
 	coverArt      bool
@@ -217,7 +217,7 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore, songIDs []string) {
 
 		var setAlbum *string
 		var setYear *int
-		var setMBGenre *string
+		var setNewMBGenre *string
 
 		if c.flags.album && metadata.Album != "" {
 			setAlbum = &metadata.Album
@@ -225,17 +225,17 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore, songIDs []string) {
 		if c.flags.year && metadata.Year > 0 {
 			setYear = &metadata.Year
 		}
-		if c.flags.genre && metadata.Genre != "" {
-			setMBGenre = &metadata.Genre
+		if c.flags.newMBGenre && metadata.Genre != "" {
+			setNewMBGenre = &metadata.Genre
 		}
 
-		if setAlbum != nil || setYear != nil || setMBGenre != nil || metadata.RecordingMBID != "" || metadata.ReleaseMBID != "" {
-			if err := ds.MediaFile(ctx).UpdateMissingMetadata(c.mf.ID, setAlbum, setYear, nil, setMBGenre, valueOrNil(metadata.RecordingMBID), valueOrNil(metadata.ReleaseMBID)); err != nil {
+		if setAlbum != nil || setYear != nil || setNewMBGenre != nil || metadata.RecordingMBID != "" || metadata.ReleaseMBID != "" {
+			if err := ds.MediaFile(ctx).UpdateMissingMetadata(c.mf.ID, setAlbum, setYear, nil, setNewMBGenre, valueOrNil(metadata.RecordingMBID), valueOrNil(metadata.ReleaseMBID)); err != nil {
 				failed++
 				log.Error(ctx, "Could not update fetched MusicBrainz metadata", "songId", c.mf.ID, err)
 			} else {
 				updated++
-				j.setUpdated(setAlbum != nil, setYear != nil, setMBGenre != nil, c.flags.recordingMBID && metadata.RecordingMBID != "", c.flags.releaseMBID && metadata.ReleaseMBID != "", false)
+				j.setUpdated(setAlbum != nil, setYear != nil, setNewMBGenre != nil, c.flags.recordingMBID && metadata.RecordingMBID != "", c.flags.releaseMBID && metadata.ReleaseMBID != "", false)
 			}
 		} else {
 			skipped++
@@ -308,7 +308,7 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 		flags := missingFlags{
 			album:         isMissingAlbum(mf.Album),
 			year:          mf.Year == 0,
-			genre:         hasMissingCoverArt(mf),
+			newMBGenre:    hasMissingCoverArt(mf),
 			recordingMBID: strings.TrimSpace(mf.MbzRecordingID) == "",
 			releaseMBID:   strings.TrimSpace(mf.MbzReleaseID) == "",
 			coverArt:      hasMissingCoverArt(mf),
@@ -319,7 +319,7 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 		}
 
 		j.incrementExisting(flags)
-		if !flags.album && !flags.year && !flags.genre && !flags.recordingMBID && !flags.releaseMBID && !flags.coverArt {
+		if !flags.album && !flags.year && !flags.newMBGenre && !flags.recordingMBID && !flags.releaseMBID && !flags.coverArt {
 			continue
 		}
 
@@ -342,8 +342,8 @@ func (j *musicBrainzMetadataJob) incrementExisting(flags missingFlags) {
 	if !flags.year {
 		j.status.Year.Existing++
 	}
-	if !flags.genre {
-		j.status.Genre.Existing++
+	if !flags.newMBGenre {
+		j.status.NewMBGenre.Existing++
 	}
 	if !flags.recordingMBID {
 		j.status.RecordingMBID.Existing++
@@ -372,9 +372,9 @@ func (j *musicBrainzMetadataJob) incrementMissing(flags missingFlags) {
 		j.status.Year.Missing++
 		j.status.Year.Left++
 	}
-	if flags.genre {
-		j.status.Genre.Missing++
-		j.status.Genre.Left++
+	if flags.newMBGenre {
+		j.status.NewMBGenre.Missing++
+		j.status.NewMBGenre.Left++
 	}
 	if flags.recordingMBID {
 		j.status.RecordingMBID.Missing++
@@ -399,8 +399,8 @@ func (j *musicBrainzMetadataJob) setFetching(flags missingFlags, delta int) {
 	if flags.year {
 		j.status.Year.Fetching += delta
 	}
-	if flags.genre {
-		j.status.Genre.Fetching += delta
+	if flags.newMBGenre {
+		j.status.NewMBGenre.Fetching += delta
 	}
 	if flags.recordingMBID {
 		j.status.RecordingMBID.Fetching += delta
@@ -413,7 +413,7 @@ func (j *musicBrainzMetadataJob) setFetching(flags missingFlags, delta int) {
 	}
 }
 
-func (j *musicBrainzMetadataJob) setUpdated(album, year, genre, recordingMBID, releaseMBID, coverArt bool) {
+func (j *musicBrainzMetadataJob) setUpdated(album, year, newMBGenre, recordingMBID, releaseMBID, coverArt bool) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	if album {
@@ -422,8 +422,8 @@ func (j *musicBrainzMetadataJob) setUpdated(album, year, genre, recordingMBID, r
 	if year {
 		j.status.Year.Updated++
 	}
-	if genre {
-		j.status.Genre.Updated++
+	if newMBGenre {
+		j.status.NewMBGenre.Updated++
 	}
 	if recordingMBID {
 		j.status.RecordingMBID.Updated++
@@ -436,7 +436,7 @@ func (j *musicBrainzMetadataJob) setUpdated(album, year, genre, recordingMBID, r
 	}
 }
 
-func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, fetchedYear, fetchedGenre, fetchedRecordingMBID, fetchedReleaseMBID, fetchedCoverArt bool) {
+func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, fetchedYear, fetchedNewMBGenre, fetchedRecordingMBID, fetchedReleaseMBID, fetchedCoverArt bool) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	if flags.album {
@@ -457,13 +457,13 @@ func (j *musicBrainzMetadataJob) finishFetch(flags missingFlags, fetchedAlbum, f
 			j.status.Year.CouldntFetch++
 		}
 	}
-	if flags.genre {
-		j.status.Genre.Fetching--
-		j.status.Genre.Left--
-		if fetchedGenre {
-			j.status.Genre.Fetched++
+	if flags.newMBGenre {
+		j.status.NewMBGenre.Fetching--
+		j.status.NewMBGenre.Left--
+		if fetchedNewMBGenre {
+			j.status.NewMBGenre.Fetched++
 		} else {
-			j.status.Genre.CouldntFetch++
+			j.status.NewMBGenre.CouldntFetch++
 		}
 	}
 	if flags.recordingMBID {

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -217,7 +217,7 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore, songIDs []string) {
 
 		var setAlbum *string
 		var setYear *int
-		var setGenre *string
+		var setMBGenre *string
 
 		if c.flags.album && metadata.Album != "" {
 			setAlbum = &metadata.Album
@@ -226,16 +226,16 @@ func (j *musicBrainzMetadataJob) run(ds model.DataStore, songIDs []string) {
 			setYear = &metadata.Year
 		}
 		if c.flags.genre && metadata.Genre != "" {
-			setGenre = &metadata.Genre
+			setMBGenre = &metadata.Genre
 		}
 
-		if setAlbum != nil || setYear != nil || setGenre != nil || metadata.RecordingMBID != "" || metadata.ReleaseMBID != "" {
-			if err := ds.MediaFile(ctx).UpdateMissingMetadata(c.mf.ID, setAlbum, setYear, setGenre, valueOrNil(metadata.RecordingMBID), valueOrNil(metadata.ReleaseMBID)); err != nil {
+		if setAlbum != nil || setYear != nil || setMBGenre != nil || metadata.RecordingMBID != "" || metadata.ReleaseMBID != "" {
+			if err := ds.MediaFile(ctx).UpdateMissingMetadata(c.mf.ID, setAlbum, setYear, nil, setMBGenre, valueOrNil(metadata.RecordingMBID), valueOrNil(metadata.ReleaseMBID)); err != nil {
 				failed++
 				log.Error(ctx, "Could not update fetched MusicBrainz metadata", "songId", c.mf.ID, err)
 			} else {
 				updated++
-				j.setUpdated(setAlbum != nil, setYear != nil, setGenre != nil, c.flags.recordingMBID && metadata.RecordingMBID != "", c.flags.releaseMBID && metadata.ReleaseMBID != "", false)
+				j.setUpdated(setAlbum != nil, setYear != nil, setMBGenre != nil, c.flags.recordingMBID && metadata.RecordingMBID != "", c.flags.releaseMBID && metadata.ReleaseMBID != "", false)
 			}
 		} else {
 			skipped++
@@ -308,7 +308,7 @@ func (j *musicBrainzMetadataJob) collectCandidates(ctx context.Context, ds model
 		flags := missingFlags{
 			album:         isMissingAlbum(mf.Album),
 			year:          mf.Year == 0,
-			genre:         strings.TrimSpace(mf.Genre) == "",
+			genre:         hasMissingCoverArt(mf),
 			recordingMBID: strings.TrimSpace(mf.MbzRecordingID) == "",
 			releaseMBID:   strings.TrimSpace(mf.MbzReleaseID) == "",
 			coverArt:      hasMissingCoverArt(mf),
@@ -1132,7 +1132,7 @@ func (j *spotifyMetadataJob) run(ds model.DataStore, songIDs []string) {
 
 		setAlbum := isMissingAlbum(mf.Album) && albumName != ""
 		if setAlbum {
-			if err := ds.MediaFile(ctx).UpdateMissingMetadata(mf.ID, &albumName, nil, nil, nil, nil); err == nil {
+			if err := ds.MediaFile(ctx).UpdateMissingMetadata(mf.ID, &albumName, nil, nil, nil, nil, nil); err == nil {
 				j.setUpdated(true, false)
 			} else {
 				setAlbum = false

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -636,7 +636,7 @@ func valueOrNil(v string) *string {
 
 func (j *musicBrainzMetadataJob) fetchMetadata(title, artist string) (metadataResult, error) {
 	query := fmt.Sprintf("artist:%s AND recording:%s", artist, title)
-	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json&inc=releases+release-groups"
+	u := "https://musicbrainz.org/ws/2/recording/?query=" + url.QueryEscape(query) + "&fmt=json&inc=releases+release-groups+genres+tags"
 	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return metadataResult{}, err

--- a/server/nativeapi/musicbrainz_metadata_test.go
+++ b/server/nativeapi/musicbrainz_metadata_test.go
@@ -1,6 +1,9 @@
 package nativeapi
 
 import (
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/navidrome/navidrome/model"
@@ -150,5 +153,35 @@ func TestHasMissingCoverArt(t *testing.T) {
 				t.Fatalf("hasMissingCoverArt() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestFetchMetadataRequestIncludesGenresAndTags(t *testing.T) {
+	job := newMusicBrainzMetadataJob()
+	job.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if got := req.URL.Query().Get("inc"); got != "releases release-groups genres tags" {
+			t.Fatalf("unexpected inc parameter: %q", got)
+		}
+
+		body := `{"recordings":[{"id":"rec-id","score":"100","artist-credit":[{"name":"The Artist"}],"genres":[{"name":"rock"}],"releases":[{"id":"rel-id","title":"Album","date":"2000-01-01","status":"Official","country":"US","release-group":{"primary-type":"Album","secondary-types":[]},"genres":[{"name":"alternative rock"}]}]}]}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	metadata, err := job.fetchMetadata("Song", "The Artist")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if metadata.Genre == "" {
+		t.Fatal("expected genre to be populated from MusicBrainz genres/tags response")
 	}
 }

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -126,7 +126,7 @@ const CovertartList = (props) => {
         <DateField source="createdAt" sortBy="recently_added" showTime />
         <TextField source="year" label="Release Year" />
         <TextField source="genre" label="Genre" />
-        <TextField source="mbGenre" label="MB-Genre" />
+        <TextField source="newMbGenre" label="New MB-Genre" sortable={false} />
         <FunctionField
           label="Fetched"
           sortBy="fetched"

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -126,6 +126,7 @@ const CovertartList = (props) => {
         <DateField source="createdAt" sortBy="recently_added" showTime />
         <TextField source="year" label="Release Year" />
         <TextField source="genre" label="Genre" />
+        <TextField source="mbGenre" label="MB-Genre" />
         <FunctionField
           label="Fetched"
           sortBy="fetched"

--- a/ui/src/layout/CoverArtPanel.jsx
+++ b/ui/src/layout/CoverArtPanel.jsx
@@ -122,7 +122,7 @@ const CoverArtPanel = () => {
     running: false,
     album: emptyProgress,
     year: emptyProgress,
-    genre: emptyProgress,
+    newMbGenre: emptyProgress,
     recordingMbid: emptyProgress,
     releaseMbid: emptyProgress,
     coverArt: emptyProgress,
@@ -153,7 +153,7 @@ const CoverArtPanel = () => {
             running: false,
             album: emptyProgress,
             year: emptyProgress,
-            genre: emptyProgress,
+            newMbGenre: emptyProgress,
             recordingMbid: emptyProgress,
             releaseMbid: emptyProgress,
             coverArt: emptyProgress,
@@ -352,8 +352,8 @@ const CoverArtPanel = () => {
               </Grid>
               <Grid item xs={12} md={4}>
                 <ProgressCard
-                  title={translate('activity.musicbrainz.genre')}
-                  progress={status.genre || emptyProgress}
+                  title="New MB-Genre"
+                  progress={status.newMbGenre || emptyProgress}
                   translate={translate}
                   classes={classes}
                 />

--- a/ui/src/song/ReorderableSongList.jsx
+++ b/ui/src/song/ReorderableSongList.jsx
@@ -304,6 +304,7 @@ const ReorderableSongList = (props) => {
         ),
       bpm: isDesktop ? <NumberField source="bpm" /> : null,
       genre: <TextField source="genre" sortBy="genre" />,
+      newMbGenre: <TextField source="newMbGenre" sortable={false} label="New MB-Genre" />,
       mood: isDesktop ? (
         <FunctionField
           source="mood"

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -216,6 +216,7 @@ const SongList = (props) => {
       ),
       bpm: isDesktop && <NumberField source="bpm" />,
       genre: <TextField source="genre" sortBy="genre" />,
+      newMbGenre: <TextField source="newMbGenre" sortable={false} label="New MB-Genre" />,
       mood: isDesktop && (
         <FunctionField
           source="mood"


### PR DESCRIPTION
### Motivation
- Keep MusicBrainz-fetched genre separate from the existing user-visible `genre` field so fetching cover-art can also populate a dedicated MusicBrainz genre without overwriting local genre tags.
- Ensure genre is fetched for every song missing cover art (regardless of whether `genre` is already present) so metadata collection is aligned with cover-art retrieval.

### Description
- Add a new DB migration that creates a `media_file.mb_genre` column via `db/migrations/20260301010101_add_mb_genre_to_media_file.go` and make the migration idempotent when the column already exists.
- Add `MBGenre string `structs:"mb_genre" json:"mbGenre,omitempty"`` to `model.MediaFile` and expose it in the repository interface by extending `UpdateMissingMetadata` to accept an `mbGenre *string` parameter.
- Update `persistence/mediafile_repository.go` to set `mb_genre` when `mbGenre` is provided and to keep prior behavior for `genre`/MBIDs/cover path.
- Change MusicBrainz fetch flow in `server/nativeapi/musicbrainz_metadata.go` to write fetched genres into `mb_genre` (not `genre`) and to treat `genre`-fetch eligibility as `hasMissingCoverArt(mf)` so the job fetches genres for all songs missing cover art.
- Add a small persistence test to verify `MBGenre` can be updated without altering the regular `genre`, and add a `MB-Genre` column to the Cover Art UI (`ui/src/covertart/CovertartList.jsx`).

### Testing
- Ran `gofmt -w` on modified files successfully to keep formatting consistent.
- Attempted `go test ./server/nativeapi ./persistence ./model/...` but tests could not complete in this environment due to missing system dependency for `taglib` (pkg-config/CGO error), so full Go test suite did not run here.
- Ran `go test ./persistence -run TestMediaFileRepository -count=1` which also failed in this environment for the same `taglib`/pkg-config issue; the newly added persistence unit test is present and should pass in CI or a developer environment where `taglib` is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b21160808322bf6cc2fbbec70d75)