### PR TITLE
Add per-device volume-control toggle and volume icon for Retail Player

### DIFF
--- a/model/retail_player_device_mapping.go
+++ b/model/retail_player_device_mapping.go
@@ -7,22 +7,24 @@ import (
 )
 
 type RetailPlayerDeviceMapping struct {
-	DeviceID     string    `db:"device_id" json:"deviceId"`
-	DeviceName   string    `db:"device_name" json:"deviceName"`
-	DeviceSlug   string    `db:"device_slug" json:"deviceSlug"`
-	IsLocked     bool      `db:"is_locked" json:"isLocked"`
-	Channel      string    `db:"channel" json:"channel"`
-	ChannelList  string    `db:"channel_list" json:"channelList"`
-	Organization string    `db:"organization" json:"organization"`
-	TimeZone     string    `db:"time_zone" json:"timeZone"`
-	RemoteCtrlID string    `db:"remote_control_id" json:"remoteControlId"`
-	UpdatedAt    time.Time `db:"updated_at" json:"updatedAt"`
+	DeviceID            string    `db:"device_id" json:"deviceId"`
+	DeviceName          string    `db:"device_name" json:"deviceName"`
+	DeviceSlug          string    `db:"device_slug" json:"deviceSlug"`
+	IsLocked            bool      `db:"is_locked" json:"isLocked"`
+	VolumeChangeEnabled bool      `db:"volume_change_enabled" json:"volumeChangeEnabled"`
+	Channel             string    `db:"channel" json:"channel"`
+	ChannelList         string    `db:"channel_list" json:"channelList"`
+	Organization        string    `db:"organization" json:"organization"`
+	TimeZone            string    `db:"time_zone" json:"timeZone"`
+	RemoteCtrlID        string    `db:"remote_control_id" json:"remoteControlId"`
+	UpdatedAt           time.Time `db:"updated_at" json:"updatedAt"`
 }
 
 type RetailPlayerDeviceMappingRepository interface {
 	Put(ctx context.Context, mapping RetailPlayerDeviceMapping) error
 	PutMany(ctx context.Context, mappings []RetailPlayerDeviceMapping) error
 	SetLocked(ctx context.Context, deviceID string, isLocked bool) error
+	SetVolumeChangeEnabled(ctx context.Context, deviceID string, enabled bool) error
 	FindByIdentifier(ctx context.Context, identifier string) (*RetailPlayerDeviceMapping, error)
 	All(ctx context.Context) ([]RetailPlayerDeviceMapping, error)
 }

--- a/persistence/retail_player_device_mapping_repository.go
+++ b/persistence/retail_player_device_mapping_repository.go
@@ -24,6 +24,7 @@ func NewRetailPlayerDeviceMappingRepository(ctx context.Context, db dbx.Builder)
 	r.registerModel(&model.RetailPlayerDeviceMapping{}, nil)
 	r.ensureRemoteControlColumn()
 	r.ensureIsLockedColumn()
+	r.ensureVolumeChangeEnabledColumn()
 	return r
 }
 
@@ -61,6 +62,23 @@ ADD COLUMN is_locked BOOLEAN NOT NULL DEFAULT 0;
 	log.Error(r.ctx, "Unable to ensure lock status column for retail player device mappings", "err", err)
 }
 
+func (r retailPlayerDeviceMappingRepository) ensureVolumeChangeEnabledColumn() {
+	_, err := r.db.NewQuery(`
+ALTER TABLE retail_player_device_mapping
+ADD COLUMN volume_change_enabled BOOLEAN NOT NULL DEFAULT 1;
+`).Execute()
+	if err == nil {
+		return
+	}
+
+	lowerErr := strings.ToLower(err.Error())
+	if strings.Contains(lowerErr, "duplicate column name") || strings.Contains(lowerErr, "already exists") {
+		return
+	}
+
+	log.Error(r.ctx, "Unable to ensure volume control status column for retail player device mappings", "err", err)
+}
+
 func (r retailPlayerDeviceMappingRepository) Put(ctx context.Context, mapping model.RetailPlayerDeviceMapping) error {
 	if mapping.DeviceID == "" {
 		return errors.New("retail player device id is required")
@@ -81,6 +99,7 @@ func (r retailPlayerDeviceMappingRepository) PutMany(ctx context.Context, mappin
 			"device_name",
 			"device_slug",
 			"is_locked",
+			"volume_change_enabled",
 			"channel",
 			"channel_list",
 			"organization",
@@ -110,6 +129,7 @@ func (r retailPlayerDeviceMappingRepository) PutMany(ctx context.Context, mappin
 			name,
 			slug,
 			mapping.IsLocked,
+			mapping.VolumeChangeEnabled,
 			strings.TrimSpace(mapping.Channel),
 			strings.TrimSpace(mapping.ChannelList),
 			strings.TrimSpace(mapping.Organization),
@@ -128,6 +148,7 @@ func (r retailPlayerDeviceMappingRepository) PutMany(ctx context.Context, mappin
                 device_name = excluded.device_name,
                 device_slug = excluded.device_slug,
                 is_locked = retail_player_device_mapping.is_locked,
+                volume_change_enabled = retail_player_device_mapping.volume_change_enabled,
                 channel = excluded.channel,
                 channel_list = excluded.channel_list,
                 organization = excluded.organization,
@@ -153,6 +174,7 @@ func (r retailPlayerDeviceMappingRepository) SetLocked(ctx context.Context, devi
 			"device_name",
 			"device_slug",
 			"is_locked",
+			"volume_change_enabled",
 			"channel",
 			"channel_list",
 			"organization",
@@ -160,9 +182,40 @@ func (r retailPlayerDeviceMappingRepository) SetLocked(ctx context.Context, devi
 			"remote_control_id",
 			"updated_at",
 		).
-		Values(trimmedID, trimmedID, defaultSlug, isLocked, "", "", "", "", "", now).
+		Values(trimmedID, trimmedID, defaultSlug, isLocked, true, "", "", "", "", "", now).
 		Suffix(`ON CONFLICT(device_id) DO UPDATE SET
 			is_locked = excluded.is_locked,
+			updated_at = excluded.updated_at`)
+
+	_, err := r.executeSQL(insert)
+	return err
+}
+
+func (r retailPlayerDeviceMappingRepository) SetVolumeChangeEnabled(ctx context.Context, deviceID string, enabled bool) error {
+	trimmedID := strings.TrimSpace(deviceID)
+	if trimmedID == "" {
+		return errors.New("retail player device id is required")
+	}
+
+	now := time.Now().UTC()
+	defaultSlug := model.RetailPlayerDeviceSlug(trimmedID)
+	insert := Insert(r.tableName).
+		Columns(
+			"device_id",
+			"device_name",
+			"device_slug",
+			"is_locked",
+			"volume_change_enabled",
+			"channel",
+			"channel_list",
+			"organization",
+			"time_zone",
+			"remote_control_id",
+			"updated_at",
+		).
+		Values(trimmedID, trimmedID, defaultSlug, false, enabled, "", "", "", "", "", now).
+		Suffix(`ON CONFLICT(device_id) DO UPDATE SET
+			volume_change_enabled = excluded.volume_change_enabled,
 			updated_at = excluded.updated_at`)
 
 	_, err := r.executeSQL(insert)
@@ -186,7 +239,7 @@ func (r retailPlayerDeviceMappingRepository) FindByIdentifier(ctx context.Contex
 	orClause := Or{}
 	orClause = append(orClause, conditions...)
 
-	sel := Select("device_id", "device_name", "device_slug", "is_locked", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "updated_at").
+	sel := Select("device_id", "device_name", "device_slug", "is_locked", "volume_change_enabled", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "updated_at").
 		From(r.tableName).
 		Where(orClause).
 		OrderBy("updated_at DESC").
@@ -200,7 +253,7 @@ func (r retailPlayerDeviceMappingRepository) FindByIdentifier(ctx context.Contex
 }
 
 func (r retailPlayerDeviceMappingRepository) All(ctx context.Context) ([]model.RetailPlayerDeviceMapping, error) {
-	sel := Select("device_id", "device_name", "device_slug", "is_locked", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "updated_at").
+	sel := Select("device_id", "device_name", "device_slug", "is_locked", "volume_change_enabled", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "updated_at").
 		From(r.tableName).
 		OrderBy("updated_at DESC")
 

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -207,20 +207,21 @@ type retailPlayerChannelsAPIResponse struct {
 }
 
 type retailPlayerDevice struct {
-	ID              string   `json:"id"`
-	Name            string   `json:"name"`
-	IsLocked        bool     `json:"isLocked"`
-	OrganizationID  string   `json:"organizationId,omitempty"`
-	OrganisationID  string   `json:"organisationid,omitempty"`
-	Channel         string   `json:"channel"`
-	ChannelName     string   `json:"channelName,omitempty"`
-	ChannelList     string   `json:"channelList"`
-	MacAddress      string   `json:"macAddress,omitempty"`
-	Organization    string   `json:"organization"`
-	TimeZone        string   `json:"timeZone,omitempty"`
-	Online          *bool    `json:"online,omitempty"`
-	FolderIDs       []string `json:"folderIds,omitempty"`
-	RemoteControlID string   `json:"remoteControlId,omitempty"`
+	ID                  string   `json:"id"`
+	Name                string   `json:"name"`
+	IsLocked            bool     `json:"isLocked"`
+	VolumeChangeEnabled bool     `json:"volumeChangeEnabled"`
+	OrganizationID      string   `json:"organizationId,omitempty"`
+	OrganisationID      string   `json:"organisationid,omitempty"`
+	Channel             string   `json:"channel"`
+	ChannelName         string   `json:"channelName,omitempty"`
+	ChannelList         string   `json:"channelList"`
+	MacAddress          string   `json:"macAddress,omitempty"`
+	Organization        string   `json:"organization"`
+	TimeZone            string   `json:"timeZone,omitempty"`
+	Online              *bool    `json:"online,omitempty"`
+	FolderIDs           []string `json:"folderIds,omitempty"`
+	RemoteControlID     string   `json:"remoteControlId,omitempty"`
 }
 
 type retailPlayerDeviceConfigResponse struct {
@@ -366,6 +367,7 @@ func (n *Router) addRetailPlayerPublicRoutes(r chi.Router) {
 func (n *Router) addRetailPlayerPrivateRoutes(r chi.Router) {
 	r.Get("/retailplayer/devices", n.handleRetailPlayerDevices())
 	r.Patch("/retailplayer/devices/{deviceID}/lock", n.handleUpdateRetailPlayerDeviceLock())
+	r.Patch("/retailplayer/devices/{deviceID}/volume-control", n.handleUpdateRetailPlayerDeviceVolumeControl())
 	r.Post("/retailplayer/folders", n.handleCreateRetailPlayerFolder())
 	r.Patch("/retailplayer/folders/{folderID}", n.handleUpdateRetailPlayerFolder())
 	r.Post("/retailplayer/folders/delete", n.handleDeleteRetailPlayerFolders())
@@ -414,6 +416,54 @@ func (n *Router) handleUpdateRetailPlayerDeviceLock() http.HandlerFunc {
 		mapping, err := repo.FindByIdentifier(ctx, deviceID)
 		if err != nil {
 			log.Error(ctx, "Unable to load retail player device mapping after lock update", "deviceID", deviceID, "err", err)
+			http.Error(w, "Unable to load retail player device", http.StatusInternalServerError)
+			return
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{"data": mapRetailPlayerMappingToDevice(*mapping)})
+	}
+}
+
+func (n *Router) handleUpdateRetailPlayerDeviceVolumeControl() http.HandlerFunc {
+	type volumeControlUpdatePayload struct {
+		Enabled bool `json:"enabled"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		deviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		if deviceID == "" {
+			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
+			return
+		}
+
+		var payload volumeControlUpdatePayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "Invalid retail player volume control payload", http.StatusBadRequest)
+			return
+		}
+
+		repo := n.ds.RetailPlayerDeviceMapping(ctx)
+		if repo == nil {
+			http.Error(w, "Retail player device mapping repository not available", http.StatusInternalServerError)
+			return
+		}
+
+		if err := repo.SetVolumeChangeEnabled(ctx, deviceID, payload.Enabled); err != nil {
+			log.Error(ctx, "Unable to update retail player volume control", "deviceID", deviceID, "err", err)
+			http.Error(w, "Unable to update retail player volume control", http.StatusInternalServerError)
+			return
+		}
+
+		mapping, err := repo.FindByIdentifier(ctx, deviceID)
+		if err != nil {
+			log.Error(ctx, "Unable to load retail player device mapping after volume control update", "deviceID", deviceID, "err", err)
 			http.Error(w, "Unable to load retail player device", http.StatusInternalServerError)
 			return
 		}
@@ -505,6 +555,7 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 					for index := range response.Data {
 						if strings.TrimSpace(response.Data[index].ID) == id {
 							response.Data[index].IsLocked = mapping.IsLocked
+							response.Data[index].VolumeChangeEnabled = mapping.VolumeChangeEnabled
 							break
 						}
 					}
@@ -649,6 +700,7 @@ func (n *Router) handleRetailPlayerDeviceByName() http.HandlerFunc {
 					for index := range filtered.Data {
 						if strings.TrimSpace(filtered.Data[index].ID) == id {
 							filtered.Data[index].IsLocked = mapping.IsLocked
+							filtered.Data[index].VolumeChangeEnabled = mapping.VolumeChangeEnabled
 							break
 						}
 					}
@@ -1536,28 +1588,30 @@ func mapRetailPlayerDeviceToMapping(device retailPlayerDevice) (model.RetailPlay
 	}
 
 	return model.RetailPlayerDeviceMapping{
-		DeviceID:     id,
-		DeviceName:   name,
-		DeviceSlug:   slug,
-		IsLocked:     device.IsLocked,
-		Channel:      strings.TrimSpace(device.Channel),
-		ChannelList:  strings.TrimSpace(device.ChannelList),
-		Organization: strings.TrimSpace(device.Organization),
-		TimeZone:     strings.TrimSpace(device.TimeZone),
-		RemoteCtrlID: strings.TrimSpace(device.RemoteControlID),
+		DeviceID:            id,
+		DeviceName:          name,
+		DeviceSlug:          slug,
+		IsLocked:            device.IsLocked,
+		VolumeChangeEnabled: device.VolumeChangeEnabled,
+		Channel:             strings.TrimSpace(device.Channel),
+		ChannelList:         strings.TrimSpace(device.ChannelList),
+		Organization:        strings.TrimSpace(device.Organization),
+		TimeZone:            strings.TrimSpace(device.TimeZone),
+		RemoteCtrlID:        strings.TrimSpace(device.RemoteControlID),
 	}, true
 }
 
 func mapRetailPlayerMappingToDevice(mapping model.RetailPlayerDeviceMapping) retailPlayerDevice {
 	return retailPlayerDevice{
-		ID:              strings.TrimSpace(mapping.DeviceID),
-		Name:            strings.TrimSpace(mapping.DeviceName),
-		IsLocked:        mapping.IsLocked,
-		Channel:         strings.TrimSpace(mapping.Channel),
-		ChannelList:     strings.TrimSpace(mapping.ChannelList),
-		Organization:    strings.TrimSpace(mapping.Organization),
-		TimeZone:        strings.TrimSpace(mapping.TimeZone),
-		RemoteControlID: strings.TrimSpace(mapping.RemoteCtrlID),
+		ID:                  strings.TrimSpace(mapping.DeviceID),
+		Name:                strings.TrimSpace(mapping.DeviceName),
+		IsLocked:            mapping.IsLocked,
+		VolumeChangeEnabled: mapping.VolumeChangeEnabled,
+		Channel:             strings.TrimSpace(mapping.Channel),
+		ChannelList:         strings.TrimSpace(mapping.ChannelList),
+		Organization:        strings.TrimSpace(mapping.Organization),
+		TimeZone:            strings.TrimSpace(mapping.TimeZone),
+		RemoteControlID:     strings.TrimSpace(mapping.RemoteCtrlID),
 	}
 }
 
@@ -3304,14 +3358,15 @@ func simplifyRetailPlayerDevice(device retailPlayerAPIDevice) (retailPlayerDevic
 	)
 
 	return retailPlayerDevice{
-		ID:           id,
-		Name:         name,
-		Channel:      strings.TrimSpace(device.Channel),
-		ChannelList:  strings.TrimSpace(device.ChannelList),
-		MacAddress:   macAddress,
-		Organization: organization,
-		TimeZone:     strings.TrimSpace(device.TimeZone),
-		Online:       device.Online,
+		ID:                  id,
+		Name:                name,
+		VolumeChangeEnabled: true,
+		Channel:             strings.TrimSpace(device.Channel),
+		ChannelList:         strings.TrimSpace(device.ChannelList),
+		MacAddress:          macAddress,
+		Organization:        organization,
+		TimeZone:            strings.TrimSpace(device.TimeZone),
+		Online:              device.Online,
 	}, true
 }
 

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1795,6 +1795,8 @@ const RetailPlayerDashboard = () => {
   const isDeviceOnline = hasRealtimeOnlineState ? device.online : hasStatusValue
   const isOfflineUi = !isDeviceOnline
   const areNowPlayingControlsDisabled = !canControlDevice || isOfflineUi
+  const isVolumeControlDisabled =
+    areNowPlayingControlsDisabled || device?.volumeChangeEnabled === false
   const formattedUpTime = useMemo(() => {
     if (statusUpTimeSeconds !== null) {
       const totalSeconds = statusUpTimeSeconds
@@ -2026,7 +2028,7 @@ const RetailPlayerDashboard = () => {
   )
 
   const handleToggleMute = useCallback(() => {
-    if (areNowPlayingControlsDisabled) {
+    if (isVolumeControlDisabled) {
       return
     }
 
@@ -2062,10 +2064,10 @@ const RetailPlayerDashboard = () => {
       }
       return 0
     })
-  }, [areNowPlayingControlsDisabled, isMuted, sendRemoteControlCommand, updateVolume])
+  }, [isMuted, isVolumeControlDisabled, sendRemoteControlCommand, updateVolume])
 
   const handleVolumeChange = useCallback((_, newValue) => {
-    if (areNowPlayingControlsDisabled) {
+    if (isVolumeControlDisabled) {
       return
     }
 
@@ -2074,7 +2076,7 @@ const RetailPlayerDashboard = () => {
       return
     }
     updateVolume(resolvedValue)
-  }, [areNowPlayingControlsDisabled, updateVolume])
+  }, [isVolumeControlDisabled, updateVolume])
 
   const handleRefresh = useCallback(() => {
     refreshStatus()
@@ -2083,9 +2085,12 @@ const RetailPlayerDashboard = () => {
 
   const handleAdjustVolume = useCallback(
     (delta) => {
+      if (isVolumeControlDisabled) {
+        return
+      }
       updateVolume((prev) => prev + delta)
     },
-    [updateVolume],
+    [isVolumeControlDisabled, updateVolume],
   )
 
   const handleBack = useCallback(() => {
@@ -2506,7 +2511,7 @@ const RetailPlayerDashboard = () => {
                   aria-label="Mute/Unmute"
                   onClick={handleToggleMute}
                   focusRipple
-                  disabled={areNowPlayingControlsDisabled}
+                  disabled={isVolumeControlDisabled}
                 >
                   <span className={classes.controlIcon} role="img" aria-hidden="true">
                     {isMuted ? <VolumeOffIcon fontSize="inherit" /> : <VolumeUpIcon fontSize="inherit" />}
@@ -2553,7 +2558,7 @@ const RetailPlayerDashboard = () => {
               <section
                 className={combineClasses(
                   classes.volumeSection,
-                  areNowPlayingControlsDisabled ? classes.volumeSectionDisabled : null,
+                  isVolumeControlDisabled ? classes.volumeSectionDisabled : null,
                 )}
                 aria-label="Volume"
               >
@@ -2569,7 +2574,7 @@ const RetailPlayerDashboard = () => {
                   classes={{
                     root: combineClasses(
                       classes.slider,
-                      areNowPlayingControlsDisabled ? classes.sliderDisabled : null,
+                      isVolumeControlDisabled ? classes.sliderDisabled : null,
                     ),
                     track: classes.sliderTrack,
                     thumb: classes.sliderThumb,
@@ -2582,7 +2587,7 @@ const RetailPlayerDashboard = () => {
                   max={100}
                   aria-label="Volume"
                   onChange={handleVolumeChange}
-                  disabled={areNowPlayingControlsDisabled}
+                  disabled={isVolumeControlDisabled}
                 />
               </section>
             </div>

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -28,6 +28,8 @@ import AddIcon from '@material-ui/icons/Add'
 import EditIcon from '@material-ui/icons/Edit'
 import LockIcon from '@material-ui/icons/Lock'
 import LockOpenIcon from '@material-ui/icons/LockOpen'
+import VolumeUpIcon from '@material-ui/icons/VolumeUp'
+import VolumeOffIcon from '@material-ui/icons/VolumeOff'
 import FolderIcon from '@material-ui/icons/Folder'
 import SpeakerGroupIcon from '@material-ui/icons/SpeakerGroup'
 import SearchIcon from '@material-ui/icons/Search'
@@ -306,6 +308,9 @@ const useStyles = makeStyles((theme) => {
   },
   lockIconActive: {
     color: theme.palette.secondary.main,
+  },
+  volumeIconDisabled: {
+    color: theme.palette.action.disabled,
   },
   breadcrumbBar: {
     display: 'flex',
@@ -655,7 +660,9 @@ const RetailPlayerDeviceRow = memo(
     onKeyDown,
     onEdit,
     onToggleLock,
+    onToggleVolumeControl,
     isLocked,
+    isVolumeChangeEnabled,
     isOnline,
   }) => {
     const { dragRef, isDragging } = useRetailPlayerDeviceDrag({
@@ -712,6 +719,22 @@ const RetailPlayerDeviceRow = memo(
           {node.remoteControlId ? node.remoteControlId : '—'}
         </div>
         <div className={classes.actionsCell}>
+          <Tooltip title={isVolumeChangeEnabled ? 'Disable volume control' : 'Enable volume control'}>
+            <IconButton
+              size="small"
+              onClick={(event) => {
+                event.stopPropagation()
+                onToggleVolumeControl(node)
+              }}
+              aria-label={`${isVolumeChangeEnabled ? 'Disable' : 'Enable'} volume control for ${node.name}`}
+            >
+              {isVolumeChangeEnabled ? (
+                <VolumeUpIcon style={{ fontSize: 15 }} />
+              ) : (
+                <VolumeOffIcon style={{ fontSize: 15 }} className={classes.volumeIconDisabled} />
+              )}
+            </IconButton>
+          </Tooltip>
           <Tooltip title={isLocked ? 'Unlock device' : 'Lock device'}>
             <IconButton
               size="small"
@@ -760,12 +783,15 @@ RetailPlayerDeviceRow.propTypes = {
   onKeyDown: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
   onToggleLock: PropTypes.func.isRequired,
+  onToggleVolumeControl: PropTypes.func.isRequired,
   isLocked: PropTypes.bool,
+  isVolumeChangeEnabled: PropTypes.bool,
   isOnline: PropTypes.bool,
 }
 
 RetailPlayerDeviceRow.defaultProps = {
   isLocked: false,
+  isVolumeChangeEnabled: true,
   isOnline: null,
 }
 
@@ -1318,6 +1344,22 @@ const RetailPlayerDeviceManagement = () => {
     }
   }, [updateDevice])
 
+  const handleToggleDeviceVolumeControl = useCallback(async (device) => {
+    if (!device) {
+      return
+    }
+
+    try {
+      const nextEnabled = !(typeof device.volumeChangeEnabled === 'boolean'
+        ? device.volumeChangeEnabled
+        : true)
+      await updateDevice({ id: device.id, volumeChangeEnabled: nextEnabled })
+      setSelectedIds((previous) => new Set(previous))
+    } catch (err) {
+      console.error('Failed to update retail player volume control state', err)
+    }
+  }, [updateDevice])
+
   const handleNavigateToDevice = useCallback(
     (device) => {
       if (!device) {
@@ -1481,7 +1523,9 @@ const RetailPlayerDeviceManagement = () => {
           onKeyDown={handleRowKeyDown}
           onEdit={handleEditDevice}
           onToggleLock={handleToggleDeviceLock}
+          onToggleVolumeControl={handleToggleDeviceVolumeControl}
           isLocked={isDeviceLocked(node)}
+          isVolumeChangeEnabled={typeof node.volumeChangeEnabled === 'boolean' ? node.volumeChangeEnabled : true}
           isOnline={isOnline}
         />
       )

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -119,6 +119,12 @@ const baseDeviceShape = (device, existing) => {
       : typeof existing?.online === 'boolean'
         ? existing.online
         : undefined
+  const normalizedVolumeChangeEnabled =
+    typeof device?.volumeChangeEnabled === 'boolean'
+      ? device.volumeChangeEnabled
+      : typeof existing?.volumeChangeEnabled === 'boolean'
+        ? existing.volumeChangeEnabled
+        : true
 
   const existingFolderIds = normalizeFolderIds(
     existing?.folderIds ?? existing?.folderId,
@@ -147,6 +153,7 @@ const baseDeviceShape = (device, existing) => {
     timeZone: normalizedTimeZone || '',
     remoteControlId: normalizedRemoteControlId || '',
     isLocked: normalizedIsLocked,
+    volumeChangeEnabled: normalizedVolumeChangeEnabled,
     ...(typeof normalizedIsOnline === 'boolean' ? { online: normalizedIsOnline } : {}),
     folderIds,
     folderId: primaryFolderId,
@@ -684,6 +691,10 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
         basePayload,
         'isLocked',
       )
+      const hasVolumeChangeEnabled = Object.prototype.hasOwnProperty.call(
+        basePayload,
+        'volumeChangeEnabled',
+      )
 
       if (hasRemoteControlId) {
         const remoteControlId = normalizeValue(basePayload.remoteControlId)
@@ -726,6 +737,29 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
               typeof json?.data?.isLocked === 'boolean'
                 ? json.data.isLocked
                 : isLocked,
+          },
+        })
+      }
+
+      if (hasVolumeChangeEnabled) {
+        const enabled = Boolean(basePayload.volumeChangeEnabled)
+        const { json } = await httpClient(
+          `/api/retailplayer/devices/${encodeURIComponent(deviceId)}/volume-control`,
+          {
+            method: 'PATCH',
+            body: JSON.stringify({ enabled }),
+            headers: new Headers({ 'Content-Type': 'application/json' }),
+          },
+        )
+
+        dispatch({
+          type: 'UPDATE_DEVICE',
+          payload: {
+            id: deviceId,
+            volumeChangeEnabled:
+              typeof json?.data?.volumeChangeEnabled === 'boolean'
+                ? json.data.volumeChangeEnabled
+                : enabled,
           },
         })
       }

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -81,6 +81,12 @@ const mapRetailPlayerDevice = (device) => {
       : typeof device.isOnline === 'boolean'
         ? device.isOnline
         : undefined
+  const volumeChangeEnabled =
+    typeof device.volumeChangeEnabled === 'boolean'
+      ? device.volumeChangeEnabled
+      : typeof device.volume_change_enabled === 'boolean'
+        ? device.volume_change_enabled
+        : undefined
 
   return {
     id: fallbackId,
@@ -100,6 +106,9 @@ const mapRetailPlayerDevice = (device) => {
     folderIds,
     remoteControlId,
     ...(typeof isLocked === 'boolean' ? { isLocked } : {}),
+    ...(typeof volumeChangeEnabled === 'boolean'
+      ? { volumeChangeEnabled }
+      : {}),
     ...(typeof isOnline === 'boolean' ? { online: isOnline } : {}),
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a per-device volume control toggle for Retail Player devices and expose a clear UI affordance so admins can enable/disable device volume control from the management list and users see the disabled state on the device page. 
- When disabled the volume controls (mute button + slider) must be non-interactive and shown as greyed/disabled to match the site theme.

### Description
- Persisted a new `volumeChangeEnabled` flag on device mappings by adding `volume_change_enabled` to the model and repository, including an auto-migration helper (`ensureVolumeChangeEnabledColumn`) and `SetVolumeChangeEnabled` repository API. (`model/retail_player_device_mapping.go`, `persistence/retail_player_device_mapping_repository.go`).
- Added private backend endpoint `PATCH /api/retailplayer/devices/{deviceID}/volume-control` to toggle the flag and wired it into device mapping ↔︎ API responses and mapping helpers so the flag is returned and preserved (`server/nativeapi/retail_player.go`).
- Frontend device parsing/normalization now reads `volumeChangeEnabled` from both camelCase and snake_case payloads (`ui/src/retailPlayer/deviceUtils.js`) and the device store normalization and `updateDevice` flow will call the new endpoint when toggling the flag (`ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx`).
- Management UI: added a professional volume icon button placed before the lock icon in the device row, with toggle handler and disabled visual style (grey) when volume control is off (`ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx`).
- Device page: updated the Retail Player dashboard to respect `volumeChangeEnabled` so mute/slider become disabled and are styled grey when volume control is disabled (`ui/src/retailPlayer/RetailPlayerDashboard.jsx`).

### Testing
- Ran formatting: `gofmt -w model/retail_player_device_mapping.go persistence/retail_player_device_mapping_repository.go server/nativeapi/retail_player.go` (succeeded).
- Ran Go unit tests: `go test ./server/nativeapi ./persistence ./model` (could not complete in this environment due to missing system dependency: the `taglib` pkg-config development package required by a cgo adapter, so tests were blocked by environment, not code).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd30ce13548322a24aa45602d0bc7b)