### PR TITLE
Add per-device volume toggle icon and support in dashboard

### DIFF
--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -719,6 +719,7 @@ const useStyles = makeStyles((theme) => {
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'space-between',
+      gap: theme.spacing(0.75),
       color: theme.palette.text.secondary,
       textTransform: 'lowercase',
       opacity: 0,
@@ -756,6 +757,9 @@ const useStyles = makeStyles((theme) => {
       textAlign: 'right',
       fontVariantNumeric: 'tabular-nums',
       fontWeight: theme.typography.fontWeightMedium,
+    },
+    volumeToggleIconDisabled: {
+      color: theme.palette.action.disabled,
     },
     dislikeMessage: {
       marginTop: theme.spacing(1),
@@ -1795,6 +1799,9 @@ const RetailPlayerDashboard = () => {
   const isDeviceOnline = hasRealtimeOnlineState ? device.online : hasStatusValue
   const isOfflineUi = !isDeviceOnline
   const areNowPlayingControlsDisabled = !canControlDevice || isOfflineUi
+  const isVolumeControlEnabled = device?.isVolumeControlEnabled !== false
+  const areVolumeControlsDisabled =
+    areNowPlayingControlsDisabled || !isVolumeControlEnabled
   const formattedUpTime = useMemo(() => {
     if (statusUpTimeSeconds !== null) {
       const totalSeconds = statusUpTimeSeconds
@@ -2026,7 +2033,7 @@ const RetailPlayerDashboard = () => {
   )
 
   const handleToggleMute = useCallback(() => {
-    if (areNowPlayingControlsDisabled) {
+    if (areVolumeControlsDisabled) {
       return
     }
 
@@ -2062,10 +2069,10 @@ const RetailPlayerDashboard = () => {
       }
       return 0
     })
-  }, [areNowPlayingControlsDisabled, isMuted, sendRemoteControlCommand, updateVolume])
+  }, [areVolumeControlsDisabled, isMuted, sendRemoteControlCommand, updateVolume])
 
   const handleVolumeChange = useCallback((_, newValue) => {
-    if (areNowPlayingControlsDisabled) {
+    if (areVolumeControlsDisabled) {
       return
     }
 
@@ -2074,7 +2081,7 @@ const RetailPlayerDashboard = () => {
       return
     }
     updateVolume(resolvedValue)
-  }, [areNowPlayingControlsDisabled, updateVolume])
+  }, [areVolumeControlsDisabled, updateVolume])
 
   const handleRefresh = useCallback(() => {
     refreshStatus()
@@ -2083,9 +2090,12 @@ const RetailPlayerDashboard = () => {
 
   const handleAdjustVolume = useCallback(
     (delta) => {
+      if (areVolumeControlsDisabled) {
+        return
+      }
       updateVolume((prev) => prev + delta)
     },
-    [updateVolume],
+    [areVolumeControlsDisabled, updateVolume],
   )
 
   const handleBack = useCallback(() => {
@@ -2553,11 +2563,15 @@ const RetailPlayerDashboard = () => {
               <section
                 className={combineClasses(
                   classes.volumeSection,
-                  areNowPlayingControlsDisabled ? classes.volumeSectionDisabled : null,
+                  areVolumeControlsDisabled ? classes.volumeSectionDisabled : null,
                 )}
                 aria-label="Volume"
               >
                 <div className={classes.volumeLabelRow}>
+                  <VolumeUpIcon
+                    fontSize="small"
+                    className={!isVolumeControlEnabled ? classes.volumeToggleIconDisabled : null}
+                  />
                   <Typography component="span">volume</Typography>
                   <Typography className={classes.volumeValue} aria-live="polite">
                     {typeof displayVolume === 'number' && !Number.isNaN(displayVolume)
@@ -2569,7 +2583,7 @@ const RetailPlayerDashboard = () => {
                   classes={{
                     root: combineClasses(
                       classes.slider,
-                      areNowPlayingControlsDisabled ? classes.sliderDisabled : null,
+                      areVolumeControlsDisabled ? classes.sliderDisabled : null,
                     ),
                     track: classes.sliderTrack,
                     thumb: classes.sliderThumb,
@@ -2582,7 +2596,7 @@ const RetailPlayerDashboard = () => {
                   max={100}
                   aria-label="Volume"
                   onChange={handleVolumeChange}
-                  disabled={areNowPlayingControlsDisabled}
+                  disabled={areVolumeControlsDisabled}
                 />
               </section>
             </div>

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -32,6 +32,7 @@ import FolderIcon from '@material-ui/icons/Folder'
 import SpeakerGroupIcon from '@material-ui/icons/SpeakerGroup'
 import SearchIcon from '@material-ui/icons/Search'
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline'
+import VolumeUpIcon from '@material-ui/icons/VolumeUp'
 import Breadcrumbs from '@material-ui/core/Breadcrumbs'
 import Link from '@material-ui/core/Link'
 import clsx from 'clsx'
@@ -305,6 +306,12 @@ const useStyles = makeStyles((theme) => {
     justifyContent: 'flex-end',
   },
   lockIconActive: {
+    color: theme.palette.secondary.main,
+  },
+  volumeIconEnabled: {
+    color: theme.palette.action.disabled,
+  },
+  volumeIconDisabled: {
     color: theme.palette.secondary.main,
   },
   breadcrumbBar: {
@@ -655,7 +662,9 @@ const RetailPlayerDeviceRow = memo(
     onKeyDown,
     onEdit,
     onToggleLock,
+    onToggleVolume,
     isLocked,
+    isVolumeControlEnabled,
     isOnline,
   }) => {
     const { dragRef, isDragging } = useRetailPlayerDeviceDrag({
@@ -712,6 +721,25 @@ const RetailPlayerDeviceRow = memo(
           {node.remoteControlId ? node.remoteControlId : '—'}
         </div>
         <div className={classes.actionsCell}>
+          <Tooltip title={isVolumeControlEnabled ? 'Disable volume control' : 'Enable volume control'}>
+            <IconButton
+              size="small"
+              onClick={(event) => {
+                event.stopPropagation()
+                onToggleVolume(node)
+              }}
+              aria-label={`${isVolumeControlEnabled ? 'Disable' : 'Enable'} volume control for device ${node.name}`}
+            >
+              <VolumeUpIcon
+                style={{ fontSize: 15 }}
+                className={
+                  isVolumeControlEnabled
+                    ? classes.volumeIconEnabled
+                    : classes.volumeIconDisabled
+                }
+              />
+            </IconButton>
+          </Tooltip>
           <Tooltip title={isLocked ? 'Unlock device' : 'Lock device'}>
             <IconButton
               size="small"
@@ -760,12 +788,15 @@ RetailPlayerDeviceRow.propTypes = {
   onKeyDown: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
   onToggleLock: PropTypes.func.isRequired,
+  onToggleVolume: PropTypes.func.isRequired,
   isLocked: PropTypes.bool,
+  isVolumeControlEnabled: PropTypes.bool,
   isOnline: PropTypes.bool,
 }
 
 RetailPlayerDeviceRow.defaultProps = {
   isLocked: false,
+  isVolumeControlEnabled: true,
   isOnline: null,
 }
 
@@ -1318,6 +1349,22 @@ const RetailPlayerDeviceManagement = () => {
     }
   }, [updateDevice])
 
+  const handleToggleDeviceVolume = useCallback(async (device) => {
+    if (!device) {
+      return
+    }
+
+    try {
+      await updateDevice({
+        id: device.id,
+        isVolumeControlEnabled: device.isVolumeControlEnabled === false,
+      })
+      setSelectedIds((previous) => new Set(previous))
+    } catch (err) {
+      console.error('Failed to update retail player volume control state', err)
+    }
+  }, [updateDevice])
+
   const handleNavigateToDevice = useCallback(
     (device) => {
       if (!device) {
@@ -1481,7 +1528,9 @@ const RetailPlayerDeviceManagement = () => {
           onKeyDown={handleRowKeyDown}
           onEdit={handleEditDevice}
           onToggleLock={handleToggleDeviceLock}
+          onToggleVolume={handleToggleDeviceVolume}
           isLocked={isDeviceLocked(node)}
+          isVolumeControlEnabled={node.isVolumeControlEnabled !== false}
           isOnline={isOnline}
         />
       )

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -119,6 +119,14 @@ const baseDeviceShape = (device, existing) => {
       : typeof existing?.online === 'boolean'
         ? existing.online
         : undefined
+  const normalizedVolumeEnabled =
+    typeof device?.isVolumeControlEnabled === 'boolean'
+      ? device.isVolumeControlEnabled
+      : typeof device?.volumeChangeEnabled === 'boolean'
+        ? device.volumeChangeEnabled
+        : typeof existing?.isVolumeControlEnabled === 'boolean'
+          ? existing.isVolumeControlEnabled
+          : true
 
   const existingFolderIds = normalizeFolderIds(
     existing?.folderIds ?? existing?.folderId,
@@ -147,6 +155,7 @@ const baseDeviceShape = (device, existing) => {
     timeZone: normalizedTimeZone || '',
     remoteControlId: normalizedRemoteControlId || '',
     isLocked: normalizedIsLocked,
+    isVolumeControlEnabled: normalizedVolumeEnabled,
     ...(typeof normalizedIsOnline === 'boolean' ? { online: normalizedIsOnline } : {}),
     folderIds,
     folderId: primaryFolderId,
@@ -302,6 +311,7 @@ const reducer = (state, action) => {
         folderId,
         remoteControlId,
         isLocked,
+        isVolumeControlEnabled,
       } = action.payload || {}
       if (!id) {
         return state
@@ -334,6 +344,10 @@ const reducer = (state, action) => {
               : device.remoteControlId,
           isLocked:
             typeof isLocked === 'boolean' ? isLocked : device.isLocked,
+          isVolumeControlEnabled:
+            typeof isVolumeControlEnabled === 'boolean'
+              ? isVolumeControlEnabled
+              : device.isVolumeControlEnabled,
         }
       })
       return { ...state, devices: nextDevices, lastUpdated: Date.now() }


### PR DESCRIPTION
### Motivation
- Allow operators to enable/disable volume control per retail player device from the management list using a compact volume icon placed before the lock icon. 
- When volume control is disabled the dashboard should render the volume UI as disabled and visually indicate the disabled state (greyed icon) to match the site theme. 
- Make the change minimal and localized so other behavior is unchanged.

### Description
- Add a per-device `isVolumeControlEnabled` property to the retail player device shape and reducer, defaulting to enabled and accepting remote `volumeChangeEnabled` payloads (file: `RetailPlayerDeviceStoreContext.jsx`).
- Add a `VolumeUp` action icon to the management device row (placed before the lock icon) with tooltip/ARIA labels, themed colors for enabled/disabled states, and a handler that toggles `isVolumeControlEnabled` via `updateDevice` (file: `RetailPlayerDeviceManagement.jsx`).
- Update the retail player dashboard to respect the flag by disabling volume interactions when `isVolumeControlEnabled` is false and adding a greyed `VolumeUp` indicator in the volume label row to visually match the disabled state (file: `RetailPlayerDashboard.jsx`).
- Keep changes minimal: only new flag wiring, a small toggle handler, a few CSS classes, and conditional checks where volume controls are used.

### Testing
- Ran the linter on modified UI files with `cd ui && npx eslint src/retailPlayer/RetailPlayerDeviceStoreContext.jsx src/retailPlayer/RetailPlayerDeviceManagement.jsx src/retailPlayer/RetailPlayerDashboard.jsx`, which reported existing `no-console` errors in `RetailPlayerDeviceManagement.jsx` and one React hooks warning in the dashboard (lint run returned non-zero). 
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd376dede88322a5b8d53f5b01d8b9)