### PR TITLE
Make Spotify match entries link to Spotify track pages

### DIFF
--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -121,6 +121,7 @@ type spotifyConfidenceEntry struct {
 	Album         string  `json:"album"`
 	SpotifyMatch  string  `json:"spotifyMatch,omitempty"`
 	SpotifyArtist string  `json:"spotifyArtist,omitempty"`
+	SpotifyURL    string  `json:"spotifyUrl,omitempty"`
 	CoverURL      string  `json:"coverUrl,omitempty"`
 	Downloaded    bool    `json:"downloaded"`
 }
@@ -1157,6 +1158,7 @@ func (j *spotifyMetadataJob) run(ds model.DataStore, songIDs []string) {
 			Album:         albumName,
 			SpotifyMatch:  strings.TrimSpace(track.Name),
 			SpotifyArtist: strings.TrimSpace(track.Artists[0].Name),
+			SpotifyURL:    "https://open.spotify.com/track/" + strings.TrimSpace(track.ID),
 			CoverURL:      coverURL,
 			Downloaded:    downloaded,
 		})

--- a/ui/src/covertart/CovertartList.jsx
+++ b/ui/src/covertart/CovertartList.jsx
@@ -151,10 +151,19 @@ const CovertartList = (props) => {
             if (!entry?.spotifyMatch) {
               return ''
             }
-            if (!entry?.spotifyArtist) {
-              return entry.spotifyMatch
+            const label = entry?.spotifyArtist
+              ? `${entry.spotifyMatch} - ${entry.spotifyArtist}`
+              : entry.spotifyMatch
+
+            if (!entry?.spotifyUrl) {
+              return label
             }
-            return `${entry.spotifyMatch} - ${entry.spotifyArtist}`
+
+            return (
+              <a href={entry.spotifyUrl} target="_blank" rel="noopener noreferrer">
+                {label}
+              </a>
+            )
           }}
         />
       ),


### PR DESCRIPTION
### Motivation
- Users should be able to click the Spotify Match value in the Cover Art list and be taken directly to the corresponding Spotify track page instead of only seeing plain text.

### Description
- Added a new `spotifyUrl` field to the Spotify confidence payload in `server/nativeapi/musicbrainz_metadata.go` and populate it with `https://open.spotify.com/track/<id>` when storing fetched entries.
- Updated the Cover Art list `Spotify Match` column in `ui/src/covertart/CovertartList.jsx` to render the label as a clickable link when `spotifyUrl` exists, and preserve a plain-text fallback when it does not.
- The frontend link uses safe attributes `target="_blank"` and `rel="noopener noreferrer"` to open external pages securely.

### Testing
- Ran `go test ./server/nativeapi`, which failed in this environment due to a missing native `taglib` pkg-config dependency and therefore did not complete successfully.
- Attempted an automated UI check by capturing a screenshot via Playwright, but the local app endpoint returned `ERR_EMPTY_RESPONSE` and the check failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c588c69c8322933c2667531f2695)