### PR TITLE
Add AI Tool page and backend /api/ai/chat endpoint

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -107,6 +107,7 @@ type configOptions struct {
 	Deezer                          deezerOptions       `json:",omitzero"`
 	ListenBrainz                    listenBrainzOptions `json:",omitzero"`
 	RetailPlayer                    retailPlayerOptions `json:",omitzero"`
+	AI                              aiOptions           `json:",omitzero"`
 	Tags                            map[string]TagConf  `json:",omitempty"`
 	Agents                          string
 
@@ -192,6 +193,11 @@ type deezerOptions struct {
 type listenBrainzOptions struct {
 	Enabled bool
 	BaseURL string
+}
+
+type aiOptions struct {
+	OpenAIAPIKey string
+	OpenAIModel  string
 }
 
 type retailPlayerNotificationOptions struct {
@@ -663,6 +669,8 @@ func setViperDefaults() {
 	viper.SetDefault("retailplayer.search", "")
 	viper.SetDefault("retailplayer.fields", []string{})
 	viper.SetDefault("retailplayer.additionalheaders", map[string]string{})
+	viper.SetDefault("ai.openaiapikey", "")
+	viper.SetDefault("ai.openaimodel", "gpt-4o-mini")
 	viper.SetDefault("httpsecurityheaders.customframeoptionsvalue", "DENY")
 	viper.SetDefault("backup.path", "")
 	viper.SetDefault("backup.schedule", "")

--- a/server/nativeapi/ai_chat.go
+++ b/server/nativeapi/ai_chat.go
@@ -1,0 +1,99 @@
+package nativeapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/log"
+)
+
+type aiChatRequest struct {
+	Message string `json:"message"`
+}
+
+type aiChatResponse struct {
+	Answer string `json:"answer"`
+}
+
+type openAIChatRequest struct {
+	Model    string              `json:"model"`
+	Messages []map[string]string `json:"messages"`
+}
+
+type openAIChatResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+}
+
+func (n *Router) addAIRoute(r chi.Router) {
+	r.Post("/ai/chat", n.handleAIChat())
+}
+
+func (n *Router) handleAIChat() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if strings.TrimSpace(conf.Server.AI.OpenAIAPIKey) == "" {
+			http.Error(w, "AI is not configured", http.StatusServiceUnavailable)
+			return
+		}
+
+		var req aiChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "Invalid request payload", http.StatusBadRequest)
+			return
+		}
+		message := strings.TrimSpace(req.Message)
+		if message == "" {
+			http.Error(w, "Message is required", http.StatusBadRequest)
+			return
+		}
+
+		body, _ := json.Marshal(openAIChatRequest{
+			Model:    conf.Server.AI.OpenAIModel,
+			Messages: []map[string]string{{"role": "user", "content": message}},
+		})
+		openAIReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, "https://api.openai.com/v1/chat/completions", bytes.NewReader(body))
+		if err != nil {
+			http.Error(w, "Could not create AI request", http.StatusInternalServerError)
+			return
+		}
+		openAIReq.Header.Set("Content-Type", "application/json")
+		openAIReq.Header.Set("Authorization", "Bearer "+conf.Server.AI.OpenAIAPIKey)
+
+		res, err := http.DefaultClient.Do(openAIReq)
+		if err != nil {
+			log.Error(r.Context(), "Error calling OpenAI", "err", err)
+			http.Error(w, "Unable to process AI request", http.StatusBadGateway)
+			return
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode >= 300 {
+			data, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
+			log.Warn(r.Context(), "OpenAI returned error", "status", res.StatusCode, "body", string(data))
+			http.Error(w, "AI provider returned an error", http.StatusBadGateway)
+			return
+		}
+
+		var openAIRes openAIChatResponse
+		if err := json.NewDecoder(res.Body).Decode(&openAIRes); err != nil {
+			http.Error(w, "Invalid AI response", http.StatusBadGateway)
+			return
+		}
+		if len(openAIRes.Choices) == 0 {
+			http.Error(w, "AI returned an empty response", http.StatusBadGateway)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(aiChatResponse{Answer: strings.TrimSpace(openAIRes.Choices[0].Message.Content)})
+	}
+}

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -153,6 +153,7 @@ func (n *Router) routes() http.Handler {
 		n.addKeepAliveRoute(r)
 		n.addInsightsRoute(r)
 		n.addRetailPlayerPrivateRoutes(r)
+		n.addAIRoute(r)
 
 		r.With(adminOnlyMiddleware).Group(func(r chi.Router) {
 			n.addInspectRoute(r)

--- a/ui/src/aiTool/AIToolPage.jsx
+++ b/ui/src/aiTool/AIToolPage.jsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react'
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Paper,
+  TextField,
+  Typography,
+  makeStyles,
+} from '@material-ui/core'
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    padding: theme.spacing(3),
+    height: 'calc(100vh - 140px)',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+  },
+  messages: {
+    flex: 1,
+    overflowY: 'auto',
+    padding: theme.spacing(2),
+    background: theme.palette.background.default,
+  },
+  message: {
+    marginBottom: theme.spacing(1),
+    padding: theme.spacing(1.5),
+  },
+  user: { background: theme.palette.grey[900] },
+  assistant: { background: theme.palette.grey[800] },
+  inputRow: { display: 'flex', gap: theme.spacing(1), alignItems: 'flex-end' },
+}))
+
+const AIToolPage = () => {
+  const classes = useStyles()
+  const [messages, setMessages] = useState([])
+  const [message, setMessage] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const sendMessage = async () => {
+    if (!message.trim() || loading) return
+    const userMessage = message.trim()
+    setMessages((m) => [...m, { role: 'user', text: userMessage }])
+    setMessage('')
+    setError('')
+    setLoading(true)
+
+    try {
+      const response = await fetch('/api/ai/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({ message: userMessage }),
+      })
+      if (!response.ok) throw new Error('Request failed')
+      const data = await response.json()
+      setMessages((m) => [...m, { role: 'assistant', text: data.answer || '' }])
+    } catch (e) {
+      setError('Failed to send message. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Paper className={classes.root}>
+      <Typography variant="h5">AI Tool</Typography>
+      <Box className={classes.messages}>
+        {messages.map((msg, idx) => (
+          <Paper
+            key={`${msg.role}-${idx}`}
+            className={`${classes.message} ${msg.role === 'user' ? classes.user : classes.assistant}`}
+          >
+            <Typography variant="body2" color="textSecondary">
+              {msg.role === 'user' ? 'You' : 'Assistant'}
+            </Typography>
+            <Typography variant="body1">{msg.text}</Typography>
+          </Paper>
+        ))}
+        {loading && <CircularProgress size={24} />}
+      </Box>
+      {error && <Typography color="error">{error}</Typography>}
+      <Box className={classes.inputRow}>
+        <TextField
+          fullWidth
+          multiline
+          minRows={3}
+          variant="outlined"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="Type your message"
+        />
+        <Button variant="contained" color="primary" onClick={sendMessage} disabled={loading}>
+          Send
+        </Button>
+      </Box>
+    </Paper>
+  )
+}
+
+export default AIToolPage

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -642,6 +642,9 @@
       "error": "Unable to load devices",
       "empty": "No devices available"
     },
+    "aiTool": {
+      "name": "AI Tool"
+    },
     "about": "About"
   },
   "player": {

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -18,6 +18,7 @@ import SpeakerGroupIcon from '@material-ui/icons/SpeakerGroup'
 import ChevronRightIcon from '@material-ui/icons/ChevronRight'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import FolderIcon from '@material-ui/icons/Folder'
+import SmartToyIcon from '@material-ui/icons/SmartToy'
 import { useHistory, useLocation } from 'react-router-dom'
 import { BiCog } from 'react-icons/bi'
 import SubMenu from './SubMenu'
@@ -460,6 +461,14 @@ const Menu = ({ dense = false }) => {
       {config.devSidebarPlaylists && open ? (
         <>
           {renderRetailPlayerMenu()}
+          <MenuItemLink
+            to="/ai-tool"
+            activeClassName={classes.active}
+            primaryText={translate('menu.aiTool.name', { _: 'AI Tool' })}
+            leftIcon={<SmartToyIcon />}
+            sidebarIsOpen={open}
+            dense={dense}
+          />
           <Divider />
           <DiscoverySubMenu
             state={state}
@@ -478,6 +487,14 @@ const Menu = ({ dense = false }) => {
       ) : (
         <>
           {renderRetailPlayerMenu()}
+          <MenuItemLink
+            to="/ai-tool"
+            activeClassName={classes.active}
+            primaryText={translate('menu.aiTool.name', { _: 'AI Tool' })}
+            leftIcon={<SmartToyIcon />}
+            sidebarIsOpen={open}
+            dense={dense}
+          />
           {resources.filter(subItems('discovery')).map(renderResourceMenuItemLink)}
           {resources.filter(subItems('playlist')).map(renderResourceMenuItemLink)}
         </>

--- a/ui/src/routes.jsx
+++ b/ui/src/routes.jsx
@@ -3,6 +3,7 @@ import { Redirect, Route } from 'react-router-dom'
 import Personal from './personal/Personal'
 import RetailPlayerDashboard from './retailPlayer/RetailPlayerDashboard'
 import RetailPlayerDeviceManagement from './retailPlayer/RetailPlayerDeviceManagement'
+import AIToolPage from './aiTool/AIToolPage'
 
 const routes = [
   <Route exact path="/personal" render={() => <Personal />} key={'personal'} />,
@@ -36,6 +37,7 @@ const routes = [
     render={() => <RetailPlayerDashboard />}
     key={'musicmatters-device'}
   />,
+  <Route exact path="/ai-tool" render={() => <AIToolPage />} key={'ai-tool'} />,
 ]
 
 export default routes


### PR DESCRIPTION
### Motivation
- Provide a minimal, isolated first-phase AI integration: a ChatGPT-style chat page inside Navidrome that calls the server-side backend rather than OpenAI directly. 
- Keep the UI consistent with the existing dark theme and place the new entry below the existing Retail Player menu item.

### Description
- Added an `AI` config block with `AI.OpenAIAPIKey` and `AI.OpenAIModel` and Viper defaults in `conf/configuration.go` so the backend reads OpenAI settings from configuration/environment. 
- Implemented a protected backend route `POST /api/ai/chat` in `server/nativeapi/ai_chat.go` that proxies the user message to OpenAI using the configured model and returns JSON `{ "answer": "..." }` while keeping the API key on the server. 
- Registered the route under existing protected routes by calling `n.addAIRoute(r)` in `server/nativeapi/native_api.go`. 
- Added a separate frontend page component `ui/src/aiTool/AIToolPage.jsx` plus route and sidebar link: imported and routed at `/ai-tool` (`ui/src/routes.jsx`) and inserted an `AI Tool` menu item below `Retail Player` in `ui/src/layout/Menu.jsx`, with a translation entry in `ui/src/i18n/en.json`. 
- The UI includes a chat message area, a multiline input, a Send button, and loading/error states; frontend calls only the Navidrome backend endpoint `/api/ai/chat` and never exposes the OpenAI API key.

### Testing
- `gofmt` was applied to modified Go files successfully. 
- Frontend lint (`cd ui && npm run lint`) produced errors in the repository unrelated to the new page (existing `no-console` violations and other pre-existing lint issues), so lint did not fully pass. 
- `go test` for the native API package could not run to completion in this environment due to a missing system dependency (`taglib` via pkg-config), so unit tests were not validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0448069d5883308d0c319bd8f6b2a7)