### PR TITLE
Add playlist comparison bulk action with duplicate cleanup

### DIFF
--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -262,7 +262,8 @@
         "compareSelectTwoPlaylists": "Select exactly two playlists to compare.",
         "compareDuplicatesFound": "Found %{smart_count} duplicate song in both playlists. |||| Found %{smart_count} duplicate songs in both playlists.",
         "compareNoDuplicates": "No duplicate songs were found between the selected playlists.",
-        "compareRemovePrompt": "Remove duplicates from which playlist?"
+        "compareRemovePrompt": "Remove duplicates from which playlist?",
+        "compareDeletedFromPlaylist": "%{smart_count} song deleted from playlist \"%{name}\". |||| %{smart_count} songs deleted from playlist \"%{name}\"."
       },
       "dialog": {
         "setPositionTitle": "Set song position",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -247,7 +247,9 @@
         "searchOrCreate": "Search playlists or type to create new...",
         "pressEnterToCreate": "Press Enter to create new playlist",
         "removeFromSelection": "Remove from selection",
-        "setPosition": "Set song position"
+        "setPosition": "Set song position",
+        "compare": "Compare",
+        "removeDuplicatesFrom": "Remove from %{name}"
       },
       "notifications": {
         "published": "%{smart_count} song from %{name} published to Sync folder |||| %{smart_count} songs from %{name} published to Sync folder"
@@ -256,7 +258,11 @@
         "duplicate_song": "Add duplicated songs",
         "song_exist": "There are duplicates being added to the playlist. Would you like to add the duplicates or skip them?",
         "noPlaylistsFound": "No playlists found",
-        "noPlaylists": "No playlists available"
+        "noPlaylists": "No playlists available",
+        "compareSelectTwoPlaylists": "Select exactly two playlists to compare.",
+        "compareDuplicatesFound": "Found %{smart_count} duplicate song in both playlists. |||| Found %{smart_count} duplicate songs in both playlists.",
+        "compareNoDuplicates": "No duplicate songs were found between the selected playlists.",
+        "compareRemovePrompt": "Remove duplicates from which playlist?"
       },
       "dialog": {
         "setPositionTitle": "Set song position",

--- a/ui/src/playlist_folder/PlaylistFolderBulkActions.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderBulkActions.jsx
@@ -27,7 +27,7 @@ import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
 import Divider from '@material-ui/core/Divider'
-import { buildDuplicateInfo } from './playlistComparison'
+import { buildDuplicateInfo, buildDuplicateTrackIdsByPlaylist } from './playlistComparison'
 
 const useStyles = makeStyles((theme) => ({
   button: {
@@ -186,12 +186,14 @@ const ComparePlaylistsButton = ({ resource }) => {
   const [open, setOpen] = useState(false)
   const [duplicates, setDuplicates] = useState([])
   const [playlists, setPlaylists] = useState([])
+  const [duplicateTrackIdsByPlaylist, setDuplicateTrackIdsByPlaylist] = useState({})
   const [loading, setLoading] = useState(false)
 
   const closeDialog = useCallback(() => {
     setOpen(false)
     setDuplicates([])
     setPlaylists([])
+    setDuplicateTrackIdsByPlaylist({})
   }, [])
 
   const selectedPlaylists = useMemo(
@@ -227,12 +229,20 @@ const ComparePlaylistsButton = ({ resource }) => {
         }),
       ])
 
-      const matches = buildDuplicateInfo(leftResult?.data || [], rightResult?.data || [])
+      const leftTracks = leftResult?.data || []
+      const rightTracks = rightResult?.data || []
+      const matches = buildDuplicateInfo(leftTracks, rightTracks)
+      const duplicateTrackIds = buildDuplicateTrackIdsByPlaylist(leftTracks, rightTracks)
+
       setDuplicates(matches)
       setPlaylists([
         { id: left.id, name: left.name || left.id },
         { id: right.id, name: right.name || right.id },
       ])
+      setDuplicateTrackIdsByPlaylist({
+        [left.id]: duplicateTrackIds.left,
+        [right.id]: duplicateTrackIds.right,
+      })
       setOpen(true)
     } catch (e) {
       notify('ra.notification.http_error', { type: 'warning' })
@@ -246,11 +256,16 @@ const ComparePlaylistsButton = ({ resource }) => {
       if (!duplicates.length || !playlistId) return
       setLoading(true)
       try {
-        const duplicateMediaIds = duplicates.map((duplicate) => duplicate.mediaFileId)
+        const trackIdsToDelete = duplicateTrackIdsByPlaylist[playlistId] || []
+        if (!trackIdsToDelete.length) {
+          notify('resources.playlist.message.compareNoDuplicates', { type: 'warning' })
+          return
+        }
+
         const result = await safeDeleteMany(
           dataProvider,
           `playlist/${playlistId}/tracks`,
-          duplicateMediaIds
+          trackIdsToDelete
         )
 
         const removedCount = Array.isArray(result?.data) ? result.data.length : 0
@@ -267,7 +282,7 @@ const ComparePlaylistsButton = ({ resource }) => {
         setLoading(false)
       }
     },
-    [duplicates, dataProvider, notify, closeDialog, unselectAll, resource, refresh]
+    [duplicates.length, duplicateTrackIdsByPlaylist, dataProvider, notify, closeDialog, unselectAll, resource, refresh]
   )
 
   return (

--- a/ui/src/playlist_folder/PlaylistFolderBulkActions.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderBulkActions.jsx
@@ -9,12 +9,42 @@ import {
 } from 'react-admin'
 import { makeStyles } from '@material-ui/core/styles'
 import DeleteIcon from '@material-ui/icons/Delete'
-import { LockOpen, Lock } from '@material-ui/icons'
+import CompareArrowsIcon from '@material-ui/icons/CompareArrows'
+import {
+  LockOpen,
+  Lock,
+  Close as CloseIcon,
+  DeleteSweep as DeleteSweepIcon,
+} from '@material-ui/icons'
 import Button from '@material-ui/core/Button'
+import Dialog from '@material-ui/core/Dialog'
+import DialogActions from '@material-ui/core/DialogActions'
+import DialogContent from '@material-ui/core/DialogContent'
+import DialogTitle from '@material-ui/core/DialogTitle'
+import IconButton from '@material-ui/core/IconButton'
+import Typography from '@material-ui/core/Typography'
+import List from '@material-ui/core/List'
+import ListItem from '@material-ui/core/ListItem'
+import ListItemText from '@material-ui/core/ListItemText'
+import Divider from '@material-ui/core/Divider'
+import { buildDuplicateInfo } from './playlistComparison'
 
 const useStyles = makeStyles((theme) => ({
   button: {
     color: theme.palette.type === 'dark' ? 'white' : undefined,
+  },
+  closeButton: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+  },
+  duplicateList: {
+    maxHeight: 360,
+    overflow: 'auto',
+    marginBottom: theme.spacing(1),
+  },
+  hint: {
+    marginBottom: theme.spacing(1),
   },
 }))
 
@@ -144,6 +174,176 @@ const CustomBulkDeleteButton = ({ resource }) => {
   )
 }
 
+const ComparePlaylistsButton = ({ resource }) => {
+  const classes = useStyles()
+  const translate = useTranslate()
+  const { selectedIds = [], data } = useListContext()
+  const dataProvider = useDataProvider()
+  const notify = useNotify()
+  const unselectAll = useUnselectAll()
+  const refresh = useRefresh()
+
+  const [open, setOpen] = useState(false)
+  const [duplicates, setDuplicates] = useState([])
+  const [playlists, setPlaylists] = useState([])
+  const [loading, setLoading] = useState(false)
+
+  const closeDialog = useCallback(() => {
+    setOpen(false)
+    setDuplicates([])
+    setPlaylists([])
+  }, [])
+
+  const selectedPlaylists = useMemo(
+    () =>
+      selectedIds
+        .map((id) => getRecord(data, id))
+        .filter((record) => record?.type === 'playlist'),
+    [selectedIds, data]
+  )
+
+  const handleCompare = useCallback(async () => {
+    if (loading) return
+
+    if (selectedIds.length !== 2 || selectedPlaylists.length !== 2) {
+      notify('resources.playlist.message.compareSelectTwoPlaylists', { type: 'warning' })
+      return
+    }
+
+    setLoading(true)
+    try {
+      const [left, right] = selectedPlaylists
+
+      const [leftResult, rightResult] = await Promise.all([
+        dataProvider.getList('playlistTrack', {
+          filter: { playlist_id: left.id },
+          pagination: { page: 1, perPage: 0 },
+          sort: { field: 'id', order: 'ASC' },
+        }),
+        dataProvider.getList('playlistTrack', {
+          filter: { playlist_id: right.id },
+          pagination: { page: 1, perPage: 0 },
+          sort: { field: 'id', order: 'ASC' },
+        }),
+      ])
+
+      const matches = buildDuplicateInfo(leftResult?.data || [], rightResult?.data || [])
+      setDuplicates(matches)
+      setPlaylists([
+        { id: left.id, name: left.name || left.id },
+        { id: right.id, name: right.name || right.id },
+      ])
+      setOpen(true)
+    } catch (e) {
+      notify('ra.notification.http_error', { type: 'warning' })
+    } finally {
+      setLoading(false)
+    }
+  }, [loading, selectedIds, selectedPlaylists, dataProvider, notify])
+
+  const handleRemoveDuplicates = useCallback(
+    async (playlistId) => {
+      if (!duplicates.length || !playlistId) return
+      setLoading(true)
+      try {
+        const duplicateMediaIds = duplicates.map((duplicate) => duplicate.mediaFileId)
+        const result = await safeDeleteMany(
+          dataProvider,
+          `playlist/${playlistId}/tracks`,
+          duplicateMediaIds
+        )
+
+        const removedCount = Array.isArray(result?.data) ? result.data.length : 0
+        notify('ra.notification.deleted', {
+          type: removedCount > 0 ? 'info' : 'warning',
+          messageArgs: { smart_count: removedCount },
+        })
+        closeDialog()
+        unselectAll(resource)
+        refresh({ hard: true })
+      } catch (e) {
+        notify('ra.notification.http_error', { type: 'warning' })
+      } finally {
+        setLoading(false)
+      }
+    },
+    [duplicates, dataProvider, notify, closeDialog, unselectAll, resource, refresh]
+  )
+
+  return (
+    <>
+      <Button
+        onClick={handleCompare}
+        startIcon={<CompareArrowsIcon />}
+        className={classes.button}
+        aria-label={translate('resources.playlist.actions.compare')}
+        disabled={loading}
+      >
+        {translate('resources.playlist.actions.compare')}
+      </Button>
+
+      <Dialog open={open} onClose={closeDialog} fullWidth maxWidth="sm">
+        <DialogTitle disableTypography>
+          <Typography variant="h6">{translate('resources.playlist.actions.compare')}</Typography>
+          <IconButton
+            aria-label={translate('ra.action.close')}
+            className={classes.closeButton}
+            onClick={closeDialog}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent>
+          {duplicates.length > 0 ? (
+            <>
+              <Typography variant="body2" className={classes.hint}>
+                {translate('resources.playlist.message.compareDuplicatesFound', {
+                  smart_count: duplicates.length,
+                })}
+              </Typography>
+              <List className={classes.duplicateList} dense>
+                {duplicates.map((duplicate) => (
+                  <ListItem key={duplicate.mediaFileId}>
+                    <ListItemText
+                      primary={duplicate.title || duplicate.mediaFileId}
+                      secondary={duplicate.artist || undefined}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+              <Divider />
+              <Typography variant="body2" className={classes.hint}>
+                {translate('resources.playlist.message.compareRemovePrompt')}
+              </Typography>
+            </>
+          ) : (
+            <Typography variant="body2">
+              {translate('resources.playlist.message.compareNoDuplicates')}
+            </Typography>
+          )}
+        </DialogContent>
+        <DialogActions>
+          {duplicates.length > 0 &&
+            playlists.map((playlist) => (
+              <Button
+                key={playlist.id}
+                startIcon={<DeleteSweepIcon />}
+                onClick={() => handleRemoveDuplicates(playlist.id)}
+                color="secondary"
+                disabled={loading}
+              >
+                {translate('resources.playlist.actions.removeDuplicatesFrom', {
+                  name: playlist.name,
+                })}
+              </Button>
+            ))}
+          <Button onClick={closeDialog}>{translate('ra.action.cancel')}</Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  )
+}
+
 const ChangePublicStatusButton = ({ resource, makePublic }) => {
   const classes = useStyles()
   const translate = useTranslate()
@@ -167,6 +367,7 @@ const ChangePublicStatusButton = ({ resource, makePublic }) => {
 
 const PlaylistFolderBulkActions = (props) => (
   <Fragment>
+    <ComparePlaylistsButton {...props} />
     <ChangePublicStatusButton makePublic={true} {...props} />
     <ChangePublicStatusButton makePublic={false} {...props} />
     <CustomBulkDeleteButton {...props} />

--- a/ui/src/playlist_folder/PlaylistFolderBulkActions.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderBulkActions.jsx
@@ -269,9 +269,12 @@ const ComparePlaylistsButton = ({ resource }) => {
         )
 
         const removedCount = Array.isArray(result?.data) ? result.data.length : 0
-        notify('ra.notification.deleted', {
+        const playlistName =
+          playlists.find((playlist) => playlist.id === playlistId)?.name || playlistId
+
+        notify('resources.playlist.message.compareDeletedFromPlaylist', {
           type: removedCount > 0 ? 'info' : 'warning',
-          messageArgs: { smart_count: removedCount },
+          messageArgs: { smart_count: removedCount, name: playlistName },
         })
         closeDialog()
         unselectAll(resource)
@@ -282,7 +285,7 @@ const ComparePlaylistsButton = ({ resource }) => {
         setLoading(false)
       }
     },
-    [duplicates.length, duplicateTrackIdsByPlaylist, dataProvider, notify, closeDialog, unselectAll, resource, refresh]
+    [duplicates.length, duplicateTrackIdsByPlaylist, dataProvider, notify, playlists, closeDialog, unselectAll, resource, refresh]
   )
 
   return (

--- a/ui/src/playlist_folder/PlaylistFolderBulkActions.test.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderBulkActions.test.jsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { buildDuplicateInfo } from './playlistComparison'
+
+describe('buildDuplicateInfo', () => {
+  it('returns unique duplicates sorted by title', () => {
+    const leftTracks = [
+      { mediaFileId: 'm2', title: 'Zebra', artist: 'Two' },
+      { mediaFileId: 'm1', title: 'Alpha', artist: 'One' },
+      { mediaFileId: 'm1', title: 'Alpha', artist: 'One' },
+    ]
+    const rightTracks = [
+      { mediaFileId: 'm3', title: 'Other' },
+      { mediaFileId: 'm1', title: 'Alpha' },
+      { mediaFileId: 'm2', title: 'Zebra' },
+    ]
+
+    expect(buildDuplicateInfo(leftTracks, rightTracks)).toEqual([
+      { mediaFileId: 'm1', title: 'Alpha', artist: 'One' },
+      { mediaFileId: 'm2', title: 'Zebra', artist: 'Two' },
+    ])
+  })
+
+  it('ignores tracks without mediaFileId', () => {
+    const leftTracks = [
+      { title: 'Unknown' },
+      { mediaFileId: '', title: 'Blank' },
+      { mediaFileId: null, title: 'Null' },
+    ]
+    const rightTracks = [{ mediaFileId: 'm1', title: 'Exists' }]
+
+    expect(buildDuplicateInfo(leftTracks, rightTracks)).toEqual([])
+  })
+})

--- a/ui/src/playlist_folder/PlaylistFolderBulkActions.test.jsx
+++ b/ui/src/playlist_folder/PlaylistFolderBulkActions.test.jsx
@@ -1,17 +1,20 @@
 import { describe, it, expect } from 'vitest'
-import { buildDuplicateInfo } from './playlistComparison'
+import {
+  buildDuplicateInfo,
+  buildDuplicateTrackIdsByPlaylist,
+} from './playlistComparison'
 
 describe('buildDuplicateInfo', () => {
   it('returns unique duplicates sorted by title', () => {
     const leftTracks = [
-      { mediaFileId: 'm2', title: 'Zebra', artist: 'Two' },
-      { mediaFileId: 'm1', title: 'Alpha', artist: 'One' },
-      { mediaFileId: 'm1', title: 'Alpha', artist: 'One' },
+      { id: 'lt2', mediaFileId: 'm2', title: 'Zebra', artist: 'Two' },
+      { id: 'lt1', mediaFileId: 'm1', title: 'Alpha', artist: 'One' },
+      { id: 'lt1-dup', mediaFileId: 'm1', title: 'Alpha', artist: 'One' },
     ]
     const rightTracks = [
-      { mediaFileId: 'm3', title: 'Other' },
-      { mediaFileId: 'm1', title: 'Alpha' },
-      { mediaFileId: 'm2', title: 'Zebra' },
+      { id: 'rt3', mediaFileId: 'm3', title: 'Other' },
+      { id: 'rt1', mediaFileId: 'm1', title: 'Alpha' },
+      { id: 'rt2', mediaFileId: 'm2', title: 'Zebra' },
     ]
 
     expect(buildDuplicateInfo(leftTracks, rightTracks)).toEqual([
@@ -29,5 +32,24 @@ describe('buildDuplicateInfo', () => {
     const rightTracks = [{ mediaFileId: 'm1', title: 'Exists' }]
 
     expect(buildDuplicateInfo(leftTracks, rightTracks)).toEqual([])
+  })
+})
+
+describe('buildDuplicateTrackIdsByPlaylist', () => {
+  it('returns playlist-track IDs to delete per selected playlist', () => {
+    const leftTracks = [
+      { id: 'lt1', mediaFileId: 'm1', title: 'Alpha' },
+      { id: 'lt2', mediaFileId: 'm2', title: 'Bravo' },
+      { id: 'lt3', mediaFileId: 'm1', title: 'Alpha duplicate in left' },
+    ]
+    const rightTracks = [
+      { id: 'rt1', mediaFileId: 'm1', title: 'Alpha' },
+      { id: 'rt4', mediaFileId: 'm4', title: 'Delta' },
+    ]
+
+    expect(buildDuplicateTrackIdsByPlaylist(leftTracks, rightTracks)).toEqual({
+      left: ['lt1', 'lt3'],
+      right: ['rt1'],
+    })
   })
 })

--- a/ui/src/playlist_folder/playlistComparison.js
+++ b/ui/src/playlist_folder/playlistComparison.js
@@ -1,0 +1,37 @@
+const normalizeTrackName = (track) => {
+  if (!track) return ''
+  return (
+    track.title || track.name || track.songTitle || track.mediaFileTitle || track.path || ''
+  )
+}
+
+const normalizeArtistName = (track) => {
+  if (!track) return ''
+  return track.artist || track.artistName || track.albumArtist || ''
+}
+
+export const buildDuplicateInfo = (tracksA = [], tracksB = []) => {
+  const bByMediaId = new Set(
+    tracksB
+      .map((track) => track?.mediaFileId)
+      .filter((mediaFileId) => mediaFileId !== undefined && mediaFileId !== null)
+  )
+
+  const deduped = new Map()
+  tracksA.forEach((track) => {
+    const mediaFileId = track?.mediaFileId
+    if (!mediaFileId || !bByMediaId.has(mediaFileId) || deduped.has(mediaFileId)) {
+      return
+    }
+
+    deduped.set(mediaFileId, {
+      mediaFileId,
+      title: normalizeTrackName(track),
+      artist: normalizeArtistName(track),
+    })
+  })
+
+  return Array.from(deduped.values()).sort((a, b) =>
+    `${a.title} ${a.artist}`.localeCompare(`${b.title} ${b.artist}`)
+  )
+}

--- a/ui/src/playlist_folder/playlistComparison.js
+++ b/ui/src/playlist_folder/playlistComparison.js
@@ -35,3 +35,17 @@ export const buildDuplicateInfo = (tracksA = [], tracksB = []) => {
     `${a.title} ${a.artist}`.localeCompare(`${b.title} ${b.artist}`)
   )
 }
+
+export const buildDuplicateTrackIdsByPlaylist = (tracksA = [], tracksB = []) => {
+  const duplicateMediaIds = new Set(buildDuplicateInfo(tracksA, tracksB).map((t) => t.mediaFileId))
+
+  const getTrackIds = (tracks) =>
+    tracks
+      .filter((track) => track?.id && duplicateMediaIds.has(track?.mediaFileId))
+      .map((track) => track.id)
+
+  return {
+    left: getTrackIds(tracksA),
+    right: getTrackIds(tracksB),
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a way to compare two selected playlists from the playlist-folder view to detect duplicated songs between them and let the user remove duplicates from either playlist.

### Description
- Add a new `Compare` bulk action (`ComparePlaylistsButton`) in `ui/src/playlist_folder/PlaylistFolderBulkActions.jsx` that validates exactly two selected playlists, fetches both playlists' tracks, computes duplicates by `mediaFileId`, and shows results in a dialog. 
- Implement cleanup actions in the dialog that call the data provider to remove duplicate tracks from the chosen playlist, then refresh the list and clear the selection. 
- Extract duplicate matching/normalization logic to a new helper `ui/src/playlist_folder/playlistComparison.js` (`buildDuplicateInfo`) that returns unique, stably-sorted duplicate entries. 
- Add unit tests `ui/src/playlist_folder/PlaylistFolderBulkActions.test.jsx` for `buildDuplicateInfo`. 
- Add English i18n strings for compare flow in `ui/src/i18n/en.json` and wire action labels/messages for the dialog and buttons.

### Testing
- Ran unit tests with `cd ui && npm test -- PlaylistSongBulkActions.test.jsx PlaylistFolderBulkActions.test.jsx` and all tests passed (5 tests total across the two files). 
- Ran lint on the modified files with `cd ui && npx eslint src/playlist_folder/PlaylistFolderBulkActions.jsx src/playlist_folder/PlaylistFolderBulkActions.test.jsx src/playlist_folder/playlistComparison.js` with no blocking errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb006c008832285061c9093c01e41)