### PR TITLE
Reorder metadata progress cards and remove redundant 'Updated' row

### DIFF
--- a/ui/src/layout/CoverArtPanel.jsx
+++ b/ui/src/layout/CoverArtPanel.jsx
@@ -318,22 +318,6 @@ const CoverArtPanel = () => {
                 />
               </Grid>
               <Grid item xs={12} md={4}>
-                <ProgressCard
-                  title="Cover Art (Spotify)"
-                  progress={spotifyStatus.coverArt || emptyProgress}
-                  translate={translate}
-                  classes={classes}
-                />
-              </Grid>
-              <Grid item xs={12} md={4}>
-                <ProgressCard
-                  title="Album (Spotify)"
-                  progress={spotifyStatus.album || emptyProgress}
-                  translate={translate}
-                  classes={classes}
-                />
-              </Grid>
-              <Grid item xs={12} md={4}>
                 <Card variant="outlined" className={classes.progressCard}>
                   <CardContent>
                     <Typography variant="subtitle2">
@@ -353,6 +337,22 @@ const CoverArtPanel = () => {
                     </Box>
                   </CardContent>
                 </Card>
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <ProgressCard
+                  title="Cover Art (Spotify)"
+                  progress={spotifyStatus.coverArt || emptyProgress}
+                  translate={translate}
+                  classes={classes}
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <ProgressCard
+                  title="Album (Spotify)"
+                  progress={spotifyStatus.album || emptyProgress}
+                  translate={translate}
+                  classes={classes}
+                />
               </Grid>
             </Grid>
           </CardContent>

--- a/ui/src/layout/CoverArtPanel.jsx
+++ b/ui/src/layout/CoverArtPanel.jsx
@@ -98,10 +98,6 @@ const ProgressCard = ({ title, progress, translate, classes }) => (
         <span>{progress.fetched || 0}</span>
       </Box>
       <Box className={classes.row}>
-        <span>{translate('activity.musicbrainz.updated')}</span>
-        <span>{progress.updated || 0}</span>
-      </Box>
-      <Box className={classes.row}>
         <span>{translate('activity.musicbrainz.toBeFetch')}</span>
         <span>{progress.left || 0}</span>
       </Box>
@@ -306,27 +302,6 @@ const CoverArtPanel = () => {
             </Box>
             <Grid container spacing={2}>
               <Grid item xs={12} md={4}>
-                <Card variant="outlined" className={classes.progressCard}>
-                  <CardContent>
-                    <Typography variant="subtitle2">
-                      {translate('activity.musicbrainz.saveProgressTitle')}
-                    </Typography>
-                    <Box className={classes.row}>
-                      <span>{translate('activity.musicbrainz.savedCount')}</span>
-                      <span>{saveSummary.saved || 0}</span>
-                    </Box>
-                    <Box className={classes.row}>
-                      <span>{translate('activity.musicbrainz.remainingCount')}</span>
-                      <span>{saveSummary.remaining || 0}</span>
-                    </Box>
-                    <Box className={classes.row}>
-                      <span>{translate('activity.musicbrainz.savingCount')}</span>
-                      <span>{saveSummary.saving || 0}</span>
-                    </Box>
-                  </CardContent>
-                </Card>
-              </Grid>
-              <Grid item xs={12} md={4}>
                 <ProgressCard
                   title="Cover Art (MusicBrainz)"
                   progress={status.coverArt || emptyProgress}
@@ -336,40 +311,8 @@ const CoverArtPanel = () => {
               </Grid>
               <Grid item xs={12} md={4}>
                 <ProgressCard
-                  title={translate('activity.musicbrainz.album')}
+                  title={`${translate('activity.musicbrainz.album')} (MusicBrainz)`}
                   progress={status.album || emptyProgress}
-                  translate={translate}
-                  classes={classes}
-                />
-              </Grid>
-              <Grid item xs={12} md={4}>
-                <ProgressCard
-                  title={translate('activity.musicbrainz.year')}
-                  progress={status.year || emptyProgress}
-                  translate={translate}
-                  classes={classes}
-                />
-              </Grid>
-              <Grid item xs={12} md={4}>
-                <ProgressCard
-                  title={translate('activity.musicbrainz.genre')}
-                  progress={status.genre || emptyProgress}
-                  translate={translate}
-                  classes={classes}
-                />
-              </Grid>
-              <Grid item xs={12} md={4}>
-                <ProgressCard
-                  title="Recording MBID"
-                  progress={status.recordingMbid || emptyProgress}
-                  translate={translate}
-                  classes={classes}
-                />
-              </Grid>
-              <Grid item xs={12} md={4}>
-                <ProgressCard
-                  title="Release MBID"
-                  progress={status.releaseMbid || emptyProgress}
                   translate={translate}
                   classes={classes}
                 />
@@ -389,6 +332,27 @@ const CoverArtPanel = () => {
                   translate={translate}
                   classes={classes}
                 />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <Card variant="outlined" className={classes.progressCard}>
+                  <CardContent>
+                    <Typography variant="subtitle2">
+                      {translate('activity.musicbrainz.saveProgressTitle')}
+                    </Typography>
+                    <Box className={classes.row}>
+                      <span>{translate('activity.musicbrainz.savedCount')}</span>
+                      <span>{saveSummary.saved || 0}</span>
+                    </Box>
+                    <Box className={classes.row}>
+                      <span>{translate('activity.musicbrainz.remainingCount')}</span>
+                      <span>{saveSummary.remaining || 0}</span>
+                    </Box>
+                    <Box className={classes.row}>
+                      <span>{translate('activity.musicbrainz.savingCount')}</span>
+                      <span>{saveSummary.saving || 0}</span>
+                    </Box>
+                  </CardContent>
+                </Card>
               </Grid>
             </Grid>
           </CardContent>


### PR DESCRIPTION
### Motivation
- Simplify and reorder the metadata popover so the most relevant progress cards appear first and redundant information is removed.
- Remove less-used metadata progress cards to declutter the UI and match the requested sequence.

### Description
- Reordered the cards in the popover to: `Cover Art (MusicBrainz)`, `Album (MusicBrainz)`, `Cover Art (Spotify)`, `Album (Spotify)`, and `Save Metadata Progress` by reorganizing the grid rendering in `CoverArtPanel.jsx`.
- Removed ProgressCard instances for `Year`, `Genre`, `Recording MBID`, and `Release MBID` from the layout.
- Removed the `Updated` row from `ProgressCard` so cards no longer display the redundant `updated` count.
- Moved the existing `Save Metadata Progress` card to the end of the grid and updated the `Album` title to include `(MusicBrainz)`.

### Testing
- Ran `npx eslint src/layout/CoverArtPanel.jsx --ext js,jsx` which completed successfully for the modified file.
- Ran `npm run -s lint -- src/layout/CoverArtPanel.jsx` which failed due to pre-existing lint errors in unrelated files (not caused by these changes).
- Attempted an automated Playwright screenshot against the local UI but the local endpoint returned `ERR_EMPTY_RESPONSE` so no screenshot could be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c2a767e4832289bfa567ed49ccfd)