### PR TITLE
Deterministic cue mapping: require stored remoteControlId and tighten frontend trigger selection

### DIFF
--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -423,6 +423,7 @@ func (n *Router) handleUpdateRetailPlayerDeviceLock() http.HandlerFunc {
 }
 
 var errRetailPlayerDeviceNotFound = errors.New("retail player device not found")
+var errRetailPlayerRemoteControlMappingMissing = errors.New("retail player remote control mapping not found")
 
 func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -1082,10 +1083,14 @@ func (n *Router) handleRetailPlayerDeviceTriggers() http.HandlerFunc {
 
 		log.Info(ctx, "Fetching retail player device triggers", "deviceID", deviceID)
 
-		triggers, err := fetchRetailPlayerDeviceTriggers(ctx, deviceID)
+		triggers, err := fetchRetailPlayerDeviceTriggers(ctx, n.ds, deviceID)
 		if err != nil {
 			if errors.Is(err, errRetailPlayerDeviceNotFound) {
 				http.Error(w, "Retail player device not found", http.StatusNotFound)
+				return
+			}
+			if errors.Is(err, errRetailPlayerRemoteControlMappingMissing) {
+				http.Error(w, "Retail player remote control mapping not found for device", http.StatusBadRequest)
 				return
 			}
 
@@ -1136,9 +1141,13 @@ func (n *Router) handleRetailPlayerDeviceTriggerAction() http.HandlerFunc {
 
 		log.Info(ctx, "Sending retail player trigger action", "deviceID", deviceID, "action", action, "value", value)
 
-		if err := sendRetailPlayerTriggerAction(ctx, deviceID, action, value); err != nil {
+		if err := sendRetailPlayerTriggerAction(ctx, n.ds, deviceID, action, value); err != nil {
 			if errors.Is(err, errRetailPlayerDeviceNotFound) {
 				http.Error(w, "Retail player device not found", http.StatusNotFound)
+				return
+			}
+			if errors.Is(err, errRetailPlayerRemoteControlMappingMissing) {
+				http.Error(w, "Retail player remote control mapping not found for device", http.StatusBadRequest)
 				return
 			}
 
@@ -2164,7 +2173,7 @@ func fetchRetailPlayerDeviceConfig(ctx context.Context, deviceID string) (retail
 	return config, nil
 }
 
-func fetchRetailPlayerDeviceTriggers(ctx context.Context, deviceID string) ([]retailPlayerTrigger, error) {
+func fetchRetailPlayerDeviceTriggers(ctx context.Context, ds model.DataStore, deviceID string) ([]retailPlayerTrigger, error) {
 	cfg := conf.Server.RetailPlayer
 	baseURL := strings.TrimSpace(cfg.RemoteControlBaseURL)
 	if baseURL == "" {
@@ -2190,7 +2199,7 @@ func fetchRetailPlayerDeviceTriggers(ctx context.Context, deviceID string) ([]re
 		return nil, errors.New("retail player device id is empty")
 	}
 
-	remoteControlID, err := fetchRetailPlayerRemoteControlID(ctx, trimmedID)
+	remoteControlID, err := fetchRetailPlayerRemoteControlID(ctx, ds, trimmedID)
 	if err != nil {
 		return nil, err
 	}
@@ -2259,7 +2268,7 @@ func fetchRetailPlayerDeviceTriggers(ctx context.Context, deviceID string) ([]re
 	return triggers, nil
 }
 
-func sendRetailPlayerTriggerAction(ctx context.Context, deviceID, action, value string) error {
+func sendRetailPlayerTriggerAction(ctx context.Context, ds model.DataStore, deviceID, action, value string) error {
 	cfg := conf.Server.RetailPlayer
 	baseURL := strings.TrimSpace(cfg.RemoteControlBaseURL)
 	if baseURL == "" {
@@ -2285,7 +2294,7 @@ func sendRetailPlayerTriggerAction(ctx context.Context, deviceID, action, value 
 		return errors.New("retail player device id is empty")
 	}
 
-	remoteControlID, err := fetchRetailPlayerRemoteControlID(ctx, trimmedID)
+	remoteControlID, err := fetchRetailPlayerRemoteControlID(ctx, ds, trimmedID)
 	if err != nil {
 		return err
 	}
@@ -2397,53 +2406,35 @@ func fetchRetailPlayerDeviceOrganizationID(ctx context.Context, deviceID string)
 	return "", errors.New("retail player device organization id not found")
 }
 
-func fetchRetailPlayerRemoteControlID(ctx context.Context, deviceID string) (string, error) {
+func fetchRetailPlayerRemoteControlID(ctx context.Context, ds model.DataStore, deviceID string) (string, error) {
 	deviceKey := strings.TrimSpace(deviceID)
 	if deviceKey == "" {
 		return "", errors.New("retail player device id is empty")
 	}
 
-	config, err := fetchRetailPlayerDeviceConfig(ctx, deviceKey)
+	if ds == nil {
+		return "", errors.New("retail player device mapping repository not available")
+	}
+
+	repo := ds.RetailPlayerDeviceMapping(ctx)
+	if repo == nil {
+		return "", errors.New("retail player device mapping repository not available")
+	}
+
+	mapping, err := repo.FindByIdentifier(ctx, deviceKey)
 	if err != nil {
+		if errors.Is(err, model.ErrNotFound) {
+			return "", errRetailPlayerRemoteControlMappingMissing
+		}
 		return "", err
 	}
 
-	organizationID := strings.TrimSpace(config.OrgUnit)
-	if organizationID == "" {
-		organizationID = strings.TrimSpace(config.Organization)
-	}
-	if organizationID == "" {
-		organizationID, err = fetchRetailPlayerDeviceOrganizationID(ctx, deviceKey)
-		if err != nil {
-			return "", err
-		}
+	remoteControlID := strings.TrimSpace(mapping.RemoteCtrlID)
+	if remoteControlID == "" {
+		return "", errRetailPlayerRemoteControlMappingMissing
 	}
 
-	dependents, err := fetchRetailPlayerDependents(ctx, organizationID)
-	if err != nil {
-		return "", err
-	}
-
-	for _, remoteControl := range dependents.RemoteControls {
-		trimmedID := strings.TrimSpace(remoteControl.ID)
-		if trimmedID == "" {
-			continue
-		}
-
-		trimmedName := strings.TrimSpace(remoteControl.Name)
-		if strings.EqualFold(trimmedID, deviceKey) || strings.EqualFold(trimmedName, deviceKey) {
-			return trimmedID, nil
-		}
-	}
-
-	for _, remoteControl := range dependents.RemoteControls {
-		trimmedID := strings.TrimSpace(remoteControl.ID)
-		if trimmedID != "" {
-			return trimmedID, nil
-		}
-	}
-
-	return "", errors.New("retail player remote control id not found")
+	return remoteControlID, nil
 }
 
 func fetchRetailPlayerDependents(ctx context.Context, orgID string) (retailPlayerDependentsResponse, error) {

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1209,12 +1209,7 @@ const RetailPlayerDashboard = () => {
       return ''
     }
 
-    return (
-      normalizeValue(trigger.id) ||
-      normalizeValue(trigger.ID) ||
-      normalizeValue(trigger.name) ||
-      ''
-    )
+    return normalizeValue(trigger.value) || normalizeValue(trigger.id) || `${trigger.ordinal ?? ''}`.trim()
   }, [])
 
   const getTriggerOrdinal = useCallback((trigger) => {
@@ -1252,54 +1247,21 @@ const RetailPlayerDashboard = () => {
   }, [device])
 
   const detectedCuePlayback = useMemo(() => {
-    const triggerIdCandidates = nowPlayingCueMetadata
-      ? [
-          nowPlayingCueMetadata.triggerId,
-          nowPlayingCueMetadata.trigger_id,
-          nowPlayingCueMetadata.triggerID,
-          nowPlayingCueMetadata.cueId,
-          nowPlayingCueMetadata.cue_id,
-          nowPlayingCueMetadata.cueID,
-          nowPlayingCueMetadata.trigger,
-          nowPlayingCueMetadata.cueTriggerId,
-          nowPlayingCueMetadata.cueTrigger_id,
-        ]
-      : []
-
-    const metadataTriggerId = triggerIdCandidates.map(normalizeValue).find(Boolean) || ''
-    const metadataOrdinalCandidate = nowPlayingCueMetadata
-      ?
-          nowPlayingCueMetadata.triggerOrdinal ??
-          nowPlayingCueMetadata.trigger_ordinal ??
-          nowPlayingCueMetadata.ordinal ??
-          nowPlayingCueMetadata.button ??
-          nowPlayingCueMetadata.buttonNumber
-      : null
-    const parsedMetadataOrdinal = Number(metadataOrdinalCandidate)
-    const resolvedMetadataOrdinal = Number.isFinite(parsedMetadataOrdinal)
-      ? parsedMetadataOrdinal
-      : null
-
-    let matchedTriggerId = metadataTriggerId
-    let matchedTriggerOrdinal = resolvedMetadataOrdinal
-
-    if (!matchedTriggerId && resolvedMetadataOrdinal !== null) {
-      const matchedTrigger = sortedCueTriggers.find((trigger) => {
-        const triggerOrdinal = getTriggerOrdinal(trigger)
-        return triggerOrdinal !== null && triggerOrdinal === resolvedMetadataOrdinal
-      })
-
-      if (matchedTrigger) {
-        matchedTriggerId = getTriggerIdentifier(matchedTrigger)
-        matchedTriggerOrdinal = resolvedMetadataOrdinal
-      }
-    }
+    const metadataTriggerId =
+      normalizeValue(nowPlayingCueMetadata?.triggerId) ||
+      normalizeValue(nowPlayingCueMetadata?.id) ||
+      normalizeValue(nowPlayingCueMetadata?.ordinal)
+    const matchedTrigger = sortedCueTriggers.find(
+      (trigger) => getTriggerIdentifier(trigger) === metadataTriggerId,
+    )
+    const matchedTriggerId = matchedTrigger ? getTriggerIdentifier(matchedTrigger) : metadataTriggerId
+    const matchedTriggerOrdinal = matchedTrigger ? getTriggerOrdinal(matchedTrigger) : null
 
     if (matchedTriggerId) {
       return { triggerId: matchedTriggerId, triggerOrdinal: matchedTriggerOrdinal }
     }
 
-    return { triggerId: '', triggerOrdinal: matchedTriggerOrdinal }
+    return { triggerId: '', triggerOrdinal: null }
   }, [getTriggerIdentifier, getTriggerOrdinal, nowPlayingCueMetadata, sortedCueTriggers])
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Ensure cue routing is deterministic so the same device + same trigger always produce the same remote control target and action payload.
- Remove heuristic/fallback remote-control resolution that could guess or change targets at runtime.
- Make frontend cue identification unambiguous by limiting which metadata fields are used to determine a trigger id.

### Description
- Backend: add `errRetailPlayerRemoteControlMappingMissing` and require `remoteControlId` be resolved only from persisted mappings in `retail_player_device_mapping` by threading `model.DataStore` into `fetchRetailPlayerDeviceTriggers`, `sendRetailPlayerTriggerAction`, and `fetchRetailPlayerRemoteControlID` in `server/nativeapi/retail_player.go`.
- Backend: return an explicit client error when a device has no stored `remoteControlId` mapping instead of falling back to API dependents or guessing a remote control id.
- Frontend: limit trigger identifier selection in `ui/src/retailPlayer/RetailPlayerDashboard.jsx` to `trigger.value`, then `trigger.id`, then `trigger.ordinal` (as string), and remove broader now-playing metadata parsing variants so metadata → trigger matching is deterministic.
- Frontend: simplify `detectedCuePlayback` logic to match triggers only by the tightened identifier rules and to avoid ordinal-heuristic matching fallbacks.

### Testing
- Ran formatting with `gofmt` successfully on modified Go file(s). 
- Attempted `go test ./server/nativeapi`, which failed to build in this environment due to a missing system dependency: `taglib` not found by `pkg-config` (error from `adapters/taglib`), so package tests could not complete.
- No automated UI tests were run for the React changes in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb871d6f208322b8841195cdeac95c)