### PR TITLE
Retry Spotify cover art lookup with cleaned title when confidence is low

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -179,6 +179,7 @@ type spotifyOptions struct {
 	Secret              string
 	Token               string
 	MinScore            float64
+	CoverRetryMinScore  float64
 	TitleScoreWeight    float64
 	ArtistScoreWeight   float64
 	DurationScoreWeight float64
@@ -633,6 +634,7 @@ func setViperDefaults() {
 	viper.SetDefault("spotify.secret", "")
 	viper.SetDefault("spotify.token", "")
 	viper.SetDefault("spotify.minscore", 0.6)
+	viper.SetDefault("spotify.coverretryminscore", 0.6)
 	viper.SetDefault("spotify.titlescoreweight", 0.5)
 	viper.SetDefault("spotify.artistscoreweight", 0.4)
 	viper.SetDefault("spotify.durationscoreweight", 0.1)

--- a/model/retail_player_device_mapping.go
+++ b/model/retail_player_device_mapping.go
@@ -7,22 +7,24 @@ import (
 )
 
 type RetailPlayerDeviceMapping struct {
-	DeviceID     string    `db:"device_id" json:"deviceId"`
-	DeviceName   string    `db:"device_name" json:"deviceName"`
-	DeviceSlug   string    `db:"device_slug" json:"deviceSlug"`
-	IsLocked     bool      `db:"is_locked" json:"isLocked"`
-	Channel      string    `db:"channel" json:"channel"`
-	ChannelList  string    `db:"channel_list" json:"channelList"`
-	Organization string    `db:"organization" json:"organization"`
-	TimeZone     string    `db:"time_zone" json:"timeZone"`
-	RemoteCtrlID string    `db:"remote_control_id" json:"remoteControlId"`
-	UpdatedAt    time.Time `db:"updated_at" json:"updatedAt"`
+	DeviceID        string    `db:"device_id" json:"deviceId"`
+	DeviceName      string    `db:"device_name" json:"deviceName"`
+	DeviceSlug      string    `db:"device_slug" json:"deviceSlug"`
+	IsLocked        bool      `db:"is_locked" json:"isLocked"`
+	IsVolumeEnabled bool      `db:"is_volume_enabled" json:"isVolumeEnabled"`
+	Channel         string    `db:"channel" json:"channel"`
+	ChannelList     string    `db:"channel_list" json:"channelList"`
+	Organization    string    `db:"organization" json:"organization"`
+	TimeZone        string    `db:"time_zone" json:"timeZone"`
+	RemoteCtrlID    string    `db:"remote_control_id" json:"remoteControlId"`
+	UpdatedAt       time.Time `db:"updated_at" json:"updatedAt"`
 }
 
 type RetailPlayerDeviceMappingRepository interface {
 	Put(ctx context.Context, mapping RetailPlayerDeviceMapping) error
 	PutMany(ctx context.Context, mappings []RetailPlayerDeviceMapping) error
 	SetLocked(ctx context.Context, deviceID string, isLocked bool) error
+	SetVolumeEnabled(ctx context.Context, deviceID string, enabled bool) error
 	FindByIdentifier(ctx context.Context, identifier string) (*RetailPlayerDeviceMapping, error)
 	All(ctx context.Context) ([]RetailPlayerDeviceMapping, error)
 }

--- a/persistence/retail_player_device_mapping_repository.go
+++ b/persistence/retail_player_device_mapping_repository.go
@@ -24,6 +24,7 @@ func NewRetailPlayerDeviceMappingRepository(ctx context.Context, db dbx.Builder)
 	r.registerModel(&model.RetailPlayerDeviceMapping{}, nil)
 	r.ensureRemoteControlColumn()
 	r.ensureIsLockedColumn()
+	r.ensureIsVolumeEnabledColumn()
 	return r
 }
 
@@ -61,6 +62,23 @@ ADD COLUMN is_locked BOOLEAN NOT NULL DEFAULT 0;
 	log.Error(r.ctx, "Unable to ensure lock status column for retail player device mappings", "err", err)
 }
 
+func (r retailPlayerDeviceMappingRepository) ensureIsVolumeEnabledColumn() {
+	_, err := r.db.NewQuery(`
+ALTER TABLE retail_player_device_mapping
+ADD COLUMN is_volume_enabled BOOLEAN NOT NULL DEFAULT 1;
+`).Execute()
+	if err == nil {
+		return
+	}
+
+	lowerErr := strings.ToLower(err.Error())
+	if strings.Contains(lowerErr, "duplicate column name") || strings.Contains(lowerErr, "already exists") {
+		return
+	}
+
+	log.Error(r.ctx, "Unable to ensure volume enabled column for retail player device mappings", "err", err)
+}
+
 func (r retailPlayerDeviceMappingRepository) Put(ctx context.Context, mapping model.RetailPlayerDeviceMapping) error {
 	if mapping.DeviceID == "" {
 		return errors.New("retail player device id is required")
@@ -81,6 +99,7 @@ func (r retailPlayerDeviceMappingRepository) PutMany(ctx context.Context, mappin
 			"device_name",
 			"device_slug",
 			"is_locked",
+			"is_volume_enabled",
 			"channel",
 			"channel_list",
 			"organization",
@@ -110,6 +129,7 @@ func (r retailPlayerDeviceMappingRepository) PutMany(ctx context.Context, mappin
 			name,
 			slug,
 			mapping.IsLocked,
+			mapping.IsVolumeEnabled,
 			strings.TrimSpace(mapping.Channel),
 			strings.TrimSpace(mapping.ChannelList),
 			strings.TrimSpace(mapping.Organization),
@@ -128,6 +148,7 @@ func (r retailPlayerDeviceMappingRepository) PutMany(ctx context.Context, mappin
                 device_name = excluded.device_name,
                 device_slug = excluded.device_slug,
                 is_locked = retail_player_device_mapping.is_locked,
+                is_volume_enabled = retail_player_device_mapping.is_volume_enabled,
                 channel = excluded.channel,
                 channel_list = excluded.channel_list,
                 organization = excluded.organization,
@@ -153,6 +174,7 @@ func (r retailPlayerDeviceMappingRepository) SetLocked(ctx context.Context, devi
 			"device_name",
 			"device_slug",
 			"is_locked",
+			"is_volume_enabled",
 			"channel",
 			"channel_list",
 			"organization",
@@ -160,9 +182,40 @@ func (r retailPlayerDeviceMappingRepository) SetLocked(ctx context.Context, devi
 			"remote_control_id",
 			"updated_at",
 		).
-		Values(trimmedID, trimmedID, defaultSlug, isLocked, "", "", "", "", "", now).
+		Values(trimmedID, trimmedID, defaultSlug, isLocked, true, "", "", "", "", "", now).
 		Suffix(`ON CONFLICT(device_id) DO UPDATE SET
 			is_locked = excluded.is_locked,
+			updated_at = excluded.updated_at`)
+
+	_, err := r.executeSQL(insert)
+	return err
+}
+
+func (r retailPlayerDeviceMappingRepository) SetVolumeEnabled(ctx context.Context, deviceID string, enabled bool) error {
+	trimmedID := strings.TrimSpace(deviceID)
+	if trimmedID == "" {
+		return errors.New("retail player device id is required")
+	}
+
+	now := time.Now().UTC()
+	defaultSlug := model.RetailPlayerDeviceSlug(trimmedID)
+	insert := Insert(r.tableName).
+		Columns(
+			"device_id",
+			"device_name",
+			"device_slug",
+			"is_locked",
+			"is_volume_enabled",
+			"channel",
+			"channel_list",
+			"organization",
+			"time_zone",
+			"remote_control_id",
+			"updated_at",
+		).
+		Values(trimmedID, trimmedID, defaultSlug, false, enabled, "", "", "", "", "", now).
+		Suffix(`ON CONFLICT(device_id) DO UPDATE SET
+			is_volume_enabled = excluded.is_volume_enabled,
 			updated_at = excluded.updated_at`)
 
 	_, err := r.executeSQL(insert)
@@ -186,7 +239,7 @@ func (r retailPlayerDeviceMappingRepository) FindByIdentifier(ctx context.Contex
 	orClause := Or{}
 	orClause = append(orClause, conditions...)
 
-	sel := Select("device_id", "device_name", "device_slug", "is_locked", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "updated_at").
+	sel := Select("device_id", "device_name", "device_slug", "is_locked", "is_volume_enabled", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "updated_at").
 		From(r.tableName).
 		Where(orClause).
 		OrderBy("updated_at DESC").
@@ -200,7 +253,7 @@ func (r retailPlayerDeviceMappingRepository) FindByIdentifier(ctx context.Contex
 }
 
 func (r retailPlayerDeviceMappingRepository) All(ctx context.Context) ([]model.RetailPlayerDeviceMapping, error) {
-	sel := Select("device_id", "device_name", "device_slug", "is_locked", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "updated_at").
+	sel := Select("device_id", "device_name", "device_slug", "is_locked", "is_volume_enabled", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "updated_at").
 		From(r.tableName).
 		OrderBy("updated_at DESC")
 

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -1378,9 +1378,27 @@ func sanitizeSpotifyRetryTitle(title string) string {
 	if title == "" {
 		return ""
 	}
-	stripped := strings.TrimSpace(spotifyParenRegex.ReplaceAllString(title, ""))
-	stripped = strings.TrimSpace(spotifyBracketRegex.ReplaceAllString(stripped, ""))
+
+	trailingParen := regexp.MustCompile(`\s*\([^)]*\)\s*$`)
+	trailingBracket := regexp.MustCompile(`\s*\[[^\]]*\]\s*$`)
+
+	stripped := title
+
+	// Keep removing trailing tags (handles multiple like "(Live) (Remix)")
+	for {
+		newStr := trailingParen.ReplaceAllString(stripped, "")
+		newStr = trailingBracket.ReplaceAllString(newStr, "")
+
+		newStr = strings.TrimSpace(newStr)
+
+		if newStr == stripped {
+			break
+		}
+		stripped = newStr
+	}
+
 	stripped = strings.Join(strings.Fields(stripped), " ")
+
 	if stripped == "" {
 		return title
 	}

--- a/server/nativeapi/musicbrainz_metadata.go
+++ b/server/nativeapi/musicbrainz_metadata.go
@@ -1373,9 +1373,23 @@ func spotifyReleaseYear(releaseDate string) int {
 	return year
 }
 
-func (j *spotifyMetadataJob) searchBestTrack(ctx context.Context, token string, mf model.MediaFile) (*spotifyTrack, float64, error) {
+func sanitizeSpotifyRetryTitle(title string) string {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return ""
+	}
+	stripped := strings.TrimSpace(spotifyParenRegex.ReplaceAllString(title, ""))
+	stripped = strings.TrimSpace(spotifyBracketRegex.ReplaceAllString(stripped, ""))
+	stripped = strings.Join(strings.Fields(stripped), " ")
+	if stripped == "" {
+		return title
+	}
+	return stripped
+}
+
+func (j *spotifyMetadataJob) searchSpotifyTrack(ctx context.Context, token string, mf model.MediaFile, title string) (*spotifyTrack, float64, error) {
 	localArtist := strings.TrimSpace(mf.Artist)
-	localTitle := strings.TrimSpace(mf.Title)
+	localTitle := strings.TrimSpace(title)
 	if localArtist == "" || localTitle == "" {
 		return nil, 0, nil
 	}
@@ -1390,7 +1404,7 @@ func (j *spotifyMetadataJob) searchBestTrack(ctx context.Context, token string, 
 	params.Set("type", "track")
 	params.Set("limit", "1")
 	endpoint.RawQuery = params.Encode()
-	log.Debug(ctx, "Spotify metadata search request", "songId", mf.ID, "title", mf.Title, "artist", mf.Artist, "url", endpoint.String())
+	log.Debug(ctx, "Spotify metadata search request", "songId", mf.ID, "title", localTitle, "artist", mf.Artist, "url", endpoint.String())
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
 	if err != nil {
@@ -1451,6 +1465,31 @@ func (j *spotifyMetadataJob) searchBestTrack(ctx context.Context, token string, 
 		}
 	}
 	return best, bestScore, nil
+}
+
+func (j *spotifyMetadataJob) searchBestTrack(ctx context.Context, token string, mf model.MediaFile) (*spotifyTrack, float64, error) {
+	track, confidence, err := j.searchSpotifyTrack(ctx, token, mf, mf.Title)
+	if err != nil || track == nil {
+		return track, confidence, err
+	}
+
+	if confidence >= conf.Server.Spotify.CoverRetryMinScore {
+		return track, confidence, nil
+	}
+
+	retryTitle := sanitizeSpotifyRetryTitle(mf.Title)
+	if retryTitle == "" || strings.EqualFold(strings.TrimSpace(mf.Title), retryTitle) {
+		return track, confidence, nil
+	}
+
+	retryTrack, retryConfidence, retryErr := j.searchSpotifyTrack(ctx, token, mf, retryTitle)
+	if retryErr != nil {
+		return nil, 0, retryErr
+	}
+	if retryTrack == nil {
+		return track, confidence, nil
+	}
+	return retryTrack, retryConfidence, nil
 }
 
 func (j *spotifyMetadataJob) fetchAndSetCoverFromURL(ctx context.Context, ds model.DataStore, songID, spotifyURL string) (spotifyConfidenceEntry, error) {

--- a/server/nativeapi/musicbrainz_metadata_test.go
+++ b/server/nativeapi/musicbrainz_metadata_test.go
@@ -152,3 +152,24 @@ func TestHasMissingCoverArt(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitizeSpotifyRetryTitle(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		want  string
+	}{
+		{name: "removes parenthesized text", title: "Song Title (Live)", want: "Song Title"},
+		{name: "removes bracketed text", title: "Song Title [Remastered 2019]", want: "Song Title"},
+		{name: "removes mixed suffixes", title: "Song (Live) [Remastered]", want: "Song"},
+		{name: "keeps original when fully stripped", title: "(Live)", want: "(Live)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeSpotifyRetryTitle(tt.title); got != tt.want {
+				t.Fatalf("sanitizeSpotifyRetryTitle() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -1100,8 +1100,9 @@ func (n *Router) handleRetailPlayerDeviceTriggers() http.HandlerFunc {
 
 func (n *Router) handleRetailPlayerDeviceTriggerAction() http.HandlerFunc {
 	type triggerActionRequest struct {
-		Action string `json:"action"`
-		Value  string `json:"value"`
+		Action          string `json:"action"`
+		Value           string `json:"value"`
+		ButtonTriggerID string `json:"buttonTriggerId"`
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -1127,16 +1128,44 @@ func (n *Router) handleRetailPlayerDeviceTriggerAction() http.HandlerFunc {
 			return
 		}
 
-		action := strings.TrimSpace(payload.Action)
+		action := strings.ToUpper(strings.TrimSpace(payload.Action))
 		value := strings.TrimSpace(payload.Value)
-		if action == "" || value == "" {
-			http.Error(w, "Trigger action and value are required", http.StatusBadRequest)
+		buttonTriggerID := strings.TrimSpace(payload.ButtonTriggerID)
+
+		triggerID := buttonTriggerID
+		if triggerID == "" && action == "PLAY" {
+			triggerID = value
+		}
+
+		if triggerID == "" && action != "STOP" {
+			http.Error(w, "Button trigger id is required", http.StatusBadRequest)
 			return
 		}
 
-		log.Info(ctx, "Sending retail player trigger action", "deviceID", deviceID, "action", action, "value", value)
+		if action == "STOP" {
+			log.Info(ctx, "Sending retail player cue stop command", "deviceID", deviceID, "value", value)
+			if err := sendRetailPlayerCueStopAction(ctx, deviceID); err != nil {
+				if errors.Is(err, errRetailPlayerDeviceNotFound) {
+					http.Error(w, "Retail player device not found", http.StatusNotFound)
+					return
+				}
 
-		if err := sendRetailPlayerTriggerAction(ctx, deviceID, action, value); err != nil {
+				log.Error(ctx, "Unable to send retail player cue stop action", "deviceID", deviceID, "err", err)
+				http.Error(w, "Unable to send trigger action", http.StatusBadGateway)
+				return
+			}
+
+			writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{
+				"success": true,
+				"action":  "STOP",
+				"value":   value,
+			})
+			return
+		}
+
+		log.Info(ctx, "Sending retail player button trigger command", "deviceID", deviceID, "buttonTriggerID", triggerID)
+
+		if err := sendRetailPlayerTriggerAction(ctx, deviceID, triggerID); err != nil {
 			if errors.Is(err, errRetailPlayerDeviceNotFound) {
 				http.Error(w, "Retail player device not found", http.StatusNotFound)
 				return
@@ -1149,8 +1178,8 @@ func (n *Router) handleRetailPlayerDeviceTriggerAction() http.HandlerFunc {
 
 		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{
 			"success": true,
-			"action":  action,
-			"value":   value,
+			"action":  "PLAY",
+			"value":   triggerID,
 		})
 	}
 }
@@ -2259,83 +2288,53 @@ func fetchRetailPlayerDeviceTriggers(ctx context.Context, deviceID string) ([]re
 	return triggers, nil
 }
 
-func sendRetailPlayerTriggerAction(ctx context.Context, deviceID, action, value string) error {
-	cfg := conf.Server.RetailPlayer
-	baseURL := strings.TrimSpace(cfg.RemoteControlBaseURL)
-	if baseURL == "" {
-		baseURL = cfg.BaseURL
-	}
-
-	apiKey := strings.TrimSpace(cfg.RemoteControlAPIKey)
-	if apiKey == "" {
-		apiKey = cfg.APIKey
-	}
-
-	apiKeyHeader := strings.TrimSpace(cfg.RemoteControlAPIKeyHeader)
-	if apiKeyHeader == "" {
-		apiKeyHeader = retailPlayerRemoteControlDefaultKeyHeader
-	}
-
-	if baseURL == "" {
-		return errors.New("retail player remote control API not configured")
-	}
-
+func sendRetailPlayerTriggerAction(ctx context.Context, deviceID, triggerID string) error {
 	trimmedID := strings.TrimSpace(deviceID)
 	if trimmedID == "" {
 		return errors.New("retail player device id is empty")
 	}
 
-	remoteControlID, err := fetchRetailPlayerRemoteControlID(ctx, trimmedID)
+	trimmedTriggerID := strings.TrimSpace(triggerID)
+	if trimmedTriggerID == "" {
+		return errors.New("retail player trigger id is empty")
+	}
+
+	command := retailPlayerCommandRequest{
+		Type: "button_trigger",
+		Payload: map[string]string{
+			"buttonTriggerId": trimmedTriggerID,
+		},
+	}
+
+	_, err := (&Router{}).sendRetailPlayerDeviceCommand(ctx, trimmedID, command)
 	if err != nil {
+		if strings.Contains(err.Error(), "status 404") || strings.Contains(err.Error(), "status 400") {
+			return errRetailPlayerDeviceNotFound
+		}
 		return err
 	}
 
-	requestConfig := retailPlayerRemoteControlConfig{
-		BaseURL:           baseURL,
-		APIKey:            apiKey,
-		APIKeyHeader:      apiKeyHeader,
-		AdditionalHeaders: cfg.AdditionalHeaders,
+	return nil
+}
+
+func sendRetailPlayerCueStopAction(ctx context.Context, deviceID string) error {
+	trimmedID := strings.TrimSpace(deviceID)
+	if trimmedID == "" {
+		return errors.New("retail player device id is empty")
 	}
 
-	body, err := json.Marshal(map[string]string{"action": action, "value": value})
+	command := retailPlayerCommandRequest{
+		Type:    "FLUSH_EVENTS",
+		Payload: map[string]any{},
+	}
+
+	_, err := (&Router{}).sendRetailPlayerDeviceCommand(ctx, trimmedID, command)
 	if err != nil {
+		if strings.Contains(err.Error(), "status 404") || strings.Contains(err.Error(), "status 400") {
+			return errRetailPlayerDeviceNotFound
+		}
 		return err
 	}
-
-	req, err := buildRetailPlayerRemoteControlRequestWithMethod(
-		ctx,
-		requestConfig,
-		remoteControlID,
-		http.MethodPost,
-		bytes.NewReader(body),
-		"triggers",
-	)
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := retailPlayerHTTPClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusBadRequest {
-		return errRetailPlayerDeviceNotFound
-	}
-
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf(
-			"retail player trigger action failed with status %d: %s",
-			resp.StatusCode,
-			strings.TrimSpace(string(bodyBytes)),
-		)
-	}
-
-	io.Copy(io.Discard, resp.Body)
 
 	return nil
 }

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -210,6 +210,7 @@ type retailPlayerDevice struct {
 	ID              string   `json:"id"`
 	Name            string   `json:"name"`
 	IsLocked        bool     `json:"isLocked"`
+	IsVolumeEnabled *bool    `json:"isVolumeEnabled,omitempty"`
 	OrganizationID  string   `json:"organizationId,omitempty"`
 	OrganisationID  string   `json:"organisationid,omitempty"`
 	Channel         string   `json:"channel"`
@@ -366,6 +367,7 @@ func (n *Router) addRetailPlayerPublicRoutes(r chi.Router) {
 func (n *Router) addRetailPlayerPrivateRoutes(r chi.Router) {
 	r.Get("/retailplayer/devices", n.handleRetailPlayerDevices())
 	r.Patch("/retailplayer/devices/{deviceID}/lock", n.handleUpdateRetailPlayerDeviceLock())
+	r.Patch("/retailplayer/devices/{deviceID}/volume-control", n.handleUpdateRetailPlayerDeviceVolumeControl())
 	r.Post("/retailplayer/folders", n.handleCreateRetailPlayerFolder())
 	r.Patch("/retailplayer/folders/{folderID}", n.handleUpdateRetailPlayerFolder())
 	r.Post("/retailplayer/folders/delete", n.handleDeleteRetailPlayerFolders())
@@ -414,6 +416,54 @@ func (n *Router) handleUpdateRetailPlayerDeviceLock() http.HandlerFunc {
 		mapping, err := repo.FindByIdentifier(ctx, deviceID)
 		if err != nil {
 			log.Error(ctx, "Unable to load retail player device mapping after lock update", "deviceID", deviceID, "err", err)
+			http.Error(w, "Unable to load retail player device", http.StatusInternalServerError)
+			return
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{"data": mapRetailPlayerMappingToDevice(*mapping)})
+	}
+}
+
+func (n *Router) handleUpdateRetailPlayerDeviceVolumeControl() http.HandlerFunc {
+	type volumeControlUpdatePayload struct {
+		Enabled bool `json:"enabled"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		deviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		if deviceID == "" {
+			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
+			return
+		}
+
+		var payload volumeControlUpdatePayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "Invalid retail player volume control payload", http.StatusBadRequest)
+			return
+		}
+
+		repo := n.ds.RetailPlayerDeviceMapping(ctx)
+		if repo == nil {
+			http.Error(w, "Retail player device mapping repository not available", http.StatusInternalServerError)
+			return
+		}
+
+		if err := repo.SetVolumeEnabled(ctx, deviceID, payload.Enabled); err != nil {
+			log.Error(ctx, "Unable to update retail player device volume controls", "deviceID", deviceID, "err", err)
+			http.Error(w, "Unable to update retail player device volume controls", http.StatusInternalServerError)
+			return
+		}
+
+		mapping, err := repo.FindByIdentifier(ctx, deviceID)
+		if err != nil {
+			log.Error(ctx, "Unable to load retail player device mapping after volume control update", "deviceID", deviceID, "err", err)
 			http.Error(w, "Unable to load retail player device", http.StatusInternalServerError)
 			return
 		}
@@ -493,12 +543,14 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 
 			if len(mappings) > 0 {
 				remoteControlByID := make(map[string]string, len(mappings))
+				volumeEnabledByID := make(map[string]bool, len(mappings))
 				for _, mapping := range mappings {
 					id := strings.TrimSpace(mapping.DeviceID)
 					remoteControlID := strings.TrimSpace(mapping.RemoteCtrlID)
 					if id == "" {
 						continue
 					}
+					volumeEnabledByID[id] = mapping.IsVolumeEnabled
 					if remoteControlID != "" {
 						remoteControlByID[id] = remoteControlID
 					}
@@ -519,6 +571,16 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 						if remoteControlID, ok := remoteControlByID[id]; ok {
 							response.Data[index].RemoteControlID = remoteControlID
 						}
+					}
+				}
+				for index := range response.Data {
+					id := strings.TrimSpace(response.Data[index].ID)
+					if id == "" {
+						continue
+					}
+					if volumeEnabled, ok := volumeEnabledByID[id]; ok {
+						enabled := volumeEnabled
+						response.Data[index].IsVolumeEnabled = &enabled
 					}
 				}
 			}
@@ -637,12 +699,14 @@ func (n *Router) handleRetailPlayerDeviceByName() http.HandlerFunc {
 
 			if len(mappings) > 0 {
 				remoteControlByID := make(map[string]string, len(mappings))
+				volumeEnabledByID := make(map[string]bool, len(mappings))
 				for _, mapping := range mappings {
 					id := strings.TrimSpace(mapping.DeviceID)
 					remoteControlID := strings.TrimSpace(mapping.RemoteCtrlID)
 					if id == "" {
 						continue
 					}
+					volumeEnabledByID[id] = mapping.IsVolumeEnabled
 					if remoteControlID != "" {
 						remoteControlByID[id] = remoteControlID
 					}
@@ -663,6 +727,16 @@ func (n *Router) handleRetailPlayerDeviceByName() http.HandlerFunc {
 						if remoteControlID, ok := remoteControlByID[id]; ok {
 							filtered.Data[index].RemoteControlID = remoteControlID
 						}
+					}
+				}
+				for index := range filtered.Data {
+					id := strings.TrimSpace(filtered.Data[index].ID)
+					if id == "" {
+						continue
+					}
+					if volumeEnabled, ok := volumeEnabledByID[id]; ok {
+						enabled := volumeEnabled
+						filtered.Data[index].IsVolumeEnabled = &enabled
 					}
 				}
 			}
@@ -1535,24 +1609,32 @@ func mapRetailPlayerDeviceToMapping(device retailPlayerDevice) (model.RetailPlay
 		slug = model.RetailPlayerDeviceSlug(id)
 	}
 
+	isVolumeEnabled := true
+	if device.IsVolumeEnabled != nil {
+		isVolumeEnabled = *device.IsVolumeEnabled
+	}
+
 	return model.RetailPlayerDeviceMapping{
-		DeviceID:     id,
-		DeviceName:   name,
-		DeviceSlug:   slug,
-		IsLocked:     device.IsLocked,
-		Channel:      strings.TrimSpace(device.Channel),
-		ChannelList:  strings.TrimSpace(device.ChannelList),
-		Organization: strings.TrimSpace(device.Organization),
-		TimeZone:     strings.TrimSpace(device.TimeZone),
-		RemoteCtrlID: strings.TrimSpace(device.RemoteControlID),
+		DeviceID:        id,
+		DeviceName:      name,
+		DeviceSlug:      slug,
+		IsLocked:        device.IsLocked,
+		IsVolumeEnabled: isVolumeEnabled,
+		Channel:         strings.TrimSpace(device.Channel),
+		ChannelList:     strings.TrimSpace(device.ChannelList),
+		Organization:    strings.TrimSpace(device.Organization),
+		TimeZone:        strings.TrimSpace(device.TimeZone),
+		RemoteCtrlID:    strings.TrimSpace(device.RemoteControlID),
 	}, true
 }
 
 func mapRetailPlayerMappingToDevice(mapping model.RetailPlayerDeviceMapping) retailPlayerDevice {
+	isVolumeEnabled := mapping.IsVolumeEnabled
 	return retailPlayerDevice{
 		ID:              strings.TrimSpace(mapping.DeviceID),
 		Name:            strings.TrimSpace(mapping.DeviceName),
 		IsLocked:        mapping.IsLocked,
+		IsVolumeEnabled: &isVolumeEnabled,
 		Channel:         strings.TrimSpace(mapping.Channel),
 		ChannelList:     strings.TrimSpace(mapping.ChannelList),
 		Organization:    strings.TrimSpace(mapping.Organization),

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -262,7 +262,8 @@
         "compareSelectTwoPlaylists": "Select exactly two playlists to compare.",
         "compareDuplicatesFound": "Found %{smart_count} duplicate song in both playlists. |||| Found %{smart_count} duplicate songs in both playlists.",
         "compareNoDuplicates": "No duplicate songs were found between the selected playlists.",
-        "compareRemovePrompt": "Remove duplicates from which playlist?"
+        "compareRemovePrompt": "Remove duplicates from which playlist?",
+        "compareDeletedFromPlaylist": "%{smart_count} song deleted from playlist \"%{name}\". |||| %{smart_count} songs deleted from playlist \"%{name}\"."
       },
       "dialog": {
         "setPositionTitle": "Set song position",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -247,7 +247,9 @@
         "searchOrCreate": "Search playlists or type to create new...",
         "pressEnterToCreate": "Press Enter to create new playlist",
         "removeFromSelection": "Remove from selection",
-        "setPosition": "Set song position"
+        "setPosition": "Set song position",
+        "compare": "Compare",
+        "removeDuplicatesFrom": "Remove from %{name}"
       },
       "notifications": {
         "published": "%{smart_count} song from %{name} published to Sync folder |||| %{smart_count} songs from %{name} published to Sync folder"
@@ -256,7 +258,11 @@
         "duplicate_song": "Add duplicated songs",
         "song_exist": "There are duplicates being added to the playlist. Would you like to add the duplicates or skip them?",
         "noPlaylistsFound": "No playlists found",
-        "noPlaylists": "No playlists available"
+        "noPlaylists": "No playlists available",
+        "compareSelectTwoPlaylists": "Select exactly two playlists to compare.",
+        "compareDuplicatesFound": "Found %{smart_count} duplicate song in both playlists. |||| Found %{smart_count} duplicate songs in both playlists.",
+        "compareNoDuplicates": "No duplicate songs were found between the selected playlists.",
+        "compareRemovePrompt": "Remove duplicates from which playlist?"
       },
       "dialog": {
         "setPositionTitle": "Set song position",

--- a/ui/src/playlist_folder/PlaylistFolderBulkActions.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderBulkActions.jsx
@@ -27,7 +27,7 @@ import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
 import Divider from '@material-ui/core/Divider'
-import { buildDuplicateInfo } from './playlistComparison'
+import { buildDuplicateInfo, buildDuplicateTrackIdsByPlaylist } from './playlistComparison'
 
 const useStyles = makeStyles((theme) => ({
   button: {
@@ -186,12 +186,14 @@ const ComparePlaylistsButton = ({ resource }) => {
   const [open, setOpen] = useState(false)
   const [duplicates, setDuplicates] = useState([])
   const [playlists, setPlaylists] = useState([])
+  const [duplicateTrackIdsByPlaylist, setDuplicateTrackIdsByPlaylist] = useState({})
   const [loading, setLoading] = useState(false)
 
   const closeDialog = useCallback(() => {
     setOpen(false)
     setDuplicates([])
     setPlaylists([])
+    setDuplicateTrackIdsByPlaylist({})
   }, [])
 
   const selectedPlaylists = useMemo(
@@ -227,12 +229,20 @@ const ComparePlaylistsButton = ({ resource }) => {
         }),
       ])
 
-      const matches = buildDuplicateInfo(leftResult?.data || [], rightResult?.data || [])
+      const leftTracks = leftResult?.data || []
+      const rightTracks = rightResult?.data || []
+      const matches = buildDuplicateInfo(leftTracks, rightTracks)
+      const duplicateTrackIds = buildDuplicateTrackIdsByPlaylist(leftTracks, rightTracks)
+
       setDuplicates(matches)
       setPlaylists([
         { id: left.id, name: left.name || left.id },
         { id: right.id, name: right.name || right.id },
       ])
+      setDuplicateTrackIdsByPlaylist({
+        [left.id]: duplicateTrackIds.left,
+        [right.id]: duplicateTrackIds.right,
+      })
       setOpen(true)
     } catch (e) {
       notify('ra.notification.http_error', { type: 'warning' })
@@ -246,11 +256,16 @@ const ComparePlaylistsButton = ({ resource }) => {
       if (!duplicates.length || !playlistId) return
       setLoading(true)
       try {
-        const duplicateMediaIds = duplicates.map((duplicate) => duplicate.mediaFileId)
+        const trackIdsToDelete = duplicateTrackIdsByPlaylist[playlistId] || []
+        if (!trackIdsToDelete.length) {
+          notify('resources.playlist.message.compareNoDuplicates', { type: 'warning' })
+          return
+        }
+
         const result = await safeDeleteMany(
           dataProvider,
           `playlist/${playlistId}/tracks`,
-          duplicateMediaIds
+          trackIdsToDelete
         )
 
         const removedCount = Array.isArray(result?.data) ? result.data.length : 0
@@ -267,7 +282,7 @@ const ComparePlaylistsButton = ({ resource }) => {
         setLoading(false)
       }
     },
-    [duplicates, dataProvider, notify, closeDialog, unselectAll, resource, refresh]
+    [duplicates.length, duplicateTrackIdsByPlaylist, dataProvider, notify, closeDialog, unselectAll, resource, refresh]
   )
 
   return (

--- a/ui/src/playlist_folder/PlaylistFolderBulkActions.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderBulkActions.jsx
@@ -9,12 +9,42 @@ import {
 } from 'react-admin'
 import { makeStyles } from '@material-ui/core/styles'
 import DeleteIcon from '@material-ui/icons/Delete'
-import { LockOpen, Lock } from '@material-ui/icons'
+import CompareArrowsIcon from '@material-ui/icons/CompareArrows'
+import {
+  LockOpen,
+  Lock,
+  Close as CloseIcon,
+  DeleteSweep as DeleteSweepIcon,
+} from '@material-ui/icons'
 import Button from '@material-ui/core/Button'
+import Dialog from '@material-ui/core/Dialog'
+import DialogActions from '@material-ui/core/DialogActions'
+import DialogContent from '@material-ui/core/DialogContent'
+import DialogTitle from '@material-ui/core/DialogTitle'
+import IconButton from '@material-ui/core/IconButton'
+import Typography from '@material-ui/core/Typography'
+import List from '@material-ui/core/List'
+import ListItem from '@material-ui/core/ListItem'
+import ListItemText from '@material-ui/core/ListItemText'
+import Divider from '@material-ui/core/Divider'
+import { buildDuplicateInfo } from './playlistComparison'
 
 const useStyles = makeStyles((theme) => ({
   button: {
     color: theme.palette.type === 'dark' ? 'white' : undefined,
+  },
+  closeButton: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+  },
+  duplicateList: {
+    maxHeight: 360,
+    overflow: 'auto',
+    marginBottom: theme.spacing(1),
+  },
+  hint: {
+    marginBottom: theme.spacing(1),
   },
 }))
 
@@ -144,6 +174,176 @@ const CustomBulkDeleteButton = ({ resource }) => {
   )
 }
 
+const ComparePlaylistsButton = ({ resource }) => {
+  const classes = useStyles()
+  const translate = useTranslate()
+  const { selectedIds = [], data } = useListContext()
+  const dataProvider = useDataProvider()
+  const notify = useNotify()
+  const unselectAll = useUnselectAll()
+  const refresh = useRefresh()
+
+  const [open, setOpen] = useState(false)
+  const [duplicates, setDuplicates] = useState([])
+  const [playlists, setPlaylists] = useState([])
+  const [loading, setLoading] = useState(false)
+
+  const closeDialog = useCallback(() => {
+    setOpen(false)
+    setDuplicates([])
+    setPlaylists([])
+  }, [])
+
+  const selectedPlaylists = useMemo(
+    () =>
+      selectedIds
+        .map((id) => getRecord(data, id))
+        .filter((record) => record?.type === 'playlist'),
+    [selectedIds, data]
+  )
+
+  const handleCompare = useCallback(async () => {
+    if (loading) return
+
+    if (selectedIds.length !== 2 || selectedPlaylists.length !== 2) {
+      notify('resources.playlist.message.compareSelectTwoPlaylists', { type: 'warning' })
+      return
+    }
+
+    setLoading(true)
+    try {
+      const [left, right] = selectedPlaylists
+
+      const [leftResult, rightResult] = await Promise.all([
+        dataProvider.getList('playlistTrack', {
+          filter: { playlist_id: left.id },
+          pagination: { page: 1, perPage: 0 },
+          sort: { field: 'id', order: 'ASC' },
+        }),
+        dataProvider.getList('playlistTrack', {
+          filter: { playlist_id: right.id },
+          pagination: { page: 1, perPage: 0 },
+          sort: { field: 'id', order: 'ASC' },
+        }),
+      ])
+
+      const matches = buildDuplicateInfo(leftResult?.data || [], rightResult?.data || [])
+      setDuplicates(matches)
+      setPlaylists([
+        { id: left.id, name: left.name || left.id },
+        { id: right.id, name: right.name || right.id },
+      ])
+      setOpen(true)
+    } catch (e) {
+      notify('ra.notification.http_error', { type: 'warning' })
+    } finally {
+      setLoading(false)
+    }
+  }, [loading, selectedIds, selectedPlaylists, dataProvider, notify])
+
+  const handleRemoveDuplicates = useCallback(
+    async (playlistId) => {
+      if (!duplicates.length || !playlistId) return
+      setLoading(true)
+      try {
+        const duplicateMediaIds = duplicates.map((duplicate) => duplicate.mediaFileId)
+        const result = await safeDeleteMany(
+          dataProvider,
+          `playlist/${playlistId}/tracks`,
+          duplicateMediaIds
+        )
+
+        const removedCount = Array.isArray(result?.data) ? result.data.length : 0
+        notify('ra.notification.deleted', {
+          type: removedCount > 0 ? 'info' : 'warning',
+          messageArgs: { smart_count: removedCount },
+        })
+        closeDialog()
+        unselectAll(resource)
+        refresh({ hard: true })
+      } catch (e) {
+        notify('ra.notification.http_error', { type: 'warning' })
+      } finally {
+        setLoading(false)
+      }
+    },
+    [duplicates, dataProvider, notify, closeDialog, unselectAll, resource, refresh]
+  )
+
+  return (
+    <>
+      <Button
+        onClick={handleCompare}
+        startIcon={<CompareArrowsIcon />}
+        className={classes.button}
+        aria-label={translate('resources.playlist.actions.compare')}
+        disabled={loading}
+      >
+        {translate('resources.playlist.actions.compare')}
+      </Button>
+
+      <Dialog open={open} onClose={closeDialog} fullWidth maxWidth="sm">
+        <DialogTitle disableTypography>
+          <Typography variant="h6">{translate('resources.playlist.actions.compare')}</Typography>
+          <IconButton
+            aria-label={translate('ra.action.close')}
+            className={classes.closeButton}
+            onClick={closeDialog}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent>
+          {duplicates.length > 0 ? (
+            <>
+              <Typography variant="body2" className={classes.hint}>
+                {translate('resources.playlist.message.compareDuplicatesFound', {
+                  smart_count: duplicates.length,
+                })}
+              </Typography>
+              <List className={classes.duplicateList} dense>
+                {duplicates.map((duplicate) => (
+                  <ListItem key={duplicate.mediaFileId}>
+                    <ListItemText
+                      primary={duplicate.title || duplicate.mediaFileId}
+                      secondary={duplicate.artist || undefined}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+              <Divider />
+              <Typography variant="body2" className={classes.hint}>
+                {translate('resources.playlist.message.compareRemovePrompt')}
+              </Typography>
+            </>
+          ) : (
+            <Typography variant="body2">
+              {translate('resources.playlist.message.compareNoDuplicates')}
+            </Typography>
+          )}
+        </DialogContent>
+        <DialogActions>
+          {duplicates.length > 0 &&
+            playlists.map((playlist) => (
+              <Button
+                key={playlist.id}
+                startIcon={<DeleteSweepIcon />}
+                onClick={() => handleRemoveDuplicates(playlist.id)}
+                color="secondary"
+                disabled={loading}
+              >
+                {translate('resources.playlist.actions.removeDuplicatesFrom', {
+                  name: playlist.name,
+                })}
+              </Button>
+            ))}
+          <Button onClick={closeDialog}>{translate('ra.action.cancel')}</Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  )
+}
+
 const ChangePublicStatusButton = ({ resource, makePublic }) => {
   const classes = useStyles()
   const translate = useTranslate()
@@ -167,6 +367,7 @@ const ChangePublicStatusButton = ({ resource, makePublic }) => {
 
 const PlaylistFolderBulkActions = (props) => (
   <Fragment>
+    <ComparePlaylistsButton {...props} />
     <ChangePublicStatusButton makePublic={true} {...props} />
     <ChangePublicStatusButton makePublic={false} {...props} />
     <CustomBulkDeleteButton {...props} />

--- a/ui/src/playlist_folder/PlaylistFolderBulkActions.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderBulkActions.jsx
@@ -269,9 +269,12 @@ const ComparePlaylistsButton = ({ resource }) => {
         )
 
         const removedCount = Array.isArray(result?.data) ? result.data.length : 0
-        notify('ra.notification.deleted', {
+        const playlistName =
+          playlists.find((playlist) => playlist.id === playlistId)?.name || playlistId
+
+        notify('resources.playlist.message.compareDeletedFromPlaylist', {
           type: removedCount > 0 ? 'info' : 'warning',
-          messageArgs: { smart_count: removedCount },
+          messageArgs: { smart_count: removedCount, name: playlistName },
         })
         closeDialog()
         unselectAll(resource)
@@ -282,7 +285,7 @@ const ComparePlaylistsButton = ({ resource }) => {
         setLoading(false)
       }
     },
-    [duplicates.length, duplicateTrackIdsByPlaylist, dataProvider, notify, closeDialog, unselectAll, resource, refresh]
+    [duplicates.length, duplicateTrackIdsByPlaylist, dataProvider, notify, playlists, closeDialog, unselectAll, resource, refresh]
   )
 
   return (

--- a/ui/src/playlist_folder/PlaylistFolderBulkActions.test.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderBulkActions.test.jsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { buildDuplicateInfo } from './playlistComparison'
+
+describe('buildDuplicateInfo', () => {
+  it('returns unique duplicates sorted by title', () => {
+    const leftTracks = [
+      { mediaFileId: 'm2', title: 'Zebra', artist: 'Two' },
+      { mediaFileId: 'm1', title: 'Alpha', artist: 'One' },
+      { mediaFileId: 'm1', title: 'Alpha', artist: 'One' },
+    ]
+    const rightTracks = [
+      { mediaFileId: 'm3', title: 'Other' },
+      { mediaFileId: 'm1', title: 'Alpha' },
+      { mediaFileId: 'm2', title: 'Zebra' },
+    ]
+
+    expect(buildDuplicateInfo(leftTracks, rightTracks)).toEqual([
+      { mediaFileId: 'm1', title: 'Alpha', artist: 'One' },
+      { mediaFileId: 'm2', title: 'Zebra', artist: 'Two' },
+    ])
+  })
+
+  it('ignores tracks without mediaFileId', () => {
+    const leftTracks = [
+      { title: 'Unknown' },
+      { mediaFileId: '', title: 'Blank' },
+      { mediaFileId: null, title: 'Null' },
+    ]
+    const rightTracks = [{ mediaFileId: 'm1', title: 'Exists' }]
+
+    expect(buildDuplicateInfo(leftTracks, rightTracks)).toEqual([])
+  })
+})

--- a/ui/src/playlist_folder/PlaylistFolderBulkActions.test.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderBulkActions.test.jsx
@@ -1,17 +1,20 @@
 import { describe, it, expect } from 'vitest'
-import { buildDuplicateInfo } from './playlistComparison'
+import {
+  buildDuplicateInfo,
+  buildDuplicateTrackIdsByPlaylist,
+} from './playlistComparison'
 
 describe('buildDuplicateInfo', () => {
   it('returns unique duplicates sorted by title', () => {
     const leftTracks = [
-      { mediaFileId: 'm2', title: 'Zebra', artist: 'Two' },
-      { mediaFileId: 'm1', title: 'Alpha', artist: 'One' },
-      { mediaFileId: 'm1', title: 'Alpha', artist: 'One' },
+      { id: 'lt2', mediaFileId: 'm2', title: 'Zebra', artist: 'Two' },
+      { id: 'lt1', mediaFileId: 'm1', title: 'Alpha', artist: 'One' },
+      { id: 'lt1-dup', mediaFileId: 'm1', title: 'Alpha', artist: 'One' },
     ]
     const rightTracks = [
-      { mediaFileId: 'm3', title: 'Other' },
-      { mediaFileId: 'm1', title: 'Alpha' },
-      { mediaFileId: 'm2', title: 'Zebra' },
+      { id: 'rt3', mediaFileId: 'm3', title: 'Other' },
+      { id: 'rt1', mediaFileId: 'm1', title: 'Alpha' },
+      { id: 'rt2', mediaFileId: 'm2', title: 'Zebra' },
     ]
 
     expect(buildDuplicateInfo(leftTracks, rightTracks)).toEqual([
@@ -29,5 +32,24 @@ describe('buildDuplicateInfo', () => {
     const rightTracks = [{ mediaFileId: 'm1', title: 'Exists' }]
 
     expect(buildDuplicateInfo(leftTracks, rightTracks)).toEqual([])
+  })
+})
+
+describe('buildDuplicateTrackIdsByPlaylist', () => {
+  it('returns playlist-track IDs to delete per selected playlist', () => {
+    const leftTracks = [
+      { id: 'lt1', mediaFileId: 'm1', title: 'Alpha' },
+      { id: 'lt2', mediaFileId: 'm2', title: 'Bravo' },
+      { id: 'lt3', mediaFileId: 'm1', title: 'Alpha duplicate in left' },
+    ]
+    const rightTracks = [
+      { id: 'rt1', mediaFileId: 'm1', title: 'Alpha' },
+      { id: 'rt4', mediaFileId: 'm4', title: 'Delta' },
+    ]
+
+    expect(buildDuplicateTrackIdsByPlaylist(leftTracks, rightTracks)).toEqual({
+      left: ['lt1', 'lt3'],
+      right: ['rt1'],
+    })
   })
 })

--- a/ui/src/playlist_folder/playlistComparison.js
+++ b/ui/src/playlist_folder/playlistComparison.js
@@ -1,0 +1,37 @@
+const normalizeTrackName = (track) => {
+  if (!track) return ''
+  return (
+    track.title || track.name || track.songTitle || track.mediaFileTitle || track.path || ''
+  )
+}
+
+const normalizeArtistName = (track) => {
+  if (!track) return ''
+  return track.artist || track.artistName || track.albumArtist || ''
+}
+
+export const buildDuplicateInfo = (tracksA = [], tracksB = []) => {
+  const bByMediaId = new Set(
+    tracksB
+      .map((track) => track?.mediaFileId)
+      .filter((mediaFileId) => mediaFileId !== undefined && mediaFileId !== null)
+  )
+
+  const deduped = new Map()
+  tracksA.forEach((track) => {
+    const mediaFileId = track?.mediaFileId
+    if (!mediaFileId || !bByMediaId.has(mediaFileId) || deduped.has(mediaFileId)) {
+      return
+    }
+
+    deduped.set(mediaFileId, {
+      mediaFileId,
+      title: normalizeTrackName(track),
+      artist: normalizeArtistName(track),
+    })
+  })
+
+  return Array.from(deduped.values()).sort((a, b) =>
+    `${a.title} ${a.artist}`.localeCompare(`${b.title} ${b.artist}`)
+  )
+}

--- a/ui/src/playlist_folder/playlistComparison.js
+++ b/ui/src/playlist_folder/playlistComparison.js
@@ -35,3 +35,17 @@ export const buildDuplicateInfo = (tracksA = [], tracksB = []) => {
     `${a.title} ${a.artist}`.localeCompare(`${b.title} ${b.artist}`)
   )
 }
+
+export const buildDuplicateTrackIdsByPlaylist = (tracksA = [], tracksB = []) => {
+  const duplicateMediaIds = new Set(buildDuplicateInfo(tracksA, tracksB).map((t) => t.mediaFileId))
+
+  const getTrackIds = (tracks) =>
+    tracks
+      .filter((track) => track?.id && duplicateMediaIds.has(track?.mediaFileId))
+      .map((track) => track.id)
+
+  return {
+    left: getTrackIds(tracksA),
+    right: getTrackIds(tracksB),
+  }
+}

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1795,6 +1795,7 @@ const RetailPlayerDashboard = () => {
   const isDeviceOnline = hasRealtimeOnlineState ? device.online : hasStatusValue
   const isOfflineUi = !isDeviceOnline
   const areNowPlayingControlsDisabled = !canControlDevice || isOfflineUi
+  const areVolumeControlsDisabled = areNowPlayingControlsDisabled || device?.isVolumeEnabled === false
   const formattedUpTime = useMemo(() => {
     if (statusUpTimeSeconds !== null) {
       const totalSeconds = statusUpTimeSeconds
@@ -2026,7 +2027,7 @@ const RetailPlayerDashboard = () => {
   )
 
   const handleToggleMute = useCallback(() => {
-    if (areNowPlayingControlsDisabled) {
+    if (areVolumeControlsDisabled) {
       return
     }
 
@@ -2062,10 +2063,17 @@ const RetailPlayerDashboard = () => {
       }
       return 0
     })
-  }, [areNowPlayingControlsDisabled, isMuted, sendRemoteControlCommand, updateVolume])
+  }, [
+    areVolumeControlsDisabled,
+    displayVolume,
+    isMuted,
+    sendRemoteControlCommand,
+    updateVolume,
+    volume,
+  ])
 
   const handleVolumeChange = useCallback((_, newValue) => {
-    if (areNowPlayingControlsDisabled) {
+    if (areVolumeControlsDisabled) {
       return
     }
 
@@ -2074,7 +2082,7 @@ const RetailPlayerDashboard = () => {
       return
     }
     updateVolume(resolvedValue)
-  }, [areNowPlayingControlsDisabled, updateVolume])
+  }, [areVolumeControlsDisabled, updateVolume])
 
   const handleRefresh = useCallback(() => {
     refreshStatus()
@@ -2083,9 +2091,12 @@ const RetailPlayerDashboard = () => {
 
   const handleAdjustVolume = useCallback(
     (delta) => {
+      if (areVolumeControlsDisabled) {
+        return
+      }
       updateVolume((prev) => prev + delta)
     },
-    [updateVolume],
+    [areVolumeControlsDisabled, updateVolume],
   )
 
   const handleBack = useCallback(() => {
@@ -2506,7 +2517,7 @@ const RetailPlayerDashboard = () => {
                   aria-label="Mute/Unmute"
                   onClick={handleToggleMute}
                   focusRipple
-                  disabled={areNowPlayingControlsDisabled}
+                  disabled={areVolumeControlsDisabled}
                 >
                   <span className={classes.controlIcon} role="img" aria-hidden="true">
                     {isMuted ? <VolumeOffIcon fontSize="inherit" /> : <VolumeUpIcon fontSize="inherit" />}
@@ -2553,7 +2564,7 @@ const RetailPlayerDashboard = () => {
               <section
                 className={combineClasses(
                   classes.volumeSection,
-                  areNowPlayingControlsDisabled ? classes.volumeSectionDisabled : null,
+                  areVolumeControlsDisabled ? classes.volumeSectionDisabled : null,
                 )}
                 aria-label="Volume"
               >
@@ -2569,7 +2580,7 @@ const RetailPlayerDashboard = () => {
                   classes={{
                     root: combineClasses(
                       classes.slider,
-                      areNowPlayingControlsDisabled ? classes.sliderDisabled : null,
+                      areVolumeControlsDisabled ? classes.sliderDisabled : null,
                     ),
                     track: classes.sliderTrack,
                     thumb: classes.sliderThumb,
@@ -2582,7 +2593,7 @@ const RetailPlayerDashboard = () => {
                   max={100}
                   aria-label="Volume"
                   onChange={handleVolumeChange}
-                  disabled={areNowPlayingControlsDisabled}
+                  disabled={areVolumeControlsDisabled}
                 />
               </section>
             </div>

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -28,6 +28,8 @@ import AddIcon from '@material-ui/icons/Add'
 import EditIcon from '@material-ui/icons/Edit'
 import LockIcon from '@material-ui/icons/Lock'
 import LockOpenIcon from '@material-ui/icons/LockOpen'
+import VolumeOffIcon from '@material-ui/icons/VolumeOff'
+import VolumeUpIcon from '@material-ui/icons/VolumeUp'
 import FolderIcon from '@material-ui/icons/Folder'
 import SpeakerGroupIcon from '@material-ui/icons/SpeakerGroup'
 import SearchIcon from '@material-ui/icons/Search'
@@ -524,7 +526,9 @@ const RetailPlayerFolderRow = memo(
     onKeyDown,
     onEdit,
     onToggleLock,
+    onToggleVolumeControl,
     isLocked,
+    isVolumeEnabled,
     onDeviceDrop,
   }) => {
     const { dropRef, isOver, canDrop } = useRetailPlayerFolderDrop({
@@ -591,6 +595,22 @@ const RetailPlayerFolderRow = memo(
               )}
             </IconButton>
           </Tooltip>
+          <Tooltip title={isVolumeEnabled ? 'Disable folder volume controls' : 'Enable folder volume controls'}>
+            <IconButton
+              size="small"
+              onClick={(event) => {
+                event.stopPropagation()
+                onToggleVolumeControl(node)
+              }}
+              aria-label={`${isVolumeEnabled ? 'Disable' : 'Enable'} volume controls for folder ${node.name}`}
+            >
+              {isVolumeEnabled ? (
+                <VolumeUpIcon style={{ fontSize: 15 }} className={classes.lockIconActive} />
+              ) : (
+                <VolumeOffIcon style={{ fontSize: 15 }} />
+              )}
+            </IconButton>
+          </Tooltip>
           <Tooltip title="Edit folder">
             <IconButton
               size="small"
@@ -622,12 +642,15 @@ RetailPlayerFolderRow.propTypes = {
   onKeyDown: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
   onToggleLock: PropTypes.func.isRequired,
+  onToggleVolumeControl: PropTypes.func.isRequired,
   isLocked: PropTypes.bool,
+  isVolumeEnabled: PropTypes.bool,
   onDeviceDrop: PropTypes.func.isRequired,
 }
 
 RetailPlayerFolderRow.defaultProps = {
   isLocked: false,
+  isVolumeEnabled: true,
 }
 
 RetailPlayerFolderRow.displayName = 'RetailPlayerFolderRow'
@@ -655,7 +678,9 @@ const RetailPlayerDeviceRow = memo(
     onKeyDown,
     onEdit,
     onToggleLock,
+    onToggleVolumeControl,
     isLocked,
+    isVolumeEnabled,
     isOnline,
   }) => {
     const { dragRef, isDragging } = useRetailPlayerDeviceDrag({
@@ -728,6 +753,22 @@ const RetailPlayerDeviceRow = memo(
               )}
             </IconButton>
           </Tooltip>
+          <Tooltip title={isVolumeEnabled ? 'Disable volume controls' : 'Enable volume controls'}>
+            <IconButton
+              size="small"
+              onClick={(event) => {
+                event.stopPropagation()
+                onToggleVolumeControl(node)
+              }}
+              aria-label={`${isVolumeEnabled ? 'Disable' : 'Enable'} volume controls for device ${node.name}`}
+            >
+              {isVolumeEnabled ? (
+                <VolumeUpIcon style={{ fontSize: 15 }} className={classes.lockIconActive} />
+              ) : (
+                <VolumeOffIcon style={{ fontSize: 15 }} />
+              )}
+            </IconButton>
+          </Tooltip>
           <Tooltip title="Edit device">
             <IconButton
               size="small"
@@ -760,12 +801,15 @@ RetailPlayerDeviceRow.propTypes = {
   onKeyDown: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
   onToggleLock: PropTypes.func.isRequired,
+  onToggleVolumeControl: PropTypes.func.isRequired,
   isLocked: PropTypes.bool,
+  isVolumeEnabled: PropTypes.bool,
   isOnline: PropTypes.bool,
 }
 
 RetailPlayerDeviceRow.defaultProps = {
   isLocked: false,
+  isVolumeEnabled: true,
   isOnline: null,
 }
 
@@ -1273,6 +1317,46 @@ const RetailPlayerDeviceManagement = () => {
     [collectDevicesInNode, updateDevice],
   )
 
+  const disableFolderDeviceVolumeControls = useCallback(
+    async (folderNode) => {
+      const devicesToDisable = collectDevicesInNode(folderNode).filter(
+        (device) => device.isVolumeEnabled !== false,
+      )
+      if (!devicesToDisable.length) {
+        return
+      }
+      for (const device of devicesToDisable) {
+        try {
+          await updateDevice({ id: device.id, isVolumeEnabled: false })
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.error('Failed to disable retail player device volume controls from folder', err)
+        }
+      }
+    },
+    [collectDevicesInNode, updateDevice],
+  )
+
+  const enableFolderDeviceVolumeControls = useCallback(
+    async (folderNode) => {
+      const devicesToEnable = collectDevicesInNode(folderNode).filter(
+        (device) => device.isVolumeEnabled === false,
+      )
+      if (!devicesToEnable.length) {
+        return
+      }
+      for (const device of devicesToEnable) {
+        try {
+          await updateDevice({ id: device.id, isVolumeEnabled: true })
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.error('Failed to enable retail player device volume controls from folder', err)
+        }
+      }
+    },
+    [collectDevicesInNode, updateDevice],
+  )
+
   const handleToggleFolderLock = useCallback(
     async (folderNode) => {
       if (!folderNode) {
@@ -1304,6 +1388,35 @@ const RetailPlayerDeviceManagement = () => {
     ],
   )
 
+  const handleToggleFolderVolumeControl = useCallback(
+    async (folderNode) => {
+      if (!folderNode) {
+        return
+      }
+
+      const folderDevices = collectDevicesInNode(folderNode)
+      if (!folderDevices.length) {
+        return
+      }
+
+      const areAllVolumeControlsEnabled = folderDevices.every(
+        (device) => device.isVolumeEnabled !== false,
+      )
+
+      if (areAllVolumeControlsEnabled) {
+        await disableFolderDeviceVolumeControls(folderNode)
+        return
+      }
+
+      await enableFolderDeviceVolumeControls(folderNode)
+    },
+    [
+      collectDevicesInNode,
+      disableFolderDeviceVolumeControls,
+      enableFolderDeviceVolumeControls,
+    ],
+  )
+
   const handleToggleDeviceLock = useCallback(async (device) => {
     if (!device) {
       return
@@ -1315,6 +1428,22 @@ const RetailPlayerDeviceManagement = () => {
       setSelectedIds((previous) => new Set(previous))
     } catch (err) {
       console.error('Failed to update retail player device lock state', err)
+    }
+  }, [updateDevice])
+
+  const handleToggleDeviceVolumeControl = useCallback(async (device) => {
+    if (!device?.id) {
+      return
+    }
+
+    try {
+      const nextIsVolumeEnabled = device.isVolumeEnabled !== false
+        ? false
+        : true
+      await updateDevice({ id: device.id, isVolumeEnabled: nextIsVolumeEnabled })
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to update retail player volume control state', err)
     }
   }, [updateDevice])
 
@@ -1450,6 +1579,10 @@ const RetailPlayerDeviceManagement = () => {
       if (node.type === 'folder') {
         const isSelected = selectedIds.has(node.id)
         const isLocked = Boolean(node.isLocked)
+        const folderDevices = collectDevicesInNode(node)
+        const isVolumeEnabled = folderDevices.length
+          ? folderDevices.every((device) => device.isVolumeEnabled !== false)
+          : true
         return (
           <RetailPlayerFolderRow
             key={`folder-row-${node.id}`}
@@ -1461,7 +1594,9 @@ const RetailPlayerDeviceManagement = () => {
             onKeyDown={handleRowKeyDown}
             onEdit={handleEditFolder}
             onToggleLock={handleToggleFolderLock}
+            onToggleVolumeControl={handleToggleFolderVolumeControl}
             isLocked={isLocked}
+            isVolumeEnabled={isVolumeEnabled}
             onDeviceDrop={handleDeviceDropOnFolder}
           />
         )
@@ -1481,7 +1616,9 @@ const RetailPlayerDeviceManagement = () => {
           onKeyDown={handleRowKeyDown}
           onEdit={handleEditDevice}
           onToggleLock={handleToggleDeviceLock}
+          onToggleVolumeControl={handleToggleDeviceVolumeControl}
           isLocked={isDeviceLocked(node)}
+          isVolumeEnabled={node.isVolumeEnabled !== false}
           isOnline={isOnline}
         />
       )

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -119,6 +119,12 @@ const baseDeviceShape = (device, existing) => {
       : typeof existing?.online === 'boolean'
         ? existing.online
         : undefined
+  const normalizedIsVolumeEnabled =
+    typeof device?.isVolumeEnabled === 'boolean'
+      ? device.isVolumeEnabled
+      : typeof existing?.isVolumeEnabled === 'boolean'
+        ? existing.isVolumeEnabled
+        : true
 
   const existingFolderIds = normalizeFolderIds(
     existing?.folderIds ?? existing?.folderId,
@@ -147,6 +153,7 @@ const baseDeviceShape = (device, existing) => {
     timeZone: normalizedTimeZone || '',
     remoteControlId: normalizedRemoteControlId || '',
     isLocked: normalizedIsLocked,
+    isVolumeEnabled: normalizedIsVolumeEnabled,
     ...(typeof normalizedIsOnline === 'boolean' ? { online: normalizedIsOnline } : {}),
     folderIds,
     folderId: primaryFolderId,
@@ -302,6 +309,7 @@ const reducer = (state, action) => {
         folderId,
         remoteControlId,
         isLocked,
+        isVolumeEnabled,
       } = action.payload || {}
       if (!id) {
         return state
@@ -334,6 +342,10 @@ const reducer = (state, action) => {
               : device.remoteControlId,
           isLocked:
             typeof isLocked === 'boolean' ? isLocked : device.isLocked,
+          isVolumeEnabled:
+            typeof isVolumeEnabled === 'boolean'
+              ? isVolumeEnabled
+              : device.isVolumeEnabled,
         }
       })
       return { ...state, devices: nextDevices, lastUpdated: Date.now() }
@@ -684,6 +696,10 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
         basePayload,
         'isLocked',
       )
+      const hasIsVolumeEnabled = Object.prototype.hasOwnProperty.call(
+        basePayload,
+        'isVolumeEnabled',
+      )
 
       if (hasRemoteControlId) {
         const remoteControlId = normalizeValue(basePayload.remoteControlId)
@@ -726,6 +742,29 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
               typeof json?.data?.isLocked === 'boolean'
                 ? json.data.isLocked
                 : isLocked,
+          },
+        })
+      }
+
+      if (hasIsVolumeEnabled) {
+        const isVolumeEnabled = Boolean(basePayload.isVolumeEnabled)
+        const { json } = await httpClient(
+          `/api/retailplayer/devices/${encodeURIComponent(deviceId)}/volume-control`,
+          {
+            method: 'PATCH',
+            body: JSON.stringify({ enabled: isVolumeEnabled }),
+            headers: new Headers({ 'Content-Type': 'application/json' }),
+          },
+        )
+
+        dispatch({
+          type: 'UPDATE_DEVICE',
+          payload: {
+            id: deviceId,
+            isVolumeEnabled:
+              typeof json?.data?.isVolumeEnabled === 'boolean'
+                ? json.data.isVolumeEnabled
+                : isVolumeEnabled,
           },
         })
       }

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -81,6 +81,14 @@ const mapRetailPlayerDevice = (device) => {
       : typeof device.isOnline === 'boolean'
         ? device.isOnline
         : undefined
+  const isVolumeEnabled =
+    typeof device.isVolumeEnabled === 'boolean'
+      ? device.isVolumeEnabled
+      : typeof device.volumeEnabled === 'boolean'
+        ? device.volumeEnabled
+        : typeof device.is_volume_enabled === 'boolean'
+          ? device.is_volume_enabled
+          : undefined
 
   return {
     id: fallbackId,
@@ -101,6 +109,9 @@ const mapRetailPlayerDevice = (device) => {
     remoteControlId,
     ...(typeof isLocked === 'boolean' ? { isLocked } : {}),
     ...(typeof isOnline === 'boolean' ? { online: isOnline } : {}),
+    ...(typeof isVolumeEnabled === 'boolean'
+      ? { isVolumeEnabled }
+      : {}),
   }
 }
 

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -718,6 +718,7 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
   const [hasRealtimeStatus, setHasRealtimeStatus] = useState(false)
   const realtimeDeviceRef = useRef(null)
   const lockedStateRef = useRef(null)
+  const volumeEnabledStateRef = useRef(null)
 
   const {
     devices,
@@ -773,6 +774,12 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
       lockedStateRef.current = baseDevice.isLocked
     }
   }, [baseDevice?.isLocked])
+
+  useEffect(() => {
+    if (typeof baseDevice?.isVolumeEnabled === 'boolean') {
+      volumeEnabledStateRef.current = baseDevice.isVolumeEnabled
+    }
+  }, [baseDevice?.isVolumeEnabled])
 
   useEffect(() => {
     if (!slugParam || !Array.isArray(devices) || !devices.length) {
@@ -1021,6 +1028,21 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
                 : undefined
       if (typeof resolvedIsLocked === 'boolean') {
         mergedDevice.isLocked = resolvedIsLocked
+      }
+      const resolvedIsVolumeEnabled =
+        typeof payloadDevice.isVolumeEnabled === 'boolean'
+          ? payloadDevice.isVolumeEnabled
+          : typeof payloadDevice.volumeEnabled === 'boolean'
+            ? payloadDevice.volumeEnabled
+            : typeof payloadDevice.is_volume_enabled === 'boolean'
+              ? payloadDevice.is_volume_enabled
+              : typeof previousDevice.isVolumeEnabled === 'boolean'
+                ? previousDevice.isVolumeEnabled
+                : typeof volumeEnabledStateRef.current === 'boolean'
+                  ? volumeEnabledStateRef.current
+                  : undefined
+      if (typeof resolvedIsVolumeEnabled === 'boolean') {
+        mergedDevice.isVolumeEnabled = resolvedIsVolumeEnabled
       }
 
       const mergedRemoteControlId =


### PR DESCRIPTION
### Motivation
- Improve Spotify cover art lookup reliability by retrying the search with a cleaned title when the initial match confidence is low. 
- Make the retry threshold configurable so administrators can tune when the fallback behavior runs (`configuration.go`).

### Description
- Added a new config field `CoverRetryMinScore` to `spotifyOptions` and a default `spotify.coverretryminscore` in `conf/configuration.go`.
- Introduced `sanitizeSpotifyRetryTitle` which trims and removes parenthesized `(...)` and bracketed `[...]` text from titles while preserving the original when sanitization would empty it.
- Factored the Spotify search into `searchSpotifyTrack(...)` and updated `searchBestTrack(...)` to retry once with the sanitized title when the initial `confidence` is below `conf.Server.Spotify.CoverRetryMinScore`.
- Added unit tests for the title sanitizer in `server/nativeapi/musicbrainz_metadata_test.go` (`TestSanitizeSpotifyRetryTitle`).

### Testing
- Ran `go test ./conf -run TestNonExistent -count=1`, which passed in this environment.
- Ran `go test ./server/nativeapi -run TestSanitizeSpotifyRetryTitle -count=1`, which could not complete successfully in this build environment due to missing native dependencies (e.g. `taglib` and sqlite cgo symbols) causing package build failures; the new test itself is scoped to the sanitizer helper and is expected to pass when native build deps are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab309741288322aa8a679a010ebfff)