### PR TITLE
Add per-device volume control flag (isVolumeEnabled) with API and UI support

### DIFF
--- a/model/retail_player_device_mapping.go
+++ b/model/retail_player_device_mapping.go
@@ -7,22 +7,24 @@ import (
 )
 
 type RetailPlayerDeviceMapping struct {
-	DeviceID     string    `db:"device_id" json:"deviceId"`
-	DeviceName   string    `db:"device_name" json:"deviceName"`
-	DeviceSlug   string    `db:"device_slug" json:"deviceSlug"`
-	IsLocked     bool      `db:"is_locked" json:"isLocked"`
-	Channel      string    `db:"channel" json:"channel"`
-	ChannelList  string    `db:"channel_list" json:"channelList"`
-	Organization string    `db:"organization" json:"organization"`
-	TimeZone     string    `db:"time_zone" json:"timeZone"`
-	RemoteCtrlID string    `db:"remote_control_id" json:"remoteControlId"`
-	UpdatedAt    time.Time `db:"updated_at" json:"updatedAt"`
+	DeviceID        string    `db:"device_id" json:"deviceId"`
+	DeviceName      string    `db:"device_name" json:"deviceName"`
+	DeviceSlug      string    `db:"device_slug" json:"deviceSlug"`
+	IsLocked        bool      `db:"is_locked" json:"isLocked"`
+	IsVolumeEnabled bool      `db:"is_volume_enabled" json:"isVolumeEnabled"`
+	Channel         string    `db:"channel" json:"channel"`
+	ChannelList     string    `db:"channel_list" json:"channelList"`
+	Organization    string    `db:"organization" json:"organization"`
+	TimeZone        string    `db:"time_zone" json:"timeZone"`
+	RemoteCtrlID    string    `db:"remote_control_id" json:"remoteControlId"`
+	UpdatedAt       time.Time `db:"updated_at" json:"updatedAt"`
 }
 
 type RetailPlayerDeviceMappingRepository interface {
 	Put(ctx context.Context, mapping RetailPlayerDeviceMapping) error
 	PutMany(ctx context.Context, mappings []RetailPlayerDeviceMapping) error
 	SetLocked(ctx context.Context, deviceID string, isLocked bool) error
+	SetVolumeEnabled(ctx context.Context, deviceID string, enabled bool) error
 	FindByIdentifier(ctx context.Context, identifier string) (*RetailPlayerDeviceMapping, error)
 	All(ctx context.Context) ([]RetailPlayerDeviceMapping, error)
 }

--- a/persistence/retail_player_device_mapping_repository.go
+++ b/persistence/retail_player_device_mapping_repository.go
@@ -24,6 +24,7 @@ func NewRetailPlayerDeviceMappingRepository(ctx context.Context, db dbx.Builder)
 	r.registerModel(&model.RetailPlayerDeviceMapping{}, nil)
 	r.ensureRemoteControlColumn()
 	r.ensureIsLockedColumn()
+	r.ensureIsVolumeEnabledColumn()
 	return r
 }
 
@@ -61,6 +62,23 @@ ADD COLUMN is_locked BOOLEAN NOT NULL DEFAULT 0;
 	log.Error(r.ctx, "Unable to ensure lock status column for retail player device mappings", "err", err)
 }
 
+func (r retailPlayerDeviceMappingRepository) ensureIsVolumeEnabledColumn() {
+	_, err := r.db.NewQuery(`
+ALTER TABLE retail_player_device_mapping
+ADD COLUMN is_volume_enabled BOOLEAN NOT NULL DEFAULT 1;
+`).Execute()
+	if err == nil {
+		return
+	}
+
+	lowerErr := strings.ToLower(err.Error())
+	if strings.Contains(lowerErr, "duplicate column name") || strings.Contains(lowerErr, "already exists") {
+		return
+	}
+
+	log.Error(r.ctx, "Unable to ensure volume enabled column for retail player device mappings", "err", err)
+}
+
 func (r retailPlayerDeviceMappingRepository) Put(ctx context.Context, mapping model.RetailPlayerDeviceMapping) error {
 	if mapping.DeviceID == "" {
 		return errors.New("retail player device id is required")
@@ -81,6 +99,7 @@ func (r retailPlayerDeviceMappingRepository) PutMany(ctx context.Context, mappin
 			"device_name",
 			"device_slug",
 			"is_locked",
+			"is_volume_enabled",
 			"channel",
 			"channel_list",
 			"organization",
@@ -110,6 +129,7 @@ func (r retailPlayerDeviceMappingRepository) PutMany(ctx context.Context, mappin
 			name,
 			slug,
 			mapping.IsLocked,
+			mapping.IsVolumeEnabled,
 			strings.TrimSpace(mapping.Channel),
 			strings.TrimSpace(mapping.ChannelList),
 			strings.TrimSpace(mapping.Organization),
@@ -128,6 +148,7 @@ func (r retailPlayerDeviceMappingRepository) PutMany(ctx context.Context, mappin
                 device_name = excluded.device_name,
                 device_slug = excluded.device_slug,
                 is_locked = retail_player_device_mapping.is_locked,
+                is_volume_enabled = retail_player_device_mapping.is_volume_enabled,
                 channel = excluded.channel,
                 channel_list = excluded.channel_list,
                 organization = excluded.organization,
@@ -153,6 +174,7 @@ func (r retailPlayerDeviceMappingRepository) SetLocked(ctx context.Context, devi
 			"device_name",
 			"device_slug",
 			"is_locked",
+			"is_volume_enabled",
 			"channel",
 			"channel_list",
 			"organization",
@@ -160,9 +182,40 @@ func (r retailPlayerDeviceMappingRepository) SetLocked(ctx context.Context, devi
 			"remote_control_id",
 			"updated_at",
 		).
-		Values(trimmedID, trimmedID, defaultSlug, isLocked, "", "", "", "", "", now).
+		Values(trimmedID, trimmedID, defaultSlug, isLocked, true, "", "", "", "", "", now).
 		Suffix(`ON CONFLICT(device_id) DO UPDATE SET
 			is_locked = excluded.is_locked,
+			updated_at = excluded.updated_at`)
+
+	_, err := r.executeSQL(insert)
+	return err
+}
+
+func (r retailPlayerDeviceMappingRepository) SetVolumeEnabled(ctx context.Context, deviceID string, enabled bool) error {
+	trimmedID := strings.TrimSpace(deviceID)
+	if trimmedID == "" {
+		return errors.New("retail player device id is required")
+	}
+
+	now := time.Now().UTC()
+	defaultSlug := model.RetailPlayerDeviceSlug(trimmedID)
+	insert := Insert(r.tableName).
+		Columns(
+			"device_id",
+			"device_name",
+			"device_slug",
+			"is_locked",
+			"is_volume_enabled",
+			"channel",
+			"channel_list",
+			"organization",
+			"time_zone",
+			"remote_control_id",
+			"updated_at",
+		).
+		Values(trimmedID, trimmedID, defaultSlug, false, enabled, "", "", "", "", "", now).
+		Suffix(`ON CONFLICT(device_id) DO UPDATE SET
+			is_volume_enabled = excluded.is_volume_enabled,
 			updated_at = excluded.updated_at`)
 
 	_, err := r.executeSQL(insert)
@@ -186,7 +239,7 @@ func (r retailPlayerDeviceMappingRepository) FindByIdentifier(ctx context.Contex
 	orClause := Or{}
 	orClause = append(orClause, conditions...)
 
-	sel := Select("device_id", "device_name", "device_slug", "is_locked", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "updated_at").
+	sel := Select("device_id", "device_name", "device_slug", "is_locked", "is_volume_enabled", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "updated_at").
 		From(r.tableName).
 		Where(orClause).
 		OrderBy("updated_at DESC").
@@ -200,7 +253,7 @@ func (r retailPlayerDeviceMappingRepository) FindByIdentifier(ctx context.Contex
 }
 
 func (r retailPlayerDeviceMappingRepository) All(ctx context.Context) ([]model.RetailPlayerDeviceMapping, error) {
-	sel := Select("device_id", "device_name", "device_slug", "is_locked", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "updated_at").
+	sel := Select("device_id", "device_name", "device_slug", "is_locked", "is_volume_enabled", "channel", "channel_list", "organization", "time_zone", "remote_control_id", "updated_at").
 		From(r.tableName).
 		OrderBy("updated_at DESC")
 

--- a/server/nativeapi/retail_player.go
+++ b/server/nativeapi/retail_player.go
@@ -210,6 +210,7 @@ type retailPlayerDevice struct {
 	ID              string   `json:"id"`
 	Name            string   `json:"name"`
 	IsLocked        bool     `json:"isLocked"`
+	IsVolumeEnabled *bool    `json:"isVolumeEnabled,omitempty"`
 	OrganizationID  string   `json:"organizationId,omitempty"`
 	OrganisationID  string   `json:"organisationid,omitempty"`
 	Channel         string   `json:"channel"`
@@ -366,6 +367,7 @@ func (n *Router) addRetailPlayerPublicRoutes(r chi.Router) {
 func (n *Router) addRetailPlayerPrivateRoutes(r chi.Router) {
 	r.Get("/retailplayer/devices", n.handleRetailPlayerDevices())
 	r.Patch("/retailplayer/devices/{deviceID}/lock", n.handleUpdateRetailPlayerDeviceLock())
+	r.Patch("/retailplayer/devices/{deviceID}/volume-control", n.handleUpdateRetailPlayerDeviceVolumeControl())
 	r.Post("/retailplayer/folders", n.handleCreateRetailPlayerFolder())
 	r.Patch("/retailplayer/folders/{folderID}", n.handleUpdateRetailPlayerFolder())
 	r.Post("/retailplayer/folders/delete", n.handleDeleteRetailPlayerFolders())
@@ -414,6 +416,54 @@ func (n *Router) handleUpdateRetailPlayerDeviceLock() http.HandlerFunc {
 		mapping, err := repo.FindByIdentifier(ctx, deviceID)
 		if err != nil {
 			log.Error(ctx, "Unable to load retail player device mapping after lock update", "deviceID", deviceID, "err", err)
+			http.Error(w, "Unable to load retail player device", http.StatusInternalServerError)
+			return
+		}
+
+		writeRetailPlayerJSON(ctx, w, http.StatusOK, map[string]any{"data": mapRetailPlayerMappingToDevice(*mapping)})
+	}
+}
+
+func (n *Router) handleUpdateRetailPlayerDeviceVolumeControl() http.HandlerFunc {
+	type volumeControlUpdatePayload struct {
+		Enabled bool `json:"enabled"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if !conf.Server.RetailPlayer.Enabled {
+			http.Error(w, "Retail player integration disabled", http.StatusNotFound)
+			return
+		}
+
+		deviceID := strings.TrimSpace(chi.URLParam(r, "deviceID"))
+		if deviceID == "" {
+			http.Error(w, "Retail player device id is required", http.StatusBadRequest)
+			return
+		}
+
+		var payload volumeControlUpdatePayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "Invalid retail player volume control payload", http.StatusBadRequest)
+			return
+		}
+
+		repo := n.ds.RetailPlayerDeviceMapping(ctx)
+		if repo == nil {
+			http.Error(w, "Retail player device mapping repository not available", http.StatusInternalServerError)
+			return
+		}
+
+		if err := repo.SetVolumeEnabled(ctx, deviceID, payload.Enabled); err != nil {
+			log.Error(ctx, "Unable to update retail player device volume controls", "deviceID", deviceID, "err", err)
+			http.Error(w, "Unable to update retail player device volume controls", http.StatusInternalServerError)
+			return
+		}
+
+		mapping, err := repo.FindByIdentifier(ctx, deviceID)
+		if err != nil {
+			log.Error(ctx, "Unable to load retail player device mapping after volume control update", "deviceID", deviceID, "err", err)
 			http.Error(w, "Unable to load retail player device", http.StatusInternalServerError)
 			return
 		}
@@ -493,12 +543,14 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 
 			if len(mappings) > 0 {
 				remoteControlByID := make(map[string]string, len(mappings))
+				volumeEnabledByID := make(map[string]bool, len(mappings))
 				for _, mapping := range mappings {
 					id := strings.TrimSpace(mapping.DeviceID)
 					remoteControlID := strings.TrimSpace(mapping.RemoteCtrlID)
 					if id == "" {
 						continue
 					}
+					volumeEnabledByID[id] = mapping.IsVolumeEnabled
 					if remoteControlID != "" {
 						remoteControlByID[id] = remoteControlID
 					}
@@ -519,6 +571,16 @@ func (n *Router) handleRetailPlayerDevices() http.HandlerFunc {
 						if remoteControlID, ok := remoteControlByID[id]; ok {
 							response.Data[index].RemoteControlID = remoteControlID
 						}
+					}
+				}
+				for index := range response.Data {
+					id := strings.TrimSpace(response.Data[index].ID)
+					if id == "" {
+						continue
+					}
+					if volumeEnabled, ok := volumeEnabledByID[id]; ok {
+						enabled := volumeEnabled
+						response.Data[index].IsVolumeEnabled = &enabled
 					}
 				}
 			}
@@ -637,12 +699,14 @@ func (n *Router) handleRetailPlayerDeviceByName() http.HandlerFunc {
 
 			if len(mappings) > 0 {
 				remoteControlByID := make(map[string]string, len(mappings))
+				volumeEnabledByID := make(map[string]bool, len(mappings))
 				for _, mapping := range mappings {
 					id := strings.TrimSpace(mapping.DeviceID)
 					remoteControlID := strings.TrimSpace(mapping.RemoteCtrlID)
 					if id == "" {
 						continue
 					}
+					volumeEnabledByID[id] = mapping.IsVolumeEnabled
 					if remoteControlID != "" {
 						remoteControlByID[id] = remoteControlID
 					}
@@ -663,6 +727,16 @@ func (n *Router) handleRetailPlayerDeviceByName() http.HandlerFunc {
 						if remoteControlID, ok := remoteControlByID[id]; ok {
 							filtered.Data[index].RemoteControlID = remoteControlID
 						}
+					}
+				}
+				for index := range filtered.Data {
+					id := strings.TrimSpace(filtered.Data[index].ID)
+					if id == "" {
+						continue
+					}
+					if volumeEnabled, ok := volumeEnabledByID[id]; ok {
+						enabled := volumeEnabled
+						filtered.Data[index].IsVolumeEnabled = &enabled
 					}
 				}
 			}
@@ -1535,24 +1609,32 @@ func mapRetailPlayerDeviceToMapping(device retailPlayerDevice) (model.RetailPlay
 		slug = model.RetailPlayerDeviceSlug(id)
 	}
 
+	isVolumeEnabled := true
+	if device.IsVolumeEnabled != nil {
+		isVolumeEnabled = *device.IsVolumeEnabled
+	}
+
 	return model.RetailPlayerDeviceMapping{
-		DeviceID:     id,
-		DeviceName:   name,
-		DeviceSlug:   slug,
-		IsLocked:     device.IsLocked,
-		Channel:      strings.TrimSpace(device.Channel),
-		ChannelList:  strings.TrimSpace(device.ChannelList),
-		Organization: strings.TrimSpace(device.Organization),
-		TimeZone:     strings.TrimSpace(device.TimeZone),
-		RemoteCtrlID: strings.TrimSpace(device.RemoteControlID),
+		DeviceID:        id,
+		DeviceName:      name,
+		DeviceSlug:      slug,
+		IsLocked:        device.IsLocked,
+		IsVolumeEnabled: isVolumeEnabled,
+		Channel:         strings.TrimSpace(device.Channel),
+		ChannelList:     strings.TrimSpace(device.ChannelList),
+		Organization:    strings.TrimSpace(device.Organization),
+		TimeZone:        strings.TrimSpace(device.TimeZone),
+		RemoteCtrlID:    strings.TrimSpace(device.RemoteControlID),
 	}, true
 }
 
 func mapRetailPlayerMappingToDevice(mapping model.RetailPlayerDeviceMapping) retailPlayerDevice {
+	isVolumeEnabled := mapping.IsVolumeEnabled
 	return retailPlayerDevice{
 		ID:              strings.TrimSpace(mapping.DeviceID),
 		Name:            strings.TrimSpace(mapping.DeviceName),
 		IsLocked:        mapping.IsLocked,
+		IsVolumeEnabled: &isVolumeEnabled,
 		Channel:         strings.TrimSpace(mapping.Channel),
 		ChannelList:     strings.TrimSpace(mapping.ChannelList),
 		Organization:    strings.TrimSpace(mapping.Organization),

--- a/ui/src/retailPlayer/RetailPlayerDashboard.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDashboard.jsx
@@ -1795,6 +1795,7 @@ const RetailPlayerDashboard = () => {
   const isDeviceOnline = hasRealtimeOnlineState ? device.online : hasStatusValue
   const isOfflineUi = !isDeviceOnline
   const areNowPlayingControlsDisabled = !canControlDevice || isOfflineUi
+  const areVolumeControlsDisabled = areNowPlayingControlsDisabled || device?.isVolumeEnabled === false
   const formattedUpTime = useMemo(() => {
     if (statusUpTimeSeconds !== null) {
       const totalSeconds = statusUpTimeSeconds
@@ -2026,7 +2027,7 @@ const RetailPlayerDashboard = () => {
   )
 
   const handleToggleMute = useCallback(() => {
-    if (areNowPlayingControlsDisabled) {
+    if (areVolumeControlsDisabled) {
       return
     }
 
@@ -2062,10 +2063,17 @@ const RetailPlayerDashboard = () => {
       }
       return 0
     })
-  }, [areNowPlayingControlsDisabled, isMuted, sendRemoteControlCommand, updateVolume])
+  }, [
+    areVolumeControlsDisabled,
+    displayVolume,
+    isMuted,
+    sendRemoteControlCommand,
+    updateVolume,
+    volume,
+  ])
 
   const handleVolumeChange = useCallback((_, newValue) => {
-    if (areNowPlayingControlsDisabled) {
+    if (areVolumeControlsDisabled) {
       return
     }
 
@@ -2074,7 +2082,7 @@ const RetailPlayerDashboard = () => {
       return
     }
     updateVolume(resolvedValue)
-  }, [areNowPlayingControlsDisabled, updateVolume])
+  }, [areVolumeControlsDisabled, updateVolume])
 
   const handleRefresh = useCallback(() => {
     refreshStatus()
@@ -2083,9 +2091,12 @@ const RetailPlayerDashboard = () => {
 
   const handleAdjustVolume = useCallback(
     (delta) => {
+      if (areVolumeControlsDisabled) {
+        return
+      }
       updateVolume((prev) => prev + delta)
     },
-    [updateVolume],
+    [areVolumeControlsDisabled, updateVolume],
   )
 
   const handleBack = useCallback(() => {
@@ -2506,7 +2517,7 @@ const RetailPlayerDashboard = () => {
                   aria-label="Mute/Unmute"
                   onClick={handleToggleMute}
                   focusRipple
-                  disabled={areNowPlayingControlsDisabled}
+                  disabled={areVolumeControlsDisabled}
                 >
                   <span className={classes.controlIcon} role="img" aria-hidden="true">
                     {isMuted ? <VolumeOffIcon fontSize="inherit" /> : <VolumeUpIcon fontSize="inherit" />}
@@ -2553,7 +2564,7 @@ const RetailPlayerDashboard = () => {
               <section
                 className={combineClasses(
                   classes.volumeSection,
-                  areNowPlayingControlsDisabled ? classes.volumeSectionDisabled : null,
+                  areVolumeControlsDisabled ? classes.volumeSectionDisabled : null,
                 )}
                 aria-label="Volume"
               >
@@ -2569,7 +2580,7 @@ const RetailPlayerDashboard = () => {
                   classes={{
                     root: combineClasses(
                       classes.slider,
-                      areNowPlayingControlsDisabled ? classes.sliderDisabled : null,
+                      areVolumeControlsDisabled ? classes.sliderDisabled : null,
                     ),
                     track: classes.sliderTrack,
                     thumb: classes.sliderThumb,
@@ -2582,7 +2593,7 @@ const RetailPlayerDashboard = () => {
                   max={100}
                   aria-label="Volume"
                   onChange={handleVolumeChange}
-                  disabled={areNowPlayingControlsDisabled}
+                  disabled={areVolumeControlsDisabled}
                 />
               </section>
             </div>

--- a/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceManagement.jsx
@@ -28,6 +28,8 @@ import AddIcon from '@material-ui/icons/Add'
 import EditIcon from '@material-ui/icons/Edit'
 import LockIcon from '@material-ui/icons/Lock'
 import LockOpenIcon from '@material-ui/icons/LockOpen'
+import VolumeOffIcon from '@material-ui/icons/VolumeOff'
+import VolumeUpIcon from '@material-ui/icons/VolumeUp'
 import FolderIcon from '@material-ui/icons/Folder'
 import SpeakerGroupIcon from '@material-ui/icons/SpeakerGroup'
 import SearchIcon from '@material-ui/icons/Search'
@@ -524,7 +526,9 @@ const RetailPlayerFolderRow = memo(
     onKeyDown,
     onEdit,
     onToggleLock,
+    onToggleVolumeControl,
     isLocked,
+    isVolumeEnabled,
     onDeviceDrop,
   }) => {
     const { dropRef, isOver, canDrop } = useRetailPlayerFolderDrop({
@@ -591,6 +595,22 @@ const RetailPlayerFolderRow = memo(
               )}
             </IconButton>
           </Tooltip>
+          <Tooltip title={isVolumeEnabled ? 'Disable folder volume controls' : 'Enable folder volume controls'}>
+            <IconButton
+              size="small"
+              onClick={(event) => {
+                event.stopPropagation()
+                onToggleVolumeControl(node)
+              }}
+              aria-label={`${isVolumeEnabled ? 'Disable' : 'Enable'} volume controls for folder ${node.name}`}
+            >
+              {isVolumeEnabled ? (
+                <VolumeUpIcon style={{ fontSize: 15 }} className={classes.lockIconActive} />
+              ) : (
+                <VolumeOffIcon style={{ fontSize: 15 }} />
+              )}
+            </IconButton>
+          </Tooltip>
           <Tooltip title="Edit folder">
             <IconButton
               size="small"
@@ -622,12 +642,15 @@ RetailPlayerFolderRow.propTypes = {
   onKeyDown: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
   onToggleLock: PropTypes.func.isRequired,
+  onToggleVolumeControl: PropTypes.func.isRequired,
   isLocked: PropTypes.bool,
+  isVolumeEnabled: PropTypes.bool,
   onDeviceDrop: PropTypes.func.isRequired,
 }
 
 RetailPlayerFolderRow.defaultProps = {
   isLocked: false,
+  isVolumeEnabled: true,
 }
 
 RetailPlayerFolderRow.displayName = 'RetailPlayerFolderRow'
@@ -655,7 +678,9 @@ const RetailPlayerDeviceRow = memo(
     onKeyDown,
     onEdit,
     onToggleLock,
+    onToggleVolumeControl,
     isLocked,
+    isVolumeEnabled,
     isOnline,
   }) => {
     const { dragRef, isDragging } = useRetailPlayerDeviceDrag({
@@ -728,6 +753,22 @@ const RetailPlayerDeviceRow = memo(
               )}
             </IconButton>
           </Tooltip>
+          <Tooltip title={isVolumeEnabled ? 'Disable volume controls' : 'Enable volume controls'}>
+            <IconButton
+              size="small"
+              onClick={(event) => {
+                event.stopPropagation()
+                onToggleVolumeControl(node)
+              }}
+              aria-label={`${isVolumeEnabled ? 'Disable' : 'Enable'} volume controls for device ${node.name}`}
+            >
+              {isVolumeEnabled ? (
+                <VolumeUpIcon style={{ fontSize: 15 }} className={classes.lockIconActive} />
+              ) : (
+                <VolumeOffIcon style={{ fontSize: 15 }} />
+              )}
+            </IconButton>
+          </Tooltip>
           <Tooltip title="Edit device">
             <IconButton
               size="small"
@@ -760,12 +801,15 @@ RetailPlayerDeviceRow.propTypes = {
   onKeyDown: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
   onToggleLock: PropTypes.func.isRequired,
+  onToggleVolumeControl: PropTypes.func.isRequired,
   isLocked: PropTypes.bool,
+  isVolumeEnabled: PropTypes.bool,
   isOnline: PropTypes.bool,
 }
 
 RetailPlayerDeviceRow.defaultProps = {
   isLocked: false,
+  isVolumeEnabled: true,
   isOnline: null,
 }
 
@@ -1273,6 +1317,46 @@ const RetailPlayerDeviceManagement = () => {
     [collectDevicesInNode, updateDevice],
   )
 
+  const disableFolderDeviceVolumeControls = useCallback(
+    async (folderNode) => {
+      const devicesToDisable = collectDevicesInNode(folderNode).filter(
+        (device) => device.isVolumeEnabled !== false,
+      )
+      if (!devicesToDisable.length) {
+        return
+      }
+      for (const device of devicesToDisable) {
+        try {
+          await updateDevice({ id: device.id, isVolumeEnabled: false })
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.error('Failed to disable retail player device volume controls from folder', err)
+        }
+      }
+    },
+    [collectDevicesInNode, updateDevice],
+  )
+
+  const enableFolderDeviceVolumeControls = useCallback(
+    async (folderNode) => {
+      const devicesToEnable = collectDevicesInNode(folderNode).filter(
+        (device) => device.isVolumeEnabled === false,
+      )
+      if (!devicesToEnable.length) {
+        return
+      }
+      for (const device of devicesToEnable) {
+        try {
+          await updateDevice({ id: device.id, isVolumeEnabled: true })
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.error('Failed to enable retail player device volume controls from folder', err)
+        }
+      }
+    },
+    [collectDevicesInNode, updateDevice],
+  )
+
   const handleToggleFolderLock = useCallback(
     async (folderNode) => {
       if (!folderNode) {
@@ -1304,6 +1388,35 @@ const RetailPlayerDeviceManagement = () => {
     ],
   )
 
+  const handleToggleFolderVolumeControl = useCallback(
+    async (folderNode) => {
+      if (!folderNode) {
+        return
+      }
+
+      const folderDevices = collectDevicesInNode(folderNode)
+      if (!folderDevices.length) {
+        return
+      }
+
+      const areAllVolumeControlsEnabled = folderDevices.every(
+        (device) => device.isVolumeEnabled !== false,
+      )
+
+      if (areAllVolumeControlsEnabled) {
+        await disableFolderDeviceVolumeControls(folderNode)
+        return
+      }
+
+      await enableFolderDeviceVolumeControls(folderNode)
+    },
+    [
+      collectDevicesInNode,
+      disableFolderDeviceVolumeControls,
+      enableFolderDeviceVolumeControls,
+    ],
+  )
+
   const handleToggleDeviceLock = useCallback(async (device) => {
     if (!device) {
       return
@@ -1315,6 +1428,22 @@ const RetailPlayerDeviceManagement = () => {
       setSelectedIds((previous) => new Set(previous))
     } catch (err) {
       console.error('Failed to update retail player device lock state', err)
+    }
+  }, [updateDevice])
+
+  const handleToggleDeviceVolumeControl = useCallback(async (device) => {
+    if (!device?.id) {
+      return
+    }
+
+    try {
+      const nextIsVolumeEnabled = device.isVolumeEnabled !== false
+        ? false
+        : true
+      await updateDevice({ id: device.id, isVolumeEnabled: nextIsVolumeEnabled })
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to update retail player volume control state', err)
     }
   }, [updateDevice])
 
@@ -1450,6 +1579,10 @@ const RetailPlayerDeviceManagement = () => {
       if (node.type === 'folder') {
         const isSelected = selectedIds.has(node.id)
         const isLocked = Boolean(node.isLocked)
+        const folderDevices = collectDevicesInNode(node)
+        const isVolumeEnabled = folderDevices.length
+          ? folderDevices.every((device) => device.isVolumeEnabled !== false)
+          : true
         return (
           <RetailPlayerFolderRow
             key={`folder-row-${node.id}`}
@@ -1461,7 +1594,9 @@ const RetailPlayerDeviceManagement = () => {
             onKeyDown={handleRowKeyDown}
             onEdit={handleEditFolder}
             onToggleLock={handleToggleFolderLock}
+            onToggleVolumeControl={handleToggleFolderVolumeControl}
             isLocked={isLocked}
+            isVolumeEnabled={isVolumeEnabled}
             onDeviceDrop={handleDeviceDropOnFolder}
           />
         )
@@ -1481,7 +1616,9 @@ const RetailPlayerDeviceManagement = () => {
           onKeyDown={handleRowKeyDown}
           onEdit={handleEditDevice}
           onToggleLock={handleToggleDeviceLock}
+          onToggleVolumeControl={handleToggleDeviceVolumeControl}
           isLocked={isDeviceLocked(node)}
+          isVolumeEnabled={node.isVolumeEnabled !== false}
           isOnline={isOnline}
         />
       )

--- a/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
+++ b/ui/src/retailPlayer/RetailPlayerDeviceStoreContext.jsx
@@ -119,6 +119,12 @@ const baseDeviceShape = (device, existing) => {
       : typeof existing?.online === 'boolean'
         ? existing.online
         : undefined
+  const normalizedIsVolumeEnabled =
+    typeof device?.isVolumeEnabled === 'boolean'
+      ? device.isVolumeEnabled
+      : typeof existing?.isVolumeEnabled === 'boolean'
+        ? existing.isVolumeEnabled
+        : true
 
   const existingFolderIds = normalizeFolderIds(
     existing?.folderIds ?? existing?.folderId,
@@ -147,6 +153,7 @@ const baseDeviceShape = (device, existing) => {
     timeZone: normalizedTimeZone || '',
     remoteControlId: normalizedRemoteControlId || '',
     isLocked: normalizedIsLocked,
+    isVolumeEnabled: normalizedIsVolumeEnabled,
     ...(typeof normalizedIsOnline === 'boolean' ? { online: normalizedIsOnline } : {}),
     folderIds,
     folderId: primaryFolderId,
@@ -302,6 +309,7 @@ const reducer = (state, action) => {
         folderId,
         remoteControlId,
         isLocked,
+        isVolumeEnabled,
       } = action.payload || {}
       if (!id) {
         return state
@@ -334,6 +342,10 @@ const reducer = (state, action) => {
               : device.remoteControlId,
           isLocked:
             typeof isLocked === 'boolean' ? isLocked : device.isLocked,
+          isVolumeEnabled:
+            typeof isVolumeEnabled === 'boolean'
+              ? isVolumeEnabled
+              : device.isVolumeEnabled,
         }
       })
       return { ...state, devices: nextDevices, lastUpdated: Date.now() }
@@ -684,6 +696,10 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
         basePayload,
         'isLocked',
       )
+      const hasIsVolumeEnabled = Object.prototype.hasOwnProperty.call(
+        basePayload,
+        'isVolumeEnabled',
+      )
 
       if (hasRemoteControlId) {
         const remoteControlId = normalizeValue(basePayload.remoteControlId)
@@ -726,6 +742,29 @@ const RetailPlayerDeviceStoreProvider = ({ children }) => {
               typeof json?.data?.isLocked === 'boolean'
                 ? json.data.isLocked
                 : isLocked,
+          },
+        })
+      }
+
+      if (hasIsVolumeEnabled) {
+        const isVolumeEnabled = Boolean(basePayload.isVolumeEnabled)
+        const { json } = await httpClient(
+          `/api/retailplayer/devices/${encodeURIComponent(deviceId)}/volume-control`,
+          {
+            method: 'PATCH',
+            body: JSON.stringify({ enabled: isVolumeEnabled }),
+            headers: new Headers({ 'Content-Type': 'application/json' }),
+          },
+        )
+
+        dispatch({
+          type: 'UPDATE_DEVICE',
+          payload: {
+            id: deviceId,
+            isVolumeEnabled:
+              typeof json?.data?.isVolumeEnabled === 'boolean'
+                ? json.data.isVolumeEnabled
+                : isVolumeEnabled,
           },
         })
       }

--- a/ui/src/retailPlayer/deviceUtils.js
+++ b/ui/src/retailPlayer/deviceUtils.js
@@ -81,6 +81,14 @@ const mapRetailPlayerDevice = (device) => {
       : typeof device.isOnline === 'boolean'
         ? device.isOnline
         : undefined
+  const isVolumeEnabled =
+    typeof device.isVolumeEnabled === 'boolean'
+      ? device.isVolumeEnabled
+      : typeof device.volumeEnabled === 'boolean'
+        ? device.volumeEnabled
+        : typeof device.is_volume_enabled === 'boolean'
+          ? device.is_volume_enabled
+          : undefined
 
   return {
     id: fallbackId,
@@ -101,6 +109,9 @@ const mapRetailPlayerDevice = (device) => {
     remoteControlId,
     ...(typeof isLocked === 'boolean' ? { isLocked } : {}),
     ...(typeof isOnline === 'boolean' ? { online: isOnline } : {}),
+    ...(typeof isVolumeEnabled === 'boolean'
+      ? { isVolumeEnabled }
+      : {}),
   }
 }
 

--- a/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
+++ b/ui/src/retailPlayer/useRetailPlayerDeviceStatus.js
@@ -718,6 +718,7 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
   const [hasRealtimeStatus, setHasRealtimeStatus] = useState(false)
   const realtimeDeviceRef = useRef(null)
   const lockedStateRef = useRef(null)
+  const volumeEnabledStateRef = useRef(null)
 
   const {
     devices,
@@ -773,6 +774,12 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
       lockedStateRef.current = baseDevice.isLocked
     }
   }, [baseDevice?.isLocked])
+
+  useEffect(() => {
+    if (typeof baseDevice?.isVolumeEnabled === 'boolean') {
+      volumeEnabledStateRef.current = baseDevice.isVolumeEnabled
+    }
+  }, [baseDevice?.isVolumeEnabled])
 
   useEffect(() => {
     if (!slugParam || !Array.isArray(devices) || !devices.length) {
@@ -1021,6 +1028,21 @@ const useRetailPlayerDeviceStatus = (slugParam) => {
                 : undefined
       if (typeof resolvedIsLocked === 'boolean') {
         mergedDevice.isLocked = resolvedIsLocked
+      }
+      const resolvedIsVolumeEnabled =
+        typeof payloadDevice.isVolumeEnabled === 'boolean'
+          ? payloadDevice.isVolumeEnabled
+          : typeof payloadDevice.volumeEnabled === 'boolean'
+            ? payloadDevice.volumeEnabled
+            : typeof payloadDevice.is_volume_enabled === 'boolean'
+              ? payloadDevice.is_volume_enabled
+              : typeof previousDevice.isVolumeEnabled === 'boolean'
+                ? previousDevice.isVolumeEnabled
+                : typeof volumeEnabledStateRef.current === 'boolean'
+                  ? volumeEnabledStateRef.current
+                  : undefined
+      if (typeof resolvedIsVolumeEnabled === 'boolean') {
+        mergedDevice.isVolumeEnabled = resolvedIsVolumeEnabled
       }
 
       const mergedRemoteControlId =


### PR DESCRIPTION
### Motivation
- Introduce a per-device flag to enable/disable volume controls so administrators can prevent user volume interaction on specific retail players.

### Description
- Add `IsVolumeEnabled` to `RetailPlayerDeviceMapping` and persist it in the DB with an `is_volume_enabled` BOOLEAN column defaulting to true, including schema-ensure logic and query/update support in the repository.
- Add repository API `SetVolumeEnabled` and wire it into a new private PATCH endpoint `/api/retailplayer/devices/{deviceID}/volume-control` that updates and returns the device mapping.
- Propagate the flag through the native API mapping functions so remote device sync and device-by-name endpoints include `isVolumeEnabled` in responses and use it when creating/updating mappings.
- Update UI device store, management list, folder actions and device dashboard to honor `isVolumeEnabled` by showing toggle controls in the management UI, sending patch requests to the new endpoint, and disabling volume UI elements when volume controls are disabled.

### Testing
- Ran the Go unit test suite with `go test ./...` and built the backend binary; tests and build succeeded.
- Ran the frontend lint/typechecks and unit tests and executed a production frontend build with `yarn build`; checks and build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce74da2420832ca8d28764caa88067)