### PR TITLE
Rename MusicBrainz metadata fetch button labels

### DIFF
--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -702,8 +702,8 @@
     "elapsedTime": "Elapsed Time",
     "musicbrainz": {
       "title": "MusicBrainz Metadata",
-      "fetch": "Fetch metadata",
-      "fetchSpotify": "Fetch Spotify metadata",
+      "fetch": "MusicBrainz",
+      "fetchSpotify": "Spofity",
       "spotifyStarted": "Spotify metadata fetch started",
       "save": "Save metadata",
       "started": "Metadata fetch started",


### PR DESCRIPTION
### Motivation
- Align the UI translation labels for metadata actions with the requested wording by renaming the generic "fetch" label to `MusicBrainz` and the Spotify-specific label to `Spofity`.

### Description
- Updated `ui/src/i18n/en.json` to replace `"fetch": "Fetch metadata"` with `"fetch": "MusicBrainz"` and `"fetchSpotify": "Fetch Spotify metadata"` with `"fetchSpotify": "Spofity"`.
- No special skills were used for this change because it is a simple translation text update.

### Testing
- Verified the modified `ui/src/i18n/en.json` parses as valid JSON with `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('ui/src/i18n/en.json','utf8')); console.log('en.json valid')"` which succeeded, and attempted a Playwright screenshot of `http://localhost:4533/#/song` which failed with `ERR_EMPTY_RESPONSE` so a UI render check could not be captured in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c166879c8322971373caca02fc8e)