### PR TITLE
Fix loudness normalization tolerance configuration

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -137,6 +137,8 @@ type configOptions struct {
 	DevExternalArtistFetchMultiplier float64
 }
 
+const DefaultLoudnessNormalizationTolerance = 0.1
+
 type scannerOptions struct {
 	Enabled               bool
 	Schedule              string
@@ -630,7 +632,7 @@ func setViperDefaults() {
 	viper.SetDefault("scanner.loudnessnormalization.targetlufs", -12.6)
 	viper.SetDefault("scanner.loudnessnormalization.truepeak", -1.5)
 	viper.SetDefault("scanner.loudnessnormalization.lra", 11.0)
-	viper.SetDefault("scanner.loudnessnormalization.tolerance", 0.5)
+	viper.SetDefault("scanner.loudnessnormalization.tolerance", DefaultLoudnessNormalizationTolerance)
 	viper.SetDefault("scanner.loudnessnormalization.backup", true)
 	viper.SetDefault("scanner.loudnessnormalization.backupsuffix", ".before_loudnorm")
 	viper.SetDefault("scanner.artistjoiner", consts.ArtistJoiner)

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -2,6 +2,7 @@ package conf_test
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -24,6 +25,23 @@ var _ = Describe("Configuration", func() {
 		viper.SetDefault("datafolder", GinkgoT().TempDir())
 		viper.SetDefault("loglevel", "error")
 		conf.ResetConf()
+	})
+
+	It("sets the loudness normalization tolerance default", func() {
+		conf.Load(true)
+
+		Expect(conf.Server.Scanner.LoudnessNormalization.Tolerance).To(Equal(conf.DefaultLoudnessNormalizationTolerance))
+	})
+
+	It("loads a 0.1 loudness normalization tolerance from configuration", func() {
+		filename := filepath.Join(GinkgoT().TempDir(), "navidrome.toml")
+		content := "[Scanner.LoudnessNormalization]\nTolerance = 0.1\n"
+		Expect(os.WriteFile(filename, []byte(content), 0600)).To(Succeed())
+
+		conf.InitConfig(filename)
+		conf.Load(true)
+
+		Expect(conf.Server.Scanner.LoudnessNormalization.Tolerance).To(Equal(0.1))
 	})
 
 	DescribeTable("should load configuration from",

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -448,7 +448,7 @@ When enabled, loudness normalization runs during folder scanning for audio files
 | `Scanner.LoudnessNormalization.TargetLUFS`      | Integrated LUFS target passed to ffmpeg `loudnorm`                           | -12.6                |
 | `Scanner.LoudnessNormalization.TruePeak`        | True-peak target passed to ffmpeg `loudnorm`                                 | -1.5                 |
 | `Scanner.LoudnessNormalization.LRA`             | Loudness-range target passed to ffmpeg `loudnorm`                            | 11                   |
-| `Scanner.LoudnessNormalization.Tolerance`       | LUFS distance from the target that is considered already normalized; values below 0.5 are treated as 0.5 so the default -12.6 target keeps tracks in the -13.1 to -12.1 LUFS range | 0.5                  |
+| `Scanner.LoudnessNormalization.Tolerance`       | LUFS distance from the target that is considered already normalized; the default -12.6 target keeps tracks in the -12.7 to -12.5 LUFS range | 0.1                  |
 | `Scanner.LoudnessNormalization.Backup`          | Whether to keep the original file before replacing it with the normalized one | true                 |
 | `Scanner.LoudnessNormalization.BackupSuffix`    | Suffix appended to the original path when creating the backup                | `.before_loudnorm`   |
 

--- a/scanner/phase_1_folders.go
+++ b/scanner/phase_1_folders.go
@@ -464,10 +464,7 @@ func (p *phaseFolders) logFolder(entry *folderEntry) (*folderEntry, error) {
 	return entry, nil
 }
 
-const (
-	defaultLoudnessTolerance     = 0.5
-	maxLoudnessNormalizeAttempts = 3
-)
+const maxLoudnessNormalizeAttempts = 3
 
 func (p *phaseFolders) normalizeLoudnessFiles(entry *folderEntry, filesToImport map[string]*model.MediaFile) {
 	options := conf.Server.Scanner.LoudnessNormalization
@@ -531,7 +528,10 @@ func (p *phaseFolders) normalizeTrackLoudnessToRange(normalizer ffmpeg.LoudnessN
 }
 
 func effectiveLoudnessTolerance(tolerance float64) float64 {
-	return max(tolerance, defaultLoudnessTolerance)
+	if tolerance < 0 {
+		return conf.DefaultLoudnessNormalizationTolerance
+	}
+	return tolerance
 }
 
 func shouldNormalizeLoudness(lufs, targetLUFS, tolerance float64) bool {

--- a/scanner/phase_1_folders_loudness_test.go
+++ b/scanner/phase_1_folders_loudness_test.go
@@ -1,0 +1,21 @@
+package scanner
+
+import "testing"
+
+func TestEffectiveLoudnessToleranceAllowsTenthLUFS(t *testing.T) {
+	if got := effectiveLoudnessTolerance(0.1); got != 0.1 {
+		t.Fatalf("effectiveLoudnessTolerance(0.1) = %v, want 0.1", got)
+	}
+}
+
+func TestShouldNormalizeLoudnessUsesConfiguredTolerance(t *testing.T) {
+	const target = -12.6
+	const tolerance = 0.1
+
+	if shouldNormalizeLoudness(-12.7, target, tolerance) {
+		t.Fatal("expected exact tolerance boundary to be considered normalized")
+	}
+	if !shouldNormalizeLoudness(-12.71, target, tolerance) {
+		t.Fatal("expected values outside 0.1 LUFS tolerance to be normalized")
+	}
+}


### PR DESCRIPTION
### Motivation
- Make the loudness normalization tolerance configurable from `conf` so values below the previous 0.5 floor are honored.
- Use a sensible smaller default (0.1 LUFS) that keeps the default -12.6 target closer to its expected range.

### Description
- Add `DefaultLoudnessNormalizationTolerance = 0.1` and wire `viper.SetDefault("scanner.loudnessnormalization.tolerance", DefaultLoudnessNormalizationTolerance)` in `conf/configuration.go` so the default comes from configuration.
- Change `effectiveLoudnessTolerance` in `scanner/phase_1_folders.go` to return the configured value unless it is negative, in which case it falls back to `conf.DefaultLoudnessNormalizationTolerance`, so `0.1` is honored instead of being clamped to `0.5`.
- Add unit tests: a configuration test in `conf/configuration_test.go` to assert the default and loading a `0.1` tolerance, and scanner tests in `scanner/phase_1_folders_loudness_test.go` to validate `effectiveLoudnessTolerance(0.1)` and boundary behavior of `shouldNormalizeLoudness`.
- Update scanner documentation (`scanner/README.md`) to reflect the new `0.1` default and the resulting LUFS range for the default target.

### Testing
- Ran `go test ./conf` which passed and confirmed the new default is loaded from configuration.
- Ran `go test ./core/ffmpeg` which passed and did not regress ffmpeg loudnorm logic.
- Attempted `go test ./scanner` but the package failed to build in this environment due to an external C dependency (`taglib` missing from `pkg-config`) and unrelated test scaffolding (`playlistRepoMock`) already present in the test suite, so full scanner tests could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0270adb06c8322a677a9c85b552c98)